### PR TITLE
[Stack 1315, 1316] : Convert VThunder dm into generic and make HardwareThunder dm inherit.

### DIFF
--- a/a10_octavia/common/data_models.py
+++ b/a10_octavia/common/data_models.py
@@ -164,7 +164,7 @@ class Thunder(BaseDataModel):
 class HardwareThunder(Thunder):
     def __init__(self, device_network_map=None, **kwargs):
         Thunder.__init__(self, **kwargs)
-        self.device_netork_map = device_netork_map
+        self.device_network_map = device_network_map
 
 
 class VThunder(Thunder):

--- a/a10_octavia/common/data_models.py
+++ b/a10_octavia/common/data_models.py
@@ -130,7 +130,7 @@ class BaseDataModel(object):
             setattr(self, key, value)
 
 
-class VThunder(BaseDataModel):
+class Thunder(BaseDataModel):
 
     def __init__(self, id=None, vthunder_id=None, amphora_id=None,
                  device_name=None, ip_address=None, username=None,
@@ -138,7 +138,7 @@ class VThunder(BaseDataModel):
                  loadbalancer_id=None, project_id=None, compute_id=None,
                  topology="STANDALONE", role="MASTER", last_udp_update=None, status="ACTIVE",
                  created_at=datetime.utcnow(), updated_at=datetime.utcnow(), partition_name=None,
-                 hierarchical_multitenancy=None, interface_vlan_map=None):
+                 hierarchical_multitenancy=None):
         self.id = id
         self.vthunder_id = vthunder_id
         self.amphora_id = amphora_id
@@ -159,7 +159,17 @@ class VThunder(BaseDataModel):
         self.updated_at = updated_at
         self.partition_name = partition_name
         self.hierarchical_multitenancy = hierarchical_multitenancy
-        self.interface_vlan_map = interface_vlan_map
+
+
+class HardwareThunder(Thunder):
+    def __init__(self, device_network_map=None, **kwargs):
+        Thunder.__init__(self, **kwargs)
+        self.device_netork_map = device_netork_map
+
+
+class VThunder(Thunder):
+    def __init__(self, **kwargs):
+        Thunder.__init__(self, **kwargs)
 
 
 class Certificate(BaseDataModel):

--- a/a10_octavia/tests/unit/common/test_utils.py
+++ b/a10_octavia/tests/unit/common/test_utils.py
@@ -54,12 +54,12 @@ DUP_PARTITION_HARDWARE_INFO = {
     'username': 'abc',
     'password': 'abc'}
 
-VTHUNDER_1 = data_models.VThunder(project_id="project-1", device_name="rack_thunder_1",
-                                  undercloud=True, username="abc", password="abc",
-                                  ip_address="10.10.10.10", partition_name="shared")
-VTHUNDER_2 = data_models.VThunder(project_id="project-2", device_name="rack_thunder_2",
-                                  undercloud=True, username="def", password="def",
-                                  ip_address="12.12.12.12", partition_name="def-sample")
+VTHUNDER_1 = data_models.HardwareThunder(project_id="project-1", device_name="rack_thunder_1",
+                                         undercloud=True, username="abc", password="abc",
+                                         ip_address="10.10.10.10", partition_name="shared")
+VTHUNDER_2 = data_models.HardwareThunder(project_id="project-2", device_name="rack_thunder_2",
+                                         undercloud=True, username="def", password="def",
+                                         ip_address="12.12.12.12", partition_name="def-sample")
 
 DUPLICATE_DICT = {'project_1': VTHUNDER_1,
                   'project_2': VTHUNDER_1}


### PR DESCRIPTION
## Description
- Made the existing `VThunder` datamodel a generic `Thunder`. Have `HardwareThunder` and `VThunder` inherit from it.
- Added device_network_map into HardwareThunder.

## Jira Ticket
[STACK-1315](https://a10networks.atlassian.net/browse/STACK-1315)
[STACK-1316](https://a10networks.atlassian.net/browse/STACK-1316)

## Technical Approach
- Convert existing `VThunder` datamodel to `Thunder` and create two extra datamodels like `HardwareThunder`  and `VThunder` inheriting the above `Thunder`.
- Add  `device_network_map` param in `HardwareThunder` model.
- Also modified the UT related to accessing this new `HardwareThunder` instead of existing `VThunder`

## Config Changes
None

## Test Cases
- Check if using new HardwareThunder data_model usage doesn't break the existing UTs.

## Manual Testing
- None
