### PR TITLE
STACK-1227: Add support for vrid setting in global config section 

### DIFF
--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -33,14 +33,16 @@ LOG = logging.getLogger(__name__)
 
 
 A10_GLOBAL_OPTS = [
-    cfg.StrOpt('vrid_floating_ip', default=None,
-               help=_('Enable VRID floating IP feature')),
     cfg.BoolOpt('enable_hierarchical_multitenancy', default=False,
                 help=_('Enable Hierarchical Multitenancy '
                        'for racked - hardware thunder devices.')),
     cfg.BoolOpt('use_parent_partition', default=False,
                 help=_('Use parent project partition on Thunder device '
                        'in hierarchical project architecture.')),
+    cfg.IntOpt('vrid', default=0,
+                help=_('VRID value')),
+    cfg.StrOpt('vrid_floating_ip', default=None,
+               help=_('Enable VRID floating IP feature')),
 ]
 
 A10_VTHUNDER_OPTS = [

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -722,7 +722,7 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
                 LOG.exception("Failed to revert VRRP floating IP delta task: %s", str(e))
 
     def update_device_vrid_fip(self, conf_floating_ip, vthunder, vrid):
-        vrid_value = 0
+        vrid_value = CONF.a10_global.vrid
         if vrid:
             vrid_value = vrid.vrid
         if not vthunder.partition_name or vthunder.partition_name == 'shared':

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
@@ -19,10 +19,13 @@ try:
     from unittest import mock
 except ImportError:
     import mock
+from oslo_config import cfg
+from oslo_config import fixture as oslo_fixture
 
 from octavia.common import data_models as o_data_models
 from octavia.network import data_models as o_net_data_models
 
+from a10_octavia.common import config_options
 from a10_octavia.common import data_models
 from a10_octavia.common import exceptions
 from a10_octavia.controller.worker.tasks import a10_network_tasks
@@ -51,6 +54,13 @@ class TestNetworkTasks(base.BaseTaskTestCase):
             'a10_octavia.controller.worker.tasks.a10_network_tasks.BaseNetworkTask.network_driver')
         self.network_driver_mock = patcher.start()
         self.client_mock = mock.Mock()
+        self.conf = self.useFixture(oslo_fixture.Config(cfg.CONF))
+        self.conf.register_opts(config_options.A10_GLOBAL_OPTS,
+                                group=a10constants.A10_GLOBAL_OPTS)
+
+    def tearDown(self):
+        super(TestNetworkTasks, self).tearDown()
+        self.conf.reset()
 
     @mock.patch('a10_octavia.common.utils.get_vrid_floating_ip_for_project', return_value=None)
     def test_HandleVRIDFloatingIP_noop_vrrpa_config_not_specified(self, mock_utils):
@@ -74,6 +84,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
         self.network_driver_mock.create_port.return_value = port
+        self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
+                         vrid=VRID_VALUE)
         mock_network_task.execute(VTHUNDER, member, None)
         self.network_driver_mock.create_port.assert_called_with(
             subnet.network_id, member.subnet_id, fixed_ip=a10constants.MOCK_VRID_FLOATING_IP_1)
@@ -98,6 +110,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
         self.network_driver_mock.create_port.return_value = port
+        self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
+                         vrid=VRID_VALUE)
         mock_network_task.execute(vthunder, member, None)
         self.network_driver_mock.create_port.assert_called_with(
             subnet.network_id, member.subnet_id, fixed_ip=a10constants.MOCK_VRID_FLOATING_IP_1)
@@ -118,6 +132,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
         self.network_driver_mock.create_port.return_value = port
+        self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
+                         vrid=VRID_VALUE)
         mock_network_task.execute(VTHUNDER, member, None)
         self.network_driver_mock.create_port.assert_called_with(
             subnet.network_id, member.subnet_id)
@@ -140,6 +156,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
         self.network_driver_mock.create_port.return_value = port
+        self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
+                         vrid=VRID_VALUE)
         mock_network_task.execute(vthunder, member, None)
         self.network_driver_mock.create_port.assert_called_with(
             subnet.network_id, member.subnet_id)
@@ -201,6 +219,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
         self.network_driver_mock.create_port.return_value = port
+        self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
+                         vrid=VRID_VALUE)
         mock_network_task.execute(VTHUNDER, member, vrid)
         self.network_driver_mock.create_port.assert_called_with(
             subnet.network_id, member.subnet_id, fixed_ip=a10constants.MOCK_VRID_FLOATING_IP_2)
@@ -230,6 +250,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
         self.network_driver_mock.create_port.return_value = port
+        self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
+                         vrid=VRID_VALUE)
         mock_network_task.execute(vthunder, member, vrid)
         self.network_driver_mock.create_port.assert_called_with(
             subnet.network_id, member.subnet_id, fixed_ip=a10constants.MOCK_VRID_FLOATING_IP_2)
@@ -277,6 +299,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
         self.network_driver_mock.create_port.return_value = port
+        self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
+                         vrid=VRID_VALUE)
         mock_network_task.execute(VTHUNDER, member, vrid)
         self.network_driver_mock.create_port.assert_called_with(
             subnet.network_id, member.subnet_id)
@@ -304,6 +328,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
         self.network_driver_mock.create_port.return_value = port
+        self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
+                         vrid=VRID_VALUE)
         mock_network_task.execute(vthunder, member, vrid)
         self.network_driver_mock.create_port.assert_called_with(
             subnet.network_id, member.subnet_id)
@@ -346,6 +372,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
         self.network_driver_mock.create_port.return_value = port
+        self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
+                         vrid=VRID_VALUE)
         mock_network_task.execute(VTHUNDER, member, None)
         self.network_driver_mock.create_port.assert_called_with(
             subnet.network_id, member.subnet_id, fixed_ip=a10constants.MOCK_VRID_FULL_FLOATING_IP)


### PR DESCRIPTION
## Description
- Added `vrid` setting in global config section.

## Jira Ticket
[STACK-1227](https://a10networks.atlassian.net/browse/STACK-1227)

## Technical Approach
- Added `vrid` in `a10_global` section with datatype as Integer and default value `0`
- Checked if there is any hardcoding for the same in existing code.
- Fixed existing UTs to accept global `vrid` during `update` calls

## Config Changes
<pre>
[a10_global]
<b>vrid = 1</b>
</pre>

## Test Cases
- If global vrid is provided, the floating ip is updated in that vrid.
- If no global setting is provided, then the previous vrid.vrid is updated or else vrid is taken as `0` 

## Manual Testing
a) Set `vrid` value in `a10-octavia.conf`  under `[a10_global]` section
b) Put pdb in `a10_octavia_worker.py`
c) While debugging, check value of `CONF.a10_global.vrid`, if it matches with the set one.
