### PR TITLE
Stack 1225, 1226: Update VThunder model with VRRP info, alembic revision for db

### DIFF
--- a/a10_octavia/common/data_models.py
+++ b/a10_octavia/common/data_models.py
@@ -137,7 +137,8 @@ class VThunder(BaseDataModel):
                  password=None, axapi_version=None, undercloud=None,
                  loadbalancer_id=None, project_id=None, compute_id=None,
                  topology="STANDALONE", role="MASTER", last_udp_update=None, status="ACTIVE",
-                 created_at=datetime.utcnow(), updated_at=datetime.utcnow(), partition=None):
+                 created_at=datetime.utcnow(), updated_at=datetime.utcnow(), partition=None,
+                 vrid_port_id=None, vrid_floating_ip=None):
         self.id = id
         self.vthunder_id = vthunder_id
         self.amphora_id = amphora_id
@@ -157,6 +158,8 @@ class VThunder(BaseDataModel):
         self.created_at = created_at
         self.updated_at = updated_at
         self.partition = partition
+        self.vrid_port_id = vrid_port_id
+        self.vrid_floating_ip = vrid_floating_ip
 
 
 class Certificate(BaseDataModel):

--- a/a10_octavia/db/migration/alembic_migrations/versions/58437bd431b9_added_vrid_port_id_and_vrid_floating_ip.py
+++ b/a10_octavia/db/migration/alembic_migrations/versions/58437bd431b9_added_vrid_port_id_and_vrid_floating_ip.py
@@ -18,7 +18,7 @@ depends_on = None
 
 def upgrade():
     op.add_column('vthunders', sa.Column('vrid_port_id', sa.String(36), nullable=True))
-    op.add_column('vthunders', sa.Column('vrid_floating_ip', sa.String(64), nullable=True))
+    op.add_column('vthunders', sa.Column('vrid_floating_ip', sa.String(15), nullable=True))
 
 
 def downgrade():

--- a/a10_octavia/db/migration/alembic_migrations/versions/58437bd431b9_added_vrid_port_id_and_vrid_floating_ip.py
+++ b/a10_octavia/db/migration/alembic_migrations/versions/58437bd431b9_added_vrid_port_id_and_vrid_floating_ip.py
@@ -1,0 +1,26 @@
+"""Added vrid port_id and vrid floating_ip
+
+Revision ID: 58437bd431b9
+Revises: ed9c523cf8ee
+Create Date: 2020-05-07 12:17:08.987483
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '58437bd431b9'
+down_revision = 'ed9c523cf8ee'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('vthunders', sa.Column('vrid_port_id', sa.String(36), nullable=True))
+    op.add_column('vthunders', sa.Column('vrid_floating_ip', sa.String(64), nullable=True))
+
+
+def downgrade():
+    op.drop_column('vthunders', 'vrid_floating_ip')
+    op.drop_column('vthunders', 'vrid_port_id')

--- a/a10_octavia/db/models.py
+++ b/a10_octavia/db/models.py
@@ -48,6 +48,8 @@ class VThunder(base_models.BASE):
     created_at = sa.Column(u'created_at', sa.DateTime(), nullable=True)
     updated_at = sa.Column(u'updated_at', sa.DateTime(), nullable=True)
     partition = sa.Column(sa.String(14), nullable=True)
+    vrid_port_id = sa.Column('vrid_port_id', sa.String(36), nullable=True)
+    vrid_floating_ip = sa.Column('vrid_floating_ip', sa.String(64), nullable=True)
 
     @classmethod
     def find_by_loadbalancer_id(cls, loadbalancer_id, db_session=None):

--- a/a10_octavia/db/models.py
+++ b/a10_octavia/db/models.py
@@ -49,7 +49,7 @@ class VThunder(base_models.BASE):
     updated_at = sa.Column(u'updated_at', sa.DateTime(), nullable=True)
     partition = sa.Column(sa.String(14), nullable=True)
     vrid_port_id = sa.Column('vrid_port_id', sa.String(36), nullable=True)
-    vrid_floating_ip = sa.Column('vrid_floating_ip', sa.String(64), nullable=True)
+    vrid_floating_ip = sa.Column('vrid_floating_ip', sa.String(15), nullable=True)
 
     @classmethod
     def find_by_loadbalancer_id(cls, loadbalancer_id, db_session=None):


### PR DESCRIPTION
## Description
- Modified `VThunder` data model to have `vrid_port_id` and `vrid_floating_ip`
- Also Included alembic revision to update `vthunders` table to add 2 new columns for  `vrid_port_id` and `vrid_floating_ip`

## Jira Ticket
[STACK-1225](https://a10networks.atlassian.net/browse/STACK-1225)
[STACK-1226](https://a10networks.atlassian.net/browse/STACK-1226)

## Technical Approach
- Updated `Vthunder` class and data model to include this feature.
- Added Alembic script to add new columns to `vthunders` table.

## Config Changes
None

## Test Cases
- None

## Manual Testing
- `sudo pip install -e .`
- `sudo systemctl restart a10-con*`
- Run `alembic upgrade head` in `a10-octavia/a10_octavia/db/migration` to update your db
- open mysql
- Run `desc vthunders;` and you will find new columns - `vrid_port_id` and `vrid_floating_ip` added. 
