### PR TITLE
STACK-1323 Updated virtual port to use listener's ID

### DIFF
--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -82,7 +82,7 @@ class ListenersParent(object):
                                 "HTTPS or TERMINATED_HTTPS listener.")
                     no_dest_nat = False
 
-                name = loadbalancer.id + "_" + str(listener.protocol_port)
+                name = listener.id
                 set_method(loadbalancer.id, name,
                            listener.protocol,
                            listener.protocol_port,

--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -82,8 +82,7 @@ class ListenersParent(object):
                                 "HTTPS or TERMINATED_HTTPS listener.")
                     no_dest_nat = False
 
-                name = listener.id
-                set_method(loadbalancer.id, name,
+                set_method(loadbalancer.id, listener.id,
                            listener.protocol,
                            listener.protocol_port,
                            listener.default_pool_id,


### PR DESCRIPTION
## Issue Description
Updated virtual port name to use the listener's ID

If Bug Fix:
- Severity Level = High
- Listener ID isn't used in Thunder configuration

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1323

## Technical Approach
- Removed  "load balancer's ID appended with a port id" assigned to the name attribute of the listener.
- Updated name parameter of the virtual port to newly created listener ID.

## Test Cases
- Required: Created multiple listeners with different port IDs

## Manual Testing
- Required: List of steps to manually test feature or fix 
step-1: created one SLB
step-2: created multiple listeners.
step-3: Verified listener ID is being used for listener name 
