### PR TITLE
STACK-1273: Added support to use listener port to create and update hm port

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
@@ -105,7 +105,7 @@ class HealthMonitorFlows(object):
             provides=a10constants.VTHUNDER))
         update_hm_flow.add(health_monitor_tasks.UpdateHealthMonitor(
             requires=[constants.LISTENERS, constants.HEALTH_MON,
-                a10constants.VTHUNDER, constants.UPDATE_DICT]))
+                      a10constants.VTHUNDER, constants.UPDATE_DICT]))
         update_hm_flow.add(database_tasks.UpdateHealthMonInDB(
             requires=[constants.HEALTH_MON, constants.UPDATE_DICT]))
         update_hm_flow.add(database_tasks.MarkHealthMonitorActiveInDB(

--- a/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
@@ -43,7 +43,7 @@ class HealthMonitorFlows(object):
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
         create_hm_flow.add(health_monitor_tasks.CreateAndAssociateHealthMonitor(
-            requires=[constants.HEALTH_MON, a10constants.VTHUNDER]))
+            requires=[constants.LISTENERS, constants.HEALTH_MON, a10constants.VTHUNDER]))
         create_hm_flow.add(database_tasks.MarkHealthMonitorActiveInDB(
             requires=constants.HEALTH_MON))
         create_hm_flow.add(database_tasks.MarkPoolActiveInDB(
@@ -104,7 +104,8 @@ class HealthMonitorFlows(object):
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
         update_hm_flow.add(health_monitor_tasks.UpdateHealthMonitor(
-            requires=[constants.HEALTH_MON, a10constants.VTHUNDER, constants.UPDATE_DICT]))
+            requires=[constants.LISTENERS, constants.HEALTH_MON,
+                a10constants.VTHUNDER, constants.UPDATE_DICT]))
         update_hm_flow.add(database_tasks.UpdateHealthMonInDB(
             requires=[constants.HEALTH_MON, constants.UPDATE_DICT]))
         update_hm_flow.add(database_tasks.MarkHealthMonitorActiveInDB(

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -30,22 +30,26 @@ class CreateAndAssociateHealthMonitor(task.Task):
     """Task to create a healthmonitor and associate it with provided pool."""
 
     @axapi_client_decorator
-    def execute(self, health_mon, vthunder):
+    def execute(self, listeners, health_mon, vthunder):
         method = None
         url = None
         expect_code = None
+
         if health_mon.type in a10constants.HTTP_TYPE:
             method = health_mon.http_method
             url = health_mon.url_path
             expect_code = health_mon.expected_codes
         args = utils.meta(health_mon, 'hm', {})
 
+        if listeners:
+            listener_port = listeners[0].protocol_port
         try:
             self.axapi_client.slb.hm.create(health_mon.id[0:5],
                                             openstack_mappings.hm_type(self.axapi_client,
-                                            health_mon.type),
+                                                                       health_mon.type),
                                             health_mon.delay, health_mon.timeout,
-                                            health_mon.rise_threshold, method=method, url=url,
+                                            health_mon.rise_threshold, method=method,
+                                            port=listener_port, url=url,
                                             expect_code=expect_code, axapi_args=args)
             LOG.debug("Health Monitor created successfully: %s", health_mon.id)
         except Exception as e:
@@ -87,7 +91,7 @@ class UpdateHealthMonitor(task.Task):
     """Task to update Health Monitor"""
 
     @axapi_client_decorator
-    def execute(self, health_mon, vthunder, update_dict):
+    def execute(self, listeners, health_mon, vthunder, update_dict):
         """ Execute update health monitor """
         # TODO(hthompson6) Length of name of healthmonitor for older vThunder devices
         health_mon.__dict__.update(update_dict)
@@ -99,12 +103,15 @@ class UpdateHealthMonitor(task.Task):
             url = health_mon.url_path
             expect_code = health_mon.expected_codes
         args = utils.meta(health_mon, 'hm', {})
+        if listeners:
+            listener_port = listeners[0].protocol_port
         try:
             self.axapi_client.slb.hm.update(
                 health_mon.id[0:5],
                 openstack_mappings.hm_type(self.axapi_client, health_mon.type),
                 health_mon.delay, health_mon.timeout, health_mon.rise_threshold,
-                method=method, url=url, expect_code=expect_code, axapi_args=args)
+                method=method, url=url, expect_code=expect_code,
+                port=listener_port, axapi_args=args)
             LOG.debug("Health Monitor updated successfully: %s", health_mon.id)
         except Exception as e:
             LOG.exception("Failed to update Health Monitor: %s", str(e))

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -41,15 +41,13 @@ class CreateAndAssociateHealthMonitor(task.Task):
             expect_code = health_mon.expected_codes
         args = utils.meta(health_mon, 'hm', {})
 
-        if listeners:
-            listener_port = listeners[0].protocol_port
         try:
             self.axapi_client.slb.hm.create(health_mon.id[0:5],
                                             openstack_mappings.hm_type(self.axapi_client,
                                                                        health_mon.type),
                                             health_mon.delay, health_mon.timeout,
                                             health_mon.rise_threshold, method=method,
-                                            port=listener_port, url=url,
+                                            port=listeners[0].protocol_port, url=url,
                                             expect_code=expect_code, axapi_args=args)
             LOG.debug("Health Monitor created successfully: %s", health_mon.id)
         except Exception as e:
@@ -103,15 +101,13 @@ class UpdateHealthMonitor(task.Task):
             url = health_mon.url_path
             expect_code = health_mon.expected_codes
         args = utils.meta(health_mon, 'hm', {})
-        if listeners:
-            listener_port = listeners[0].protocol_port
         try:
             self.axapi_client.slb.hm.update(
                 health_mon.id[0:5],
                 openstack_mappings.hm_type(self.axapi_client, health_mon.type),
                 health_mon.delay, health_mon.timeout, health_mon.rise_threshold,
                 method=method, url=url, expect_code=expect_code,
-                port=listener_port, axapi_args=args)
+                port=listeners[0].protocol_port, axapi_args=args)
             LOG.debug("Health Monitor updated successfully: %s", health_mon.id)
         except Exception as e:
             LOG.exception("Failed to update Health Monitor: %s", str(e))


### PR DESCRIPTION
## Description
- Severity Level : **Low**
- We don't use the listener port to create and update the health monitor port. We just use the hardcoding from acos-client.

## Jira Ticket
[STACK-1273](https://a10networks.atlassian.net/browse/STACK-1273)

## Technical Approach
- Added param `port` taken from `listeners[0].protocol_port` to `hm.create` and `hm.update` method.

## Manual Testing
a) Add a LB, a LISTENER and a POOL

```
openstack loadbalancer create --vip-subnet-id 6cf85683-6f16-4bf6-8570-18e114e44f90 --name SLB1
openstack loadbalancer listener create SLB1 --name L1 --protocol HTTP --protocol-port 8001
openstack loadbalancer pool create --protocol HTTP --lb-algorithm SOURCE_IP --listener L1 --name P1
```
b) Add a HM associated with that POOL.

   i) for create
`openstack loadbalancer healthmonitor create --name HM1 --delay 5 --timeout 3 --max-retries 3 --type HTTP P1`
    Output : 

```
health monitor 51a39
  override-port 8001
  interval 5 timeout 3
  method http port 80 expect response-code 201 url GET /

```
 ii) for update

`openstack loadbalancer healthmonitor set --timeout 4 --http-method HEAD HM1`
   Output: 
```
health monitor 51a39
  override-port 8001
  interval 5 timeout 4
  method http port 8001 expect response-code 201 url HEAD /
```
