### PR TITLE
[STACK-1347, 1349] : DCHP -> Static & Static -> DHCP config changes fail

### DIFF
--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -74,7 +74,8 @@ class VThunderComputeConnectivityWait(VThunderBaseTask):
                         http_client.BadStatusLine, req_exceptions.ReadTimeout):
                     attemptid = 21 - attempts
                     time.sleep(20)
-                    LOG.debug("VThunder connection attempt - " + str(attemptid))
+                    LOG.debug("VThunder connection attempt - " +
+                              str(attemptid))
                     pass
             if attempts < 0:
                 LOG.error("Failed to connect vThunder in expected amount of boot time: %s",
@@ -138,9 +139,11 @@ class EnableInterface(VThunderBaseTask):
     def execute(self, vthunder):
         try:
             self.axapi_client.system.action.setInterface(1)
-            LOG.debug("Configured the mgmt interface for vThunder: %s", vthunder.id)
+            LOG.debug(
+                "Configured the mgmt interface for vThunder: %s", vthunder.id)
         except Exception as e:
-            LOG.exception("Failed to configure  mgmt interface vThunder: %s", str(e))
+            LOG.exception(
+                "Failed to configure  mgmt interface vThunder: %s", str(e))
             raise
 
 
@@ -162,14 +165,17 @@ class EnableInterfaceForMembers(VThunderBaseTask):
                 while attempts > 0 and configured_interface is False:
                     try:
                         target_interface = len(nics)
-                        self.axapi_client.system.action.setInterface(target_interface - 1)
+                        self.axapi_client.system.action.setInterface(
+                            target_interface - 1)
                         configured_interface = True
-                        LOG.debug("Configured the new interface required for member.")
+                        LOG.debug(
+                            "Configured the new interface required for member.")
                     except (req_exceptions.ConnectionError, acos_errors.ACOSException,
                             http_client.BadStatusLine, req_exceptions.ReadTimeout):
                         attempts = attempts - 1
             else:
-                LOG.debug("Configuration of new interface is not required for member.")
+                LOG.debug(
+                    "Configuration of new interface is not required for member.")
         except Exception as e:
             LOG.exception("Failed to configure vthunder interface: %s", str(e))
             raise
@@ -183,9 +189,11 @@ class ConfigureVRRPMaster(VThunderBaseTask):
     def execute(self, vthunder):
         try:
             self.axapi_client.system.action.configureVRRP(1, 1)
-            LOG.debug("Successfully configured VRRP for vThunder: %s", vthunder.id)
+            LOG.debug(
+                "Successfully configured VRRP for vThunder: %s", vthunder.id)
         except Exception as e:
-            LOG.exception("Failed to configure master vThunder VRRP: %s", str(e))
+            LOG.exception(
+                "Failed to configure master vThunder VRRP: %s", str(e))
             raise
 
 
@@ -197,9 +205,11 @@ class ConfigureVRRPBackup(VThunderBaseTask):
     def execute(self, vthunder):
         try:
             self.axapi_client.system.action.configureVRRP(2, 1)
-            LOG.debug("Successfully configured VRRP for vThunder: %s", vthunder.id)
+            LOG.debug(
+                "Successfully configured VRRP for vThunder: %s", vthunder.id)
         except Exception as e:
-            LOG.exception("Failed to configure backup vThunder VRRP: %s", str(e))
+            LOG.exception(
+                "Failed to configure backup vThunder VRRP: %s", str(e))
             raise
 
 
@@ -256,7 +266,8 @@ class ConfigureaVCSMaster(VThunderBaseTask):
                            floating_ip, floating_ip_mask)
             LOG.debug("Configured the master vThunder for aVCS: %s", vthunder.id)
         except Exception as e:
-            LOG.exception("Failed to configure master vThunder aVCS: %s", str(e))
+            LOG.exception(
+                "Failed to configure master vThunder aVCS: %s", str(e))
             raise
 
 
@@ -275,12 +286,14 @@ class ConfigureaVCSBackup(VThunderBaseTask):
                     configure_avcs(self.axapi_client, device_id, device_priority,
                                    floating_ip, floating_ip_mask)
                     attempts = 0
-                    LOG.debug("Configured the backup vThunder for aVCS: %s", vthunder.id)
+                    LOG.debug(
+                        "Configured the backup vThunder for aVCS: %s", vthunder.id)
                 except (req_exceptions.ConnectionError, acos_errors.ACOSException,
                         http_client.BadStatusLine, req_exceptions.ReadTimeout):
                     attempts = attempts - 1
         except Exception as e:
-            LOG.exception("Failed to configure backup vThunder aVCS: %s", str(e))
+            LOG.exception(
+                "Failed to configure backup vThunder aVCS: %s", str(e))
             raise
 
 
@@ -314,7 +327,8 @@ class CreateHealthMonitorOnVThunder(VThunderBaseTask):
                                                          self.axapi_client, 'UDP'),
                                                      interval, timeout, max_retries, method, url,
                                                      expect_code, port, ipv4)
-            LOG.debug("Successfully created health monitor for vThunder %s", vthunder.id)
+            LOG.debug(
+                "Successfully created health monitor for vThunder %s", vthunder.id)
         except Exception as e:
             LOG.debug("Failed to create health monitor: %s", str(e))
 
@@ -322,10 +336,13 @@ class CreateHealthMonitorOnVThunder(VThunderBaseTask):
             ip_address = CONF.a10_health_manager.udp_server_ip_address
             health_check = a10constants.OCTAVIA_HEALTH_MONITOR
             try:
-                self.axapi_client.slb.server.create(name, ip_address, health_check=health_check)
-                LOG.debug("Server created successfully. Enabled health check for health monitor.")
+                self.axapi_client.slb.server.create(
+                    name, ip_address, health_check=health_check)
+                LOG.debug(
+                    "Server created successfully. Enabled health check for health monitor.")
             except Exception as e:
-                LOG.exception("Failed to create health monitor server: %s", str(e))
+                LOG.exception(
+                    "Failed to create health monitor server: %s", str(e))
 
 
 class CheckVRRPStatus(VThunderBaseTask):
@@ -387,7 +404,8 @@ class TagInterfaceBaseTask(VThunderBaseTask):
 
     def reserve_ve_ip_with_neutron(self, vlan_id, subnet_id, device_id=None, default_device_id=None,
                                    project_id=None):
-        ve_ip = self._get_ve_ip(vlan_id, device_id, default_device_id, project_id)
+        ve_ip = self._get_ve_ip(
+            vlan_id, device_id, default_device_id, project_id)
         if ve_ip is None:
             return None
 
@@ -397,18 +415,20 @@ class TagInterfaceBaseTask(VThunderBaseTask):
                         self._subnet_mask, subnet_id)
             return None
 
-        self.network_driver.create_port(self._subnet.network_id, fixed_ip=ve_ip)
+        self.network_driver.create_port(
+            self._subnet.network_id, fixed_ip=ve_ip)
 
     def release_ve_ip_from_neutron(self, vlan_id, subnet_id, device_id=None, default_device_id=None,
                                    project_id=None):
-        ve_ip = self._get_ve_ip(vlan_id, device_id, default_device_id, project_id)
+        ve_ip = self._get_ve_ip(
+            vlan_id, device_id, default_device_id, project_id)
         port_id = self.network_driver.get_port_id_from_ip(ve_ip)
         if ve_ip and port_id:
             self.network_driver.delete_port(port_id)
 
     def _get_ve_ip(self, vlan_id, device_id=None, default_device_id=None, project_id=None):
         if default_device_id != device_id and project_id:
-            vthunder_conf = CONF.hardware_thunder.devices[project_id] 
+            vthunder_conf = CONF.hardware_thunder.devices[project_id]
             api_ver = acos_client.AXAPI_21 if vthunder_conf.axapi_version == 21 else acos_client.AXAPI_30
             axapi_client = acos_client.Client(vthunder_conf.standby_ip_address, api_ver,
                                               vthunder_conf.username, vthunder_conf.password,
@@ -417,7 +437,7 @@ class TagInterfaceBaseTask(VThunderBaseTask):
         else:
             axapi_client = self.axapi_client
             close_axapi_client = False
-          
+
             try:
                 resp = axapi_client.interface.ve.get_oper(vlan_id)
                 if close_axapi_client:
@@ -432,7 +452,8 @@ class TagInterfaceBaseTask(VThunderBaseTask):
 
     def get_subnet_and_mask(self, subnet_id):
         self._subnet = self.network_driver.get_subnet(subnet_id)
-        subnet_ip, subnet_mask = a10_utils.get_net_info_from_cidr(self._subnet.cidr)
+        subnet_ip, subnet_mask = a10_utils.get_net_info_from_cidr(
+            self._subnet.cidr)
         self._subnet_ip = subnet_ip
         self._subnet_mask = subnet_mask
 
@@ -445,10 +466,30 @@ class TagInterfaceBaseTask(VThunderBaseTask):
         return a10_utils.merge_host_and_network_ip(self._subnet.cidr, ve_ip)
 
     @device_context_switch_decorator
-    def delete_device_vlan(self, vlan_id, subnet_id, device_id=None, default_device_id=None, project_id=None):
+    def check_ve_ip_exists(self, vlan_id, config_ve_ip):
+        if self.axapi_client.vlan.exists(vlan_id):
+            if self.axapi_client.interface.ve.exists(vlan_id):
+                ve = self.axapi_client.interface.ve.get(vlan_id)
+                if config_ve_ip == 'dhcp':
+                    if ve.get('ve').get('ip') and ve.get('ve').get('ip').get('dhcp'):
+                        return True
+                    return False
+                else:
+                    if ve.get('ve').get('ip') and ve.get('ve').get('ip').get('address-list'):
+                        existing_ve_ip = ve.get('ve').get('ip').get(
+                            'address-list')[0].get('ipv4-address')
+                        if self._get_patched_ve_ip(config_ve_ip) == existing_ve_ip:
+                            return True
+                    return False
+            return False
+
+    @device_context_switch_decorator
+    def delete_device_vlan(self, vlan_id, subnet_id, device_id=None, default_device_id=None,
+                           project_id=None):
         if self.axapi_client.vlan.exists(vlan_id):
             LOG.debug("Delete VLAN with id %s", vlan_id)
-            self.release_ve_ip_from_neutron(vlan_id, subnet_id, device_id, default_device_id, project_id)
+            self.release_ve_ip_from_neutron(
+                vlan_id, subnet_id, device_id, default_device_id, project_id)
             self.axapi_client.vlan.delete(vlan_id)
 
     @device_context_switch_decorator
@@ -469,7 +510,8 @@ class TagInterfaceBaseTask(VThunderBaseTask):
             eth = self.axapi_client.interface.ethernet.get(ifnum)
             if ('ethernet' in eth and ('action' not in eth['ethernet'] or
                                        eth['ethernet']['action'] == 'disable')):
-                LOG.warning("ethernet interface %s not enabled, enabling it", ifnum)
+                LOG.warning(
+                    "ethernet interface %s not enabled, enabling it", ifnum)
                 self.axapi_client.interface.ethernet.update(ifnum, enable=True)
 
         vlan_exists = self.axapi_client.vlan.exists(vlan_id)
@@ -478,21 +520,33 @@ class TagInterfaceBaseTask(VThunderBaseTask):
 
         if not vlan_exists:
             if is_trunk:
-                self.axapi_client.vlan.create(vlan_id, tagged_trunks=[ifnum], veth=True)
-                LOG.debug("Tagged ethernet interface %s with VLAN with id %s", ifnum, vlan_id)
+                self.axapi_client.vlan.create(
+                    vlan_id, tagged_trunks=[ifnum], veth=True)
+                LOG.debug(
+                    "Tagged ethernet interface %s with VLAN with id %s", ifnum, vlan_id)
             else:
-                self.axapi_client.vlan.create(vlan_id, tagged_eths=[ifnum], veth=True)
-                LOG.debug("Tagged trunk interface %s with VLAN with id %s", ifnum, vlan_id)
+                self.axapi_client.vlan.create(
+                    vlan_id, tagged_eths=[ifnum], veth=True)
+                LOG.debug(
+                    "Tagged trunk interface %s with VLAN with id %s", ifnum, vlan_id)
         else:
             self.release_ve_ip_from_neutron(vlan_id, vlan_subnet_id_dict[vlan_id],
-                                            device_id, default_device_id,project_id)
+                                            device_id, default_device_id, project_id)
+
+        ve_ip_exist = self.check_ve_ip_exists(vlan_id, ve_info)
+        if not ve_ip_exist:
+            self.axapi_client.interface.ve.delete(vlan_id)
 
         if ve_info == 'dhcp':
-            self.axapi_client.interface.ve.update(vlan_id, dhcp=True, enable=True)
+            if not ve_ip_exist:
+                self.axapi_client.interface.ve.create(
+                    vlan_id, dhcp=True, enable=True)
         else:
             patched_ip = self._get_patched_ve_ip(ve_info)
-            self.axapi_client.interface.ve.update(vlan_id, ip_address=patched_ip,
-                                                  ip_netmask=self._subnet_mask, enable=True)
+            if not ve_ip_exist:
+                self.axapi_client.interface.ve.create(vlan_id, ip_address=patched_ip,
+                                                      ip_netmask=self._subnet_mask, enable=True)
+
         self.reserve_ve_ip_with_neutron(vlan_id, vlan_subnet_id_dict[vlan_id],
                                         device_id, default_device_id, project_id)
 
@@ -510,7 +564,8 @@ class TagInterfaceBaseTask(VThunderBaseTask):
                     device_id = device_obj.vcs_device_id
                     for eth_interface in device_obj.ethernet_interfaces:
                         ifnum = str(eth_interface.interface_num)
-                        assert len(eth_interface.tags) == len(eth_interface.ve_ips)
+                        assert len(eth_interface.tags) == len(
+                            eth_interface.ve_ips)
                         for i in range(len(eth_interface.tags)):
                             tag = str(eth_interface.tags[i])
                             ve_ip = eth_interface.ve_ips[i]
@@ -521,7 +576,8 @@ class TagInterfaceBaseTask(VThunderBaseTask):
                                                project_id=project_id)
                     for trunk_interface in device_obj.trunk_interfaces:
                         ifnum = str(trunk_interface.interface_num)
-                        assert len(trunk_interface.tags) == len(trunk_interface.ve_ips)
+                        assert len(trunk_interface.tags) == len(
+                            trunk_interface.ve_ips)
                         for i in range(len(trunk_interface.tags)):
                             tag = str(trunk_interface.tags[i])
                             ve_ip = trunk_interface.ve_ips[i]
@@ -572,7 +628,8 @@ class TagInterfaceForLB(TagInterfaceBaseTask):
         vlan_id = self.get_vlan_id(loadbalancer.vip.subnet_id, True)
         if self.axapi_client.vlan.exists(vlan_id) and self.is_vlan_deletable():
             LOG.warning("Revert TagInterfaceForLB with VLAN id %s", vlan_id)
-            self.release_ve_ip_from_neutron(vlan_id, loadbalancer.vip.subnet_id)
+            self.release_ve_ip_from_neutron(
+                vlan_id, loadbalancer.vip.subnet_id)
             self.axapi_client.vlan.delete(vlan_id)
 
 
@@ -589,7 +646,8 @@ class TagInterfaceForMember(TagInterfaceBaseTask):
     def revert(self, member, vthunder, *args, **kwargs):
         vlan_id = self.get_vlan_id(member.subnet_id, True)
         if self.axapi_client.vlan.exists(vlan_id) and self.is_vlan_deletable():
-            LOG.warning("Revert TagInterfaceForMember with VLAN id %s", vlan_id)
+            LOG.warning(
+                "Revert TagInterfaceForMember with VLAN id %s", vlan_id)
             self.release_ve_ip_from_neutron(vlan_id, member.subnet_id)
             self.axapi_client.vlan.delete(vlan_id)
 
@@ -605,7 +663,8 @@ class DeleteInterfaceTagIfNotInUseForLB(TagInterfaceBaseTask):
                 vlan_id = self.get_vlan_id(loadbalancer.vip.subnet_id, False)
                 if self.axapi_client.vlan.exists(vlan_id) and self.is_vlan_deletable():
                     LOG.debug("Delete VLAN with id %s", vlan_id)
-                    self.release_ve_ip_from_neutron(vlan_id, loadbalancer.vip.subnet_id)
+                    self.release_ve_ip_from_neutron(
+                        vlan_id, loadbalancer.vip.subnet_id)
                     self.axapi_client.vlan.delete(vlan_id)
         except Exception as e:
             LOG.exception("Failed to delete VLAN on vThunder: %s", str(e))


### PR DESCRIPTION
## Description
- Severity Level : High
- DCHP -> Static & Static -> DHCP config changes fail
- Neutron ports are created, updated and deleted according to config.

## Jira Ticket
[STACK-1347](https://a10networks.atlassian.net/browse/STACK-1347)
[STACK-1349](https://a10networks.atlassian.net/browse/STACK-1349)

## Technical Approach:
Updation Approach
- Since ACOS client api `interface.ve.update()` doesn't seem to work in case of static ve_ip to dhcp updation. It throws error 
`DHCP address has to be the first configured under an interface.`

Hence used approach of first `interface.ve.delete()` then `interface.ve.create()`.

This PR also include pep8 and flake8 fixes.


## Config Changes
None

## Test Cases

CREATION on vThunder and openstack neutron ports
- if a static `ve_ip` is configured in `ethernet_interfaces` -> CREATED
- if `use_dhcp` set as `True` in `ethernet_interfaces` -> CREATED
- if static `ve_ip` is configured in `trunk_interfaces` -> CREATED
- if `use_dhcp` set as `True` in `trunk_interfaces` -> CREATED


UPDATION on vThunder and openstack neutron ports
- if existing static `ve_ip` is changed to new `ve_ip` in `ethernet_interfaces` -> UPDATED
- if existing static `ve_ip` is changed to dhcp setting in `ethernet_interfaces` -> UPDATED
- if existing dhcp is changed to static ve_ip in `ethernet_interfaces` -> UPDATED
- if existing static `ve_ip` is changed to new `ve_ip` in `trunk_interfaces` -> UPDATED
- if existing static `ve_ip` is changed to dhcp setting in `trunk_interfaces` -> UPDATED
- if existing dhcp is changed to static ve_ip in `trunk_interfaces` -> UPDATED

DELETION on vThunder and openstack neutron ports
- if member is deleted, corresponding vlan, ve/trunk ve_ip configs are deleted 

## Manual Testing
Prerequisite : 
- Use `install-a10-octavia` to install vlan setup.
- Have required ovs-vsctl setting. eg creating bonds etc.
- On aVCS setup, in vthunders, have set up vrid floating ip
- In `a10-octavia.conf`, include `vrid_floating_ip` and `standby_ip_address` setting.

STEP 1: Configure required ve_ip/dhcp setting for `ethernet_interfaces` or/and `trunk_interfaces` in `a10-octavia.conf`
STEP 2: Restart `a10-controller-worker.service` service
STEP 3: Create loadbalancer, listener, pool and member. 
STEP 4: Check on vThunder, if proper ve/trunk ips are configured.
STEP 5: Check on openstack UI for neutron port created with same ve_ip addresses.
