### PR TITLE
STACK-1210 : Create CreateVRRPEntry task in database tasks

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -278,3 +278,19 @@ class CreateSpareVThunderEntry(BaseDatabaseTask):
             updated_at=datetime.utcnow())
         LOG.info("Successfully created vthunder entry in database.")
         return vthunder
+
+
+class UpdateVThunderVRRPEntry(BaseDatabaseTask):
+    def execute(self, vthunder, port):
+        if port:
+            port_id = port.id
+            vrid_floating_ip = port.fixed_ips[0].ip_address
+            try:
+                vthunder = self.vthunder_repo.update(
+                    db_apis.get_session(),
+                    vthunder.id,
+                    vrrp_port_id=port_id,
+                    vrid_floating_ip=vrid_floating_ip)
+                LOG.info("Updated vthunder entry in db with vrrp information")
+            except Exception as e:
+                LOG.exception("Failed UpdateVThunderVRRPEntry: %s", str(e))

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -283,14 +283,12 @@ class CreateSpareVThunderEntry(BaseDatabaseTask):
 class UpdateVThunderVRRPEntry(BaseDatabaseTask):
     def execute(self, vthunder, port):
         if port:
-            port_id = port.id
-            vrid_floating_ip = port.fixed_ips[0].ip_address
             try:
                 vthunder = self.vthunder_repo.update(
                     db_apis.get_session(),
                     vthunder.id,
-                    vrrp_port_id=port_id,
-                    vrid_floating_ip=vrid_floating_ip)
+                    vrrp_port_id=port.id,
+                    vrid_floating_ip=port.fixed_ips[0].ip_address)
                 LOG.info("Updated vthunder entry in db with vrrp information")
             except Exception as e:
                 LOG.exception("Failed UpdateVThunderVRRPEntry: %s", str(e))

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -45,7 +45,7 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         super(TestA10DatabaseTasks, self).tearDown()
         self.db_session.stop()
 
-    def test_update_vthunder_vrrp_entry(self):
+    def test_update_vthunder_vrrp_entry_with_not_none_port(self):
         mock_vthunder_entry = task.UpdateVThunderVRRPEntry()
         mock_vthunder_entry.vthunder_repo = mock.Mock()
         mock_vthunder_entry.execute(VTHUNDER, PORT)
@@ -54,3 +54,9 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
             VTHUNDER_ID_1,
             vrrp_port_id=PORT.id,
             vrid_floating_ip=PORT.fixed_ips[0].ip_address)
+
+    def test_update_vthunder_vrrp_entry_with_none_port(self):
+        mock_vthunder_entry = task.UpdateVThunderVRRPEntry()
+        mock_vthunder_entry.vthunder_repo = mock.Mock()
+        mock_vthunder_entry.execute(VTHUNDER, None)
+        mock_vthunder_entry.vthunder_repo.update.assert_not_called()

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -45,7 +45,7 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         super(TestA10DatabaseTasks, self).tearDown()
         self.db_session.stop()
 
-    def test_update_vthunder_vrrp_entry_with_not_none_port(self):
+    def test_update_vthunder_vrrp_entry_with_port_info(self):
         mock_vthunder_entry = task.UpdateVThunderVRRPEntry()
         mock_vthunder_entry.vthunder_repo = mock.Mock()
         mock_vthunder_entry.execute(VTHUNDER, PORT)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -1,0 +1,56 @@
+#    Copyright 2020, A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+import imp
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from oslo_utils import uuidutils
+
+from octavia.network import data_models as o_data_models
+
+from a10_octavia.common import data_models
+from a10_octavia.controller.worker.tasks import a10_database_tasks as task
+from a10_octavia.tests.unit import base
+
+VTHUNDER_ID_1 = uuidutils.generate_uuid()
+VTHUNDER = data_models.VThunder(id=VTHUNDER_ID_1)
+FIXED_IP = o_data_models.FixedIP(ip_address='10.10.10.10')
+PORT = o_data_models.Port(id=uuidutils.generate_uuid(), fixed_ips=[FIXED_IP])
+
+
+class TestA10DatabaseTasks(base.BaseTaskTestCase):
+    def setUp(self):
+        super(TestA10DatabaseTasks, self).setUp()
+        imp.reload(task)
+        self.db_session = mock.patch(
+            'a10_octavia.controller.worker.tasks.a10_database_tasks.db_apis.get_session')
+        self.db_session.start()
+
+    def tearDown(self):
+        super(TestA10DatabaseTasks, self).tearDown()
+        self.db_session.stop()
+
+    def test_update_vthunder_vrrp_entry(self):
+        mock_vthunder_entry = task.UpdateVThunderVRRPEntry()
+        mock_vthunder_entry.vthunder_repo = mock.Mock()
+        mock_vthunder_entry.execute(VTHUNDER, PORT)
+        mock_vthunder_entry.vthunder_repo.update.assert_called_once_with(
+            mock.ANY,
+            VTHUNDER_ID_1,
+            vrrp_port_id=PORT.id,
+            vrid_floating_ip=PORT.fixed_ips[0].ip_address)


### PR DESCRIPTION
## Description
- Added Database task to update `vthunders` table with `Port` info like `vrid_port_id` and `vrid_floating_ip`


## Jira Ticket
[STACK-1210](https://a10networks.atlassian.net/browse/STACK-1210)

## Technical Approach
- This task is supposed to get executed if config flag `vrid_floating_ip` is not `None`. Hence this task will update `vthunders` table with `vrid` info, if fetched `port` is not `None`.

## Config Changes
- N/A

## Test Cases
a) If `port` is None         :  `vthunders` table is not updated
b) If `port` is not None  :  `vthunders` table is updated with `vrid_port_id` and `vrid_floating_ip` 

## Manual Testing
- Added UTs to test above mentioned TCs. No manual testing done yet.
