### PR TITLE
STACK-581 : [VLAN] Delete flows for load balancer

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -206,12 +206,17 @@ class LoadBalancerFlows(object):
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
             provides=a10constants.STATUS))
 
-        # delete_LB_flow.add(listeners_delete)
-        # delete_LB_flow.add(network_tasks.UnplugVIP(
-        #    requires=constants.LOADBALANCER))
-        # delete_LB_flow.add(network_tasks.DeallocateVIP(
-        #    requires=constants.LOADBALANCER))
+        # TODO: delete flow for flat network
+        network_type = 'vlan'
         if deleteCompute:
+            if network_type == 'vlan':
+                delete_LB_flow.add(a10_network_tasks.DeallocateTrunk(
+                    requires=constants.LOADBALANCER,
+                    provides=a10constants.TRUNK))
+                delete_LB_flow.add(a10_network_tasks.UnplugVIP(
+                    requires=constants.LOADBALANCER))
+                delete_LB_flow.add(a10_network_tasks.DeallocateVIP(
+                    requires=constants.LOADBALANCER))
             delete_LB_flow.add(a10_compute_tasks.DeleteAmphoraeOnLoadBalancer(
                 requires=constants.LOADBALANCER))
         delete_LB_flow.add(a10_database_tasks.MarkVThunderStatusInDB(

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -213,9 +213,9 @@ class LoadBalancerFlows(object):
                 delete_LB_flow.add(a10_network_tasks.DeallocateTrunk(
                     requires=constants.LOADBALANCER,
                     provides=a10constants.TRUNK))
-                delete_LB_flow.add(a10_network_tasks.UnplugVIP(
+                delete_LB_flow.add(network_tasks.UnplugVIP(
                     requires=constants.LOADBALANCER))
-                delete_LB_flow.add(a10_network_tasks.DeallocateVIP(
+                delete_LB_flow.add(network_tasks.DeallocateVIP(
                     requires=constants.LOADBALANCER))
             delete_LB_flow.add(a10_compute_tasks.DeleteAmphoraeOnLoadBalancer(
                 requires=constants.LOADBALANCER))

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -48,7 +48,7 @@ class MemberFlows(object):
 
         :returns: The flow for creating a member
         """
-        create_member_flow = linear.Flow(constants.CREATE_MEMBER_FLOW)
+        create_member_flow = linear_flow.Flow(constants.CREATE_MEMBER_FLOW)
         create_member_flow.add(lifecycle_tasks.MemberToErrorOnRevertTask(
             requires=[constants.MEMBER,
                       constants.LISTENERS,

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -411,7 +411,7 @@ class DeallocateVIP(BaseNetworkTask):
 
     def execute(self, loadbalancer):
         """Deallocate a VIP."""
-        LOG.info("Deallocating a VIP %s", loadbalancer.vip.ip_address)
+        LOG.debug("Deallocating a VIP %s", loadbalancer.vip.ip_address)
         vip = loadbalancer.vip
         vip.load_balancer = loadbalancer
         self.network_driver.deallocate_vip(vip)
@@ -682,10 +682,10 @@ class DeallocateTrunk(BaseNetworkTask):
     def execute(self, loadbalancer):
         try:
             parent_port = self.network_driver.get_plugged_parent_port(loadbalancer.vip)
-            LOG.info('Deleting trunk with id %s', parent_port.trunk_id)
+            LOG.debug('Deleting trunk with id %s', parent_port.trunk_id)
             self.network_driver.deallocate_trunk(parent_port.trunk_id)
         except Exception:
-            LOG.warning('Failed to deallocate a trunk with vip ')
+            LOG.warning('Failed to deallocate a trunk with vip %s', loadbalancer.vip)
 
 
 class AllocateTrunk(BaseNetworkTask):
@@ -693,7 +693,7 @@ class AllocateTrunk(BaseNetworkTask):
 
     def execute(self, vip):
         parent_port_id = vip.port_id
-        LOG.info('Creating trunk for port with ID: %s', parent_port_id)
+        LOG.debug('Creating trunk for port with ID: %s', parent_port_id)
         self.network_driver.allocate_trunk(parent_port_id)
 
     def revert(self, result, vip, *args, **kwargs):
@@ -701,7 +701,7 @@ class AllocateTrunk(BaseNetworkTask):
             parent_port = self.network_driver.get_plugged_parent_port(vip)
             self.network_driver.deallocate_trunk(parent_port.trunk_id)
         except Exception:
-            LOG.warning('Failed to deallocate a trunk with vip ')
+            LOG.warning('Failed to deallocate a trunk with vip %s', loadbalancer.vip)
 
 
 class GetParentPort(BaseNetworkTask):

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -246,7 +246,7 @@ class UnPlugNetworks(BaseNetworkTask):
             except base.NetworkNotFound:
                 LOG.debug("Network %d not found", nic.network_id)
             except Exception:
-                LOG.error("Unable to unplug network")
+                LOG.exception("Unable to unplug network")
 
 
 class GetMemberPorts(BaseNetworkTask):
@@ -361,20 +361,6 @@ class PlugVIPAmpphora(BaseNetworkTask):
         except Exception as e:
             LOG.error('Failed to unplug AAP port. Resources may still be in '
                       'use for VIP: %s due to error: %s', loadbalancer.vip, e)
-
-
-class UnplugVIP(BaseNetworkTask):
-    """Task to unplug the vip."""
-
-    def execute(self, loadbalancer):
-        """Unplug the vip."""
-
-        LOG.debug("Unplug vip on amphora")
-        try:
-            self.network_driver.unplug_vip(loadbalancer, loadbalancer.vip)
-        except Exception:
-            LOG.error("Unable to unplug vip from load balancer %s",
-                          loadbalancer.id)
 
 
 class AllocateVIP(BaseNetworkTask):
@@ -513,7 +499,7 @@ class HandleNetworkDelta(BaseNetworkTask):
             except base.NetworkNotFound:
                 LOG.debug("Network %d not found ", nic.network_id)
             except Exception:
-                LOG.error("Unable to unplug network")
+                LOG.exception("Unable to unplug network")
         return added_ports
 
     def revert(self, result, amphora, delta, *args, **kwargs):
@@ -685,7 +671,7 @@ class DeallocateTrunk(BaseNetworkTask):
             LOG.debug('Deleting trunk with id %s', parent_port.trunk_id)
             self.network_driver.deallocate_trunk(parent_port.trunk_id)
         except Exception:
-            LOG.error('Failed to deallocate the trunk %s with vip', parent_port.trunk_id)
+            LOG.error('Failed to deallocate the trunk with vip')
 
 
 class AllocateTrunk(BaseNetworkTask):
@@ -701,7 +687,7 @@ class AllocateTrunk(BaseNetworkTask):
             parent_port = self.network_driver.get_plugged_parent_port(vip)
             self.network_driver.deallocate_trunk(parent_port.trunk_id)
         except Exception:
-            LOG.error('Failed to deallocate the trunk %s with vip', parent_port.trunk_id)
+            LOG.error('Failed to deallocate the trunk with vip')
 
 
 class GetParentPort(BaseNetworkTask):

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -246,7 +246,7 @@ class UnPlugNetworks(BaseNetworkTask):
             except base.NetworkNotFound:
                 LOG.debug("Network %d not found", nic.network_id)
             except Exception:
-                LOG.exception("Unable to unplug network")
+                LOG.error("Unable to unplug network")
 
 
 class GetMemberPorts(BaseNetworkTask):
@@ -373,7 +373,7 @@ class UnplugVIP(BaseNetworkTask):
         try:
             self.network_driver.unplug_vip(loadbalancer, loadbalancer.vip)
         except Exception:
-            LOG.exception("Unable to unplug vip from load balancer %s",
+            LOG.error("Unable to unplug vip from load balancer %s",
                           loadbalancer.id)
 
 
@@ -513,7 +513,7 @@ class HandleNetworkDelta(BaseNetworkTask):
             except base.NetworkNotFound:
                 LOG.debug("Network %d not found ", nic.network_id)
             except Exception:
-                LOG.exception("Unable to unplug network")
+                LOG.error("Unable to unplug network")
         return added_ports
 
     def revert(self, result, amphora, delta, *args, **kwargs):
@@ -563,7 +563,7 @@ class HandleNICDeltas(BaseNetworkTask):
                 except base.NetworkNotFound:
                     LOG.debug("Network %d not found ", nic.network_id)
                 except Exception:
-                    LOG.exception("Unable to unplug network")
+                    LOG.error("Unable to unplug network")
         return added_ports
 
     def revert(self, result, nic_deltas, *args, **kwargs):
@@ -606,7 +606,7 @@ class HandlePortDeltas(BaseNetworkTask):
             try:
                 self.network_driver.plug_trunk_subports(parent_port.trunk_id, delta.add_subports)
             except Exception:
-                LOG.exception("Unable to plug subports")
+                LOG.error("Unable to plug subports")
             added_ports[amp_id] = delta.add_subports
         return added_ports
 
@@ -639,7 +639,7 @@ class HandleDeletePortDeltas(BaseNetworkTask):
             try:
                 self.network_driver.unplug_trunk_subports(parent_port.trunk_id, delta.delete_subports)
             except Exception:
-                LOG.exception("Unable to unplug subports")
+                LOG.error("Unable to unplug subports")
             deleted_ports[amp_id] = delta.delete_subports
         return deleted_ports
 
@@ -672,7 +672,7 @@ class PlugVIPPort(BaseNetworkTask):
             vrrp_port = amphorae_network_config.get(amphora.id).vrrp_port
             self.network_driver.unplug_port(amphora, vrrp_port)
         except Exception:
-            LOG.warning('Failed to unplug vrrp port: %(port)s from amphora: '
+            LOG.error('Failed to unplug vrrp port: %(port)s from amphora: '
                         '%(amp)s', {'port': vrrp_port.id, 'amp': amphora.id})
 
 
@@ -701,7 +701,7 @@ class AllocateTrunk(BaseNetworkTask):
             parent_port = self.network_driver.get_plugged_parent_port(vip)
             self.network_driver.deallocate_trunk(parent_port.trunk_id)
         except Exception:
-            LOG.warning('Failed to deallocate the trunk %s with vip', parent_port.trunk_id)
+            LOG.error('Failed to deallocate the trunk %s with vip', parent_port.trunk_id)
 
 
 class GetParentPort(BaseNetworkTask):
@@ -786,7 +786,7 @@ class ApplyQosAmphora(BaseNetworkTask):
             if not is_revert:
                 raise
             else:
-                LOG.warning('Failed to undo qos policy %(qos_id)s '
+                LOG.error('Failed to undo qos policy %(qos_id)s '
                             'on vrrp port: %(port)s from '
                             'amphorae: %(amp)s',
                             {'qos_id': request_qos_id,

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -685,7 +685,7 @@ class DeallocateTrunk(BaseNetworkTask):
             LOG.debug('Deleting trunk with id %s', parent_port.trunk_id)
             self.network_driver.deallocate_trunk(parent_port.trunk_id)
         except Exception:
-            LOG.warning('Failed to deallocate a trunk with vip %s', loadbalancer.vip)
+            LOG.error('Failed to deallocate the trunk %s with vip', parent_port.trunk_id)
 
 
 class AllocateTrunk(BaseNetworkTask):
@@ -701,7 +701,7 @@ class AllocateTrunk(BaseNetworkTask):
             parent_port = self.network_driver.get_plugged_parent_port(vip)
             self.network_driver.deallocate_trunk(parent_port.trunk_id)
         except Exception:
-            LOG.warning('Failed to deallocate a trunk with vip %s', loadbalancer.vip)
+            LOG.warning('Failed to deallocate the trunk %s with vip', parent_port.trunk_id)
 
 
 class GetParentPort(BaseNetworkTask):

--- a/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
+++ b/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
@@ -189,7 +189,7 @@ class A10OctaviaNeutronDriver(AllowedAddressPairsDriver):
     def get_plugged_parent_port(self, vip):
         parent_port = None
         try:
-            port = self.neutron_client.show_port(vip.port_id)
+            port = self.get_port(vip.port_id)
             parent_port = self._port_to_parent_port(port.get("port"))
         except Exception:
             LOG.debug('Couldn\'t retrieve port with id: {}'.format(vip.port_id))

--- a/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
+++ b/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
@@ -189,7 +189,7 @@ class A10OctaviaNeutronDriver(AllowedAddressPairsDriver):
     def get_plugged_parent_port(self, vip):
         parent_port = None
         try:
-            port = self.get_port(vip.port_id)
+            port = self.neutron_client.show_port(vip.port_id)
             parent_port = self._port_to_parent_port(port.get("port"))
         except Exception:
             LOG.debug('Couldn\'t retrieve port with id: {}'.format(vip.port_id))

--- a/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
+++ b/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
@@ -168,7 +168,6 @@ class A10OctaviaNeutronDriver(AllowedAddressPairsDriver):
 
     def plug_trunk_subports(self, trunk_id, subports):
         payload = self._build_subport_payload(subports)
-
         updated_trunk = None
         try:
             updated_trunk = self.neutron_client.trunk_add_subports(trunk_id, payload)
@@ -188,6 +187,7 @@ class A10OctaviaNeutronDriver(AllowedAddressPairsDriver):
             LOG.exception(message)
 
     def get_plugged_parent_port(self, vip):
+        parent_port = None
         try:
             port = self.neutron_client.show_port(vip.port_id)
             parent_port = self._port_to_parent_port(port.get("port"))

--- a/a10_octavia/tests/common/a10constants.py
+++ b/a10_octavia/tests/common/a10constants.py
@@ -12,7 +12,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-SEGMENTATION_ID = 23
+SEGMENTATION_ID1 = 23
+SEGMENTATION_ID2 = 24
 VLAN_ID = 22
 SUBNET_IP = '10.10.10.10'
 TRUNK_ID = 11

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_network_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_network_tasks.py
@@ -33,6 +33,7 @@ VIP = o_data_models.Vip(port_id=t_constants.MOCK_PORT_ID,
                         qos_policy_id=t_constants.MOCK_QOS_POLICY_ID1)
 LB = o_data_models.LoadBalancer(vip=VIP)
 PARENT_PORT = data_models.ParentPort(trunk_id=a10_test_constants.TRUNK_ID)
+EMPTY_PARENT_PORT = data_models.ParentPort()
 DELETE_SUBPORTS = {t_constants.MOCK_AMP_ID1: [SUBPORT1]}
 MULTIPLE_DELETE_SUBPORTS = {t_constants.MOCK_AMP_ID1: [SUBPORT1, SUBPORT2]}
 
@@ -72,12 +73,6 @@ class TestNetworkTasks(base.TestCase):
         self.network_driver_mock.unplug_trunk_subports.assert_called_with(
             PARENT_PORT.trunk_id, MULTIPLE_DELETE_SUBPORTS)
 
-
-    def test_deallocate_vip(self):
-        network_task = a10_network_tasks.DeallocateVIP()
-        network_task.execute(LB)
-        self.network_driver_mock.deallocate_vip.assert_called_with(LB.vip) 
-
     def test_deallocate_trunk(self):
         network_task =  a10_network_tasks.DeallocateTrunk()
         self.network_driver_mock.get_plugged_parent_port.return_value = PARENT_PORT
@@ -85,7 +80,8 @@ class TestNetworkTasks(base.TestCase):
         self.network_driver_mock.get_plugged_parent_port.assert_called_with(LB.vip)
         self.network_driver_mock.deallocate_trunk.assert_called_with(PARENT_PORT.trunk_id)
 
-    def test_unplug_vip(self):
-        network_task = a10_network_tasks.UnplugVIP()
+    def test_deallocate_trunk_not_found(self):
+        network_task =  a10_network_tasks.DeallocateTrunk()
         network_task.execute(LB)
-        self.network_driver_mock.unplug_vip.assert_called_with(LB, LB.vip) 
+        self.network_driver_mock.deallocate_trunk.side_effect = Exception()
+        self.assertRaises(Exception, self.network_driver_mock.deallocate_trunk, EMPTY_PARENT_PORT.trunk_id)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_network_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_network_tasks.py
@@ -74,7 +74,7 @@ class TestNetworkTasks(base.TestCase):
             PARENT_PORT.trunk_id, MULTIPLE_DELETE_SUBPORTS)
 
     def test_deallocate_trunk(self):
-        network_task =  a10_network_tasks.DeallocateTrunk()
+        network_task = a10_network_tasks.DeallocateTrunk()
         self.network_driver_mock.get_plugged_parent_port.return_value = PARENT_PORT
         network_task.execute(LB)
         self.network_driver_mock.get_plugged_parent_port.assert_called_with(LB.vip)
@@ -82,6 +82,7 @@ class TestNetworkTasks(base.TestCase):
 
     def test_deallocate_trunk_not_found(self):
         network_task =  a10_network_tasks.DeallocateTrunk()
+        self.network_driver_mock.get_plugged_parent_port.return_value = EMPTY_PARENT_PORT
         network_task.execute(LB)
-        self.network_driver_mock.deallocate_trunk.side_effect = Exception()
-        self.assertRaises(Exception, self.network_driver_mock.deallocate_trunk, EMPTY_PARENT_PORT.trunk_id)
+        self.network_driver_mock.get_plugged_parent_port.assert_called_with(LB.vip)
+        self.network_driver_mock.deallocate_trunk.assert_called_with(EMPTY_PARENT_PORT.trunk_id)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_network_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_network_tasks.py
@@ -14,9 +14,11 @@
 
 
 import mock
+from unittest.mock import patch
 
+from octavia.common import data_models as o_data_models
 from octavia.tests.common import constants as t_constants
-import octavia.tests.unit.base as base
+from octavia.tests.unit import base
 
 from a10_octavia.controller.worker.tasks import a10_network_tasks
 from a10_octavia.network import data_models
@@ -25,25 +27,53 @@ from a10_octavia.tests.common import a10constants as a10_test_constants
 
 SUBPORT = Subport(segmentation_id=a10_test_constants.SEGMENTATION_ID)
 
+VIP = o_data_models.Vip(port_id=t_constants.MOCK_PORT_ID,
+                        subnet_id=t_constants.MOCK_SUBNET_ID,
+                        qos_policy_id=t_constants.MOCK_QOS_POLICY_ID1)
+LB = o_data_models.LoadBalancer(vip=VIP)
+PARENT_PORT = data_models.ParentPort(trunk_id=a10_test_constants.TRUNK_ID)
+DELETE_SUBPORTS = {t_constants.MOCK_AMP_ID1: [SUBPORT]}
+PORT_DELTA = data_models.PortDelta(
+            amphora_id=t_constants.MOCK_AMP_ID1, compute_id=t_constants.MOCK_AMP_COMPUTE_ID1,
+            add_subports=[], delete_subports=[])
+
 
 class TestNetworkTasks(base.TestCase):
 
-    @mock.patch('a10_octavia.controller.worker.tasks.a10_network_tasks.BaseNetworkTask.network_driver')
-    def test_handle_delete_port_deltas(self, get_network_drivers_mock):
-        get_network_drivers_mock.return_value = mock.Mock()
-        mock_parent_port = data_models.ParentPort(trunk_id=a10_test_constants.TRUNK_ID)
+    def setUp(self):
+        patcher = patch(
+            'a10_octavia.controller.worker.tasks.a10_network_tasks.BaseNetworkTask.network_driver')
+        self.network_driver_mock = patcher.start()
+        self.network_driver_mock.return_value = mock.Mock()
+        super(TestNetworkTasks, self).setUp()
 
-        empty_mock_port_deltas = {t_constants.MOCK_AMP_ID1: data_models.PortDelta(
-            amphora_id=t_constants.MOCK_AMP_ID1, compute_id=t_constants.MOCK_AMP_COMPUTE_ID1,
-            add_subports=[], delete_subports=[])}
+    def test_handle_delete_port_deltas_with_empty_port_deltas(self):
+        empty_mock_port_deltas = {t_constants.MOCK_AMP_ID1: PORT_DELTA}
         net = a10_network_tasks.HandleDeletePortDeltas()
         self.assertEqual({t_constants.MOCK_AMP_ID1: []}, net.execute(
-            mock_parent_port, empty_mock_port_deltas))
+            PARENT_PORT, empty_mock_port_deltas))
 
-        delete_subports = {t_constants.MOCK_AMP_ID2: [SUBPORT]}
-        mock_port_deltas = {t_constants.MOCK_AMP_ID2: data_models.PortDelta(
-            amphora_id=t_constants.MOCK_AMP_ID2, compute_id=t_constants.MOCK_AMP_COMPUTE_ID2,
-            add_subports=[], delete_subports=delete_subports)}
-        net.execute(mock_parent_port, mock_port_deltas)
-        get_network_drivers_mock.unplug_trunk_subports.assert_called_with(
-            mock_parent_port.trunk_id, delete_subports)
+    def test_handle_delete_port_deltas_with_port_deltas(self):
+        PORT_DELTA.delete_subports = DELETE_SUBPORTS
+        mock_port_deltas = {t_constants.MOCK_AMP_ID1: PORT_DELTA}
+        net = a10_network_tasks.HandleDeletePortDeltas()
+        net.execute(PARENT_PORT, mock_port_deltas)
+        self.network_driver_mock.unplug_trunk_subports.assert_called_with(
+            PARENT_PORT.trunk_id, DELETE_SUBPORTS)
+
+    def test_deallocate_vip(self):
+        net = a10_network_tasks.DeallocateVIP()
+        net.execute(LB)
+        self.network_driver_mock.deallocate_vip.assert_called_with(LB.vip) 
+
+    def test_deallocate_trunk(self):
+        net =  a10_network_tasks.DeallocateTrunk()
+        self.network_driver_mock.get_plugged_parent_port.return_value = PARENT_PORT
+        net.execute(LB)
+        self.network_driver_mock.get_plugged_parent_port.assert_called_with(LB.vip)
+        self.network_driver_mock.deallocate_trunk.assert_called_with(PARENT_PORT.trunk_id)
+
+    def test_unplug_vip(self):
+        net = a10_network_tasks.UnplugVIP()
+        net.execute(LB)
+        self.network_driver_mock.unplug_vip.assert_called_with(LB, LB.vip) 


### PR DESCRIPTION
## Non-Customer Highlights 
- Delete flow for loadbalancer added 
- Unit Tests added for applicable network tasks.

## Closes 
[STACK-581](https://a10networks.atlassian.net/browse/STACK-581)
[STACK-589](https://a10networks.atlassian.net/browse/STACK-589)
[STACK-590](https://a10networks.atlassian.net/browse/STACK-590)
[STACK-842](https://a10networks.atlassian.net/browse/STACK-842)