### PR TITLE
STACK-1253 and STACK-1244 - Refactor and unison a10-octavia-neutron driver

### DIFF
--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -15,7 +15,20 @@
 
 from octavia.common import exceptions
 from octavia.i18n import _
+from octavia.network import base
 
 
 class NoDatabaseURL(exceptions.OctaviaException):
     message = _("Must set db connection url in configuration file.")
+
+
+class PortCreationFailedException(base.NetworkException):
+    pass
+
+
+class DeallocateTrunkException(base.NetworkException):
+    pass
+
+
+class AllocateTrunkException(base.NetworkException):
+    pass

--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -21,11 +21,12 @@ import netaddr
 import socket
 import struct
 
-from oslo_config.cfg import ConfigFileValueError
+from oslo_config import cfg
 from oslo_log import log as logging
 
 from keystoneclient.v3 import client as keystone_client
 from octavia.common import keystone
+from stevedore import driver as stevedore_driver
 
 from a10_octavia.common import a10constants
 from a10_octavia.common import data_models
@@ -36,7 +37,8 @@ LOG = logging.getLogger(__name__)
 def validate_ipv4(address):
     """Validates for IP4 address format"""
     if not netaddr.valid_ipv4(address, netaddr.core.INET_PTON):
-        raise ConfigFileValueError('Invalid IPAddress value given in configuration: ' + address)
+        raise cfg.ConfigFileValueError(
+            'Invalid IPAddress value given in configuration: ' + address)
 
 
 def validate_partial_ipv4(address):
@@ -47,8 +49,8 @@ def validate_partial_ipv4(address):
         octets.insert(0, '0')
 
     if not netaddr.valid_ipv4('.'.join(octets), netaddr.core.INET_PTON):
-        raise ConfigFileValueError('Invalid partial IPAddress value given in configuration: '
-                                   + address)
+        raise cfg.ConfigFileValueError('Invalid partial IPAddress value given in configuration: '
+                                       + address)
 
 
 def validate_partition(hardware_device):
@@ -71,9 +73,9 @@ def validate_params(hardware_info):
             validate_ipv4(hardware_info['ip_address'])
             hardware_info = validate_partition(hardware_info)
             return hardware_info
-    raise ConfigFileValueError('Please check your configuration. The params `project_id`, '
-                               '`ip_address`, `username`, `password` and `device_name` '
-                               'under [hardware_thunder] section cannot be None ')
+    raise cfg.ConfigFileValueError('Please check your configuration. The params `project_id`, '
+                                   '`ip_address`, `username`, `password` and `device_name` '
+                                   'under [hardware_thunder] section cannot be None ')
 
 
 def check_duplicate_entries(hardware_dict):
@@ -92,18 +94,18 @@ def convert_to_hardware_thunder_conf(hardware_list):
     for hardware_device in hardware_list:
         hardware_device = validate_params(hardware_device)
         if hardware_dict.get(hardware_device['project_id']):
-            raise ConfigFileValueError('Supplied duplicate project_id ' +
-                                       hardware_device['project_id'] +
-                                       ' in [hardware_thunder] section')
+            raise cfg.ConfigFileValueError('Supplied duplicate project_id ' +
+                                           hardware_device['project_id'] +
+                                           ' in [hardware_thunder] section')
         hardware_device['undercloud'] = True
         vthunder_conf = data_models.VThunder(**hardware_device)
         hardware_dict[hardware_device['project_id']] = vthunder_conf
 
     duplicates_list = check_duplicate_entries(hardware_dict)
     if duplicates_list:
-        raise ConfigFileValueError('Duplicates found for the following '
-                                   '\'ip_address:partition_name\' entries: {}'
-                                   .format(list(duplicates_list)))
+        raise cfg.ConfigFileValueError('Duplicates found for the following '
+                                       '\'ip_address:partition_name\' entries: {}'
+                                       .format(list(duplicates_list)))
     return hardware_dict
 
 
@@ -145,3 +147,13 @@ def merge_host_and_network_ip(cidr, host_ip):
     int_net_ip = struct.unpack('>L', socket.inet_aton(network_ip))[0]
     full_ip_packed = struct.pack('>L', int_net_ip | (int_host_ip & int_host_bits))
     return socket.inet_ntoa(full_ip_packed)
+
+
+def get_network_driver():
+    CONF.import_group('a10_controller_worker', 'a10_octavia.common.config_options')
+    network_driver = stevedore_driver.DriverManager(
+        namespace='octavia.network.drivers',
+        name=CONF.a10_controller_worker.network_driver,
+        invoke_on_load=True
+    ).driver
+    return network_driver

--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -32,25 +32,26 @@ from a10_octavia.common import a10constants
 from a10_octavia.common import data_models
 
 LOG = logging.getLogger(__name__)
+CONF = cfg.CONF
 
 
 def validate_ipv4(address):
-    """Validates for IP4 address format"""
+    """Validate for IP4 address format"""
     if not netaddr.valid_ipv4(address, netaddr.core.INET_PTON):
         raise cfg.ConfigFileValueError(
-            'Invalid IPAddress value given in configuration: ' + address)
+            'Invalid IPAddress value given in configuration: {0}'.format(address))
 
 
 def validate_partial_ipv4(address):
-    """Validates the partial IPv4 suffix provided"""
+    """Validate the partial IPv4 suffix provided"""
     partial_ip = address.lstrip('.')
     octets = partial_ip.split('.')
     for idx in range(4 - len(octets)):
         octets.insert(0, '0')
 
     if not netaddr.valid_ipv4('.'.join(octets), netaddr.core.INET_PTON):
-        raise cfg.ConfigFileValueError('Invalid partial IPAddress value given in configuration: '
-                                       + address)
+        raise cfg.ConfigFileValueError('Invalid partial IPAddress value given'
+                                       ' in configuration: {0}'.format(address))
 
 
 def validate_partition(hardware_device):
@@ -64,8 +65,7 @@ def validate_partition(hardware_device):
 
 
 def validate_params(hardware_info):
-    """Check for all the required parameters for hardware configurations.
-    """
+    """Check for all the required parameters for hardware configurations."""
     if all(k in hardware_info for k in ('project_id', 'ip_address',
                                         'username', 'password', 'device_name')):
         if all(hardware_info[x] is not None for x in ('project_id', 'ip_address',
@@ -87,9 +87,7 @@ def check_duplicate_entries(hardware_dict):
 
 
 def convert_to_hardware_thunder_conf(hardware_list):
-    """ Validates for all vthunder nouns for hardware devices
-        configurations.
-    """
+    """Validate for all vthunder nouns for hardware devices configurations."""
     hardware_dict = {}
     for hardware_device in hardware_list:
         hardware_device = validate_params(hardware_device)

--- a/a10_octavia/network/data_models.py
+++ b/a10_octavia/network/data_models.py
@@ -1,0 +1,60 @@
+#    Copyright 2019, A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from octavia.common import data_models as base_data_models
+from octavia.network import data_models as network_data_models
+
+
+class ParentPort(network_data_models.Port):
+
+    def __init__(self, id=None, name=None, device_id=None, device_owner=None,
+                 mac_address=None, network_id=None, status=None, project_id=None,
+                 admin_state_up=None, fixed_ips=None, qos_policy_id=None,
+                 trunk_id=None, subports=None):
+        self.id = id
+        self.name = name
+        self.device_id = device_id
+        self.device_owner = device_owner
+        self.mac_address = mac_address
+        self.network_id = network_id
+        self.status = status
+        self.project_id = project_id
+        self.admin_state_up = admin_state_up
+        self.fixed_ips = fixed_ips or []
+        self.qos_policy_id = qos_policy_id
+        self.trunk_id = trunk_id
+        self.subports = subports or []
+
+
+class Subport(base_data_models.BaseDataModel):
+    """Sometimes reffered to as subport"""
+
+    def __init__(self, segmentation_id=None, port_id=None,
+                 segmentation_type=None, mac_address=None,
+                 network_id=None):
+        self.segmentation_id = segmentation_id
+        self.port_id = port_id
+        self.segmentation_type = segmentation_type
+        self.mac_address = mac_address
+        self.network_id = network_id
+
+
+class PortDelta(base_data_models.BaseDataModel):
+
+    def __init__(self, amphora_id=None, compute_id=None,
+                 add_subports=None, delete_subports=None):
+        self.compute_id = compute_id
+        self.amphora_id = amphora_id
+        self.add_subports = add_subports
+        self.delete_subports = delete_subports

--- a/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
+++ b/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
@@ -16,7 +16,6 @@ from oslo_config import cfg
 from oslo_log import log as logging
 from stevedore import driver as stevedore_driver
 
-from neutronclient.common import exceptions as neutron_client_exceptions
 from octavia.network import data_models as n_data_models
 from octavia.network.drivers.neutron import allowed_address_pairs
 from octavia.network.drivers.neutron import utils
@@ -159,22 +158,3 @@ class A10OctaviaNeutronDriver(allowed_address_pairs.AllowedAddressPairsDriver):
         except Exception:
             message = "Error deleting port: {0}".format(port_id)
             LOG.exception(message)
-
-    def get_port_by_ip(self, ip):
-        try:
-            ports = self.neutron_client.list_ports(device_owner=OCTAVIA_OWNER)
-            if not ports or not ports.get('ports'):
-                return None
-            for port in ports['ports']:
-                if port.get('fixed_ips'):
-                    fixed_ips = port['fixed_ips']
-                    for ipaddr in fixed_ips:
-                        if ipaddr.get('ip_address') == ip:
-                            return n_data_models.Port(id=port['id'])
-        except (neutron_client_exceptions.NotFound,
-                neutron_client_exceptions.PortNotFoundClient):
-            pass
-        except Exception:
-            message = "Error listing ports, ip {} ".format(ip)
-            LOG.exception(message)
-        return None

--- a/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
+++ b/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
@@ -12,27 +12,19 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import ipaddress
-import time
-
-from neutronclient.common import exceptions as neutron_client_exceptions
-from novaclient import exceptions as nova_client_exceptions
 from oslo_config import cfg
 from oslo_log import log as logging
-import six
 from stevedore import driver as stevedore_driver
 
-from octavia.common import constants
-from octavia.common import data_models
-from octavia.common import exceptions
-from octavia.i18n import _
 from octavia.network import base
 from octavia.network import data_models as n_data_models
-from octavia.network.drivers.neutron import base as neutron_base
+from octavia.network.drivers.neutron.allowed_address_pairs import AllowedAddressPairsDriver
 from octavia.network.drivers.neutron import utils
 
+from a10_octavia.common import exceptions
+from a10_octavia.network import data_models
+
 LOG = logging.getLogger(__name__)
-AAP_EXT_ALIAS = 'allowed-address-pairs'
 PROJECT_ID_ALIAS = 'project-id'
 VIP_SECURITY_GRP_PREFIX = 'lb-'
 OCTAVIA_OWNER = 'Octavia'
@@ -40,328 +32,47 @@ OCTAVIA_OWNER = 'Octavia'
 CONF = cfg.CONF
 
 
-class A10OctaviaNeutronDriver(neutron_base.BaseNeutronDriver):
+class A10OctaviaNeutronDriver(AllowedAddressPairsDriver):
 
     def __init__(self):
-        super(A10OctaviaNeutronDriver, self).__init__()
-#        self._check_aap_loaded()
+        super(AllowedAddressPairsDriver, self).__init__()
         self.compute = stevedore_driver.DriverManager(
             namespace='octavia.compute.drivers',
             name=CONF.controller_worker.compute_driver,
             invoke_on_load=True
         ).driver
 
-    def _check_aap_loaded(self):
-        if not self._check_extension_enabled(AAP_EXT_ALIAS):
-            raise base.NetworkException(
-                'The {alias} extension is not enabled in neutron.  This '
-                'driver cannot be used with the {alias} extension '
-                'disabled.'.format(alias=AAP_EXT_ALIAS))
+    def _port_to_parent_port(self, port):
+        fixed_ips = [n_data_models.FixedIP(subnet_id=fixed_ip.get('subnet_id'),
+                                           ip_address=fixed_ip.get('ip_address'))
+                     for fixed_ip in port.get('fixed_ips', [])]
 
-    def _get_interfaces_to_unplug(self, interfaces, network_id,
-                                  ip_address=None):
-        ret = []
-        for interface in interfaces:
-            if interface.network_id == network_id:
-                if ip_address:
-                    for fixed_ip in interface.fixed_ips:
-                        if ip_address == fixed_ip.ip_address:
-                            ret.append(interface)
-                else:
-                    ret.append(interface)
-        return ret
+        trunk_id = port['trunk_details']['trunk_id'] if port.get('trunk_details') else None
+        subports = port['trunk_details']['sub_ports'] if port.get('trunk_details') else None
+        subport_list = []
+        if subports:
+            subport_list = [data_models.Subport(segmentation_id=subport['segmentation_id'],
+                                                port_id=subport['port_id'],
+                                                segmentation_type=subport['segmentation_type'],
+                                                mac_address=subport['mac_address'])
+                            for subport in subports]
+        return data_models.ParentPort(id=port.get('id'),
+                                      name=port.get('name'),
+                                      device_id=port.get('device_id'),
+                                      device_owner=port.get('device_owner'),
+                                      mac_address=port.get('mac_address'),
+                                      network_id=port.get('network_id'),
+                                      status=port.get('status'),
+                                      project_id=port.get('project_id'),
+                                      admin_state_up=port.get('admin_state_up'),
+                                      fixed_ips=fixed_ips,
+                                      qos_policy_id=port.get('qos_policy_id'),
+                                      trunk_id=trunk_id, subports=subport_list)
 
-    def _get_plugged_interface(self, compute_id, network_id, lb_network_ip):
-        interfaces = self.get_plugged_networks(compute_id)
-        for interface in interfaces:
-            is_correct_interface = interface.network_id == network_id
-            for ip in interface.fixed_ips:
-                if ip.ip_address == lb_network_ip:
-                    is_correct_interface = False
-            if is_correct_interface:
-                return interface
-        return None
-
-    def _plug_amphora_vip(self, amphora, subnet):
-        # We need a vip port owned by Octavia for Act/Stby and failover
-        try:
-            port = {'port': {'name': 'octavia-lb-vrrp-' + amphora.id,
-                             'network_id': subnet.network_id,
-                             'fixed_ips': [{'subnet_id': subnet.id}],
-                             'admin_state_up': True,
-                             'device_owner': OCTAVIA_OWNER}}
-            new_port = self.neutron_client.create_port(port)
-            new_port = utils.convert_port_dict_to_model(new_port)
-
-            LOG.debug('Created vip port: %(port_id)s for amphora: %(amp)s',
-                      {'port_id': new_port.id, 'amp': amphora.id})
-
-        except Exception:
-            message = _('Error creating the base (VRRP) port for the VIP with '
-                        'port details: {}').format(port)
-            LOG.exception(message)
-            raise base.PlugVIPException(message)
-
-        try:
-            interface = self.plug_port(amphora, new_port)
-        except Exception:
-            message = _('Error plugging amphora (compute_id: {compute_id}) '
-                        'into vip network {network_id}.').format(
-                            compute_id=amphora.compute_id,
-                            network_id=subnet.network_id)
-            LOG.exception(message)
-            try:
-                if new_port:
-                    self.neutron_client.delete_port(new_port.id)
-                    LOG.debug('Deleted base (VRRP) port %s due to plug_port '
-                              'failure.', new_port.id)
-            except Exception:
-                LOG.exception('Failed to delete base (VRRP) port %s after '
-                              'plug_port failed. This resource is being '
-                              'abandoned and should be manually deleted when '
-                              'neutron is functional.', new_port.id)
-            raise base.PlugVIPException(message)
-        return interface
-
-    def _add_vip_address_pair(self, port_id, vip_address):
-        try:
-            self._add_allowed_address_pair_to_port(port_id, vip_address)
-        except neutron_client_exceptions.PortNotFoundClient as e:
-            raise base.PortNotFound(str(e))
-        except Exception:
-            message = _('Error adding allowed address pair {ip} '
-                        'to port {port_id}.').format(ip=vip_address,
-                                                     port_id=port_id)
-            LOG.exception(message)
-            raise base.PlugVIPException(message)
-
-    def _get_lb_security_group(self, load_balancer_id):
-        sec_grp_name = VIP_SECURITY_GRP_PREFIX + load_balancer_id
-        sec_grps = self.neutron_client.list_security_groups(name=sec_grp_name)
-        if sec_grps and sec_grps.get('security_groups'):
-            return sec_grps.get('security_groups')[0]
-        return None
-
-    def _get_ethertype_for_ip(self, ip):
-        address = ipaddress.ip_address(
-            ip if isinstance(ip, six.text_type) else six.u(ip))
-        return 'IPv6' if address.version == 6 else 'IPv4'
-
-    def _update_security_group_rules(self, load_balancer, sec_grp_id):
-        rules = self.neutron_client.list_security_group_rules(
-            security_group_id=sec_grp_id)
-        updated_ports = [
-            (listener.protocol_port,
-             constants.PROTOCOL_TCP.lower()
-             if listener.protocol != constants.PROTOCOL_UDP else
-             constants.PROTOCOL_UDP.lower())
-            for listener in load_balancer.listeners
-            if listener.provisioning_status != constants.PENDING_DELETE
-            and listener.provisioning_status != constants.DELETED]
-        # As the peer port will hold the tcp connection for keepalived and
-        # haproxy session synchronization, so here the security group rule
-        # should be just related with tcp protocol only.
-        peer_ports = [
-            (listener.peer_port,
-             constants.PROTOCOL_TCP.lower())
-            for listener in load_balancer.listeners
-            if listener.provisioning_status != constants.PENDING_DELETE
-            and listener.provisioning_status != constants.DELETED]
-        updated_ports.extend(peer_ports)
-        # Just going to use port_range_max for now because we can assume that
-        # port_range_max and min will be the same since this driver is
-        # responsible for creating these rules
-        old_ports = [(rule.get('port_range_max'), rule.get('protocol'))
-                     for rule in rules.get('security_group_rules', [])
-                     # Don't remove egress rules and don't
-                     # confuse other protocols with None ports
-                     # with the egress rules.  VRRP uses protocol
-                     # 51 and 112
-                     if rule.get('direction') != 'egress'
-                     and rule.get('protocol', '').lower() in ['tcp', 'udp']]
-        add_ports = set(updated_ports) - set(old_ports)
-        del_ports = set(old_ports) - set(updated_ports)
-        for rule in rules.get('security_group_rules', []):
-            if (rule.get('protocol', '') and rule.get('protocol', '').lower() in [
-                    'tcp', 'udp'] and (rule.get('port_range_max'),
-                                       rule.get('protocol')) in del_ports):
-                rule_id = rule.get('id')
-                try:
-                    self.neutron_client.delete_security_group_rule(rule_id)
-                except neutron_client_exceptions.NotFound:
-                    LOG.info("Security group rule %s not found, will assume "
-                             "it is already deleted.", rule_id)
-
-        ethertype = self._get_ethertype_for_ip(load_balancer.vip.ip_address)
-        for port_protocol in add_ports:
-            self._create_security_group_rule(sec_grp_id, port_protocol[1],
-                                             port_min=port_protocol[0],
-                                             port_max=port_protocol[0],
-                                             ethertype=ethertype)
-
-        # Currently we are using the VIP network for VRRP
-        # so we need to open up the protocols for it
-        if load_balancer.topology == constants.TOPOLOGY_ACTIVE_STANDBY:
-            try:
-                self._create_security_group_rule(
-                    sec_grp_id,
-                    constants.VRRP_PROTOCOL_NUM,
-                    direction='ingress',
-                    ethertype=ethertype)
-            except neutron_client_exceptions.Conflict:
-                # It's ok if this rule already exists
-                pass
-            except Exception as e:
-                raise base.PlugVIPException(str(e))
-
-            try:
-                self._create_security_group_rule(
-                    sec_grp_id, constants.AUTH_HEADER_PROTOCOL_NUMBER,
-                    direction='ingress', ethertype=ethertype)
-            except neutron_client_exceptions.Conflict:
-                # It's ok if this rule already exists
-                pass
-            except Exception as e:
-                raise base.PlugVIPException(str(e))
-
-    def _update_vip_security_group(self, load_balancer, vip):
-        sec_grp = self._get_lb_security_group(load_balancer.id)
-        if not sec_grp:
-            sec_grp_name = VIP_SECURITY_GRP_PREFIX + load_balancer.id
-            sec_grp = self._create_security_group(sec_grp_name)
-        self._update_security_group_rules(load_balancer, sec_grp.get('id'))
-        self._add_vip_security_group_to_port(load_balancer.id, vip.port_id,
-                                             sec_grp.get('id'))
-
-    def _add_vip_security_group_to_port(self, load_balancer_id, port_id,
-                                        sec_grp_id=None):
-        sec_grp_id = (sec_grp_id or self._get_lb_security_group(
-            load_balancer_id).get('id'))
-        try:
-            self._add_security_group_to_port(sec_grp_id, port_id)
-        except base.PortNotFound:
-            raise
-        except base.NetworkException as e:
-            raise base.PlugVIPException(str(e))
-
-    def _delete_vip_security_group(self, sec_grp):
-        """Deletes a security group in neutron.
-
-        Retries upon an exception because removing a security group from
-        a neutron port does not happen immediately.
-        """
-        attempts = 0
-        while attempts <= CONF.networking.max_retries:
-            try:
-                self.neutron_client.delete_security_group(sec_grp)
-                LOG.info("Deleted security group %s", sec_grp)
-                return
-            except neutron_client_exceptions.NotFound:
-                LOG.info("Security group %s not found, will assume it is "
-                         "already deleted", sec_grp)
-                return
-            except Exception:
-                LOG.warning("Attempt %(attempt)s to remove security group "
-                            "%(sg)s failed.",
-                            {'attempt': attempts + 1, 'sg': sec_grp})
-            attempts += 1
-            time.sleep(CONF.networking.retry_interval)
-        message = _("All attempts to remove security group {0} have "
-                    "failed.").format(sec_grp)
-        LOG.exception(message)
-        raise base.DeallocateVIPException(message)
-
-    def _delete_security_group(self, vip, port):
-        if self.sec_grp_enabled:
-            sec_grp = self._get_lb_security_group(vip.load_balancer.id)
-            if sec_grp:
-                sec_grp_id = sec_grp.get('id')
-                LOG.info(
-                    "Removing security group %(sg)s from port %(port)s",
-                    {'sg': sec_grp_id, 'port': vip.port_id})
-                raw_port = None
-                try:
-                    if port:
-                        raw_port = self.neutron_client.show_port(port.id)
-                except Exception:
-                    LOG.warning('Unable to get port information for port '
-                                '%s. Continuing to delete the security '
-                                'group.', port.id)
-                if raw_port:
-                    sec_grps = raw_port.get(
-                        'port', {}).get('security_groups', [])
-                    if sec_grp_id in sec_grps:
-                        sec_grps.remove(sec_grp_id)
-                        port_update = {'port': {'security_groups': sec_grps}}
-                        try:
-                            self.neutron_client.update_port(port.id,
-                                                            port_update)
-                        except neutron_client_exceptions.PortNotFoundClient:
-                            LOG.warning('Unable to update port information '
-                                        'for port %s. Continuing to delete '
-                                        'the security group since port not '
-                                        'found', port.id)
-
-                try:
-                    self._delete_vip_security_group(sec_grp_id)
-                except base.DeallocateVIPException:
-                    # Try to delete any leftover ports on this security group.
-                    # Because this security group is created and managed by us,
-                    # it *should* only return ports that we own / can delete.
-                    LOG.warning('Failed to delete security group on first '
-                                'pass: %s', sec_grp_id)
-                    extra_ports = self._get_ports_by_security_group(sec_grp_id)
-                    for extra_port in extra_ports:
-                        port_id = extra_port.get('id')
-                        try:
-                            LOG.warning('Deleting extra port %s on security '
-                                        'group %s...', port_id, sec_grp_id)
-                            self.neutron_client.delete_port(port_id)
-                        except Exception:
-                            LOG.warning('Failed to delete extra port %s on '
-                                        'security group %s.',
-                                        port_id, sec_grp_id)
-                    # Now try it again
-                    self._delete_vip_security_group(sec_grp_id)
-
-    def deallocate_vip(self, vip):
-        """Delete the vrrp_port (instance port) in case nova didn't
-
-        This can happen if a failover has occurred.
-        """
-        for amphora in vip.load_balancer.amphorae:
-            try:
-                self.neutron_client.delete_port(amphora.vrrp_port_id)
-            except (neutron_client_exceptions.NotFound,
-                    neutron_client_exceptions.PortNotFoundClient):
-                LOG.debug('VIP instance port %s already deleted. Skipping.',
-                          amphora.vrrp_port_id)
-
-        try:
-            port = self.get_port(vip.port_id)
-        except base.PortNotFound:
-            LOG.warning("Can't deallocate VIP because the vip port {0} "
-                        "cannot be found in neutron. "
-                        "Continuing cleanup.".format(vip.port_id))
-            port = None
-
-        self._delete_security_group(vip, port)
-
-        if port and port.device_owner == OCTAVIA_OWNER:
-            try:
-                self.neutron_client.delete_port(vip.port_id)
-            except (neutron_client_exceptions.NotFound,
-                    neutron_client_exceptions.PortNotFoundClient):
-                LOG.debug('VIP port %s already deleted. Skipping.',
-                          vip.port_id)
-            except Exception:
-                message = _('Error deleting VIP port_id {port_id} from '
-                            'neutron').format(port_id=vip.port_id)
-                LOG.exception(message)
-                raise base.DeallocateVIPException(message)
-        elif port:
-            LOG.info("Port %s will not be deleted by Octavia as it was "
-                     "not created by Octavia.", vip.port_id)
+    def _subport_model_to_dict(self, subport):
+        return {'port_id': subport.port_id,
+                'segmentation_type': subport.segmentation_type,
+                'segmentation_id': subport.segmentation_id}
 
     def deallocate_security_group(self, vip):
         """Delete the sec group (instance port) in case nova didn't
@@ -378,331 +89,88 @@ class A10OctaviaNeutronDriver(neutron_base.BaseNeutronDriver):
 
         self._delete_security_group(vip, port)
 
-    def update_vip_sg(self, load_balancer, vip):
-        if self.sec_grp_enabled:
-            self._update_vip_security_group(load_balancer, vip)
-
-    def plug_aap_port(self, load_balancer, vip, amphora, subnet):
-        interface = self._get_plugged_interface(
-            amphora.compute_id, subnet.network_id, amphora.lb_network_ip)
-        if not interface:
-            interface = self._plug_amphora_vip(amphora, subnet)
-
-        self._add_vip_address_pair(interface.port_id, vip.ip_address)
-        if self.sec_grp_enabled:
-            self._add_vip_security_group_to_port(load_balancer.id,
-                                                 interface.port_id)
-        vrrp_ip = None
-        for fixed_ip in interface.fixed_ips:
-            is_correct_subnet = fixed_ip.subnet_id == subnet.id
-            is_management_ip = fixed_ip.ip_address == amphora.lb_network_ip
-            if is_correct_subnet and not is_management_ip:
-                vrrp_ip = fixed_ip.ip_address
-                break
-        return data_models.Amphora(
-            id=amphora.id,
-            compute_id=amphora.compute_id,
-            vrrp_ip=vrrp_ip,
-            ha_ip=vip.ip_address,
-            vrrp_port_id=interface.port_id,
-            ha_port_id=vip.port_id)
-
-    # todo (xgerman): Delete later
-    def plug_vip(self, load_balancer, vip):
-        self.update_vip_sg(load_balancer, vip)
-        plugged_amphorae = []
-        subnet = self.get_subnet(vip.subnet_id)
-        for amphora in six.moves.filter(
-            lambda amp: amp.status == constants.AMPHORA_ALLOCATED,
-                load_balancer.amphorae):
-            plugged_amphorae.append(self.plug_aap_port(load_balancer, vip,
-                                                       amphora, subnet))
-        return plugged_amphorae
-
-    def allocate_vip(self, load_balancer):
-        if load_balancer.vip.port_id:
-            LOG.info('Port %s already exists. Nothing to be done.',
-                     load_balancer.vip.port_id)
-            port = self.get_port(load_balancer.vip.port_id)
-            return self._port_to_vip(port, load_balancer)
-
-        fixed_ip = {}
-        if load_balancer.vip.subnet_id:
-            fixed_ip['subnet_id'] = load_balancer.vip.subnet_id
-        if load_balancer.vip.ip_address:
-            fixed_ip['ip_address'] = load_balancer.vip.ip_address
-
-        # Make sure we are backward compatible with older neutron
-        if self._check_extension_enabled(PROJECT_ID_ALIAS):
-            project_id_key = 'project_id'
-        else:
-            project_id_key = 'tenant_id'
-
-        # It can be assumed that network_id exists
-        port = {'port': {'name': 'octavia-lb-' + load_balancer.id,
-                         'network_id': load_balancer.vip.network_id,
-                         'admin_state_up': False,
-                         'device_id': 'lb-{0}'.format(load_balancer.id),
-                         'device_owner': OCTAVIA_OWNER,
-                         project_id_key: load_balancer.project_id}}
-
-        if fixed_ip:
-            port['port']['fixed_ips'] = [fixed_ip]
+    def allocate_trunk(self, parent_port_id):
+        payload = {"trunk": {"port_id": parent_port_id,
+                             "admin_state_up": "true"}}
         try:
+            new_trunk = self.neutron_client.create_trunk(payload)
+        except Exception:
+            message = "Error creating trunk on port "
+            "{port_id}".format(
+                port_id=parent_port_id)
+            LOG.exception(message)
+            raise exceptions.AllocateTrunkException(message)
+
+        return new_trunk
+
+    def deallocate_trunk(self, trunk_id):
+        try:
+            self.neutron_client.delete_trunk(trunk_id)
+        except Exception:
+            message = "Trunk {0} already deleted. "
+            "Skipping. ".format(trunk_id)
+            LOG.exception(message)
+            raise exceptions.DeallocateTrunkException(message)
+
+    def _build_subport_payload(self, subports):
+        payload = {'sub_ports': []}
+        for subport in subports:
+            payload['sub_ports'].append(self._subport_model_to_dict(subport))
+        return payload
+
+    def plug_trunk_subports(self, trunk_id, subports):
+        payload = self._build_subport_payload(subports)
+        updated_trunk = None
+        try:
+            updated_trunk = self.neutron_client.trunk_add_subports(trunk_id, payload)
+        except Exception:
+            message = "Error adding subports"
+            LOG.exception(message)
+
+        return updated_trunk
+
+    def unplug_trunk_subports(self, trunk_id, subports):
+        payload = self._build_subport_payload(subports)
+
+        try:
+            self.neutron_client.trunk_remove_subports(trunk_id, payload)
+        except Exception:
+            message = "Error deleting subports"
+            LOG.exception(message)
+
+    def get_plugged_parent_port(self, vip):
+        parent_port = None
+        try:
+            port = self.neutron_client.show_port(vip.port_id)
+            parent_port = self._port_to_parent_port(port.get("port"))
+        except Exception:
+            LOG.debug('Couldn\'t retrieve port with id: {}'.format(vip.port_id))
+
+        return parent_port
+
+    def create_port(self, network_id, subnet_id=None, fixed_ip=None):
+        new_port = None
+        if not subnet_id:
+            subnet_id = self.neutron_client.get_network(network_id).subnets[0]
+        try:
+            port = {'port': {'name': 'octavia-port-' + network_id,
+                             'network_id': network_id,
+                             'admin_state_up': True,
+                             'device_owner': OCTAVIA_OWNER,
+                             'fixed_ips': [{'subnet_id': subnet_id}]}}
+            if fixed_ip:
+                port['port']['fixed_ips'][0]['ip_address'] = fixed_ip
             new_port = self.neutron_client.create_port(port)
-        except Exception as e:
-            message = _('Error creating neutron port on network '
-                        '{network_id}.').format(
-                network_id=load_balancer.vip.network_id)
-            LOG.exception(message)
-            raise base.AllocateVIPException(
-                message,
-                orig_msg=getattr(e, 'message', None),
-                orig_code=getattr(e, 'status_code', None),
-            )
-        new_port = utils.convert_port_dict_to_model(new_port)
-        return self._port_to_vip(new_port, load_balancer)
-
-    def unplug_aap_port(self, vip, amphora, subnet):
-        interface = self._get_plugged_interface(
-            amphora.compute_id, subnet.network_id, amphora.lb_network_ip)
-        if not interface:
-            # Thought about raising PluggedVIPNotFound exception but
-            # then that wouldn't evaluate all amphorae, so just continue
-            LOG.debug('Cannot get amphora %s interface, skipped',
-                      amphora.compute_id)
-            return
-        try:
-            self.unplug_network(amphora.compute_id, subnet.network_id)
+            new_port = utils.convert_port_dict_to_model(new_port)
         except Exception:
-            pass
-        try:
-            aap_update = {'port': {
-                'allowed_address_pairs': []
-            }}
-            self.neutron_client.update_port(interface.port_id,
-                                            aap_update)
-        except Exception:
-            message = _('Error unplugging VIP. Could not clear '
-                        'allowed address pairs from port '
-                        '{port_id}.').format(port_id=vip.port_id)
+            message = "Error creating port in network: {0}".format(network_id)
             LOG.exception(message)
-            raise base.UnplugVIPException(message)
+            raise exceptions.PortCreationFailedException(message)
+        return new_port
 
-        # Delete the VRRP port if we created it
+    def delete_port(self, port_id):
         try:
-            port = self.get_port(amphora.vrrp_port_id)
-            if port.name.startswith('octavia-lb-vrrp-'):
-                self.neutron_client.delete_port(amphora.vrrp_port_id)
-        except (neutron_client_exceptions.NotFound,
-                neutron_client_exceptions.PortNotFoundClient):
-            pass
-        except Exception as e:
-            LOG.error('Failed to delete port.  Resources may still be in '
-                      'use for port: %(port)s due to error: %s(except)s',
-                      {'port': amphora.vrrp_port_id, 'except': e})
-
-    def unplug_vip(self, load_balancer, vip):
-        try:
-            subnet = self.get_subnet(vip.subnet_id)
-        except base.SubnetNotFound:
-            msg = ("Can't unplug vip because vip subnet {0} was not "
-                   "found").format(vip.subnet_id)
-            LOG.exception(msg)
-            raise base.PluggedVIPNotFound(msg)
-        for amphora in six.moves.filter(
-                lambda amp: amp.status == constants.AMPHORA_ALLOCATED,
-                load_balancer.amphorae):
-            self.unplug_aap_port(vip, amphora, subnet)
-
-    def plug_network(self, compute_id, network_id, ip_address=None):
-        try:
-            interface = self.compute.attach_network_or_port(
-                compute_id=compute_id, network_id=network_id,
-                ip_address=ip_address)
-        except nova_client_exceptions.NotFound as e:
-            if 'Instance' in str(e):
-                raise base.AmphoraNotFound(str(e))
-            elif 'Network' in str(e):
-                raise base.NetworkNotFound(str(e))
-            else:
-                raise base.PlugNetworkException(str(e))
+            self.neutron_client.delete_port(port_id)
         except Exception:
-            message = _('Error plugging amphora (compute_id: {compute_id}) '
-                        'into network {network_id}.').format(
-                            compute_id=compute_id,
-                            network_id=network_id)
+            message = "Error deleting port: {0}".format(port_id)
             LOG.exception(message)
-            raise base.PlugNetworkException(message)
-
-        return self._nova_interface_to_octavia_interface(compute_id, interface)
-
-    def unplug_network(self, compute_id, network_id, ip_address=None):
-        interfaces = self.get_plugged_networks(compute_id)
-        if not interfaces:
-            msg = ('Amphora with compute id {compute_id} does not have any '
-                   'plugged networks').format(compute_id=compute_id)
-            raise base.NetworkNotFound(msg)
-
-        unpluggers = self._get_interfaces_to_unplug(interfaces, network_id,
-                                                    ip_address=ip_address)
-        for index, unplugger in enumerate(unpluggers):
-            self.compute.detach_port(
-                compute_id=compute_id, port_id=unplugger.port_id)
-
-    def update_vip(self, load_balancer, for_delete=False):
-        sec_grp = self._get_lb_security_group(load_balancer.id)
-        if sec_grp:
-            self._update_security_group_rules(load_balancer, sec_grp.get('id'))
-        elif not for_delete:
-            raise exceptions.MissingVIPSecurityGroup(lb_id=load_balancer.id)
-        else:
-            LOG.warning('VIP security group missing when updating the VIP for '
-                        'delete on load balancer: {lb_id}. Skipping update '
-                        'because this is for delete.'.format(
-                            lb_id=load_balancer.id))
-
-    def failover_preparation(self, amphora):
-        if self.dns_integration_enabled:
-            self._failover_preparation(amphora)
-
-    def _failover_preparation(self, amphora):
-        interfaces = self.get_plugged_networks(compute_id=amphora.compute_id)
-
-        ports = []
-        for interface_ in interfaces:
-            port = self.get_port(port_id=interface_.port_id)
-            ips = port.fixed_ips
-            lb_network = False
-            for ip in ips:
-                if ip.ip_address == amphora.lb_network_ip:
-                    lb_network = True
-            if not lb_network:
-                ports.append(port)
-
-        for port in ports:
-            try:
-                self.neutron_client.update_port(port.id,
-                                                {'port': {'dns_name': ''}})
-
-            except (neutron_client_exceptions.NotFound,
-                    neutron_client_exceptions.PortNotFoundClient):
-                raise base.PortNotFound()
-
-    def plug_port(self, amphora, port):
-        try:
-            interface = self.compute.attach_network_or_port(
-                compute_id=amphora.compute_id, network_id=None,
-                ip_address=None, port_id=port.id)
-            plugged_interface = self._nova_interface_to_octavia_interface(
-                amphora.compute_id, interface)
-        except nova_client_exceptions.NotFound as e:
-            if 'Instance' in str(e):
-                raise base.AmphoraNotFound(str(e))
-            elif 'Network' in str(e):
-                raise base.NetworkNotFound(str(e))
-            else:
-                raise base.PlugNetworkException(str(e))
-        except nova_client_exceptions.Conflict:
-            LOG.info('Port %(portid)s is already plugged, '
-                     'skipping', {'portid': port.id})
-            plugged_interface = n_data_models.Interface(
-                compute_id=amphora.compute_id,
-                network_id=port.network_id,
-                port_id=port.id,
-                fixed_ips=port.fixed_ips)
-        except Exception:
-            message = _('Error plugging amphora (compute_id: '
-                        '{compute_id}) into port '
-                        '{port_id}.').format(
-                            compute_id=amphora.compute_id,
-                            port_id=port.id)
-            LOG.exception(message)
-            raise base.PlugNetworkException(message)
-
-        return plugged_interface
-
-    def _get_amp_net_configs(self, amp, amp_configs, vip_subnet, vip_port):
-        if amp.status != constants.DELETED:
-            LOG.debug("Retrieving network details for amphora %s", amp.id)
-            vrrp_port = self.get_port(amp.vrrp_port_id)
-            vrrp_subnet = self.get_subnet(
-                vrrp_port.get_subnet_id(amp.vrrp_ip))
-            vrrp_port.network = self.get_network(vrrp_port.network_id)
-            ha_port = self.get_port(amp.ha_port_id)
-            ha_subnet = self.get_subnet(
-                ha_port.get_subnet_id(amp.ha_ip))
-
-            amp_configs[amp.id] = n_data_models.AmphoraNetworkConfig(
-                amphora=amp,
-                vip_subnet=vip_subnet,
-                vip_port=vip_port,
-                vrrp_subnet=vrrp_subnet,
-                vrrp_port=vrrp_port,
-                ha_subnet=ha_subnet,
-                ha_port=ha_port
-            )
-
-    def get_network_configs(self, loadbalancer, amphora=None):
-        vip_subnet = self.get_subnet(loadbalancer.vip.subnet_id)
-        vip_port = self.get_port(loadbalancer.vip.port_id)
-        amp_configs = {}
-        if amphora:
-            self._get_amp_net_configs(amphora, amp_configs,
-                                      vip_subnet, vip_port)
-        else:
-            for amp in loadbalancer.amphorae:
-                self._get_amp_net_configs(amp, amp_configs,
-                                          vip_subnet, vip_port)
-        return amp_configs
-
-    def wait_for_port_detach(self, amphora):
-        """Waits for the amphora ports device_id to be unset.
-
-        This method waits for the ports on an amphora device_id
-        parameter to be '' or None which signifies that nova has
-        finished detaching the port from the instance.
-
-        :param amphora: Amphora to wait for ports to detach.
-        :returns: None
-        :raises TimeoutException: Port did not detach in interval.
-        :raises PortNotFound: Port was not found by neutron.
-        """
-        interfaces = self.get_plugged_networks(compute_id=amphora.compute_id)
-
-        ports = []
-        port_detach_timeout = CONF.networking.port_detach_timeout
-        for interface_ in interfaces:
-            port = self.get_port(port_id=interface_.port_id)
-            ips = port.fixed_ips
-            lb_network = False
-            for ip in ips:
-                if ip.ip_address == amphora.lb_network_ip:
-                    lb_network = True
-            if not lb_network:
-                ports.append(port)
-
-        for port in ports:
-            try:
-                neutron_port = self.neutron_client.show_port(
-                    port.id).get('port')
-                device_id = neutron_port['device_id']
-                start = int(time.time())
-
-                while device_id:
-                    time.sleep(CONF.networking.retry_interval)
-                    neutron_port = self.neutron_client.show_port(
-                        port.id).get('port')
-                    device_id = neutron_port['device_id']
-
-                    timed_out = int(time.time()) - start >= port_detach_timeout
-
-                    if device_id and timed_out:
-                        message = ('Port %s failed to detach (device_id %s) '
-                                   'within the required time (%s s).' %
-                                   (port.id, device_id, port_detach_timeout))
-                        raise base.TimeoutException(message)
-
-            except (neutron_client_exceptions.NotFound,
-                    neutron_client_exceptions.PortNotFoundClient):
-                pass

--- a/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
+++ b/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
@@ -18,7 +18,6 @@ from oslo_utils import uuidutils
 from stevedore import driver as stevedore_driver
 
 from neutronclient.common import exceptions as neutron_client_exceptions
-from octavia.network import base
 from octavia.network import data_models as n_data_models
 from octavia.network.drivers.neutron.allowed_address_pairs import AllowedAddressPairsDriver
 from octavia.network.drivers.neutron import utils
@@ -75,21 +74,6 @@ class A10OctaviaNeutronDriver(AllowedAddressPairsDriver):
         return {'port_id': subport.port_id,
                 'segmentation_type': subport.segmentation_type,
                 'segmentation_id': subport.segmentation_id}
-
-    def deallocate_security_group(self, vip):
-        """Delete the sec group (instance port) in case nova didn't
-
-        This can happen if a failover has occurred.
-        """
-        try:
-            port = self.get_port(vip.port_id)
-        except base.PortNotFound:
-            LOG.warning("Can't deallocate VIP because the vip port {0} "
-                        "cannot be found in neutron. "
-                        "Continuing cleanup.".format(vip.port_id))
-            port = None
-
-        self._delete_security_group(vip, port)
 
     def allocate_trunk(self, parent_port_id):
         payload = {"trunk": {"port_id": parent_port_id,


### PR DESCRIPTION
## Description
Refactored neutron driver
Added create and delete port to a10-octavia-neutron driver
Merged together code for trunking + VRID + auto ve/vlan branches - code credits - @hthompson-a10  @ssrinivasan-a10 

## Jira Ticket
[STACK-1253](https://a10networks.atlassian.net/browse/STACK-1253)
[STACK-1244](https://a10networks.atlassian.net/browse/STACK-1244)

## Technical Approach
Used allowedaddresspair as parent driver to write custom a10-octavia-neutron driver so that we can enhance the functionalities supported by the neutron driver.
Added create and delete port functions, used feature/trunking branch to add trunking solutions to the master.





## Test Cases
- Booted a vThunder with normal approach
- Booted a vThunder with rack approach
- Created a port for VRID member creation 
- Deleted a port for VRID member deletion

## Manual Testing
- Create a LB, check network driver was called
- create a LB on rack, check network driver was not called
- create a member with VRID, check create port called
- change VRID, check delete port was called 