### PR TITLE
[STACK-1061] Added no-dest-nat check filter

### DIFF
--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -42,6 +42,7 @@ SP_OBJ_DICT = {
 }
 HTTP_TYPE = ['HTTP', 'HTTPS']
 PERS_TYPE = ['cookie_persistence', 'src_ip_persistence']
+NO_DEST_NAT_SUPPORTED_PROTOCOL = ['tcp', 'udp']
 # Taskflow flow and task names
 
 BACKUP_AMPHORA_PLUG = 'backup-amphora-plug'

--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -72,7 +72,10 @@ class ListenersParent(object):
 
                 # Add all config filters here
                 if no_dest_nat and (
-                    listener.protocol.lower() not in a10constants.NO_DEST_NAT_SUPPORTED_PROTOCOL):
+                        listener.protocol.lower()
+                        not in a10constants.NO_DEST_NAT_SUPPORTED_PROTOCOL):
+                    LOG.warning("'no_dest_nat' is not allowed for HTTP," +
+                                "HTTPS or TERMINATED_HTTPS listener.")
                     no_dest_nat = False
 
                 name = loadbalancer.id + "_" + str(listener.protocol_port)

--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -19,6 +19,7 @@ from taskflow import task
 import acos_client.errors as acos_errors
 from octavia.certificates.common.auth.barbican_acl import BarbicanACLAuth
 
+from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
 from a10_octavia.controller.worker.tasks import utils
 
@@ -68,6 +69,11 @@ class ListenersParent(object):
 
                 virtual_port_template = CONF.listener.template_policy
                 virtual_port_templates['template-policy'] = virtual_port_template
+
+                # Add all config filters here
+                if no_dest_nat and (
+                    listener.protocol.lower() not in a10constants.NO_DEST_NAT_SUPPORTED_PROTOCOL):
+                    no_dest_nat = False
 
                 name = loadbalancer.id + "_" + str(listener.protocol_port)
                 set_method(loadbalancer.id, name,


### PR DESCRIPTION
**Issue**

https://a10networks.atlassian.net/browse/STACK-1061

**Test Cases**
We can create 5 types of listener

Enable no_dest_nat in [listener] section of a10-octavia.conf

Create HTTP listener - should get created without no-dest-nat enabled
Create HTTPS listener - should get created without no-dest-nat enabled
Create TERMINATED_HTTP listener - should get created without no-dest-nat enabled

Create TCP listener - should get created with no-dest-nat enabled
Create UDP listener - should get created with no-dest-nat enabled
 
**functional changes**
Add a condition that checks if no-dest-nat is enabled, if protocol is not in TCP or UDP, disable the no-dest-nat argument.

**Non-functional changes**
Added a comment flag so can we can add more filters
As I can see more filters are supposed to be added