### PR TITLE
Stack-1132: Config file refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ $ touch /etc/a10/a10-octavia.conf
 
 #### 3ac. Sample a10-octavia.conf for vThunders
 ```shell
-[VTHUNDER]
-DEFAULT_VTHUNDER_USERNAME = "admin"
-DEFAULT_VTHUNDER_PASSWORD = "a10"
-DEFAULT_AXAPI_VERSION = "30"
+[vthunder]
+default_vthunder_username = "admin"
+default_vthunder_password = "a10"
+default_axapi_version = "30"
 
 [a10_controller_worker]
 amp_image_owner_id = <admin_project_id>
@@ -183,25 +183,22 @@ amp_active_retries = 100
 amp_active_wait_sec = 2
 loadbalancer_topology = SINGLE
 
-[RACK_VTHUNDER]
+[hardware_thunder]
 devices = """[
                     {
                      "project_id":"<project_id>",
                      "ip_address":"10.0.0.4",
-                     "undercloud":"True",
                      "username":"<username>",
                      "password":"<password>",
                      "device_name":"<device_name>",
-                     "axapi_version":"30"
                      },
                      {
                      "project_id":"<another_project_id>",
                      "ip_address":"10.0.0.5",
-                     "undercloud":"True",
                      "username":"<username>",
                      "password":"<password>",
                      "device_name":"<device_name>",
-                     "axapi_version":"30",
+                     "partition_name" : "<partition_name>"
                      }
              ]
        """
@@ -255,22 +252,19 @@ These settings are added to the `a10-octavia.conf` file. They allow the operator
 #### Global section config example
 ```shell
 [a10_global]
-
+enable_hierarchical_multitenancy = False
+use_parent_partition = False
 ```
 #### Loadbalancer/virtual server config example
 ```shell
-[SLB]
+[slb]
 arp_disable = False
 default_virtual_server_vrid = "10"
-logging_template = "Logging_temp1"
-policy_template = "policy_temp1"
-template_virtual_server = "virtual_server_template1"
-default_virtual_server_vrid = 0
 ```
 
 #### Listener/virtual port config example
 ```shell
-[LISTENER]
+[listener]
 ipinip = False
 no_dest_nat = False
 ha_conn_mirror = False
@@ -280,20 +274,23 @@ template_policy = "policy_temp1"
 autosnat = True
 conn_limit = 5000
 template_http = "http_template"
+use_rcv_hop_for_resp = False
 ```
 
 #### Pool/service group config example
 ```shell
-[SERVICE - GROUP]
-templates = "server1"
+[service_group]
+template_server = "server_template"
+template_port = "port_template"
+template_policy = "policy_template"`
 ```
 
 #### Member config example
 ```shell
-[SERVER]
+[server]
 conn_limit = 5000
 conn_resume = 1
-templates = "server1"
+template_server = "server_template"
 ```
 
 Full list of options can be found here: [Config Options Module](https://github.com/a10networks/a10-octavia/blob/master/a10_octavia/common/config_options.py)

--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -109,24 +109,6 @@ A10_SERVICE_GROUP_OPTS = [
                help=_('Service Group Policy Template')),
 ]
 
-A10_L7_POLICY_OPTS = [
-    cfg.StrOpt('p1',
-               default=None,
-               help=_('For future reference')),
-    cfg.StrOpt('p2',
-               default=None,
-               help=_('For future reference')),
-]
-
-A10_L7_RULE_OPTS = [
-    cfg.StrOpt('r1',
-               default=None,
-               help=_('For future reference')),
-    cfg.StrOpt('r2',
-               default=None,
-               help=_('For future reference')),
-]
-
 A10_SERVER_OPTS = [
     cfg.IntOpt('conn_limit', min=1, max=64000000,
                default=64000000,
@@ -139,7 +121,7 @@ A10_SERVER_OPTS = [
                help=_('Template Server')),
 ]
 
-A10_RACK_VTHUNDER_OPTS = [
+A10_HARDWARE_THUNDER_OPTS = [
     config_types.ListOfDictOpt('devices', default=[],
                                item_type=config_types.ListOfObjects(),
                                bounds=True,
@@ -327,10 +309,8 @@ cfg.CONF.register_opts(A10_VTHUNDER_OPTS, group='vthunder')
 cfg.CONF.register_opts(A10_SLB_OPTS, group='slb')
 cfg.CONF.register_opts(A10_LISTENER_OPTS, group='listener')
 cfg.CONF.register_opts(A10_SERVICE_GROUP_OPTS, group='service_group')
-cfg.CONF.register_opts(A10_L7_POLICY_OPTS, group='l7policy')
-cfg.CONF.register_opts(A10_L7_RULE_OPTS, group='l7rule')
 cfg.CONF.register_opts(A10_SERVER_OPTS, group='server')
-cfg.CONF.register_opts(A10_RACK_VTHUNDER_OPTS, group='rack_vthunder')
+cfg.CONF.register_opts(A10_HARDWARE_THUNDER_OPTS, group='hardware_thunder')
 
 
 # Ensure that the control exchange is set correctly

--- a/a10_octavia/common/config_types.py
+++ b/a10_octavia/common/config_types.py
@@ -81,4 +81,4 @@ class ListOfObjects(List):
             item = item.replace("\'", "\"")
             single_dict = json.loads(item)
             final_list.append(single_dict)
-        return utils.convert_to_rack_vthunder_conf(final_list)
+        return utils.convert_to_hardware_thunder_conf(final_list)

--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -48,60 +48,60 @@ def validate_partial_ipv4(address):
                                    + address)
 
 
-def validate_partition(rack_device):
-    partition_name = rack_device.get('partition_name')
+def validate_partition(hardware_device):
+    partition_name = hardware_device.get('partition_name')
     if not partition_name:
-        rack_device['partition_name'] = a10constants.SHARED_PARTITION
+        hardware_device['partition_name'] = a10constants.SHARED_PARTITION
     elif len(partition_name) > 14:
         raise ValueError("Supplied partition value '%s' exceeds maximum length 14" %
                          (partition_name))
-    return rack_device
+    return hardware_device
 
 
-def validate_params(rack_info):
-    """Check for all the required parameters for rack configurations.
+def validate_params(hardware_info):
+    """Check for all the required parameters for hardware configurations.
     """
-    if all(k in rack_info for k in ('project_id', 'ip_address',
-                                    'username', 'password', 'device_name')):
-        if all(rack_info[x] is not None for x in ('project_id', 'ip_address',
-                                                  'username', 'password', 'device_name')):
-            validate_ipv4(rack_info['ip_address'])
-            rack_info = validate_partition(rack_info)
-            return rack_info
+    if all(k in hardware_info for k in ('project_id', 'ip_address',
+                                        'username', 'password', 'device_name')):
+        if all(hardware_info[x] is not None for x in ('project_id', 'ip_address',
+                                                      'username', 'password', 'device_name')):
+            validate_ipv4(hardware_info['ip_address'])
+            hardware_info = validate_partition(hardware_info)
+            return hardware_info
     raise ConfigFileValueError('Please check your configuration. The params `project_id`, '
                                '`ip_address`, `username`, `password` and `device_name` '
-                               'under [rack_vthunder] section cannot be None ')
+                               'under [hardware_thunder] section cannot be None ')
 
 
-def check_duplicate_entries(rack_dict):
-    rack_count_dict = {}
-    for rack_device in rack_dict.values():
-        candidate = '{}:{}'.format(rack_device.ip_address, rack_device.partition_name)
-        rack_count_dict[candidate] = rack_count_dict.get(candidate, 0) + 1
-    return [k for k, v in rack_count_dict.items() if v > 1]
+def check_duplicate_entries(hardware_dict):
+    hardware_count_dict = {}
+    for hardware_device in hardware_dict.values():
+        candidate = '{}:{}'.format(hardware_device.ip_address, hardware_device.partition_name)
+        hardware_count_dict[candidate] = hardware_count_dict.get(candidate, 0) + 1
+    return [k for k, v in hardware_count_dict.items() if v > 1]
 
 
-def convert_to_rack_vthunder_conf(rack_list):
-    """ Validates for all vthunder nouns for rack devices
+def convert_to_hardware_thunder_conf(hardware_list):
+    """ Validates for all vthunder nouns for hardware devices
         configurations.
     """
-    rack_dict = {}
-    for rack_device in rack_list:
-        rack_device = validate_params(rack_device)
-        if rack_dict.get(rack_device['project_id']):
+    hardware_dict = {}
+    for hardware_device in hardware_list:
+        hardware_device = validate_params(hardware_device)
+        if hardware_dict.get(hardware_device['project_id']):
             raise ConfigFileValueError('Supplied duplicate project_id ' +
-                                       rack_device['project_id'] +
-                                       ' in [rack_vthunder] section')
-        rack_device['undercloud'] = True
-        vthunder_conf = data_models.VThunder(**rack_device)
-        rack_dict[rack_device['project_id']] = vthunder_conf
+                                       hardware_device['project_id'] +
+                                       ' in [hardware_thunder] section')
+        hardware_device['undercloud'] = True
+        vthunder_conf = data_models.VThunder(**hardware_device)
+        hardware_dict[hardware_device['project_id']] = vthunder_conf
 
-    duplicates_list = check_duplicate_entries(rack_dict)
+    duplicates_list = check_duplicate_entries(hardware_dict)
     if duplicates_list:
         raise ConfigFileValueError('Duplicates found for the following '
                                    '\'ip_address:partition_name\' entries: {}'
                                    .format(list(duplicates_list)))
-    return rack_dict
+    return hardware_dict
 
 
 def get_parent_project(project_id):

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -194,7 +194,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             raise db_exceptions.NoResultFound
 
         load_balancer = listener.load_balancer
-        if listener.project_id in CONF.rack_vthunder.devices:
+        if listener.project_id in CONF.hardware_thunder.devices:
             create_listener_tf = self._taskflow_load(self._listener_flows.
                                                      get_rack_vthunder_create_listener_flow(
                                                          listener.project_id),
@@ -225,7 +225,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         listener = self._listener_repo.get(db_apis.get_session(),
                                            id=listener_id)
         load_balancer = listener.load_balancer
-        if listener.project_id in CONF.rack_vthunder.devices:
+        if listener.project_id in CONF.hardware_thunder.devices:
             delete_listener_tf = self._taskflow_load(
                 self._listener_flows.get_delete_rack_listener_flow(),
                 store={constants.LOADBALANCER: load_balancer,
@@ -301,11 +301,11 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         store[constants.UPDATE_DICT] = {
             constants.TOPOLOGY: topology
         }
-        if lb.project_id in CONF.rack_vthunder.devices:
+        if lb.project_id in CONF.hardware_thunder.devices:
             LOG.info('A10ControllerWorker.create_load_balancer fetched project_id : %s'
                      'from config file for Rack Vthunder' % (lb.project_id))
             create_lb_flow = self._lb_flows.get_create_rack_vthunder_load_balancer_flow(
-                vthunder_conf=CONF.rack_vthunder.devices[lb.project_id],
+                vthunder_conf=CONF.hardware_thunder.devices[lb.project_id],
                 topology=topology, listeners=lb.listeners)
             create_lb_tf = self._taskflow_load(create_lb_flow, store=store)
         else:
@@ -417,7 +417,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         load_balancer = pool.load_balancer
 
         topology = CONF.a10_controller_worker.loadbalancer_topology
-        if member.project_id in CONF.rack_vthunder.devices:
+        if member.project_id in CONF.hardware_thunder.devices:
             create_member_tf = self._taskflow_load(
                 self._member_flows.get_rack_vthunder_create_member_flow(),
                 store={

--- a/a10_octavia/tests/unit/common/test_utils.py
+++ b/a10_octavia/tests/unit/common/test_utils.py
@@ -25,12 +25,12 @@ from a10_octavia.common import data_models
 from a10_octavia.common import utils
 from a10_octavia.tests.common import a10constants
 
-SHARED_RACK_DEVICE = {'partition_name': 'shared'}
-RACK_DEVICE = {
+SHARED_HARDWARE_DEVICE = {'partition_name': 'shared'}
+HARDWARE_DEVICE = {
     'partition_name': 'sample-1'
 }
 
-RACK_INFO = {
+HARDWARE_INFO = {
     'project_id': 'project-1',
     'ip_address': '10.10.10.10',
     'device_name': 'rack_thunder_1',
@@ -38,7 +38,7 @@ RACK_INFO = {
     'password': 'abc'
 }
 
-RACK_INFO_2 = {
+HARDWARE_INFO_2 = {
     'project_id': 'project-2',
     'ip_address': '12.12.12.12',
     'device_name': 'rack_thunder_2',
@@ -47,7 +47,7 @@ RACK_INFO_2 = {
     'partition_name': 'def-sample'
 }
 
-DUP_PARTITION_RACK_INFO = {
+DUP_PARTITION_HARDWARE_INFO = {
     'project_id': 'project-3',
     'ip_address': '10.10.10.10',
     'device_name': 'rack_thunder_3',
@@ -66,17 +66,17 @@ DUPLICATE_DICT = {'project_1': VTHUNDER_1,
 DUP_LIST = ['10.10.10.10:shared']
 NON_DUPLICATE_DICT = {'project_1': VTHUNDER_1, 'project_2': VTHUNDER_2}
 
-DUPLICATE_PROJECT_RACK_DEVICE_LIST = [
-    RACK_INFO, RACK_INFO
+DUPLICATE_PROJECT_HARDWARE_DEVICE_LIST = [
+    HARDWARE_INFO, HARDWARE_INFO
 ]
 
-RACK_DEVICE_LIST = [
-    RACK_INFO, RACK_INFO_2
+HARDWARE_DEVICE_LIST = [
+    HARDWARE_INFO, HARDWARE_INFO_2
 ]
 
-DUPLICATE_PARTITION_RACK_DEVICE_LIST = [DUP_PARTITION_RACK_INFO, RACK_INFO]
-RESULT_RACK_DEVICE_LIST = {'project-1': VTHUNDER_1,
-                           'project-2': VTHUNDER_2}
+DUPLICATE_PARTITION_HARDWARE_DEVICE_LIST = [DUP_PARTITION_HARDWARE_INFO, HARDWARE_INFO]
+RESULT_HARDWARE_DEVICE_LIST = {'project-1': VTHUNDER_1,
+                               'project-2': VTHUNDER_2}
 
 
 class FakeProject(object):
@@ -106,25 +106,27 @@ class TestUtils(unittest.TestCase):
         self.assertRaises(cfg.ConfigFileValueError, utils.validate_partial_ipv4, '10.333.11.10')
 
     def test_validate_partition_valid(self):
-        self.assertEqual(utils.validate_partition(RACK_DEVICE), RACK_DEVICE)
-        empty_rack_device = {}
-        self.assertEqual(utils.validate_partition(empty_rack_device), SHARED_RACK_DEVICE)
+        self.assertEqual(utils.validate_partition(HARDWARE_DEVICE), HARDWARE_DEVICE)
+        empty_hardware_device = {}
+        self.assertEqual(utils.validate_partition(empty_hardware_device), SHARED_HARDWARE_DEVICE)
 
     def test_validate_partition_invalid(self):
-        long_partition_rack_device = copy.deepcopy(RACK_DEVICE)
-        long_partition_rack_device['partition_name'] = 'sample_long_partition_name'
-        self.assertRaises(ValueError, utils.validate_partition, long_partition_rack_device)
+        long_partition_hardware_device = copy.deepcopy(HARDWARE_DEVICE)
+        long_partition_hardware_device['partition_name'] = 'sample_long_partition_name'
+        self.assertRaises(ValueError, utils.validate_partition, long_partition_hardware_device)
 
     def test_validate_params_valid(self):
-        shared_rack_info = copy.deepcopy(RACK_INFO)
-        shared_rack_info['partition_name'] = 'shared'
-        self.assertEqual(utils.validate_params(RACK_INFO), shared_rack_info)
+        shared_hardware_info = copy.deepcopy(HARDWARE_INFO)
+        shared_hardware_info['partition_name'] = 'shared'
+        self.assertEqual(utils.validate_params(HARDWARE_INFO), shared_hardware_info)
 
     def test_validate_params_invalid(self):
-        empty_param_rack_info = {}
-        missing_param_rack_info = {'project_id': 'abc'}
-        self.assertRaises(cfg.ConfigFileValueError, utils.validate_params, empty_param_rack_info)
-        self.assertRaises(cfg.ConfigFileValueError, utils.validate_params, missing_param_rack_info)
+        empty_param_hardware_info = {}
+        missing_param_hardware_info = {'project_id': 'abc'}
+        self.assertRaises(cfg.ConfigFileValueError, utils.validate_params,
+                          empty_param_hardware_info)
+        self.assertRaises(cfg.ConfigFileValueError, utils.validate_params,
+                          missing_param_hardware_info)
 
     def test_check_duplicate_entries_dup_found(self):
         self.assertEqual(utils.check_duplicate_entries(DUPLICATE_DICT), DUP_LIST)
@@ -132,16 +134,16 @@ class TestUtils(unittest.TestCase):
     def test_check_duplicate_entries_no_dup_found(self):
         self.assertEqual(utils.check_duplicate_entries(NON_DUPLICATE_DICT), [])
 
-    def test_convert_to_rack_vthunder_conf_valid(self):
-        self.assertEqual(utils.convert_to_rack_vthunder_conf(RACK_DEVICE_LIST),
-                         RESULT_RACK_DEVICE_LIST)
-        self.assertEqual(utils.convert_to_rack_vthunder_conf([]), {})
+    def test_convert_to_hardware_thunder_conf_valid(self):
+        self.assertEqual(utils.convert_to_hardware_thunder_conf(HARDWARE_DEVICE_LIST),
+                         RESULT_HARDWARE_DEVICE_LIST)
+        self.assertEqual(utils.convert_to_hardware_thunder_conf([]), {})
 
-    def test_convert_to_rack_vthunder_conf_invalid(self):
-        self.assertRaises(cfg.ConfigFileValueError, utils.convert_to_rack_vthunder_conf,
-                          DUPLICATE_PROJECT_RACK_DEVICE_LIST)
-        self.assertRaises(cfg.ConfigFileValueError, utils.convert_to_rack_vthunder_conf,
-                          DUPLICATE_PARTITION_RACK_DEVICE_LIST)
+    def test_convert_to_hardware_thunder_conf_invalid(self):
+        self.assertRaises(cfg.ConfigFileValueError, utils.convert_to_hardware_thunder_conf,
+                          DUPLICATE_PROJECT_HARDWARE_DEVICE_LIST)
+        self.assertRaises(cfg.ConfigFileValueError, utils.convert_to_hardware_thunder_conf,
+                          DUPLICATE_PARTITION_HARDWARE_DEVICE_LIST)
 
     @mock.patch('octavia.common.keystone.KeystoneSession')
     @mock.patch('a10_octavia.common.utils.keystone_client.Client')


### PR DESCRIPTION
## Description
- **Severity Level (Low)**
- **Issue:** Refactor config file with following changes:
a) Make sure all configs are lower case
b) Change `rack_vthunder` to `hardware_thunder`
c) Remove l7policy and l7rule opts, as it is not needed.

## Jira Ticket
[STACK-1132](https://a10networks.atlassian.net/browse/STACK-1132)

## Technical Approach
a) Updated `README` with lower case configs, also added some more `a10_global` configs
b) Removed L7 Policy and L7 Rule Opts.
c) Removed `rack` from modified variable, method name.

## Config Changes
<pre>
[hardware_thunder]

devices=[{
 "project_id": "fake_uuid",
 "username" : "username",
 "password" : "password",
 "ip_address" : "10.43.12.137",
 "device_name" : "rack_1"
 }]
</pre>

## Test Cases
a) Configuration should accept `[hardware_thunder]` as valid section 
b) Existing UTs should pass.
c) README updates are valid and are visible

## Manual Testing
- Add configuration in `/etc/a10/a10-octavia.conf`.
- Restart `a10-controller-worker` service.