### PR TITLE
[STACK-1300, 1302, 1324]: Refactored `interface_vlan_map` config section

### DIFF
--- a/a10_octavia/common/data_models.py
+++ b/a10_octavia/common/data_models.py
@@ -164,7 +164,7 @@ class Thunder(BaseDataModel):
 class HardwareThunder(Thunder):
     def __init__(self, device_network_map=None, **kwargs):
         Thunder.__init__(self, **kwargs)
-        self.device_network_map = device_network_map
+        self.device_network_map = device_network_map or []
 
 
 class VThunder(Thunder):

--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -13,6 +13,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from oslo_config import cfg
+
 from octavia.common import exceptions
 from octavia.i18n import _
 from octavia.network import base
@@ -32,3 +34,46 @@ class DeallocateTrunkException(base.NetworkException):
 
 class AllocateTrunkException(base.NetworkException):
     pass
+
+
+class MissingVlanIDConfigError(cfg.ConfigFileValueError):
+
+    def __init__(self, interface_num):
+        msg = ('Missing `vlan_id` attribute for `interface_num` {0} ' +
+               ' in `interface_vlan_map` under ' +
+               '[hardware_thunder] section.').format(interface_num)
+        super(MissingVlanIDConfigError, self).__init__(msg=msg)
+
+
+class DuplicateVlanTagsConfigError(cfg.ConfigFileValueError):
+
+    def __init__(self, interface_num, vlan_id):
+        msg = ('Duplicate `vlan_tags` entry of `vlan_id` {0} ' +
+               'found for `interface_num` {1} in `interface_vlan_map` under ' +
+               '[hardware_thunder] section.').format(vlan_id, interface_num)
+        super(DuplicateVlanTagsConfigError, self).__init__(msg=msg)
+
+
+class MissingInterfaceNumConfigError(cfg.ConfigFileValueError):
+
+    def __init__(self):
+        msg = ('Missing `interface_num` in `interface_vlan_map` under [hardware_thunder] section.')
+        super(MissingInterfaceNumConfigError, self).__init__(msg=msg)
+
+
+class VirtEthCollisionConfigError(cfg.ConfigFileValueError):
+
+    def __init__(self, interface_num, vlan_id):
+        msg = ('Check settings for `vlan_id` {0} of `interface_num` {1}. ' +
+               'Please set `use_dhcp` to False ' +
+               'before setting the `ve_ip`').format(vlan_id, interface_num)
+        super(VirtEthCollisionConfigError, self).__init__(msg=msg)
+
+
+class VirtEthMissingConfigError(cfg.ConfigFileValueError):
+
+    def __init__(self, interface_num, vlan_id):
+        msg = ('Check settings for `vlan_id` {0} of `interface_num` {1}. ' +
+               'Missing `use_dhcp` and `ve_ip` in config. ' +
+               'Please provide either.').format(vlan_id, interface_num)
+        super(VirtEthMissingConfigError, self).__init__(msg=msg)

--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -30,6 +30,7 @@ from stevedore import driver as stevedore_driver
 
 from a10_octavia.common import a10constants
 from a10_octavia.common import data_models
+from a10_octavia.common import exceptions
 
 LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
@@ -97,7 +98,7 @@ def convert_to_hardware_thunder_conf(hardware_list):
                                            ' in [hardware_thunder] section')
         hardware_device['undercloud'] = True
         if hardware_device.get('interface_vlan_map'):
-            hardware_device = validate_interface_vlan_map(hardware_device)
+            hardware_device['device_network_map'] = validate_interface_vlan_map(hardware_device)
             del hardware_device['interface_vlan_map']
         vthunder_conf = data_models.HardwareThunder(**hardware_device)
         hardware_dict[hardware_device['project_id']] = vthunder_conf
@@ -160,76 +161,44 @@ def get_network_driver():
     return network_driver
 
 
-def validate_interface_object(interface):
-    tags = []
-    ve_ips = []
-    new_interface_obj = {}
-    if not interface.get('interface_num'):
-        raise cfg.ConfigFileValueError(
-            'Missing `interface_num` in `interface_vlan_map` under [hardware_thunder] section.')
-    if interface.get('vlan_tags'):
-        for vlan_tag in interface.get('vlan_tags'):
-            if not vlan_tag.get('vlan_id'):
-                raise cfg.ConfigFileValueError('Missing `vlan_id` for `interface_num` ' +
-                                               str(interface.get('interface_num')) +
-                                               ' in `interface_vlan_map` under ' +
-                                               '[hardware_thunder] section.')
-            if vlan_tag.get('vlan_id') and vlan_tag.get('vlan_id') in tags:
-                raise cfg.ConfigFileValueError('Duplicate `vlan_tags` entry for `vlan_id` '
-                                               + str(vlan_tag.get('vlan_id')) +
-                                               ' found for `interface_num` '
-                                               + str(interface.get('interface_num')) +
-                                               ' in `interface_vlan_map` under ' +
-                                               '[hardware_thunder] section.')
-            tags.append(vlan_tag.get('vlan_id'))
-            ve_ips.append(validate_ve_ips(vlan_tag))
-    new_interface_obj['interface_num'] = interface.get('interface_num')
-    new_interface_obj['tags'] = tags
-    new_interface_obj['ve_ips'] = ve_ips
-    return data_models.Interface(**new_interface_obj)
+def convert_interface_to_data_model(interface_obj):
+    vlan_map_list = interface_obj.get('vlan_map_list')
+    interface_num = interface_obj.get('interface_num')
+    interface_dm = data_models.Interface()
+    if not interface_num:
+        raise exceptions.MissingInterfaceNumConfigError()
+    if not vlan_map_list:
+        LOG.warning("Empty vlan map provided in configuration file")
+    for vlan_map in vlan_map_list:
+        vlan_id = vlan_map.get('vlan_id')
+        if not vlan_id:
+            raise exceptions.MissingVlanIDConfigError(interface_num)
+        if vlan_id in interface_dm.tags:
+            raise exceptions.DuplicateVlanTagsConfigError(interface_num, vlan_id)
+        if vlan_map.get('use_dhcp'):
+            if vlan_map.get('ve_ip'):
+                raise exceptions.VirtEthCollisionConfigError(interface_num, vlan_id)
+            else:
+                interface_dm.ve_ips.append('dhcp')
+        else:
+            if not vlan_map.get('ve_ip'):
+                raise exceptions.VirtEthMissingConfigError(interface_num, vlan_id)
+            interface_dm.ve_ips.append(validate_partial_ipv4(vlan_map.get('ve_ip')))
+        interface_dm.tags.append(vlan_id)
+    interface_dm.interface_num = interface_num
 
-
-def validate_ve_ips(vlan_tag):
-    if vlan_tag.get('use_dhcp') and vlan_tag.get('ve_ip'):
-        raise cfg.ConfigFileValueError('Check settings for `vlan_id` ' +
-                                       str(vlan_tag.get('vlan_id')) +
-                                       '. Please do not set `ve_ip` in `interface_vlan_map`' +
-                                       ' when `use_dhcp` is True')
-        if not vlan_tag.get('use_dhcp'):
-            if not vlan_tag.get('ve_ip'):
-                raise cfg.ConfigFileValueError('Check settings for `vlan_id` ' +
-                                               str(vlan_tag.get('vlan_id')) +
-                                               '. Please set valid `ve_ip` in ' +
-                                               '`interface_vlan_map` when `use_dhcp` is False')
-            validate_partial_ipv4(vlan_tag.get('ve_ip'))
-    elif not vlan_tag.get('use_dhcp') and not vlan_tag.get('ve_ip'):
-        raise cfg.ConfigFileValueError('Missing both `use_dhcp` and `ve_ip` in config' +
-                                       ' for `vlan_id` ' + str(vlan_tag.get('vlan_id')) +
-                                       ' in `interface_vlan_map` ' +
-                                       'under [hardware_thunder] section. ' +
-                                       'Please provide either of them.')
-    if vlan_tag.get('use_dhcp'):
-        return 'dhcp'
-    else:
-        return vlan_tag.get('ve_ip')
+    return interface_dm
 
 
 def validate_interface_vlan_map(hardware_device):
-    ivmap = hardware_device.get('interface_vlan_map')
     device_network_map = []
-    interface_map = {}
-    eth_list = []
-    trunk_list = []
-    for device, device_obj in ivmap.items():
+    for device_id, device_obj in hardware_device.get('interface_vlan_map').items():
+        device_map = data_models.DeviceNetworkMap(device_id)
         if device_obj.get('ethernet_interfaces'):
             for eth in device_obj.get('ethernet_interfaces'):
-                eth_list.append(validate_interface_object(eth))
+                device_map.ethernet_interfaces.append(convert_interface_to_data_model(eth))
         if device_obj.get('trunk_interfaces'):
-            for eth in device_obj.get('trunk_interfaces'):
-                trunk_list.append(validate_interface_object(eth))
-        interface_map['device_id'] = device[-1]
-        interface_map['ethernet_interfaces'] = eth_list
-        interface_map['trunk_interfaces'] = trunk_list
-        device_network_map.append(data_models.DeviceNetworkMap(**interface_map))
-    hardware_device['device_network_map'] = device_network_map
-    return hardware_device
+            for trunk in device_obj.get('trunk_interfaces'):
+                device_map.trunk_interfaces.append(convert_interface_to_data_model(trunk))
+        device_network_map.append(device_map)
+    return device_network_map

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -475,7 +475,7 @@ class TagEthernetBaseTask(VThunderBaseTask):
                 for device_obj in vthunder_conf.device_network_map:
                     for eth_interface in device_obj.ethernet_interfaces:
                         ifnum = eth_interface.interface_num
-                        for tag, ve_ip in list(zip(eth_interface.tags, eth_interface.ve_ips)):
+                        for tag, ve_ip in zip(eth_interface.tags, eth_interface.ve_ips):
                             self.tag_interface(create_vlan_id, str(tag), str(ifnum),
                                                ve_ip, vlan_subnet_id_dict)
 


### PR DESCRIPTION
## Description
- Modify utility for validating the json struct in `utils.py` and return `DeviceNetworkMap` data model as value
- Refactor `tag_interfaces` method to use new `interface_network_map`.
- Create a utility function to parse the json and return a network map dict with project_id is key and DeviceNetworkMap data model as value


## Jira Ticket
[STACK-1300](https://a10networks.atlassian.net/browse/STACK-1300)
[STACK-1302](https://a10networks.atlassian.net/browse/STACK-1302)
[STACK-1324](https://a10networks.atlassian.net/browse/STACK-1324)

## Technical Approach
- Modified utils.py to parse `interface_vlan_map` from `[hardware_thunder]` 's `devices` config.
- Added validations for throwing error where ever, invalid config is provided.
- Using parsed data and converting it to respective data_models(`Interface` and `DeviceNetworkMap`) and passing it to our main `HardwareThunder` model correctly.
- Refactored the code which uses `CONF.hardware_thunder.device_network_map` to use the modified version of data models config.


## Config Changes
<pre>
[hardware_thunder]

devices=[
 {
 "project_id": "fake_uuid",
 "username" : "username",
 "password" : "password",
 "ip_address" : "10.43.12.137",
 "device_name" : "rack_1"
 <b>""interface_vlan_map": {
        "device_1": {
                "ethernet_interfaces": [
                        {"interface_num": 1,
                                "vlan_map_list": [
                                        { "vlan_id": 11, "use_dhcp": True},
                                        {"vlan_id": 12, "use_dhcp": True},
                                        {"vlan_id": 11, "ve_ip": "10.20"}]
                        },
                        {"interface_num": 1,
                                "vlan_map_list": [
                                        {"vlan_id": 11, "use_dhcp": True},
                                        {"vlan_id": 12, "use_dhcp": True},
                                        {"vlan_id": 13, "ve_ip": "10.20"}]
                        },
                        {"interface_num": 3,
                                "vlan_map_list": [
                                        {"vlan_id": 11, "use_dhcp": True},
                                        {"vlan_id": 12, "use_dhcp": True},
                                        {"vlan_id": 13, "ve_ip": "10.20"}]
            }]}
</b>
 }
 }]
</pre>

## Test Cases
- `interface_num` is required param. If not provided, error is thrown.
- if for an `interface_num`, no `vlan_id` is given, error is thrown.
- For given `vlan_id` , missing `interface_num`  will throw Error.
- For given `vlan_id` and given `use_dhcp` or `ve_ip` , missing `interface_num` will throw Error.
- For given `vlan_id`, not providing any of  `use_dhcp`  and `ve_ip` will throw Error.
- If  `ve_ip` is given along with `use_dhcp` as True, error will be thrown.
- `ve_ip` accepts partial ips.
- Duplicate `vlan_id` within a `interface_num` is considered invalid and thrown error.

## Limitations
- At config level, it is difficult to figure out duplicacy in partial like -> `.10` and `10`. This should be invalid if provided to different `vlan_id`
- Scenarios for duplicate 'device_id' is not handled right now. The config accepts it as valid. We will resolve it in future or during PR review.

## Manual Testing
- Used `pdb` to check the `CONF.hardware_thunder.devices` is valid and has everything placed rightly where they are supposed to be.
