### PR TITLE
STACK-1215 Few IPV4 utility functions

### DIFF
--- a/a10_octavia/tests/unit/common/test_utils.py
+++ b/a10_octavia/tests/unit/common/test_utils.py
@@ -162,3 +162,43 @@ class TestUtils(unittest.TestCase):
         client_mock.projects.get.return_value = FakeProject()
         mock_key_client.return_value = client_mock
         self.assertIsNone(utils.get_parent_project(a10constants.MOCK_CHILD_PROJECT_ID))
+
+    def test_get_net_info_from_cidr_valid(self):
+        self.assertEqual(utils.get_net_info_from_cidr('10.10.10.1/32'),
+                         ('10.10.10.1', '255.255.255.255'))
+        self.assertEqual(utils.get_net_info_from_cidr('10.10.10.0/24'),
+                         ('10.10.10.0', '255.255.255.0'))
+        self.assertEqual(utils.get_net_info_from_cidr('10.10.0.0/16'),
+                         ('10.10.0.0', '255.255.0.0'))
+
+    def test_get_net_info_from_cidr_invalid(self):
+        self.assertRaises(Exception, utils.get_net_info_from_cidr, '10.10.10.1/33')
+
+    def test_check_ip_in_subnet_range_valid(self):
+        self.assertEqual(utils.check_ip_in_subnet_range('10.10.10.1', '10.10.10.1',
+                         '255.255.255.255'), True)
+        self.assertEqual(utils.check_ip_in_subnet_range('10.10.10.1', '10.10.11.0',
+                         '255.255.255.0'), False)
+        self.assertEqual(utils.check_ip_in_subnet_range('10.10.10.1', '10.10.0.0',
+                         '255.255.0.0'), True)
+        self.assertEqual(utils.check_ip_in_subnet_range('10.11.10.2', '10.10.0.0',
+                         '255.255.0.0'), False)
+
+    def test_check_ip_in_subnet_range_invalid(self):
+        self.assertRaises(Exception, utils.check_ip_in_subnet_range, '1010.10.10.2',
+                          '10.10.10.1', '255.255.255.255')
+        self.assertRaises(Exception, utils.check_ip_in_subnet_range, '10.10.10.2',
+                          '10.333.10.0', '255.255.255.0')
+        self.assertRaises(Exception, utils.check_ip_in_subnet_range, '10.11.10.2',
+                          '10.10.0.0', '2555.255.0.0')
+
+    def test_merge_host_and_network_ip_valid(self):
+        self.assertEqual(utils.merge_host_and_network_ip('10.10.10.0/24', '0.0.0.9'),
+                         '10.10.10.9')
+        self.assertEqual(utils.merge_host_and_network_ip('10.10.10.0/24', '0.0.0.9'),
+                         '10.10.10.9')
+        self.assertEqual(utils.merge_host_and_network_ip('10.10.0.0/16', '0.0.11.9'),
+                         '10.10.11.9')
+
+    def test_merge_host_and_network_ip_invalid(self):
+        self.assertRaises(Exception, utils.merge_host_and_network_ip, '10.10.10.0/42', '99')


### PR DESCRIPTION
## Description
Added a few IPV4 utility functions.
1) To get subnet_ip and netmask from CIDR
2) To check whether the IP lies in the subnet range
3) Merge the (partial) host IP provider with the network IP of CIDR

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1215

## Technical Approach
Used python socket library which accesses BSD socket interface to write the utilities as suggested by Hunter.

## Test Cases
Unit tests updated with positive and negative testcases.

## Manual Testing
1. Tested with STACK-1146 changes.
2. Added "interface_vlan_map" config to rack_vthunder device config.  
   "interface_vlan_map": {  
       "1": {
           "11": {"use_dhcp": False, "ve_ip_address": "20"},
           "12": {"ve_ip_address": ".10"},
           "13": {"use_dhcp": True}
       }
   }
3. Created VIP on VLAN 11 subnet and Members on VLAN 12 and 13 subnets.