### PR TITLE
STACK-1165: Default a10-octavia.conf section

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ These settings are added to the `a10-octavia.conf` file. They allow the operator
 
 *WARNING: Any option specified here will apply globally meaning all projects and devices*
 
-#### Default config example
+#### Global section config example
 ```shell
 [a10_global]
 

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ These settings are added to the `a10-octavia.conf` file. They allow the operator
 
 #### Default config example
 ```shell
-[DEFAULT]
+[a10_global]
 
 ```
 #### Loadbalancer/virtual server config example

--- a/README.md
+++ b/README.md
@@ -250,6 +250,11 @@ These settings are added to the `a10-octavia.conf` file. They allow the operator
 
 *WARNING: Any option specified here will apply globally meaning all projects and devices*
 
+#### Default config example
+```shell
+[DEFAULT]
+
+```
 #### Loadbalancer/virtual server config example
 ```shell
 [SLB]

--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -32,7 +32,7 @@ from a10_octavia.common import config_types
 LOG = logging.getLogger(__name__)
 
 
-A10_DEFAULT_OPTS = [
+A10_GLOBAL_OPTS = [
 ]
 
 A10_VTHUNDER_OPTS = [
@@ -309,7 +309,7 @@ A10_NOVA_OPTS = [
 
 
 # Register the configuration options
-cfg.CONF.register_opts(A10_DEFAULT_OPTS)
+cfg.CONF.register_opts(A10_GLOBAL_OPTS, group='a10_global')
 cfg.CONF.register_opts(A10_CONTROLLER_WORKER_OPTS, group='a10_controller_worker')
 cfg.CONF.register_opts(A10_HOUSE_KEEPING_OPTS, group='a10_house_keeping')
 cfg.CONF.register_cli_opts(A10_HEALTH_MANAGER_OPTS, group='a10_health_manager')

--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -32,6 +32,9 @@ from a10_octavia.common import config_types
 LOG = logging.getLogger(__name__)
 
 
+A10_DEFAULT_OPTS = [
+]
+
 A10_VTHUNDER_OPTS = [
     cfg.StrOpt('default_vthunder_username',
                default='admin',
@@ -306,6 +309,7 @@ A10_NOVA_OPTS = [
 
 
 # Register the configuration options
+cfg.CONF.register_opts(A10_DEFAULT_OPTS)
 cfg.CONF.register_opts(A10_CONTROLLER_WORKER_OPTS, group='a10_controller_worker')
 cfg.CONF.register_opts(A10_HOUSE_KEEPING_OPTS, group='a10_house_keeping')
 cfg.CONF.register_cli_opts(A10_HEALTH_MANAGER_OPTS, group='a10_health_manager')


### PR DESCRIPTION
## Non Customer Highlights
- Now customer can add global configuration inside namespace [a10_global] section in `/etc/a10/a10-octavia.conf` as follows. 

```
[a10_global]
<user_defined_flags> = <random_value>
```

- Added section in README for `[a10_global]`. Though, currently doesn't have any options set.

## Closes 
[STACK-1165](https://a10networks.atlassian.net/browse/STACK-1165)