### PR TITLE
STACK-1092 and STACK-1091 changes to support use-rcv-for-resp

### DIFF
--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -86,6 +86,9 @@ A10_LISTENER_OPTS = [
                default=None,
                max_length=127,
                help=_('HTTP Template Name')),
+    cfg.BoolOpt('use_rcv_hop_for_resp',
+                default=False,
+                help=_('Use receive hop for response to client')),
 ]
 
 A10_SERVICE_GROUP_OPTS = [

--- a/a10_octavia/common/defaults.py
+++ b/a10_octavia/common/defaults.py
@@ -31,5 +31,6 @@ DEFAULT = {
     'templates': None,
     'conn_limit': None,
     'conn_resume': None,
-    'templates': None
+    'templates': None,
+    'use_rcv_hop_for_resp': False
 }

--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -35,6 +35,7 @@ class ListenersParent(object):
         no_dest_nat = CONF.listener.no_dest_nat
         autosnat = CONF.listener.autosnat
         conn_limit = CONF.listener.conn_limit
+        use_rcv_hop = CONF.listener.use_rcv_hop_for_resp
         virtual_port_templates = {}
         template_virtual_port = CONF.listener.template_virtual_port
         virtual_port_templates['template-virtual-port'] = template_virtual_port
@@ -91,6 +92,7 @@ class ListenersParent(object):
                            autosnat=autosnat, ipinip=ipinip,
                            # TODO(hthompson6) resolve in acos client
                            # ha_conn_mirror=ha_conn_mirror,
+                           use_rcv_hop=use_rcv_hop,
                            conn_limit=conn_limit,
                            virtual_port_templates=virtual_port_templates,
                            **template_args)

--- a/a10_octavia/etc/example_config.py
+++ b/a10_octavia/etc/example_config.py
@@ -23,6 +23,7 @@ template_policy = "policy_temp1"
 autosnat = True
 conn_limit = 5000
 template_http = "http_template"
+use_rcv_hop_for_resp = True
 
 [SERVICE - GROUP]
 templates = "server1"

--- a/a10_octavia/tests/common/a10constants.py
+++ b/a10_octavia/tests/common/a10constants.py
@@ -28,3 +28,4 @@ MOCK_CERT_ACTION = 'import'
 MOCK_CERT_TYPE = 'pem'
 
 SERVICE_GROUP_CONF_SECTION = 'service_group'
+LISTENER_CONF_SECTION = 'listener'

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
@@ -19,7 +19,6 @@ except ImportError:
     import mock
 
 from octavia.common import data_models as o_data_models
-from octavia.tests.common import constants as t_constants
 
 from oslo_config import cfg
 
@@ -52,7 +51,7 @@ class TestHandlerVirtualPortTasks(BaseTaskTestCase):
         return listener
 
     def test_create_virtual_port_task(self):
-        conf = self._mock_conf(True, False)
+        self._mock_conf(True, False)
         listener = self._mock_listener('HTTP', 1000)
 
         client_mock = mock.Mock()
@@ -64,7 +63,7 @@ class TestHandlerVirtualPortTasks(BaseTaskTestCase):
         self.assertEqual(kwargs.get('conn_limit'), 1000)
 
     def test_update_virtual_port_task(self):
-        conf = self._mock_conf(False, False)
+        self._mock_conf(False, False)
         listener = self._mock_listener('HTTP', 1000)
 
         client_mock = mock.Mock()

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
@@ -23,7 +23,8 @@ from octavia.common import data_models as o_data_models
 from oslo_config import cfg
 from oslo_config import fixture as oslo_fixture
 
-from a10_octavia.common import data_models, config_options
+from a10_octavia.common import config_options
+from a10_octavia.common import data_models
 from a10_octavia.controller.worker.tasks import virtual_port_tasks as task
 from a10_octavia.tests.common import a10constants
 from a10_octavia.tests.unit import base

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
@@ -61,7 +61,7 @@ class TestHandlerVirtualPortTasks(BaseTaskTestCase):
         listener_task.execute(LB, [listener], VTHUNDER)
         args, kwargs = client_mock.slb.virtual_server.vport.create.call_args
         self.assertTrue(kwargs.get('use_rcv_hop'))
-        self.assertEquals(kwargs.get('conn_limit'), 1000)
+        self.assertEqual(kwargs.get('conn_limit'), 1000)
 
     def test_update_virtual_port_task(self):
         conf = self._mock_conf(False, False)
@@ -73,4 +73,4 @@ class TestHandlerVirtualPortTasks(BaseTaskTestCase):
         listener_task.execute(LB, [listener], VTHUNDER)
         args, kwargs = client_mock.slb.virtual_server.vport.update.call_args
         self.assertFalse(kwargs.get('use_rcv_hop'))
-        self.assertEquals(kwargs.get('conn_limit'), 1000)
+        self.assertEqual(kwargs.get('conn_limit'), 1000)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
@@ -1,0 +1,76 @@
+#    Copyright 2020, A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import imp
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from octavia.common import data_models as o_data_models
+from octavia.tests.common import constants as t_constants
+
+from oslo_config import cfg
+
+from a10_octavia.common.data_models import VThunder
+import a10_octavia.controller.worker.tasks.virtual_port_tasks as task
+from a10_octavia.tests.common import a10constants
+from a10_octavia.tests.unit.base import BaseTaskTestCase
+
+VTHUNDER = VThunder()
+LB = o_data_models.LoadBalancer(id=a10constants.MOCK_LOAD_BALANCER_ID)
+
+
+class TestHandlerVirtualPortTasks(BaseTaskTestCase):
+
+    def setUp(self):
+        super(TestHandlerVirtualPortTasks, self).setUp()
+        imp.reload(task)
+
+    def _mock_conf(self, use_rcv_hop_for_resp, no_dest_nat):
+        conf = cfg.CONF
+        conf.listener = mock.Mock()
+        conf.listener.use_rcv_hop_for_resp = use_rcv_hop_for_resp
+        conf.listener.no_dest_nat = no_dest_nat
+        return conf
+
+    def _mock_listener(self, protocol, conn_limit):
+        listener = o_data_models.Listener(id=a10constants.MOCK_LISTENER_ID)
+        listener.protocol = protocol
+        listener.connection_limit = conn_limit
+        return listener
+
+    def test_create_virtual_port_task(self):
+        conf = self._mock_conf(True, False)
+        listener = self._mock_listener('HTTP', 1000)
+
+        client_mock = mock.Mock()
+        listener_task = task.ListenersCreate()
+        listener_task.axapi_client = client_mock
+        listener_task.execute(LB, [listener], VTHUNDER)
+        args, kwargs = client_mock.slb.virtual_server.vport.create.call_args
+        self.assertTrue(kwargs.get('use_rcv_hop'))
+        self.assertEquals(kwargs.get('conn_limit'), 1000)
+
+    def test_update_virtual_port_task(self):
+        conf = self._mock_conf(False, False)
+        listener = self._mock_listener('HTTP', 1000)
+
+        client_mock = mock.Mock()
+        listener_task = task.ListenersUpdate()
+        listener_task.axapi_client = client_mock
+        listener_task.execute(LB, [listener], VTHUNDER)
+        args, kwargs = client_mock.slb.virtual_server.vport.update.call_args
+        self.assertFalse(kwargs.get('use_rcv_hop'))
+        self.assertEquals(kwargs.get('conn_limit'), 1000)


### PR DESCRIPTION
Tested with use_rcv_hop_for_resp config option True, False, 0, 1 and Other.