### PR TITLE
STACK-1138 : Implement Hierarchical Multitenancy Feature for racked hardware

### DIFF
--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -35,7 +35,7 @@ LOG = logging.getLogger(__name__)
 A10_GLOBAL_OPTS = [
     cfg.BoolOpt('enable_hierarchical_multitenancy', default=False,
                 help=_('Enable Hierarchical Multitenancy '
-                'for racked devices.')),
+                       'for racked - hardware thunder devices.')),
 ]
 
 A10_VTHUNDER_OPTS = [

--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -33,6 +33,9 @@ LOG = logging.getLogger(__name__)
 
 
 A10_GLOBAL_OPTS = [
+    cfg.BoolOpt('enable_hierarchical_multitenancy', default=False,
+                help=_('Enable Hierarchical Multitenancy '
+                'for racked devices.')),
 ]
 
 A10_VTHUNDER_OPTS = [

--- a/a10_octavia/common/data_models.py
+++ b/a10_octavia/common/data_models.py
@@ -137,7 +137,7 @@ class VThunder(BaseDataModel):
                  password=None, axapi_version=None, undercloud=None,
                  loadbalancer_id=None, project_id=None, compute_id=None,
                  topology="STANDALONE", role="MASTER", last_udp_update=None, status="ACTIVE",
-                 created_at=datetime.utcnow(), updated_at=datetime.utcnow(), partition=None,
+                 created_at=datetime.utcnow(), updated_at=datetime.utcnow(), partition_name=None,
                  hierarchical_multitenancy=None):
         self.id = id
         self.vthunder_id = vthunder_id
@@ -157,7 +157,7 @@ class VThunder(BaseDataModel):
         self.status = status
         self.created_at = created_at
         self.updated_at = updated_at
-        self.partition = partition
+        self.partition_name = partition_name
         self.hierarchical_multitenancy = hierarchical_multitenancy
 
 

--- a/a10_octavia/common/data_models.py
+++ b/a10_octavia/common/data_models.py
@@ -137,7 +137,8 @@ class VThunder(BaseDataModel):
                  password=None, axapi_version=None, undercloud=None,
                  loadbalancer_id=None, project_id=None, compute_id=None,
                  topology="STANDALONE", role="MASTER", last_udp_update=None, status="ACTIVE",
-                 created_at=datetime.utcnow(), updated_at=datetime.utcnow(), partition=None):
+                 created_at=datetime.utcnow(), updated_at=datetime.utcnow(), partition=None,
+                 hierarchical_multitenancy=None):
         self.id = id
         self.vthunder_id = vthunder_id
         self.amphora_id = amphora_id
@@ -157,6 +158,7 @@ class VThunder(BaseDataModel):
         self.created_at = created_at
         self.updated_at = updated_at
         self.partition = partition
+        self.hierarchical_multitenancy = hierarchical_multitenancy
 
 
 class Certificate(BaseDataModel):

--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -69,8 +69,12 @@ def convert_to_rack_vthunder_conf(rack_list):
                                            rack_device['project_id'] +
                                            ' in [rack_vthunder] section')
             rack_device['undercloud'] = True
-            if not rack_device.get('partition'):
+            partition_name = rack_device.get('partition')
+            if not partition_name:
                 rack_device['partition'] = a10constants.SHARED_PARTITION
+            elif len(partition_name) > 14:
+                raise ConfigFileValueError('Supplied partition name `' + partition_name +
+                                           '` should not be greater than 14 characters')
             vthunder_conf = data_models.VThunder(**rack_device)
             rack_dict[rack_device['project_id']] = vthunder_conf
 

--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -33,9 +33,9 @@ def validate_ipv4(address):
 
 
 def validate_partition(rack_device):
-    partition_name = rack_device.get('partition')
+    partition_name = rack_device.get('partition_name')
     if not partition_name:
-        rack_device['partition'] = a10constants.SHARED_PARTITION
+        rack_device['partition_name'] = a10constants.SHARED_PARTITION
     elif len(partition_name) > 14:
         raise ValueError("Supplied partition value '%s' exceeds maximum length 14" %
                          (partition_name))
@@ -59,8 +59,8 @@ def validate_params(rack_info):
 
 def check_duplicate_entries(rack_dict):
     rack_count_dict = {}
-    for rack_value in rack_dict.values():
-        candidate = '{}:{}'.format(rack_value.ip_address, rack_value.partition)
+    for rack_device in rack_dict.values():
+        candidate = '{}:{}'.format(rack_device.ip_address, rack_device.partition_name)
         rack_count_dict[candidate] = rack_count_dict.get(candidate, 0) + 1
     return [k for k, v in rack_count_dict.items() if v > 1]
 
@@ -83,6 +83,6 @@ def convert_to_rack_vthunder_conf(rack_list):
     duplicates_list = check_duplicate_entries(rack_dict)
     if duplicates_list:
         raise ConfigFileValueError('Duplicates found for the following '
-                                   '\'ip_address:partition\' entries: {}'
+                                   '\'ip_address:partition_name\' entries: {}'
                                    .format(list(duplicates_list)))
     return rack_dict

--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -28,7 +28,18 @@ LOG = logging.getLogger(__name__)
 
 def validate_ipv4(address):
     """Validates for IP4 address format"""
-    return netaddr.valid_ipv4(address, netaddr.core.INET_PTON)
+    if not netaddr.valid_ipv4(address, netaddr.core.INET_PTON):
+        raise ConfigFileValueError('Invalid IPAddress value given in configuration: ' + address)
+
+
+def validate_partition(rack_device):
+    partition_name = rack_device.get('partition')
+    if not partition_name:
+        rack_device['partition'] = a10constants.SHARED_PARTITION
+    elif len(partition_name) > 14:
+        raise ValueError("Supplied partition value '%s' exceeds maximum length 14" %
+                         (partition_name))
+    return rack_device
 
 
 def validate_params(rack_info):
@@ -38,18 +49,17 @@ def validate_params(rack_info):
                                     'username', 'password', 'device_name')):
         if all(rack_info[x] is not None for x in ('project_id', 'ip_address',
                                                   'username', 'password', 'device_name')):
-            if validate_ipv4(rack_info['ip_address']):
-                return True
-            raise ConfigFileValueError('Invalid IPAddress value given ' + rack_info['ip_address'])
+            validate_ipv4(rack_info['ip_address'])
+            rack_info = validate_partition(rack_info)
+            return rack_info
     raise ConfigFileValueError('Please check your configuration. The params `project_id`, '
                                '`ip_address`, `username`, `password` and `device_name` '
                                'under [rack_vthunder] section cannot be None ')
-    return False
 
 
 def check_duplicate_entries(rack_dict):
     rack_count_dict = {}
-    for rack_key, rack_value in rack_dict.items():
+    for rack_value in rack_dict.values():
         candidate = '{}:{}'.format(rack_value.ip_address, rack_value.partition)
         rack_count_dict[candidate] = rack_count_dict.get(candidate, 0) + 1
     return [k for k, v in rack_count_dict.items() if v > 1]
@@ -60,26 +70,18 @@ def convert_to_rack_vthunder_conf(rack_list):
         configurations.
     """
     rack_dict = {}
-    validation_flag = False
     for rack_device in rack_list:
-        validation_flag = validate_params(rack_device)
-        if validation_flag:
-            if rack_dict.get(rack_device['project_id']):
-                raise ConfigFileValueError('Supplied duplicate project_id ' +
-                                           rack_device['project_id'] +
-                                           ' in [rack_vthunder] section')
-            rack_device['undercloud'] = True
-            partition_name = rack_device.get('partition')
-            if not partition_name:
-                rack_device['partition'] = a10constants.SHARED_PARTITION
-            elif len(partition_name) > 14:
-                raise ConfigFileValueError('Supplied partition name `' + partition_name +
-                                           '` should not be greater than 14 characters')
-            vthunder_conf = data_models.VThunder(**rack_device)
-            rack_dict[rack_device['project_id']] = vthunder_conf
+        rack_device = validate_params(rack_device)
+        if rack_dict.get(rack_device['project_id']):
+            raise ConfigFileValueError('Supplied duplicate project_id ' +
+                                       rack_device['project_id'] +
+                                       ' in [rack_vthunder] section')
+        rack_device['undercloud'] = True
+        vthunder_conf = data_models.VThunder(**rack_device)
+        rack_dict[rack_device['project_id']] = vthunder_conf
 
     duplicates_list = check_duplicate_entries(rack_dict)
-    if len(duplicates_list) != 0:
+    if duplicates_list:
         raise ConfigFileValueError('Duplicates found for the following '
                                    '\'ip_address:partition\' entries: {}'
                                    .format(list(duplicates_list)))

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -227,7 +227,7 @@ class CreateRackVthunderEntry(BaseDatabaseTask):
         except Exception as e:
             LOG.error('Failed to create vThunder entry in db for load balancer: %s.',
                       loadbalancer.id)
-            raise
+            raise e
 
     def revert(self, loadbalancer, vthunder_config, *args, **kwargs):
         try:

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -201,9 +201,9 @@ class CreateRackVthunderEntry(BaseDatabaseTask):
     def execute(self, loadbalancer, vthunder_config):
         hierarchical_multitenancy = CONF.a10_global.enable_hierarchical_multitenancy
         if hierarchical_multitenancy:
-            partition = vthunder_config.project_id[:14]
+            partition_name = vthunder_config.project_id[:14]
         else:
-            partition = vthunder_config.partition
+            partition_name = vthunder_config.partition_name
         try:
             self.vthunder_repo.create(db_apis.get_session(),
                                       vthunder_id=uuidutils.generate_uuid(),
@@ -221,7 +221,7 @@ class CreateRackVthunderEntry(BaseDatabaseTask):
                                       last_udp_update=datetime.utcnow(),
                                       created_at=datetime.utcnow(),
                                       updated_at=datetime.utcnow(),
-                                      partition=partition,
+                                      partition_name=partition_name,
                                       hierarchical_multitenancy=hierarchical_multitenancy)
             LOG.info("Successfully created vthunder entry in database.")
         except Exception as e:

--- a/a10_octavia/controller/worker/tasks/decorators.py
+++ b/a10_octavia/controller/worker/tasks/decorators.py
@@ -42,8 +42,8 @@ def axapi_client_decorator(func):
                                                    vthunder.username, vthunder.password,
                                                    timeout=30)
 
-            if vthunder.partition != a10constants.SHARED_PARTITION:
-                activate_partition(self.axapi_client, vthunder.partition)
+            if vthunder.partition_name != a10constants.SHARED_PARTITION:
+                activate_partition(self.axapi_client, vthunder.partition_name)
 
         else:
             self.axapi_client = None

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -348,8 +348,8 @@ class HandleACOSPartitionChange(task.Task):
     @axapi_client_decorator
     def execute(self, vthunder):
         try:
-            self.axapi_client.system.partition.create(vthunder.partition)
-            LOG.info("Partition %s created", vthunder.partition)
+            self.axapi_client.system.partition.create(vthunder.partition_name)
+            LOG.info("Partition %s created", vthunder.partition_name)
         except acos_errors.Exists:
             pass
         except Exception as e:
@@ -359,7 +359,7 @@ class HandleACOSPartitionChange(task.Task):
     @axapi_client_decorator
     def revert(self, vthunder, *args, **kwargs):
         try:
-            self.axapi_client.system.partition.delete(vthunder.partition)
+            self.axapi_client.system.partition.delete(vthunder.partition_name)
         except Exception as e:
             LOG.exception("Failed to revert partition create : %s", str(e))
             raise

--- a/a10_octavia/db/migration/alembic_migrations/versions/b02c78488551_updating_vthunders_table_with_new_column.py
+++ b/a10_octavia/db/migration/alembic_migrations/versions/b02c78488551_updating_vthunders_table_with_new_column.py
@@ -1,0 +1,23 @@
+"""Updating vthunders table with new column
+
+Revision ID: b02c78488551
+Revises: ed9c523cf8ee
+Create Date: 2020-04-23 06:05:04.792826
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b02c78488551'
+down_revision = 'ed9c523cf8ee'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('vthunders', sa.Column('hierarchical_multitenancy', sa.Boolean(), default=False, nullable=True))
+
+def downgrade():
+    op.drop_column('vthunders', 'hierarchical_multitenancy')

--- a/a10_octavia/db/migration/alembic_migrations/versions/ed9c523cf8ee_adding_ha_features.py
+++ b/a10_octavia/db/migration/alembic_migrations/versions/ed9c523cf8ee_adding_ha_features.py
@@ -37,7 +37,7 @@ def upgrade():
         sa.Column('status', sa.String(36), default='ACTIVE', nullable=False),
         sa.Column(u'created_at', sa.DateTime(), nullable=True),
         sa.Column(u'updated_at', sa.DateTime(), nullable=True),
-        sa.Column('partition', sa.String(14), nullable=True)
+        sa.Column('partition_name', sa.String(14), nullable=True)
     )
 
 

--- a/a10_octavia/db/migration/alembic_migrations/versions/ed9c523cf8ee_adding_ha_features.py
+++ b/a10_octavia/db/migration/alembic_migrations/versions/ed9c523cf8ee_adding_ha_features.py
@@ -42,4 +42,4 @@ def upgrade():
 
 
 def downgrade():
-    pass
+    op.drop_table('vthunders')

--- a/a10_octavia/db/models.py
+++ b/a10_octavia/db/models.py
@@ -47,7 +47,7 @@ class VThunder(base_models.BASE):
     status = sa.Column('status', sa.String(36), default='ACTIVE', nullable=False)
     created_at = sa.Column(u'created_at', sa.DateTime(), nullable=True)
     updated_at = sa.Column(u'updated_at', sa.DateTime(), nullable=True)
-    partition = sa.Column(sa.String(14), nullable=True)
+    partition_name = sa.Column(sa.String(14), nullable=True)
     hierarchical_multitenancy = sa.Column(sa.Boolean(), default=False, nullable=True)
 
     @classmethod

--- a/a10_octavia/db/models.py
+++ b/a10_octavia/db/models.py
@@ -48,6 +48,7 @@ class VThunder(base_models.BASE):
     created_at = sa.Column(u'created_at', sa.DateTime(), nullable=True)
     updated_at = sa.Column(u'updated_at', sa.DateTime(), nullable=True)
     partition = sa.Column(sa.String(14), nullable=True)
+    hierarchical_multitenancy = sa.Column(sa.Boolean(), default=False, nullable=True)
 
     @classmethod
     def find_by_loadbalancer_id(cls, loadbalancer_id, db_session=None):

--- a/a10_octavia/tests/unit/common/test_utils.py
+++ b/a10_octavia/tests/unit/common/test_utils.py
@@ -1,0 +1,108 @@
+# Copyright 2020, A10 Networks.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from copy import deepcopy
+from oslo_config.cfg import ConfigFileValueError
+
+from a10_octavia.tests.unit.base import BaseTaskTestCase
+from a10_octavia.common.data_models import VThunder
+import a10_octavia.common.utils as utils
+#from unittest.mock import patch
+
+RACK_LIST = [{
+}]
+SHARED_RACK_DEVICE = {'partition': 'shared'}
+RACK_DEVICE = {
+    'partition': 'sample-1'
+}
+
+RACK_INFO = {
+    'project_id': 'project-1',
+    'ip_address': '10.10.10.10',
+    'device_name': 'rack_thunder_1',
+    'username': 'abc',
+    'password': 'abc'
+}
+
+RACK_INFO_2 = {
+    'project_id': 'project-2',
+    'ip_address': '12.12.12.12',
+    'device_name': 'rack_thunder_2',
+    'username': 'def',
+    'password': 'def',
+    'partition': 'def-sample'
+}
+
+DUP_PARTITION_RACK_INFO = {
+    'project_id': 'project-3',
+    'ip_address': '10.10.10.10',
+    'device_name': 'rack_thunder_3',
+    'username': 'abc',
+    'password': 'abc'}
+
+INVALID_RACK_INFO = {}
+VTHUNDER_1 = VThunder(project_id="project-1", device_name="rack_thunder_1", undercloud=True,
+                      username="abc", password="abc", ip_address="10.10.10.10", partition="shared")
+VTHUNDER_2 = VThunder(project_id="project-2", device_name="rack_thunder_2", undercloud=True,
+                      username="def", password="def", ip_address="12.12.12.12",
+                      partition="def-sample")
+
+DUPLICATE_DICT = {'project_1': VTHUNDER_1,
+                  'project_2': VTHUNDER_1}
+DUP_LIST = ['10.10.10.10:shared']
+NON_DUPLICATE_DICT = {'project_1': VTHUNDER_1, 'project_2': VTHUNDER_2}
+
+DUPLICATE_PROJECT_RACK_DEVICE_LIST = [
+    RACK_INFO, RACK_INFO
+]
+
+RACK_DEVICE_LIST = [
+    RACK_INFO, RACK_INFO_2
+]
+
+DUPLICATE_PARTITION_RACK_DEVICE_LIST = [DUP_PARTITION_RACK_INFO, RACK_INFO]
+RESULT_RACK_DEVICE_LIST = {'project-1': VTHUNDER_1,
+                           'project-2': VTHUNDER_2}
+
+
+class TestUtils(BaseTaskTestCase):
+
+    def test_validate_ipv4(self):
+        self.assertEqual(utils.validate_ipv4('10.43.12.122'), None)
+        self.assertRaises(ConfigFileValueError, utils.validate_ipv4, '192.0.20')
+
+    def test_validate_partition(self):
+        self.assertEqual(utils.validate_partition(RACK_DEVICE), RACK_DEVICE)
+        RACK_DEVICE['partition'] = 'sample_long_partition_name'
+        self.assertRaises(ValueError, utils.validate_partition, RACK_DEVICE)
+        EMPTY_RACK_DEVICE = {}
+        self.assertEqual(utils.validate_partition(EMPTY_RACK_DEVICE), SHARED_RACK_DEVICE)
+
+    def test_validate_params(self):
+        SHARED_RACK_INFO = deepcopy(RACK_INFO)
+        SHARED_RACK_INFO['partition'] = 'shared'
+        self.assertEqual(utils.validate_params(RACK_INFO), SHARED_RACK_INFO)
+        self.assertRaises(ConfigFileValueError, utils.validate_params, INVALID_RACK_INFO)
+
+    def test_check_duplicate_entries(self):
+        self.assertEquals(utils.check_duplicate_entries(DUPLICATE_DICT), DUP_LIST)
+        self.assertEquals(utils.check_duplicate_entries(NON_DUPLICATE_DICT), [])
+
+    def test_convert_to_rack_vthunder_conf(self):
+        self.assertRaises(ConfigFileValueError, utils.convert_to_rack_vthunder_conf,
+                          DUPLICATE_PROJECT_RACK_DEVICE_LIST)
+        self.assertRaises(ConfigFileValueError, utils.convert_to_rack_vthunder_conf,
+                          DUPLICATE_PARTITION_RACK_DEVICE_LIST)
+        self.assertEqual(utils.convert_to_rack_vthunder_conf(RACK_DEVICE_LIST),
+                         RESULT_RACK_DEVICE_LIST)

--- a/a10_octavia/tests/unit/common/test_utils.py
+++ b/a10_octavia/tests/unit/common/test_utils.py
@@ -15,13 +15,10 @@
 from copy import deepcopy
 from oslo_config.cfg import ConfigFileValueError
 
-from a10_octavia.tests.unit.base import BaseTaskTestCase
 from a10_octavia.common.data_models import VThunder
 import a10_octavia.common.utils as utils
-#from unittest.mock import patch
+from a10_octavia.tests.unit.base import BaseTaskTestCase
 
-RACK_LIST = [{
-}]
 SHARED_RACK_DEVICE = {'partition': 'shared'}
 RACK_DEVICE = {
     'partition': 'sample-1'
@@ -96,8 +93,8 @@ class TestUtils(BaseTaskTestCase):
         self.assertRaises(ConfigFileValueError, utils.validate_params, INVALID_RACK_INFO)
 
     def test_check_duplicate_entries(self):
-        self.assertEquals(utils.check_duplicate_entries(DUPLICATE_DICT), DUP_LIST)
-        self.assertEquals(utils.check_duplicate_entries(NON_DUPLICATE_DICT), [])
+        self.assertEqual(utils.check_duplicate_entries(DUPLICATE_DICT), DUP_LIST)
+        self.assertEqual(utils.check_duplicate_entries(NON_DUPLICATE_DICT), [])
 
     def test_convert_to_rack_vthunder_conf(self):
         self.assertRaises(ConfigFileValueError, utils.convert_to_rack_vthunder_conf,


### PR DESCRIPTION
## Non Customer Highlights
- Adding `hierarchical_multitenancy` to db and models. 
- Added alembic revision script.
- Adding `enable_hierarchical_multitenancy` config support in `[a10_global]` settings.
- Supported for `enable_hierarchical_multitenancy` in `CreateRackVThunderEntry()` and added `revert()`.
- Refactored utils.py to add partition name length validation in config.
- Modified `partition` -> `partition_name` in db as well as configuration
- Added UTs for testing `common/utils.py`

## Testing config
```
[a10_global]
enable_hierarchical_multitenancy = False

[rack_vthunder]
devices=[
 {
 "project_id": "d215d1a6f7d44057922bfc6433b1dcbf", 
 "username" : "admin", 
 "password" : "devops123",
 "ip_address" : "10.43.12.122", 
 "partition_name" : "development", 
 "device_name" : "rack_1"
 }]
```

## Closes 
[STACK-1138](https://a10networks.atlassian.net/browse/STACK-1138)