### PR TITLE
STACK-1110 script to create and teardown provider poc vlan networking

### DIFF
--- a/a10_octavia/contrib/scripts/a10_setup_provider_vlan_poc
+++ b/a10_octavia/contrib/scripts/a10_setup_provider_vlan_poc
@@ -1,0 +1,440 @@
+#!/bin/bash
+
+#
+# This script is used for setting up devstack VLAN config with provider VLAN and Openstack 
+# VLAN networks. This scripts sets up three openstack networks 
+# provider-vlan-11 (vlan id:11, subnet:10.0.11.0/24)
+# provider-vlan-12 (vlan id:12, subnet:10.0.12.0/24)
+# provider-vlan-13 (vlan id:13, subnet:10.0.13.0/24)
+# with which openstack instances can be launched and communicate with vthunder on provider 
+# network.
+#
+
+function usage {
+cat << EOF
+usage: $0
+
+OPTIONS:
+  --help                     prints this message
+  --setup-provider-vlan      sets up provider ovs bridge br-vlanp, neutron vlan config and
+                             openstack vlan networks.
+                             make sure to delete all non devstack entities created by user
+                             in openstack before running this command. 
+  --teardown-provider-vlan   tears down the openstack vlan networks, ovs bridge settings and
+                             removes neutron vlan config.
+                             make sure to delete all vlan entities created by user
+                             in openstack before running this command.
+EOF
+}
+
+function check_exists {
+    local cmd="${1}"
+    local pattern="${2}"
+
+    local output=$(${cmd})
+    local exists=$(echo "${output}" | grep "${pattern}")
+    if [ -z "${exists}" ]
+    then
+        echo 0
+        return
+    fi
+
+    echo 1
+}
+
+function host_install_packages {
+    echo "[+] Installing virt-manager on host"
+    sudo apt-get install -y virt-manager
+}
+
+function setup_host_networking {
+    local exists=$(check_exists "ip addr show" "veth0")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Creating veth pair veth0-veth1 on the host"
+        sudo ip link add veth0 type veth peer name veth1
+        sudo ip link set veth0 up
+        sudo ip link set veth1 up
+        echo "[=] Setting 10.0.0.1/24 on veth0"
+        sudo ip addr add 10.0.0.1/24 dev veth0
+    fi
+
+    exists=$(check_exists "ip addr show" "veth2")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Creating veth pair veth2-veth3 on the host"
+        sudo ip link add veth2 type veth peer name veth3
+        sudo ip link set veth2 up
+        sudo ip link set veth3 up
+        echo "[=] Setting 10.0.11.1/24 on veth2"
+        sudo ip addr add 10.0.11.1/24 dev veth2
+    fi
+
+    exists=$(check_exists "ip addr show" "veth4")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Creating veth pair veth4-veth5 on the host"
+        sudo ip link add veth4 type veth peer name veth5
+        sudo ip link set veth4 up
+        sudo ip link set veth5 up
+        echo "[=] Setting 10.0.12.1/24 on veth4"
+        sudo ip addr add 10.0.12.1/24 dev veth4
+    fi
+
+    exists=$(check_exists "ip addr show" "veth6")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Creating veth pair veth6-veth7 on the host"
+        sudo ip link add veth6 type veth peer name veth7
+        sudo ip link set veth6 up
+        sudo ip link set veth7 up
+        echo "[=] Setting 10.0.13.1/24 on veth6"
+        sudo ip addr add 10.0.13.1/24 dev veth6
+    fi
+
+    exists=$(check_exists "ip addr show" "tap1")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Creating tap1 on the host for vlan 11"
+        sudo ip tuntap add mode tap tap1
+    fi
+
+    exists=$(check_exists "ip addr show" "tap2")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Creating tap2 on the host for vlan 12"
+        sudo ip tuntap add mode tap tap2
+    fi
+
+    exists=$(check_exists "ip addr show" "tap3")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Creating tap3 on the host for vlan 13"
+        sudo ip tuntap add mode tap tap3
+    fi
+
+    pvlan_dhcp_running=$(ps -ef | grep -v grep | grep setu-vlanp-dnsmasq.pid)
+    if [[ -z ${pvlan_dhcp_running} ]]; then
+        echo "[+] Starting DHCP server for management and vlan networks" 
+        sudo dnsmasq --no-hosts --pid-file=/var/run/setup-vlanp-dnsmasq.pid --dhcp-range=interface:vnet0,10.0.0.40,10.0.0.90,72h --dhcp-range=interface:vnet2,10.0.11.40,10.0.11.90,72h --dhcp-range=interface:vnet4,10.0.12.40,10.0.12.90,72h --dhcp-range=interface:vnet6,10.0.13.40,10.0.13.90,72h --dhcp-option=19,0 --local-service --bind-dynamic --conf-file=
+    fi
+}
+
+function setup_host_ovs_bridges {
+    local exists=$(check_exists "sudo ovs-vsctl list-br" "br-mgmt")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Creating OVS bridge br-mgmt"
+        sudo ovs-vsctl add-br br-mgmt
+    fi 
+
+    exists=$(check_exists "sudo ovs-vsctl list-ports br-mgmt" "veth1")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Adding port veth1 to OVS bridge br-mgmt"
+        sudo ovs-vsctl add-port br-mgmt veth1
+    fi
+
+    exists=$(check_exists "sudo ovs-vsctl list-br" "br-vlanp")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Creating OVS bridge br-vlanp"
+        sudo ovs-vsctl add-br br-vlanp
+    fi 
+
+    exists=$(check_exists "sudo ovs-vsctl list-ports br-vlanp" "tap1")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Adding port tap1 to OVS bridge br-vlanp"
+        sudo ovs-vsctl add-port br-vlanp tap1 tag=11
+    fi
+
+    exists=$(check_exists "sudo ovs-vsctl list-ports br-vlanp" "veth3")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Adding port veth3 to OVS bridge br-vlanp"
+        sudo ovs-vsctl add-port br-vlanp veth3 tag=11
+    fi
+
+    exists=$(check_exists "sudo ovs-vsctl list-ports br-vlanp" "tap2")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Adding port tap2 to OVS bridge br-vlanp"
+        sudo ovs-vsctl add-port br-vlanp tap2 tag=12
+    fi
+
+    exists=$(check_exists "sudo ovs-vsctl list-ports br-vlanp" "veth5")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Adding port veth5 to OVS bridge br-vlanp"
+        sudo ovs-vsctl add-port br-vlanp veth5 tag=12
+    fi
+
+    exists=$(check_exists "sudo ovs-vsctl list-ports br-vlanp" "tap3")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Adding port tap3 to OVS bridge br-vlanp"
+        sudo ovs-vsctl add-port br-vlanp tap3 tag=13
+    fi
+
+    exists=$(check_exists "sudo ovs-vsctl list-ports br-vlanp" "veth7")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Adding port veth7 to OVS bridge br-vlanp"
+        sudo ovs-vsctl add-port br-vlanp veth7 tag=13
+    fi
+}
+
+function patch_conf_files {
+    echo "[+] Patching config files"
+
+    exists=$(check_exists "/bin/cat /etc/neutron/neutron.conf" "service_plugins = router,qos")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[=] Overwriting service_plugins in /etc/neutron/neutron.conf"
+        sed -i "s/service_plugins = router,qos/service_plugins = /" /etc/neutron/neutron.conf
+    fi
+
+    exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "#type_drivers =")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[=] Overwriting type_drivers in /etc/neutron/plugins/ml2/ml2_conf.ini"
+        sed -i "s/#type_drivers = /type_drivers = flat,vlan/" /etc/neutron/plugins/ml2/ml2_conf.ini
+    fi
+
+    exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "mechanism_drivers = openvswitch,linuxbridge")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[=] Overwriting mechanism_drivers in /etc/neutron/plugins/ml2/ml2_conf.ini"
+        sed -i "s/mechanism_drivers = .*/mechanism_drivers = openvswitch/" /etc/neutron/plugins/ml2/ml2_conf.ini
+    fi
+
+    exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "tenant_network_types = vxlan")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[=] Overwriting tenant_network_types in /etc/neutron/plugins/ml2/ml2_conf.ini"
+        sed -i "s/tenant_network_types = .*/tenant_network_types = /" /etc/neutron/plugins/ml2/ml2_conf.ini
+    fi
+
+    exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "#network_vlan_ranges =")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[=] Overwriting network_vlan_ranges /etc/neutron/plugins/ml2/ml2_conf.ini"
+        sed -i "s/#network_vlan_ranges =/network_vlan_ranges = provider/" /etc/neutron/plugins/ml2/ml2_conf.ini
+    fi
+
+    exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "provider:br-vlanp")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[=] Overwriting bridge_mappings in /etc/neutron/plugins/ml2/ml2_conf.ini"
+        sed -i "s/bridge_mappings = .*/bridge_mappings = public:br-ex,provider:br-vlanp/" /etc/neutron/plugins/ml2/ml2_conf.ini
+    fi
+}
+
+function restart_services {
+    echo "[=] Restarting devstack@neutron-* services"
+    pushd /etc/systemd/system/
+    sudo systemctl restart devstack@neutron-*
+    popd
+}
+
+function create_network {
+    local vlan_id="${1}"
+    local network_name="${2}"
+    local subnet_name="${3}"
+    local subnet_range="${4}"
+    local allocation_pool="${5}"
+
+    exists=$(check_exists "openstack network list" "${network_name}")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Creating ${network_name}"
+        openstack network create --provider-segment ${vlan_id} --provider-network-type vlan --provider-physical-network provider --share ${network_name}
+        sleep 1
+    fi
+
+    exists=$(check_exists "openstack subnet list" "${subnet_name}")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Creating ${subnet_name}"
+        openstack subnet create --ip-version 4 --allocation-pool ${allocation_pool} --network ${network_name} --subnet-range ${subnet_range} ${subnet_name}
+        sleep 1
+    fi
+}
+
+function setup_provider_vlan {
+    host_install_packages
+    setup_host_networking
+    setup_host_ovs_bridges
+    patch_conf_files
+    restart_services
+    sleep 2
+    create_network 11 provider-vlan-11 provider-vlan-11-subnet 10.0.11.0/24 start=10.0.11.100,end=10.0.11.200
+    create_network 12 provider-vlan-12 provider-vlan-12-subnet 10.0.12.0/24 start=10.0.12.100,end=10.0.12.200
+    create_network 13 provider-vlan-13 provider-vlan-13-subnet 10.0.13.0/24 start=10.0.13.100,end=10.0.13.200
+}
+
+function delete_network {
+    local network_name="${1}"
+    local subnet_name="${2}"
+
+    local exists=$(check_exists "openstack subnet list" "${subnet_name}")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[-] Deleting ${subnet_name}"
+        openstack subnet delete ${subnet_name}
+    fi
+
+    exists=$(check_exists "openstack network list" "${network_name}")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[-] Deleting ${network_name}"
+        openstack network delete ${network_name}
+    fi
+}
+
+function delete_ostack_networks {
+    delete_network provider-vlan-13 provider-vlan-13-subnet
+    delete_network provider-vlan-12 provider-vlan-12-subnet
+    delete_network provider-vlan-11 provider-vlan-11-subnet
+}
+
+function unpatch_conf_files {
+    echo "[-] Removing vlan patch in config files"
+
+    local exists=$(check_exists "/bin/cat /etc/neutron/neutron.conf" "service_plugins = router,qos")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[=] Overwriting service_plugins in /etc/neutron/neutron.conf"
+        sed -i "s/service_plugins =/service_plugins = router,qos/" /etc/neutron/neutron.conf
+    fi
+
+    exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "type_drivers = flat,vlan")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[=] Overwriting type_drivers in /etc/neutron/plugins/ml2/ml2_conf.ini"
+        sed -i "s/type_drivers = flat,vlan/#type_drivers = /" /etc/neutron/plugins/ml2/ml2_conf.ini
+    fi
+
+    exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "mechanism_drivers = openvswitch,linuxbridge")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[=] Overwriting mechanism_drivers in /etc/neutron/plugins/ml2/ml2_conf.ini"
+        sed -i "s/mechanism_drivers = .*/mechanism_drivers = openvswitch,linuxbridge/" /etc/neutron/plugins/ml2/ml2_conf.ini
+    fi
+
+    exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "tenant_network_types = vxlan")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[=] Overwriting tenant_network_types in /etc/neutron/plugins/ml2/ml2_conf.ini"
+        sed -i "s/tenant_network_types =/tenant_network_types = vxlan/" /etc/neutron/plugins/ml2/ml2_conf.ini
+    fi
+
+    exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "network_vlan_ranges = provider")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[=] Overwriting network_vlan_ranges /etc/neutron/plugins/ml2/ml2_conf.ini"
+        sed -i "s/network_vlan_ranges = provider/#network_vlan_ranges =/" /etc/neutron/plugins/ml2/ml2_conf.ini
+    fi
+
+    exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "provider:br-vlanp")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[=] Overwriting bridge_mappings in /etc/neutron/plugins/ml2/ml2_conf.ini"
+        sed -i "s/bridge_mappings = public:br-ex,provider:br-vlanp/bridge_mappings = public:br-ex/" /etc/neutron/plugins/ml2/ml2_conf.ini
+    fi
+}
+
+function delete_ovs_bridges {
+    local exists=$(check_exists "sudo ovs-vsctl list-br" "br-vlanp")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[-] Deleting tap ports from br-vlanp"
+        sudo ovs-vsctl del-port br-vlanp tap3
+        sudo ovs-vsctl del-port br-vlanp tap2
+        sudo ovs-vsctl del-port br-vlanp tap1
+
+        echo "[-] Deleting veth ports from br-vlanp"
+        sudo ovs-vsctl del-port br-vlanp veth7
+        sudo ovs-vsctl del-port br-vlanp veth5
+        sudo ovs-vsctl del-port br-vlanp veth3
+
+        echo "[-] Deleting OVS bridge br-vlanp"
+        sudo ovs-vsctl del-br br-vlanp
+    fi
+
+    exists=$(check_exists "sudo ovs-vsctl list-br" "br-mgmt")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[-] Deleting veth port from br-mgmt"
+        sudo ovs-vsctl del-port br-mgmt veth1
+
+        echo "[-] Deleting OVS bridge br-mgmt"
+        sudo ovs-vsctl del-br br-mgmt
+    fi
+}
+
+function delete_host_tap_and_veth_interfaces {
+    local pvlan_dhcp_pid=$(ps -ef | grep -v grep | grep setup-vlanp-dnsmasq.pid | awk '{print $2}')
+    if [[ -n ${pvlan_dhcp_pid} ]]; then
+        echo "[-] Stoping DHCP server for management and vlan networks"
+        sudo kill -9 ${pvlan_dhcp_pid}
+        sudo rm -f /var/run/setup-vlanp-dnsmasq.pid
+    fi
+
+    local exists=$(check_exists "ip addr show" "tap3")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[-] Deleting interface tap3"
+        sudo ip tuntap del mode tap tap3
+    fi
+
+    exists=$(check_exists "ip addr show" "tap2")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[-] Deleting interface tap2"
+        sudo ip tuntap del mode tap tap2
+    fi
+
+    exists=$(check_exists "ip addr show" "tap1")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[-] Deleting interface tap1"
+        sudo ip tuntap del mode tap tap1
+    fi
+
+    exists=$(check_exists "ip addr show" "veth0")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[-] Deleting veth0 veth pair"
+        sudo ip link del veth0
+    fi
+
+    exists=$(check_exists "ip addr show" "veth2")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[-] Deleting veth2 veth pair"
+        sudo ip link del veth2
+    fi
+
+    exists=$(check_exists "ip addr show" "veth4")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[-] Deleting veth4 veth pair"
+        sudo ip link del veth4
+    fi
+
+    exists=$(check_exists "ip addr show" "veth6")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[-] Deleting veth6 veth pair"
+        sudo ip link del veth6
+    fi
+}
+
+function teardown_provider_vlan {
+    delete_ostack_networks
+    unpatch_conf_files
+    delete_ovs_bridges
+    delete_host_tap_and_veth_interfaces
+    restart_services
+}
+
+arg_setup_provider_vlan=false
+arg_teardown_provider_vlan=false
+
+function set_args {
+    if [[ $# -eq 0 ]] || [[ $# -gt 1 ]]; then
+        echo "Improper number of arguments. Pass only one argument."
+        usage
+        exit 0
+    fi
+    while [ "${1:-}" != "" ]; do
+        case "$1" in
+            "--help")
+                usage
+                exit 0
+                ;;
+            "--setup-provider-vlan")
+                arg_setup_provider_vlan=true
+                ;;
+            "--teardown-provider-vlan")
+                arg_teardown_provider_vlan=true
+                ;;
+            *)
+                usage
+                exit 0
+        esac
+        shift
+    done
+}
+
+function main {
+    set_args "$@"
+    if [[ $arg_setup_provider_vlan = true ]]; then
+        setup_provider_vlan
+    else
+        teardown_provider_vlan
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
1) This script takes following arguments:

OPTIONS:
  --help                     prints this message
  --setup-provider-vlan      sets up provider ovs bridge br-vlanp, neutron vlan config and
                             openstack vlan networks.
                             make sure to delete all non devstack entities created by user
                             in openstack before running this command. 
  --teardown-provider-vlan   tears down the openstack vlan networks, ovs bridge settings and
                             removes neutron vlan config.
                             make sure to delete all vlan entities created by user
                             in openstack before running this command.

2) After running the above script with argument --setup-provider-vlan argument one can run the following command to create a vThunder instance outside of openstack. Make sure to run it from the directory where vthunder qcow2 is present.

virt-install -n vThunder-1 --vcpus 4 --ram 8196 --virt-type kvm --disk path=./ACOS_vThunder_4_1_4-GR1-P2_151.qcow2,format=qcow2,bus=virtio,cache=none --network=bridge:br-mgmt,model=virtio,virtualport_type=openvswitch --network=bridge:br-vlanp,model=virtio,virtualport_type=openvswitch --os-type=linux --graphics none --import

3) After starting the thunder instance execute the following ovs-vsctl command to set trunk vlans to port ethernet1 on vthunder.

sudo ovs-vsctl set port vnet1 trunks=11,12,13

4) Instances can be launched on openstack vlan networks. Set up vlan and ve on thunder and they can communicate to each other.