### PR TITLE
STACK-1233 Add utility func to patch partial IP octets

### DIFF
--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -36,30 +36,16 @@ def validate_ipv4(address):
         raise ConfigFileValueError('Invalid IPAddress value given in configuration: ' + address)
 
 
-def patch_ipv4_suffix(suffix, subnet):
-    """Patch the partial IPv4 suffix with subnet provided
-       If suffix contains valid ip returns suffix itself.
-       Returns patched_ip if valid patch else returns None
-    """
-    suffix_octets = suffix.split('.')
-    if suffix_octets[0] == '':
-        suffix_octets.pop(0)
+def validate_partial_ipv4(address):
+    """Validates the partial IPv4 suffix provided"""
+    partial_ip = address.lstrip('.')
+    octets = partial_ip.split('.')
+    for idx in range(4 - len(octets)):
+        octets.insert(0, '0')
 
-    suffix_len = len(suffix_octets)
-    if not 0 < suffix_len <= 4:
-        return None
-
-    prefix_octets = subnet.split('.')
-    idx = 4 - suffix_len
-    while idx > 0:
-        suffix_octets.insert(0, prefix_octets[idx - 1])
-        idx -= 1
-
-    patched_ip = '.'.join(suffix_octets)
-    if netaddr.valid_ipv4(patched_ip, netaddr.core.INET_PTON):
-        return patched_ip
-
-    return None
+    if not netaddr.valid_ipv4('.'.join(octets), netaddr.core.INET_PTON):
+        raise ConfigFileValueError('Invalid partial IPAddress value given in configuration: '
+                                   + address)
 
 
 def validate_partition(rack_device):

--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -36,6 +36,32 @@ def validate_ipv4(address):
         raise ConfigFileValueError('Invalid IPAddress value given in configuration: ' + address)
 
 
+def patch_ipv4_suffix(suffix, subnet):
+    """Patch the partial IPv4 suffix with subnet provided
+       If suffix contains valid ip returns suffix itself.
+       Returns patched_ip if valid patch else returns None
+    """
+    suffix_octets = suffix.split('.')
+    if suffix_octets[0] == '':
+        suffix_octets.pop(0)
+
+    suffix_len = len(suffix_octets)
+    if not 0 < suffix_len <= 4:
+        return None
+
+    prefix_octets = subnet.split('.')
+    idx = 4 - suffix_len
+    while idx > 0:
+        suffix_octets.insert(0, prefix_octets[idx - 1])
+        idx -= 1
+
+    patched_ip = '.'.join(suffix_octets)
+    if netaddr.valid_ipv4(patched_ip, netaddr.core.INET_PTON):
+        return patched_ip
+
+    return None
+
+
 def validate_partition(rack_device):
     partition_name = rack_device.get('partition_name')
     if not partition_name:

--- a/a10_octavia/tests/unit/common/test_utils.py
+++ b/a10_octavia/tests/unit/common/test_utils.py
@@ -93,17 +93,17 @@ class TestUtils(unittest.TestCase):
         self.assertRaises(cfg.ConfigFileValueError, utils.validate_ipv4, '192.0.20')
         self.assertRaises(cfg.ConfigFileValueError, utils.validate_ipv4, 'abc')
 
-    def test_patch_ipv4_suffix_valid(self):
-        self.assertEqual(utils.patch_ipv4_suffix('10', '10.0.0.0'), '10.0.0.10')
-        self.assertEqual(utils.patch_ipv4_suffix('.10', '10.0.0.0'), '10.0.0.10')
-        self.assertEqual(utils.patch_ipv4_suffix('11.10', '10.0.0.0'), '10.0.11.10')
-        self.assertEqual(utils.patch_ipv4_suffix('11.0.11.10', '10.0.0.0'), '11.0.11.10')
+    def test_validate_partial_ipv4_valid(self):
+        self.assertEqual(utils.validate_partial_ipv4('10'), None)
+        self.assertEqual(utils.validate_partial_ipv4('.10'), None)
+        self.assertEqual(utils.validate_partial_ipv4('.5.11.10'), None)
+        self.assertEqual(utils.validate_partial_ipv4('11.5.11.10'), None)
 
-    def test_patch_ipv4_suffix_invalid(self):
-        self.assertEqual(utils.patch_ipv4_suffix('325', '10.0.0.0'), None)
-        self.assertEqual(utils.patch_ipv4_suffix('abc.cef', '10.0.0.0'), None)
-        self.assertEqual(utils.patch_ipv4_suffix('11.10.0.11.10', '10.0.0.0'), None)
-        self.assertEqual(utils.patch_ipv4_suffix('10.abc.11.10', '10.0.0.0'), None)
+    def test_validate_partial_ipv4_invalid(self):
+        self.assertRaises(cfg.ConfigFileValueError, utils.validate_partial_ipv4, '777')
+        self.assertRaises(cfg.ConfigFileValueError, utils.validate_partial_ipv4, 'abc.cef')
+        self.assertRaises(cfg.ConfigFileValueError, utils.validate_partial_ipv4, '11.10.0.11.10')
+        self.assertRaises(cfg.ConfigFileValueError, utils.validate_partial_ipv4, '10.333.11.10')
 
     def test_validate_partition_valid(self):
         self.assertEqual(utils.validate_partition(RACK_DEVICE), RACK_DEVICE)

--- a/a10_octavia/tests/unit/common/test_utils.py
+++ b/a10_octavia/tests/unit/common/test_utils.py
@@ -93,6 +93,18 @@ class TestUtils(unittest.TestCase):
         self.assertRaises(cfg.ConfigFileValueError, utils.validate_ipv4, '192.0.20')
         self.assertRaises(cfg.ConfigFileValueError, utils.validate_ipv4, 'abc')
 
+    def test_patch_ipv4_suffix_valid(self):
+        self.assertEqual(utils.patch_ipv4_suffix('10', '10.0.0.0'), '10.0.0.10')
+        self.assertEqual(utils.patch_ipv4_suffix('.10', '10.0.0.0'), '10.0.0.10')
+        self.assertEqual(utils.patch_ipv4_suffix('11.10', '10.0.0.0'), '10.0.11.10')
+        self.assertEqual(utils.patch_ipv4_suffix('11.0.11.10', '10.0.0.0'), '11.0.11.10')
+
+    def test_patch_ipv4_suffix_invalid(self):
+        self.assertEqual(utils.patch_ipv4_suffix('325', '10.0.0.0'), None)
+        self.assertEqual(utils.patch_ipv4_suffix('abc.cef', '10.0.0.0'), None)
+        self.assertEqual(utils.patch_ipv4_suffix('11.10.0.11.10', '10.0.0.0'), None)
+        self.assertEqual(utils.patch_ipv4_suffix('10.abc.11.10', '10.0.0.0'), None)
+
     def test_validate_partition_valid(self):
         self.assertEqual(utils.validate_partition(RACK_DEVICE), RACK_DEVICE)
         empty_rack_device = {}


### PR DESCRIPTION
## Description
The utility function to patches partial IPv4 suffix with subnet provided.
If the IPV4 suffix contains the complete valid IP then returns the suffix provided.
Otherwise returns the patched IP if it is valid, else returns None.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1233

## Technical Approach
1) For validating the Partial IP provided in the config check the return value of patch_ipv4_suffix(config_partial_ip, '10.0.0.0') to be not None.
2) To patch the partial IP with neutron subnet and validate it, use the return value of patch_ipv4_suffix(config_partial_ip, subnet)

## Test Cases
1) Positive test cases with Partial IP strings '10', '.10', '11.10', '11.0.11.10'.
2) Negative test cases with Partial IP strings '325', 'abc.cef', '11.10.0.11.10', '10.abc.11.10'.

## Manual Testing
1) Tested with STACK-1146 changes.
2) Added "interface_vlan_map" config to rack_vthunder device config.
"interface_vlan_map": {
    "1": {
         "11": {"use_dhcp": False, "ve_ip_address": "20"}, i
         "12": {"ve_ip_address": ".10"}, 
         "13": {"use_dhcp": True}
    }
}
3) Created VIP on VLAN 11 subnet and Member on VLAN 12 subnet. 