### PR TITLE
[STACK-1303, 1306]: VE VLAN Trunking Support

### DIFF
--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -53,6 +53,7 @@ def validate_partial_ipv4(address):
     if not netaddr.valid_ipv4('.'.join(octets), netaddr.core.INET_PTON):
         raise cfg.ConfigFileValueError('Invalid partial IPAddress value given'
                                        ' in configuration: {0}'.format(address))
+    return address
 
 
 def validate_partition(hardware_device):
@@ -162,7 +163,7 @@ def get_network_driver():
 
 
 def convert_interface_to_data_model(interface_obj):
-    vlan_map_list = interface_obj.get('vlan_map_list')
+    vlan_map_list = interface_obj.get('vlan_map')
     interface_num = interface_obj.get('interface_num')
     interface_dm = data_models.Interface()
     if not interface_num:

--- a/a10_octavia/contrib/scripts/a10_setup_provider_vlan_poc
+++ b/a10_octavia/contrib/scripts/a10_setup_provider_vlan_poc
@@ -139,10 +139,10 @@ function setup_host_ovs_bridges {
 function patch_conf_files {
     echo "[+] Patching config files"
 
-    exists=$(check_exists "/bin/cat /etc/neutron/neutron.conf" "service_plugins = router,qos")
+    exists=$(check_exists "/bin/cat /etc/neutron/neutron.conf" "service_plugins = neutron.services.l3_router.l3_router_plugin.L3RouterPlugin")
     if [[ ${exists} -eq 1 ]]; then
         echo "[=] Overwriting service_plugins in /etc/neutron/neutron.conf"
-        sed -i "s/service_plugins = router,qos/service_plugins = /" /etc/neutron/neutron.conf
+        sed -i "s/service_plugins = .*/service_plugins = /" /etc/neutron/neutron.conf
     fi
 
     exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "#type_drivers =")
@@ -163,10 +163,10 @@ function patch_conf_files {
         sed -i "s/tenant_network_types = .*/tenant_network_types = /" /etc/neutron/plugins/ml2/ml2_conf.ini
     fi
 
-    exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "#network_vlan_ranges =")
+    exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "network_vlan_ranges = public")
     if [[ ${exists} -eq 1 ]]; then
         echo "[=] Overwriting network_vlan_ranges /etc/neutron/plugins/ml2/ml2_conf.ini"
-        sed -i "s/#network_vlan_ranges =/network_vlan_ranges = provider/" /etc/neutron/plugins/ml2/ml2_conf.ini
+        sed -i "s/network_vlan_ranges = .*/network_vlan_ranges = provider/" /etc/neutron/plugins/ml2/ml2_conf.ini
     fi
 
     exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "provider:br-vlanp")
@@ -185,7 +185,7 @@ function patch_conf_files {
 function restart_services {
     echo "[=] Restarting devstack@neutron-* services"
     pushd /etc/systemd/system/
-    sudo systemctl restart devstack@neutron-*
+    sudo systemctl restart devstack@q-*
     popd
 }
 
@@ -268,10 +268,10 @@ function delete_ostack_networks {
 function unpatch_conf_files {
     echo "[-] Removing vlan patch in config files"
 
-    local exists=$(check_exists "/bin/cat /etc/neutron/neutron.conf" "service_plugins = router,qos")
+    local exists=$(check_exists "/bin/cat /etc/neutron/neutron.conf" "service_plugins = neutron.services.l3_router.l3_router_plugin.L3RouterPlugin")
     if [[ ${exists} -ne 1 ]]; then
         echo "[=] Overwriting service_plugins in /etc/neutron/neutron.conf"
-        sed -i "s/service_plugins =/service_plugins = router,qos/" /etc/neutron/neutron.conf
+        sed -i "s/service_plugins =/service_plugins = neutron.services.l3_router.l3_router_plugin.L3RouterPlugin/" /etc/neutron/neutron.conf
     fi
 
     exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "type_drivers = flat,vlan")
@@ -295,7 +295,7 @@ function unpatch_conf_files {
     exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "network_vlan_ranges = provider")
     if [[ ${exists} -eq 1 ]]; then
         echo "[=] Overwriting network_vlan_ranges /etc/neutron/plugins/ml2/ml2_conf.ini"
-        sed -i "s/network_vlan_ranges = provider/#network_vlan_ranges =/" /etc/neutron/plugins/ml2/ml2_conf.ini
+        sed -i "s/network_vlan_ranges = provider/network_vlan_ranges = public/" /etc/neutron/plugins/ml2/ml2_conf.ini
     fi
 
     exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "provider:br-vlanp")

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -180,7 +180,7 @@ class LoadBalancerFlows(object):
         delete_LB_flow.add(virtual_server_tasks.DeleteVirtualServerTask(
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER)))
         if CONF.a10_global.network_type == 'vlan':
-            delete_LB_flow.add(vthunder_tasks.DeleteEthernetTagIfNotInUseForLB(
+            delete_LB_flow.add(vthunder_tasks.DeleteInterfaceTagIfNotInUseForLB(
                 requires=[constants.LOADBALANCER,
                           a10constants.VTHUNDER]))
 
@@ -286,7 +286,7 @@ class LoadBalancerFlows(object):
         update_LB_flow.add(database_tasks.UpdateLoadbalancerInDB(
             requires=[constants.LOADBALANCER, constants.UPDATE_DICT]))
         if CONF.a10_global.network_type == 'vlan':
-            update_LB_flow.add(vthunder_tasks.TagEthernetForLB(
+            update_LB_flow.add(vthunder_tasks.TagInterfaceForLB(
                 requires=[constants.LOADBALANCER,
                           a10constants.VTHUNDER]))
         update_LB_flow.add(database_tasks.MarkLBActiveInDB(
@@ -334,7 +334,7 @@ class LoadBalancerFlows(object):
         post_create_lb_flow.add(database_tasks.UpdateLoadbalancerInDB(
             requires=[constants.LOADBALANCER, constants.UPDATE_DICT]))
         if CONF.a10_global.network_type == 'vlan':
-            post_create_lb_flow.add(vthunder_tasks.TagEthernetForLB(
+            post_create_lb_flow.add(vthunder_tasks.TagInterfaceForLB(
                 requires=[constants.LOADBALANCER,
                           a10constants.VTHUNDER]))
         if mark_active:

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -126,7 +126,7 @@ class MemberFlows(object):
         delete_member_flow.add(database_tasks.DecrementMemberQuota(
             requires=constants.MEMBER))
         if CONF.a10_global.network_type == 'vlan':
-            delete_member_flow.add(vthunder_tasks.DeleteEthernetTagIfNotInUseForMember(
+            delete_member_flow.add(vthunder_tasks.DeleteInterfaceTagIfNotInUseForMember(
                 requires=[constants.MEMBER,
                           a10constants.VTHUNDER]))
         delete_member_flow.add(database_tasks.MarkPoolActiveInDB(
@@ -159,7 +159,7 @@ class MemberFlows(object):
         update_member_flow.add(database_tasks.UpdateMemberInDB(
             requires=[constants.MEMBER, constants.UPDATE_DICT]))
         if CONF.a10_global.network_type == 'vlan':
-            update_member_flow.add(vthunder_tasks.TagEthernetForMember(
+            update_member_flow.add(vthunder_tasks.TagInterfaceForMember(
                 requires=[constants.MEMBER, a10constants.VTHUNDER]))
         update_member_flow.add(database_tasks.MarkMemberActiveInDB(
             requires=constants.MEMBER))
@@ -278,7 +278,7 @@ class MemberFlows(object):
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
         if CONF.a10_global.network_type == 'vlan':
-            create_member_flow.add(vthunder_tasks.TagEthernetForMember(
+            create_member_flow.add(vthunder_tasks.TagInterfaceForMember(
                 requires=[constants.MEMBER,
                           a10constants.VTHUNDER]))
         create_member_flow.add(server_tasks.MemberCreate(

--- a/a10_octavia/controller/worker/tasks/decorators.py
+++ b/a10_octavia/controller/worker/tasks/decorators.py
@@ -59,20 +59,3 @@ def axapi_client_decorator(func):
         return result
 
     return wrapper
-
-def device_context_switch_decorator(func):
-    def wrapper(self, *args, **kwargs):
-        default_device_id = kwargs.get('default_device_id')
-        device_id = kwargs.get('device_id')
-
-        if default_device_id and device_id and device_id != default_device_id:
-            self.axapi_client.device_context.switch(device_id, None)
-
-        result = func(self, *args, **kwargs)
-
-        if default_device_id and device_id and device_id != default_device_id:
-            self.axapi_client.device_context.switch(default_device_id, None)
-
-        return result
-
-    return wrapper

--- a/a10_octavia/controller/worker/tasks/decorators.py
+++ b/a10_octavia/controller/worker/tasks/decorators.py
@@ -59,3 +59,20 @@ def axapi_client_decorator(func):
         return result
 
     return wrapper
+
+def device_context_switch_decorator(func):
+    def wrapper(self, *args, **kwargs):
+        default_device_id = kwargs.get('default_device_id')
+        device_id = kwargs.get('device_id')
+
+        if default_device_id and device_id and device_id != default_device_id:
+            self.axapi_client.device_context.switch(device_id, None)
+
+        result = func(self, *args, **kwargs)
+
+        if default_device_id and device_id and device_id != default_device_id:
+            self.axapi_client.device_context.switch(default_device_id, None)
+
+        return result
+
+    return wrapper

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -442,7 +442,8 @@ class TagInterfaceBaseTask(VThunderBaseTask):
                 LOG.error("ethernet interface %s does not exist", ifnum)
                 raise
             eth = self.axapi_client.interface.ethernet.get(ifnum)
-            if 'action' not in eth or not eth['action'] == 'disable':
+            if ('ethernet' in eth and ('action' not in eth['ethernet'] or
+                                       eth['ethernet']['action'] == 'disable')):
                 LOG.warning("ethernet interface %s not enabled, enabling it", ifnum)
                 self.axapi_client.interface.ethernet.update(ifnum, enable=True)
 

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -479,15 +479,21 @@ class TagInterfaceBaseTask(VThunderBaseTask):
                     vlan_subnet_id_dict[str(vlan_id)] = network.subnets[0]
                 for device_obj in vthunder_conf.device_network_map:
                     for eth_interface in device_obj.ethernet_interfaces:
-                        ifnum = eth_interface.interface_num
-                        for tag, ve_ip in zip(eth_interface.tags, eth_interface.ve_ips):
-                            self.tag_interface(False, create_vlan_id, str(tag),
-                                               str(ifnum), ve_ip, vlan_subnet_id_dict)
+                        ifnum = str(eth_interface.interface_num)
+                        assert len(eth_interface.tags) == len(eth_interface.ve_ips)
+                        for i in range(len(eth_interface.tags)):
+                            tag = str(eth_interface.tags[i])
+                            ve_ip = eth_interface.ve_ips[i]
+                            self.tag_interface(False, create_vlan_id, tag, ifnum,
+                                               ve_ip, vlan_subnet_id_dict)
                     for trunk_interface in device_obj.trunk_interfaces:
-                        ifnum = trunk_interface.interface_num
-                        for tag, ve_ip in zip(trunk_interface.tags, trunk_interface.ve_ips):
-                            self.tag_interface(True, create_vlan_id, str(tag),
-                                               str(ifnum), ve_ip, vlan_subnet_id_dict)
+                        ifnum = str(trunk_interface.interface_num)
+                        assert len(trunk_interface.tags) == len(trunk_interface.ve_ips)
+                        for i in range(len(trunk_interface.tags)):
+                            tag = str(trunk_interface.tags[i])
+                            ve_ip = trunk_interface.ve_ips[i]
+                            self.tag_interface(True, create_vlan_id, tag, ifnum,
+                                               ve_ip, vlan_subnet_id_dict)
 
     def get_vlan_id(self, subnet_id, is_revert):
         self._subnet = self.network_driver.get_subnet(subnet_id)

--- a/a10_octavia/tests/unit/common/test_config_types.py
+++ b/a10_octavia/tests/unit/common/test_config_types.py
@@ -33,8 +33,17 @@ RACK_DEVICE_1 = {
     "device_name": "rack_thunder_1",
     "username": "abc",
     "password": "abc",
-    "interface_vlan_map": {"5": {"11": {"use_dhcp": "True"},
-                                 "12": {"ve_ip_address": ".10"}}}
+    "interface_vlan_map": {
+        "device_1": {
+            "ethernet_interfaces": [{
+                "interface_num": "5",
+                "vlan_map": [
+                    {"vlan_id": 11, "use_dhcp": "True"},
+                    {"vlan_id": 12, "ve_ip": ".10"}
+                ]
+            }]
+        }
+    }
 }
 
 RACK_DEVICE_2 = {
@@ -46,14 +55,16 @@ RACK_DEVICE_2 = {
     'partition_name': 'def-sample'
 }
 
-VTHUNDER_1 = data_models.VThunder(project_id="project-1", device_name="rack_thunder_1",
-                                  undercloud=True, username="abc", password="abc",
-                                  ip_address="10.0.0.1", partition_name="shared",
-                                  interface_vlan_map='{"5": {"11": {"use_dhcp": "True"},'
-                                  '"12": {"ve_ip_address": ".10"}}}')
-VTHUNDER_2 = data_models.VThunder(project_id="project-2", device_name="rack_thunder_2",
-                                  undercloud=True, username="def", password="def",
-                                  ip_address="11.0.0.1", partition_name="def-sample")
+VTHUNDER_1 = data_models.HardwareThunder(project_id="project-1", device_name="rack_thunder_1",
+                                         undercloud=True, username="abc", password="abc",
+                                         ip_address="10.0.0.1", partition_name="shared",
+                                         device_network_map='"device_1":{"ethernet_interfaces":'
+                                         '[{"interface_num": "5", "vlan_map": ['
+                                         '{"vlan_id": 11, "use_dhcp": "True"},'
+                                         '{"vlan_id": 12, "ve_ip": ".10"}]}]}}')
+VTHUNDER_2 = data_models.HardwareThunder(project_id="project-2", device_name="rack_thunder_2",
+                                         undercloud=True, username="def", password="def",
+                                         ip_address="11.0.0.1", partition_name="def-sample")
 
 RESULT_RACK_DEVICE_LIST = {'project-1': VTHUNDER_1,
                            'project-2': VTHUNDER_2}
@@ -70,23 +81,23 @@ class TestConfigTypes(base.TestCase):
         self.conf.reset()
 
     def test_rack_device_valid_devices(self):
-        self.conf.register_opts(config_options.A10_RACK_VTHUNDER_OPTS,
-                                group=a10constants.A10_RACK_VTHUNDER_CONF_SECTION)
+        self.conf.register_opts(config_options.A10_HARDWARE_THUNDER_OPTS,
+                                group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION)
         devices_str = json.dumps([RACK_DEVICE_1, RACK_DEVICE_2])
-        self.conf.config(group=a10constants.A10_RACK_VTHUNDER_CONF_SECTION,
+        self.conf.config(group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION,
                          devices=devices_str)
-        self.assertIn('project-1', CONF.rack_vthunder.devices)
-        self.assertIn('project-2', CONF.rack_vthunder.devices)
-        self.assertEqual('rack_thunder_1', CONF.rack_vthunder.devices['project-1'].device_name)
-        self.assertEqual('rack_thunder_2', CONF.rack_vthunder.devices['project-2'].device_name)
+        self.assertIn('project-1', CONF.hardware_thunder.devices)
+        self.assertIn('project-2', CONF.hardware_thunder.devices)
+        self.assertEqual('rack_thunder_1', CONF.hardware_thunder.devices['project-1'].device_name)
+        self.assertEqual('rack_thunder_2', CONF.hardware_thunder.devices['project-2'].device_name)
 
     def test_rack_device_valid_no_devices(self):
-        self.conf.register_opts(config_options.A10_RACK_VTHUNDER_OPTS,
-                                group=a10constants.A10_RACK_VTHUNDER_CONF_SECTION)
+        self.conf.register_opts(config_options.A10_HARDWARE_THUNDER_OPTS,
+                                group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION)
         devices_str = json.dumps([])
-        self.conf.config(group=a10constants.A10_RACK_VTHUNDER_CONF_SECTION,
+        self.conf.config(group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION,
                          devices=devices_str)
-        self.assertEqual(CONF.rack_vthunder.devices, {})
+        self.assertEqual(CONF.hardware_thunder.devices, {})
 
     def test_rack_device_valid_invalid_array(self):
         devices_str = '[' + json.dumps(RACK_DEVICE_1)

--- a/a10_octavia/tests/unit/common/test_utils.py
+++ b/a10_octavia/tests/unit/common/test_utils.py
@@ -94,10 +94,10 @@ class TestUtils(unittest.TestCase):
         self.assertRaises(cfg.ConfigFileValueError, utils.validate_ipv4, 'abc')
 
     def test_validate_partial_ipv4_valid(self):
-        self.assertEqual(utils.validate_partial_ipv4('10'), None)
-        self.assertEqual(utils.validate_partial_ipv4('.10'), None)
-        self.assertEqual(utils.validate_partial_ipv4('.5.11.10'), None)
-        self.assertEqual(utils.validate_partial_ipv4('11.5.11.10'), None)
+        self.assertEqual(utils.validate_partial_ipv4('10'), '10')
+        self.assertEqual(utils.validate_partial_ipv4('.10'), '.10')
+        self.assertEqual(utils.validate_partial_ipv4('.5.11.10'), '.5.11.10')
+        self.assertEqual(utils.validate_partial_ipv4('11.5.11.10'), '11.5.11.10')
 
     def test_validate_partial_ipv4_invalid(self):
         self.assertRaises(cfg.ConfigFileValueError, utils.validate_partial_ipv4, '777')


### PR DESCRIPTION
## Description
Modification to handle trunk_interfaces in config

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1303
https://a10networks.atlassian.net/browse/STACK-1306

## Technical Approach
Modify tag_interfaces and tag_interface to handle trunk_interfaces in config and call axapi to
create vlan with tagged_trunks.

## Config Changes
<pre>
[hardware_thunder]

devices=[
 {
 "project_id": "fake_uuid",
 "username" : "username",
 "password" : "password",
 "ip_address" : "10.43.12.137",
 "device_name" : "rack_1"
 <b>
 "interface_vlan_map": {
  "device_1": {
   "ethernet_interfaces": [{
    "interface_num": 3,
    "vlan_map": [
     {"vlan_id": 13, "ve_ip": ".10"}
    ]
   }],
   "trunk_interfaces": [{
    "interface_num": 1,
    "vlan_map": [
     {"vlan_id": 11, "ve_ip": ".10"},
     {"vlan_id": 12, "ve_ip": ".10"}
    ]
   }],
  }
 }
</b>
 },
 }]
</pre>

## Test Cases
Updated unit tests for addition of trunk_interfaces.

## Manual Testing
Used the sample config provided and created vip on VLAN 11, multiple members on VLAN 12 and VLAN 13. Tested with traffic and delete members and vip.