### PR TITLE
STACK-1285 Added 4 VLANs and fixed external access issues

### DIFF
--- a/a10_octavia/contrib/scripts/a10_setup_provider_vlan_poc
+++ b/a10_octavia/contrib/scripts/a10_setup_provider_vlan_poc
@@ -6,6 +6,7 @@
 # provider-vlan-11 (vlan id:11, subnet:10.0.11.0/24)
 # provider-vlan-12 (vlan id:12, subnet:10.0.12.0/24)
 # provider-vlan-13 (vlan id:13, subnet:10.0.13.0/24)
+# provider-vlan-14 (vlan id:14, subnet:10.0.14.0/24)
 # with which openstack instances can be launched and communicate with vthunder on provider 
 # network.
 #
@@ -47,126 +48,92 @@ function host_install_packages {
     sudo apt-get install -y virt-manager
 }
 
+function add_veth_pair {
+    local interface_1="${1}"
+    local interface_2="${2}"
+    local ip_address="${3}"
+
+    local exists=$(check_exists "ip link show" "${interface_1}")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Creating veth pair ${interface_1}-${interface_2} on the host"
+        sudo ip link add ${interface_1} type veth peer name ${interface_2}
+        sudo ip link set ${interface_1} up
+        sudo ip link set ${interface_2} up
+        echo "[=] Setting ${ip_address}/24 on ${interface_1}"
+        sudo ip addr add ${ip_address}/24 dev ${interface_1}
+    fi
+}
+
+function add_tap_interface {
+    local interface="${1}"
+
+    exists=$(check_exists "ip link show" "${interface}")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Creating tap interface ${interface} on the host"
+        sudo ip tuntap add mode tap ${interface}
+    fi
+}
+
 function setup_host_networking {
-    local exists=$(check_exists "ip addr show" "veth0")
-    if [[ ${exists} -ne 1 ]]; then
-        echo "[+] Creating veth pair veth0-veth1 on the host"
-        sudo ip link add veth0 type veth peer name veth1
-        sudo ip link set veth0 up
-        sudo ip link set veth1 up
-        echo "[=] Setting 10.0.0.1/24 on veth0"
-        sudo ip addr add 10.0.0.1/24 dev veth0
-    fi
+    add_veth_pair veth0 veth1 10.0.0.1
+    add_veth_pair veth2 veth3 10.0.11.1
+    add_veth_pair veth4 veth5 10.0.12.1
+    add_veth_pair veth6 veth7 10.0.13.1
+    add_veth_pair veth8 veth9 10.0.14.1
 
-    exists=$(check_exists "ip addr show" "veth2")
-    if [[ ${exists} -ne 1 ]]; then
-        echo "[+] Creating veth pair veth2-veth3 on the host"
-        sudo ip link add veth2 type veth peer name veth3
-        sudo ip link set veth2 up
-        sudo ip link set veth3 up
-        echo "[=] Setting 10.0.11.1/24 on veth2"
-        sudo ip addr add 10.0.11.1/24 dev veth2
-    fi
+    add_tap_interface tap1
+    add_tap_interface tap2
+    add_tap_interface tap3
+    add_tap_interface tap4
 
-    exists=$(check_exists "ip addr show" "veth4")
-    if [[ ${exists} -ne 1 ]]; then
-        echo "[+] Creating veth pair veth4-veth5 on the host"
-        sudo ip link add veth4 type veth peer name veth5
-        sudo ip link set veth4 up
-        sudo ip link set veth5 up
-        echo "[=] Setting 10.0.12.1/24 on veth4"
-        sudo ip addr add 10.0.12.1/24 dev veth4
-    fi
-
-    exists=$(check_exists "ip addr show" "veth6")
-    if [[ ${exists} -ne 1 ]]; then
-        echo "[+] Creating veth pair veth6-veth7 on the host"
-        sudo ip link add veth6 type veth peer name veth7
-        sudo ip link set veth6 up
-        sudo ip link set veth7 up
-        echo "[=] Setting 10.0.13.1/24 on veth6"
-        sudo ip addr add 10.0.13.1/24 dev veth6
-    fi
-
-    exists=$(check_exists "ip addr show" "tap1")
-    if [[ ${exists} -ne 1 ]]; then
-        echo "[+] Creating tap1 on the host for vlan 11"
-        sudo ip tuntap add mode tap tap1
-    fi
-
-    exists=$(check_exists "ip addr show" "tap2")
-    if [[ ${exists} -ne 1 ]]; then
-        echo "[+] Creating tap2 on the host for vlan 12"
-        sudo ip tuntap add mode tap tap2
-    fi
-
-    exists=$(check_exists "ip addr show" "tap3")
-    if [[ ${exists} -ne 1 ]]; then
-        echo "[+] Creating tap3 on the host for vlan 13"
-        sudo ip tuntap add mode tap tap3
-    fi
-
-    pvlan_dhcp_running=$(ps -ef | grep -v grep | grep setu-vlanp-dnsmasq.pid)
+    pvlan_dhcp_running=$(ps -ef | grep -v grep | grep setup-vlanp-dnsmasq.pid)
     if [[ -z ${pvlan_dhcp_running} ]]; then
         echo "[+] Starting DHCP server for management and vlan networks" 
-        sudo dnsmasq --no-hosts --pid-file=/var/run/setup-vlanp-dnsmasq.pid --dhcp-range=interface:vnet0,10.0.0.40,10.0.0.90,72h --dhcp-range=interface:vnet2,10.0.11.40,10.0.11.90,72h --dhcp-range=interface:vnet4,10.0.12.40,10.0.12.90,72h --dhcp-range=interface:vnet6,10.0.13.40,10.0.13.90,72h --dhcp-option=19,0 --local-service --bind-dynamic --conf-file=
+        sudo dnsmasq --no-hosts --pid-file=/var/run/setup-vlanp-dnsmasq.pid --dhcp-range=interface:vnet0,10.0.0.40,10.0.0.90,72h --dhcp-range=interface:vnet2,10.0.11.40,10.0.11.90,72h --dhcp-range=interface:vnet4,10.0.12.40,10.0.12.90,72h --dhcp-range=interface:vnet6,10.0.13.40,10.0.13.90,72h --dhcp-range=interface:vnet8,10.0.14.40,10.0.14.90,72h --dhcp-option=19,0 --local-service --bind-dynamic --conf-file=
+    fi
+}
+
+function add_ovs_bridge {
+    local bridge="${1}"
+
+    local exists=$(check_exists "sudo ovs-vsctl list-br" "${bridge}")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Creating OVS bridge ${bridge}"
+        sudo ovs-vsctl add-br ${bridge}
+    fi
+}
+
+function add_port_to_bridge {
+    local bridge="${1}"
+    local port="${2}"
+    local tag="${3}"
+
+    exists=$(check_exists "sudo ovs-vsctl list-ports ${bridge}" "${port}")
+    if [[ ${exists} -ne 1 ]]; then
+        if [[ ! -z ${tag} ]]; then
+            echo "[+] Adding port ${port} to OVS bridge ${bridge} with tag ${tag}"
+            sudo ovs-vsctl add-port ${bridge} ${port} tag=${tag}
+        else
+            echo "[+] Adding port ${port} to OVS bridge ${bridge}"
+            sudo ovs-vsctl add-port ${bridge} ${port}
+        fi
     fi
 }
 
 function setup_host_ovs_bridges {
-    local exists=$(check_exists "sudo ovs-vsctl list-br" "br-mgmt")
-    if [[ ${exists} -ne 1 ]]; then
-        echo "[+] Creating OVS bridge br-mgmt"
-        sudo ovs-vsctl add-br br-mgmt
-    fi 
+    add_ovs_bridge br-mgmt
+    add_port_to_bridge br-mgmt veth1 ""
 
-    exists=$(check_exists "sudo ovs-vsctl list-ports br-mgmt" "veth1")
-    if [[ ${exists} -ne 1 ]]; then
-        echo "[+] Adding port veth1 to OVS bridge br-mgmt"
-        sudo ovs-vsctl add-port br-mgmt veth1
-    fi
+    add_ovs_bridge br-vlanp
+    add_port_to_bridge br-vlanp veth3 11
+    add_port_to_bridge br-vlanp veth5 12
+    add_port_to_bridge br-vlanp veth7 13
+    add_port_to_bridge br-vlanp veth9 14
 
-    exists=$(check_exists "sudo ovs-vsctl list-br" "br-vlanp")
-    if [[ ${exists} -ne 1 ]]; then
-        echo "[+] Creating OVS bridge br-vlanp"
-        sudo ovs-vsctl add-br br-vlanp
-    fi 
-
-    exists=$(check_exists "sudo ovs-vsctl list-ports br-vlanp" "tap1")
-    if [[ ${exists} -ne 1 ]]; then
-        echo "[+] Adding port tap1 to OVS bridge br-vlanp"
-        sudo ovs-vsctl add-port br-vlanp tap1 tag=11
-    fi
-
-    exists=$(check_exists "sudo ovs-vsctl list-ports br-vlanp" "veth3")
-    if [[ ${exists} -ne 1 ]]; then
-        echo "[+] Adding port veth3 to OVS bridge br-vlanp"
-        sudo ovs-vsctl add-port br-vlanp veth3 tag=11
-    fi
-
-    exists=$(check_exists "sudo ovs-vsctl list-ports br-vlanp" "tap2")
-    if [[ ${exists} -ne 1 ]]; then
-        echo "[+] Adding port tap2 to OVS bridge br-vlanp"
-        sudo ovs-vsctl add-port br-vlanp tap2 tag=12
-    fi
-
-    exists=$(check_exists "sudo ovs-vsctl list-ports br-vlanp" "veth5")
-    if [[ ${exists} -ne 1 ]]; then
-        echo "[+] Adding port veth5 to OVS bridge br-vlanp"
-        sudo ovs-vsctl add-port br-vlanp veth5 tag=12
-    fi
-
-    exists=$(check_exists "sudo ovs-vsctl list-ports br-vlanp" "tap3")
-    if [[ ${exists} -ne 1 ]]; then
-        echo "[+] Adding port tap3 to OVS bridge br-vlanp"
-        sudo ovs-vsctl add-port br-vlanp tap3 tag=13
-    fi
-
-    exists=$(check_exists "sudo ovs-vsctl list-ports br-vlanp" "veth7")
-    if [[ ${exists} -ne 1 ]]; then
-        echo "[+] Adding port veth7 to OVS bridge br-vlanp"
-        sudo ovs-vsctl add-port br-vlanp veth7 tag=13
-    fi
+    add_port_to_bridge br-vlanp tap1 11
+    add_port_to_bridge br-vlanp tap2 12
+    add_port_to_bridge br-vlanp tap3 13
+    add_port_to_bridge br-vlanp tap4 14
 }
 
 function patch_conf_files {
@@ -207,6 +174,12 @@ function patch_conf_files {
         echo "[=] Overwriting bridge_mappings in /etc/neutron/plugins/ml2/ml2_conf.ini"
         sed -i "s/bridge_mappings = .*/bridge_mappings = public:br-ex,provider:br-vlanp/" /etc/neutron/plugins/ml2/ml2_conf.ini
     fi
+
+    exists=$(check_exists "/bin/cat /etc/neutron/dhcp_agent.ini" "#force_metadata =")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[=] Overwriting force_metadata in /etc/neutron/dhcp_agent.ini"
+        sed -i "s/#force_metadata = .*/force_metadata = true/" /etc/neutron/dhcp_agent.ini
+    fi
 }
 
 function restart_services {
@@ -226,7 +199,7 @@ function create_network {
     exists=$(check_exists "openstack network list" "${network_name}")
     if [[ ${exists} -ne 1 ]]; then
         echo "[+] Creating ${network_name}"
-        openstack network create --provider-segment ${vlan_id} --provider-network-type vlan --provider-physical-network provider --share ${network_name}
+        openstack network create --external --provider-segment ${vlan_id} --provider-network-type vlan --provider-physical-network provider --share ${network_name}
         sleep 1
     fi
 
@@ -236,25 +209,43 @@ function create_network {
         openstack subnet create --ip-version 4 --allocation-pool ${allocation_pool} --network ${network_name} --subnet-range ${subnet_range} ${subnet_name}
         sleep 1
     fi
+
+    local snat_rule="POSTROUTING -s ${subnet_range} ! -d ${subnet_range} -j MASQUERADE"
+    exists=$(check_exists "sudo iptables-save -t nat" "${snat_rule}")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Creating SNAT rule ${snat_rule}"
+        sudo iptables -t nat -A ${snat_rule}
+    fi
 }
 
 function setup_provider_vlan {
     host_install_packages
     setup_host_networking
     setup_host_ovs_bridges
+
     patch_conf_files
     restart_services
     sleep 2
+
     create_network 11 provider-vlan-11 provider-vlan-11-subnet 10.0.11.0/24 start=10.0.11.100,end=10.0.11.200
     create_network 12 provider-vlan-12 provider-vlan-12-subnet 10.0.12.0/24 start=10.0.12.100,end=10.0.12.200
     create_network 13 provider-vlan-13 provider-vlan-13-subnet 10.0.13.0/24 start=10.0.13.100,end=10.0.13.200
+    create_network 14 provider-vlan-14 provider-vlan-14-subnet 10.0.14.0/24 start=10.0.14.100,end=10.0.14.200
 }
 
 function delete_network {
     local network_name="${1}"
     local subnet_name="${2}"
+    local subnet_range="${3}"
 
-    local exists=$(check_exists "openstack subnet list" "${subnet_name}")
+    local snat_rule="POSTROUTING -s ${subnet_range} ! -d ${subnet_range} -j MASQUERADE"
+    local exists=$(check_exists "sudo iptables-save -t nat" "${snat_rule}")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[-] Deleting SNAT rule ${snat_rule}"
+        sudo iptables -t nat -D ${snat_rule}
+    fi
+
+    exists=$(check_exists "openstack subnet list" "${subnet_name}")
     if [[ ${exists} -eq 1 ]]; then
         echo "[-] Deleting ${subnet_name}"
         openstack subnet delete ${subnet_name}
@@ -268,9 +259,10 @@ function delete_network {
 }
 
 function delete_ostack_networks {
-    delete_network provider-vlan-13 provider-vlan-13-subnet
-    delete_network provider-vlan-12 provider-vlan-12-subnet
-    delete_network provider-vlan-11 provider-vlan-11-subnet
+    delete_network provider-vlan-14 provider-vlan-14-subnet 10.0.14.0/24
+    delete_network provider-vlan-13 provider-vlan-13-subnet 10.0.13.0/24
+    delete_network provider-vlan-12 provider-vlan-12-subnet 10.0.12.0/24
+    delete_network provider-vlan-11 provider-vlan-11-subnet 10.0.11.0/24
 }
 
 function unpatch_conf_files {
@@ -317,11 +309,13 @@ function delete_ovs_bridges {
     local exists=$(check_exists "sudo ovs-vsctl list-br" "br-vlanp")
     if [[ ${exists} -eq 1 ]]; then
         echo "[-] Deleting tap ports from br-vlanp"
+        sudo ovs-vsctl del-port br-vlanp tap4
         sudo ovs-vsctl del-port br-vlanp tap3
         sudo ovs-vsctl del-port br-vlanp tap2
         sudo ovs-vsctl del-port br-vlanp tap1
 
         echo "[-] Deleting veth ports from br-vlanp"
+        sudo ovs-vsctl del-port br-vlanp veth9
         sudo ovs-vsctl del-port br-vlanp veth7
         sudo ovs-vsctl del-port br-vlanp veth5
         sudo ovs-vsctl del-port br-vlanp veth3
@@ -340,6 +334,26 @@ function delete_ovs_bridges {
     fi
 }
 
+function delete_veth_pair {
+    local interface="${1}"
+
+    exists=$(check_exists "ip link show" "${interface}")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[-] Deleting ${interface} veth pair"
+        sudo ip link del ${interface}
+    fi
+}
+
+function delete_tap_interface {
+    local interface="${1}"
+
+    exists=$(check_exists "ip link show" "${interface}")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[-] Deleting ${interface} interface"
+        sudo ip tuntap del mode tap ${interface}
+    fi
+}
+
 function delete_host_tap_and_veth_interfaces {
     local pvlan_dhcp_pid=$(ps -ef | grep -v grep | grep setup-vlanp-dnsmasq.pid | awk '{print $2}')
     if [[ -n ${pvlan_dhcp_pid} ]]; then
@@ -348,47 +362,16 @@ function delete_host_tap_and_veth_interfaces {
         sudo rm -f /var/run/setup-vlanp-dnsmasq.pid
     fi
 
-    local exists=$(check_exists "ip addr show" "tap3")
-    if [[ ${exists} -eq 1 ]]; then
-        echo "[-] Deleting interface tap3"
-        sudo ip tuntap del mode tap tap3
-    fi
+    delete_veth_pair veth0
+    delete_veth_pair veth2
+    delete_veth_pair veth4
+    delete_veth_pair veth6
+    delete_veth_pair veth8
 
-    exists=$(check_exists "ip addr show" "tap2")
-    if [[ ${exists} -eq 1 ]]; then
-        echo "[-] Deleting interface tap2"
-        sudo ip tuntap del mode tap tap2
-    fi
-
-    exists=$(check_exists "ip addr show" "tap1")
-    if [[ ${exists} -eq 1 ]]; then
-        echo "[-] Deleting interface tap1"
-        sudo ip tuntap del mode tap tap1
-    fi
-
-    exists=$(check_exists "ip addr show" "veth0")
-    if [[ ${exists} -eq 1 ]]; then
-        echo "[-] Deleting veth0 veth pair"
-        sudo ip link del veth0
-    fi
-
-    exists=$(check_exists "ip addr show" "veth2")
-    if [[ ${exists} -eq 1 ]]; then
-        echo "[-] Deleting veth2 veth pair"
-        sudo ip link del veth2
-    fi
-
-    exists=$(check_exists "ip addr show" "veth4")
-    if [[ ${exists} -eq 1 ]]; then
-        echo "[-] Deleting veth4 veth pair"
-        sudo ip link del veth4
-    fi
-
-    exists=$(check_exists "ip addr show" "veth6")
-    if [[ ${exists} -eq 1 ]]; then
-        echo "[-] Deleting veth6 veth pair"
-        sudo ip link del veth6
-    fi
+    delete_tap_interface tap4
+    delete_tap_interface tap3
+    delete_tap_interface tap2
+    delete_tap_interface tap1
 }
 
 function teardown_provider_vlan {


### PR DESCRIPTION
## Description

Severity Level: Low

1) The client and server instances launched in openstack VLAN subnets do not have external connectivity.
2) There are two different DHCP running for single VLAN subnet, one neutron DHCP for openstack instances and other for VMs outside openstack present in the same VLAN. Check if outside VMs can use the neutron DHCP.
3) Four VLANs are required for simultaneously sending traffic to two partitions with 2 arm mode.

## Jira Ticket

https://a10networks.atlassian.net/browse/STACK-1285

## Technical Approach

1) Made the openstack VLAN networks external and added the SNAT rules on the host device for the external access from the instances launched in openstack VLAN subnets.

2) We cannot use neutron DHCP server for VMs outside openstack as the neutron DHCP server configuration is hardcoded to be static and not allocate dynamic IP addresses. So retaining the current mechanism.

## Manual Testing

1) Launched instances in openstack and checked connectivity.
2) Launched vThunder outside openstack and checked connectivity.