### PR TITLE
STACK-1213, STACK-1211 - Added vrid_floating_ip option in a10_global

### DIFF
--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -34,7 +34,7 @@ LOG = logging.getLogger(__name__)
 
 A10_GLOBAL_OPTS = [
     cfg.StrOpt('vrid_floating_ip', default=None,
-               regex="([dhcp]|(?:\d{1,3}\.){3}\d{1,3})\w+",
+               regex=r"([dhcp]|(?:\d{1,3}\.){3}\d{1,3})\w+",
                ignore_case=True,
                help=_('Enable VRID floating IP feature')),
     cfg.IntOpt('vrrp_floating_ip_octet', default=None,

--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -34,12 +34,7 @@ LOG = logging.getLogger(__name__)
 
 A10_GLOBAL_OPTS = [
     cfg.StrOpt('vrid_floating_ip', default=None,
-               regex=r"([dhcp]|(?:\d{1,3}\.){3}\d{1,3})\w+",
-               ignore_case=True,
                help=_('Enable VRID floating IP feature')),
-    cfg.IntOpt('vrrp_floating_ip_octet', default=None,
-               min=1, max=253,
-               help=_('VRID floating IP octet')),
     cfg.BoolOpt('enable_hierarchical_multitenancy', default=False,
                 help=_('Enable Hierarchical Multitenancy '
                        'for racked - hardware thunder devices.')),

--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -33,6 +33,13 @@ LOG = logging.getLogger(__name__)
 
 
 A10_GLOBAL_OPTS = [
+    cfg.StrOpt('vrid_floating_ip', default=None,
+               regex="([dhcp]|(?:\d{1,3}\.){3}\d{1,3})\w+",
+               ignore_case=True,
+               help=_('Enable VRID floating IP feature')),
+    cfg.IntOpt('vrrp_floating_ip_octet', default=None,
+               min=1, max=253,
+               help=_('VRID floating IP octet'))
 ]
 
 A10_VTHUNDER_OPTS = [


### PR DESCRIPTION
## Description
- `a10_global` now accepts `vrid_floating_ip `  as option
- `vrid_floating_ip`  accepts both string `dhcp` or  IP addresses as value

## Jira Ticket
[STACK-1211](https://a10networks.atlassian.net/browse/STACK-1211)
[STACK-1213](https://a10networks.atlassian.net/browse/STACK-1213)

## Technical Approach
- oslo_config does not have a provision of supporting both string and IP addresses

## Config Changes

<pre>
<b>vrid_floating_ip 
</b>
</pre>

<pre>
[a10_global]

vrid_floating_ip = "dhcp"
 or 
vrid_floating_ip = "10.10.10.12"
</pre>

## Test Cases
<b>vrrp_floating_ip </b>
a) if `vrrp_floating_ip`  is random string not matching regex -  **Service fails.**
b) if `vrrp_floating_ip`  is dhcp -  **Service starts.**
c) if `vrrp_floating_ip`  is invalid IPv4 address   **Service fails.**
d) if `vrrp_floating_ip`  is a valid IPv4 address   **Service starts.**



## Manual Testing
a) Edit `/etc/a10/a10-octavia.conf` to accept above changes 
b)  Do `sudo systemctl restart a10-controller-worker.service` 
c) If passed, service will start successfully.