### PR TITLE
STACK-1309 utility function to check device ids

### DIFF
--- a/a10_octavia/tests/unit/common/test_utils.py
+++ b/a10_octavia/tests/unit/common/test_utils.py
@@ -202,3 +202,20 @@ class TestUtils(unittest.TestCase):
 
     def test_merge_host_and_network_ip_invalid(self):
         self.assertRaises(Exception, utils.merge_host_and_network_ip, '10.10.10.0/42', '99')
+
+    def test_validate_vcs_device_ids_valid(self):
+        self.assertEqual(utils.validate_vcs_device_ids([1, 2]), None)
+        self.assertEqual(utils.validate_vcs_device_ids([4, 1]), None)
+        self.assertEqual(utils.validate_vcs_device_ids([1]), None)
+        self.assertEqual(utils.validate_vcs_device_ids([4]), None)
+        self.assertEqual(utils.validate_vcs_device_ids([None]), None)
+
+    def test_validate_vcs_device_ids_invalid(self):
+        self.assertRaises(Exception, utils.validate_vcs_device_ids, [5])
+        self.assertRaises(Exception, utils.validate_vcs_device_ids, [0])
+        self.assertRaises(Exception, utils.validate_vcs_device_ids, [1, 5])
+        self.assertRaises(Exception, utils.validate_vcs_device_ids, [0, 2])
+        self.assertRaises(Exception, utils.validate_vcs_device_ids, [1, None])
+        self.assertRaises(Exception, utils.validate_vcs_device_ids, [None, 2])
+        self.assertRaises(Exception, utils.validate_vcs_device_ids, [1, 2, 3])
+        self.assertRaises(Exception, utils.validate_vcs_device_ids, ["hello", 1])


### PR DESCRIPTION
## Description
Added utility function to check VCS Device IDs

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1309

## Test Cases
Unit Tests for positive and negative test cases written. The positive test cases include single device without vcs_device_id and two devices with device ids within range. The negative test cases include invalid device ids.
 
## Manual Testing
1) Tested a10-controller-worker coming up with proper device ids.
2) Tested a10-controller-worker startup failure with improper device_ids.