### PR TITLE
STACK-1375, STACK-1376, STACK-1377 Changes from PP sessions with team

### DIFF
--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -41,7 +41,7 @@ A10_GLOBAL_OPTS = [
                 help=_('Use parent project partition on Thunder device '
                        'in hierarchical project architecture.')),
     cfg.IntOpt('vrid', default=0,
-                help=_('VRID value')),
+               help=_('VRID value')),
     cfg.StrOpt('vrid_floating_ip', default=None,
                help=_('Enable VRID floating IP feature')),
     cfg.StrOpt('network_type',

--- a/a10_octavia/common/data_models.py
+++ b/a10_octavia/common/data_models.py
@@ -139,7 +139,7 @@ class Thunder(BaseDataModel):
                  topology="STANDALONE", role="MASTER", last_udp_update=None, status="ACTIVE",
                  created_at=datetime.utcnow(), updated_at=datetime.utcnow(), partition_name=None,
                  hierarchical_multitenancy=None, vrid_floating_ip=None,
-                 interface_vlan_map=None):
+                 device_network_map=None):
         self.id = id
         self.vthunder_id = vthunder_id
         self.amphora_id = amphora_id
@@ -161,14 +161,12 @@ class Thunder(BaseDataModel):
         self.partition_name = partition_name
         self.hierarchical_multitenancy = hierarchical_multitenancy
         self.vrid_floating_ip = vrid_floating_ip
-        self.interface_vlan_map = interface_vlan_map
+        self.device_network_map = device_network_map or []
 
 
 class HardwareThunder(Thunder):
-    def __init__(self, standby_ip_address=None, device_network_map=None, **kwargs):
+    def __init__(self, **kwargs):
         Thunder.__init__(self, **kwargs)
-        self.standby_ip_address = standby_ip_address
-        self.device_network_map = device_network_map or []
 
 
 class VThunder(Thunder):
@@ -209,7 +207,10 @@ class Interface(BaseDataModel):
 
 class DeviceNetworkMap(BaseDataModel):
 
-    def __init__(self, vcs_device_id=None, ethernet_interfaces=None, trunk_interfaces=None):
+    def __init__(self, vcs_device_id=None, mgmt_ip_address=None, ethernet_interfaces=None,
+                 trunk_interfaces=None):
         self.vcs_device_id = vcs_device_id
+        self.mgmt_ip_address = mgmt_ip_address
         self.ethernet_interfaces = ethernet_interfaces or []
         self.trunk_interfaces = trunk_interfaces or []
+        self.state = 'Unknown'

--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -81,3 +81,27 @@ class VirtEthMissingConfigError(cfg.ConfigFileValueError):
                'Missing `use_dhcp` and `ve_ip` in config. ' +
                'Please provide either.').format(vlan_id, interface_num)
         super(VirtEthMissingConfigError, self).__init__(msg=msg)
+
+
+class VcsDevicesNumberExceedsConfigError(cfg.ConfigFileValueError):
+
+    def __init__(self, num_devices):
+        msg = ('Number of vcs devices {0} exceeds the maximum allowed value 2. ' +
+               'Please reduce the devices in cluster.').format(num_devices)
+        super(VcsDevicesNumberExceedsConfigError, self).__init__(msg=msg)
+
+
+class InvalidVcsDeviceIdConfigError(cfg.ConfigFileValueError):
+
+    def __init__(self, vcs_device_id):
+        msg = ('Invalid `vcs_device_id` {0}, it should be in the range 1-2. ' +
+               'Please provide the proper `vcs_device_id`.').format(vcs_device_id)
+        super(InvalidVcsDeviceIdConfigError, self).__init__(msg=msg)
+
+
+class MissingMgmtIpConfigError(cfg.ConfigFileValueError):
+
+    def __init__(self, vcs_device_id):
+        msg = ('Missing `mgmt_ip_address` for vcs device with id {0}. ' +
+               'Please provide management IP address').format(vcs_device_id)
+        super(MissingMgmtIpConfigError, self).__init__(msg=msg)

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -173,6 +173,9 @@ class LoadBalancerFlows(object):
             name="set load balancer status PENDING_DELETE",
             requires=a10constants.VTHUNDER,
             inject={"status": constants.PENDING_DELETE}))
+        delete_LB_flow.add(vthunder_tasks.SetupDeviceNetworkMap(
+            requires=a10constants.VTHUNDER,
+            provides=a10constants.VTHUNDER))
         delete_LB_flow.add(compute_tasks.NovaServerGroupDelete(
             requires=constants.SERVER_GROUP_ID))
         delete_LB_flow.add(database_tasks.MarkLBAmphoraeHealthBusy(
@@ -277,6 +280,9 @@ class LoadBalancerFlows(object):
             name="set load balancer status PENDING_UPDATE",
             requires=a10constants.VTHUNDER,
             inject={"status": constants.PENDING_UPDATE}))
+        update_LB_flow.add(vthunder_tasks.SetupDeviceNetworkMap(
+            requires=a10constants.VTHUNDER,
+            provides=a10constants.VTHUNDER))
         update_LB_flow.add(network_tasks.ApplyQos(
             requires=(constants.LOADBALANCER, constants.UPDATE_DICT)))
         # update_LB_flow.add(amphora_driver_tasks.ListenersUpdate(
@@ -325,6 +331,9 @@ class LoadBalancerFlows(object):
 
         sf_name = prefix + '-' + constants.POST_LB_AMP_ASSOCIATION_SUBFLOW
         post_create_lb_flow = linear_flow.Flow(sf_name)
+        post_create_lb_flow.add(vthunder_tasks.SetupDeviceNetworkMap(
+            requires=a10constants.VTHUNDER,
+            provides=a10constants.VTHUNDER))
         post_create_lb_flow.add(
             database_tasks.ReloadLoadBalancer(
                 name=sf_name + '-' + constants.RELOAD_LB_AFTER_AMP_ASSOC,

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -125,6 +125,9 @@ class MemberFlows(object):
         delete_member_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
+        delete_member_flow.add(vthunder_tasks.SetupDeviceNetworkMap(
+            requires=a10constants.VTHUNDER,
+            provides=a10constants.VTHUNDER))
         delete_member_flow.add(server_tasks.MemberDelete(
             requires=(constants.MEMBER, a10constants.VTHUNDER, constants.POOL)))
         delete_member_flow.add(database_tasks.DecrementMemberQuota(
@@ -165,6 +168,9 @@ class MemberFlows(object):
             requires=constants.MEMBER))
         update_member_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
+            provides=a10constants.VTHUNDER))
+        update_member_flow.add(vthunder_tasks.SetupDeviceNetworkMap(
+            requires=a10constants.VTHUNDER,
             provides=a10constants.VTHUNDER))
         # Handle VRID settings
         update_member_flow.add(a10_database_tasks.GetVRIDForProjectMember(
@@ -298,6 +304,9 @@ class MemberFlows(object):
             requires=constants.MEMBER))
         create_member_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
+            provides=a10constants.VTHUNDER))
+        create_member_flow.add(vthunder_tasks.SetupDeviceNetworkMap(
+            requires=a10constants.VTHUNDER,
             provides=a10constants.VTHUNDER))
         create_member_flow.add(a10_database_tasks.GetVRIDForProjectMember(
             requires=constants.MEMBER,

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -24,10 +24,10 @@ from octavia.controller.worker import task_utils
 from octavia.network import base
 from octavia.network import data_models as n_data_models
 
+from a10_octavia.common import a10constants
 from a10_octavia.common import exceptions
 from a10_octavia.common import utils as a10_utils
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
-from a10_octavia.common import a10constants
 
 LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
@@ -747,6 +747,7 @@ class DeleteMemberVRIDPort(BaseNetworkTask):
             except Exception as e:
                 LOG.exception("Failed to delete vrid port : %s", str(e))
         return False
+
 
 class GetSubnetVLANIDParent(object):
     """Get the Subnet VLAN_ID"""

--- a/a10_octavia/controller/worker/tasks/decorators.py
+++ b/a10_octavia/controller/worker/tasks/decorators.py
@@ -63,12 +63,12 @@ def axapi_client_decorator(func):
 
 def device_context_switch_decorator(func):
     def wrapper(self, *args, **kwargs):
-        default_device_id = kwargs.get('default_device_id')
+        master_device_id = kwargs.get('master_device_id')
         device_id = kwargs.get('device_id')
-        if default_device_id and device_id and device_id != default_device_id:
+        if master_device_id and device_id and device_id != master_device_id:
             self.axapi_client.device_context.switch(device_id, None)
         result = func(self, *args, **kwargs)
-        if default_device_id and device_id and device_id != default_device_id:
-            self.axapi_client.device_context.switch(default_device_id, None)
+        if master_device_id and device_id and device_id != master_device_id:
+            self.axapi_client.device_context.switch(master_device_id, None)
         return result
     return wrapper

--- a/a10_octavia/tests/unit/common/test_utils.py
+++ b/a10_octavia/tests/unit/common/test_utils.py
@@ -91,10 +91,11 @@ INTERFACE_CONF = {"interface_num": 1,
 INTERFACE = data_models.Interface(interface_num=1, tags=[11, 12, 13], ve_ips=[
                                   "10.20", "dhcp", "10.30"])
 DEVICE_NETWORK_MAP = [data_models.DeviceNetworkMap(
-    device_id='device_1', ethernet_interfaces=[INTERFACE])]
+    vcs_device_id=1, ethernet_interfaces=[INTERFACE])]
 HARDWARE_VLAN_INFO = {
     "interface_vlan_map": {
         "device_1": {
+            "vcs_device_id": 1,
             "ethernet_interfaces": [INTERFACE_CONF]
         }
     }
@@ -339,3 +340,57 @@ class TestUtils(base.BaseTaskTestCase):
                                                {"vlan_id": 11, "use_dhcp": True}]}
         self.assertRaises(exceptions.DuplicateVlanTagsConfigError,
                           utils.convert_interface_to_data_model, duplicate_vlan_ids_in_iface_obj)
+
+    def test_validate_vcs_device_info_valid(self):
+        interface = utils.convert_interface_to_data_model(INTERFACE_CONF)
+        device1_network_map = data_models.DeviceNetworkMap(vcs_device_id=1,
+                                                           ethernet_interfaces=[interface])
+        device2_network_map = data_models.DeviceNetworkMap(vcs_device_id=2,
+                                                           mgmt_ip_address="10.0.0.2",
+                                                           ethernet_interfaces=[interface])
+        device_network_map = []
+        self.assertEqual(utils.validate_vcs_device_info(device_network_map), None)
+        device_network_map = [device1_network_map]
+        self.assertEqual(utils.validate_vcs_device_info(device_network_map), None)
+        device1_network_map.mgmt_ip_address = "10.0.0.1"
+        self.assertEqual(utils.validate_vcs_device_info(device_network_map), None)
+        device_network_map = [device1_network_map, device2_network_map]
+        self.assertEqual(utils.validate_vcs_device_info(device_network_map), None)
+
+    def test_validate_vcs_device_info_invalid(self):
+        interface = utils.convert_interface_to_data_model(INTERFACE_CONF)
+        device1_network_map = data_models.DeviceNetworkMap(mgmt_ip_address="10.0.0.1",
+                                                           ethernet_interfaces=[interface])
+        device2_network_map = data_models.DeviceNetworkMap(mgmt_ip_address="10.0.0.2",
+                                                           ethernet_interfaces=[interface])
+        device1_network_map.vcs_device_id = 3
+        device_network_map = [device1_network_map]
+        self.assertRaises(exceptions.InvalidVcsDeviceIdConfigError,
+                          utils.validate_vcs_device_info, device_network_map)
+        device1_network_map.vcs_device_id = 0
+        device_network_map = [device1_network_map]
+        self.assertRaises(exceptions.InvalidVcsDeviceIdConfigError,
+                          utils.validate_vcs_device_info, device_network_map)
+        device1_network_map.vcs_device_id = 1
+        device2_network_map.vcs_device_id = 3
+        device_network_map = [device1_network_map, device2_network_map]
+        self.assertRaises(exceptions.InvalidVcsDeviceIdConfigError,
+                          utils.validate_vcs_device_info, device_network_map)
+        device1_network_map.vcs_device_id = 0
+        device2_network_map.vcs_device_id = 2
+        device_network_map = [device1_network_map, device2_network_map]
+        self.assertRaises(exceptions.InvalidVcsDeviceIdConfigError,
+                          utils.validate_vcs_device_info, device_network_map)
+        device1_network_map.vcs_device_id = 1
+        device2_network_map.vcs_device_id = None
+        device_network_map = [device1_network_map, device2_network_map]
+        self.assertRaises(exceptions.InvalidVcsDeviceIdConfigError,
+                          utils.validate_vcs_device_info, device_network_map)
+        device_network_map = [device1_network_map, device2_network_map, device2_network_map]
+        self.assertRaises(exceptions.VcsDevicesNumberExceedsConfigError,
+                          utils.validate_vcs_device_info, device_network_map)
+        device2_network_map.vcs_device_id = 2
+        device2_network_map.mgmt_ip_address = None
+        device_network_map = [device1_network_map, device2_network_map]
+        self.assertRaises(exceptions.MissingMgmtIpConfigError,
+                          utils.validate_vcs_device_info, device_network_map)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -227,7 +227,7 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         self.client_mock.vlan.create.assert_called_with(VE_IP_VLAN_ID,
                                                         tagged_eths=[TAG_INTERFACE],
                                                         veth=True)
-        self.client_mock.interface.ve.update.assert_called_with(VE_IP_VLAN_ID,
+        self.client_mock.interface.ve.create.assert_called_with(VE_IP_VLAN_ID,
                                                                 ip_address=STATIC_VE_IP,
                                                                 ip_netmask="255.255.255.0",
                                                                 enable=True)
@@ -255,7 +255,7 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         self.client_mock.vlan.create.assert_called_with(VE_IP_VLAN_ID,
                                                         tagged_trunks=[TAG_TRUNK_INTERFACE],
                                                         veth=True)
-        self.client_mock.interface.ve.update.assert_called_with(VE_IP_VLAN_ID,
+        self.client_mock.interface.ve.create.assert_called_with(VE_IP_VLAN_ID,
                                                                 ip_address=STATIC_VE_IP,
                                                                 ip_netmask="255.255.255.0",
                                                                 enable=True)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -28,12 +28,14 @@ from octavia.network.drivers.neutron import utils
 
 from a10_octavia.common import config_options
 from a10_octavia.common import data_models as a10_data_models
+from a10_octavia.common import utils as a10_utils
 from a10_octavia.controller.worker.tasks import vthunder_tasks as task
 from a10_octavia.network.drivers.neutron import a10_octavia_neutron
 from a10_octavia.tests.common import a10constants
 from a10_octavia.tests.unit import base
 
-VTHUNDER = a10_data_models.VThunder()
+PROJECT_ID = "project-rack-vthunder"
+VTHUNDER = a10_data_models.VThunder(project_id=PROJECT_ID)
 VLAN_ID = '11'
 VE_IP_VLAN_ID = '12'
 DELETE_VLAN = True
@@ -42,38 +44,51 @@ TAG_TRUNK_INTERFACE = '1'
 ETH_DATA = {"action": "enable"}
 SUBNET_MASK = ["10.0.11.0", "255.255.255.0", "10.0.11.0/24"]
 VE_IP_SUBNET_MASK = ["10.0.12.0", "255.255.255.0", "10.0.12.0/24"]
+ETHERNET_INTERFACE = {
+    "interface_num": "5",
+    "vlan_map": [
+        {"vlan_id": 11, "use_dhcp": "True"},
+        {"vlan_id": 12, "ve_ip": ".10"}
+    ]
+}
+TRUNK_INTERFACE = {
+    "interface_num": "1",
+    "vlan_map": [
+        {"vlan_id": 12, "ve_ip": ".10"}
+    ]
+}
+DEVICE1_MGMT_IP = "10.0.0.1"
+DEVICE2_MGMT_IP = "10.0.0.2"
 RACK_DEVICE = {
-    "project_id": "project-rack-vthunder",
-    "ip_address": "10.0.0.1",
+    "project_id": PROJECT_ID,
+    "ip_address": "10.0.0.10",
     "device_name": "rack_vthunder",
     "username": "abc",
     "password": "abc",
     "interface_vlan_map": {
         "device_1": {
-            "ethernet_interfaces": [{
-                "interface_num": "5",
-                "vlan_map": [
-                    {"vlan_id": 11, "use_dhcp": "True"},
-                    {"vlan_id": 12, "ve_ip": ".10"}
-                ]
-            }]
+            "vcs_device_id": 1,
+            "mgmt_ip_address": DEVICE1_MGMT_IP,
+            "trunk_interfaces": [TRUNK_INTERFACE]
         }
     }
 }
-RACK_DEVICE_TRUNK_INTERFACE = {
-    "project_id": "project-rack-vthunder",
-    "ip_address": "10.0.0.1",
+RACK_DEVICE_VCS = {
+    "project_id": PROJECT_ID,
+    "ip_address": "10.0.0.10",
     "device_name": "rack_vthunder",
     "username": "abc",
     "password": "abc",
     "interface_vlan_map": {
         "device_1": {
-            "trunk_interfaces": [{
-                "interface_num": "1",
-                "vlan_map": [
-                    {"vlan_id": 12, "ve_ip": ".10"}
-                ]
-            }]
+            "vcs_device_id": 1,
+            "mgmt_ip_address": DEVICE1_MGMT_IP,
+            "ethernet_interfaces": [ETHERNET_INTERFACE]
+        },
+        "device_2": {
+            "vcs_device_id": 2,
+            "mgmt_ip_address": DEVICE2_MGMT_IP,
+            "ethernet_interfaces": [ETHERNET_INTERFACE]
         }
     }
 }
@@ -86,6 +101,35 @@ NETWORK_11 = n_data_models.Network(id="mock-network-1", subnets=["mock-subnet-1"
                                    provider_segmentation_id=11)
 NETWORK_12 = n_data_models.Network(id="mock-network-2", subnets=["mock-subnet-2"],
                                    provider_segmentation_id=12)
+VCS_DISABLED = {"vcs-summary": {"oper": {"vcs-enabled": "Invalid"}}}
+VCS_MASTER_VBLADE = {
+    "vcs-summary": {
+        "oper": {
+            "vcs-enabled": "Yes",
+            "member-list": [{
+                "port": 41216, "priority": 125, "state": "vMaster(*)",
+                "ip-list": [{"ip": "10.0.0.1"}], "location": "Local", "id": 1
+            }, {
+                "port": 41216, "priority": 120, "state": "vBlade",
+                "ip-list": [{"ip": "10.0.0.2"}], "location": "Remote", "id": 2
+            }]
+        }
+    }
+}
+VCS_DEVICE1_FAILED = {
+    "vcs-summary": {
+        "oper": {
+            "vcs-enabled": "Yes",
+            "member-list": [{
+                "port": 41216, "priority": 120, "state": "Unknown",
+                "ip-list": [{"ip": "N/A"}], "location": "Remote", "id": 1
+            }, {
+                "port": 41216, "priority": 125, "state": "vMaster(*)",
+                "ip-list": [{"ip": "10.0.0.2"}], "location": "Local", "id": 2
+            }]
+        }
+    }
+}
 
 
 class TestVThunderTasks(base.BaseTaskTestCase):
@@ -135,11 +179,10 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         mock_task._network_driver = a10_octavia_neutron.A10OctaviaNeutronDriver()
 
     def test_TagInterfaceForLB_create_vlan_ve_with_dhcp(self):
-        self.conf.register_opts(config_options.A10_HARDWARE_THUNDER_OPTS,
-                                group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION)
-        devices_str = json.dumps([RACK_DEVICE])
-        self.conf.config(group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION,
-                         devices=devices_str)
+        intf = a10_utils.convert_interface_to_data_model(ETHERNET_INTERFACE)
+        device1_network_map = a10_data_models.DeviceNetworkMap(vcs_device_id=1,
+                                                               ethernet_interfaces=[intf])
+        VTHUNDER.device_network_map = [device1_network_map]
         lb = self._mock_lb()
         mock_task = task.TagInterfaceForLB()
         self._mock_tag_task(mock_task)
@@ -162,11 +205,10 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         self.assertEqual(VE_IP, fixed_ip['ip_address'])
 
     def test_TagInterfaceForLB_create_ethernet_vlan_ve_with_static_ip(self):
-        self.conf.register_opts(config_options.A10_HARDWARE_THUNDER_OPTS,
-                                group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION)
-        devices_str = json.dumps([RACK_DEVICE])
-        self.conf.config(group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION,
-                         devices=devices_str)
+        intf = a10_utils.convert_interface_to_data_model(ETHERNET_INTERFACE)
+        device1_network_map = a10_data_models.DeviceNetworkMap(vcs_device_id=1,
+                                                               ethernet_interfaces=[intf])
+        VTHUNDER.device_network_map = [device1_network_map]
         lb = self._mock_lb()
         mock_task = task.TagInterfaceForLB()
         self._mock_tag_task(mock_task)
@@ -191,11 +233,10 @@ class TestVThunderTasks(base.BaseTaskTestCase):
                                                                 enable=True)
 
     def test_TagInterfaceForLB_create_trunk_vlan_ve_with_static_ip(self):
-        self.conf.register_opts(config_options.A10_HARDWARE_THUNDER_OPTS,
-                                group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION)
-        devices_str = json.dumps([RACK_DEVICE_TRUNK_INTERFACE])
-        self.conf.config(group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION,
-                         devices=devices_str)
+        intf = a10_utils.convert_interface_to_data_model(TRUNK_INTERFACE)
+        device1_network_map = a10_data_models.DeviceNetworkMap(vcs_device_id=1,
+                                                               trunk_interfaces=[intf])
+        VTHUNDER.device_network_map = [device1_network_map]
         lb = self._mock_lb()
         mock_task = task.TagInterfaceForLB()
         self._mock_tag_task(mock_task)
@@ -219,6 +260,18 @@ class TestVThunderTasks(base.BaseTaskTestCase):
                                                                 ip_netmask="255.255.255.0",
                                                                 enable=True)
 
+    def test_TagInterfaceForLB_create_vlan_ve_with_axapi_exception(self):
+        intf = a10_utils.convert_interface_to_data_model(ETHERNET_INTERFACE)
+        device1_network_map = a10_data_models.DeviceNetworkMap(vcs_device_id=1,
+                                                               ethernet_interfaces=[intf])
+        VTHUNDER.device_network_map = [device1_network_map]
+        lb = self._mock_lb()
+        mock_task = task.TagInterfaceForLB()
+        self._mock_tag_task(mock_task)
+        self.client_mock.interface.ethernet.get.return_value = ETH_DATA
+        self.client_mock.vlan.exists.side_effect = Exception
+        self.assertRaises(Exception, lambda: mock_task.execute(lb, VTHUNDER))
+
     def test_TagInterfaceForLB_revert_created_vlan(self):
         lb = self._mock_lb()
         mock_task = task.TagInterfaceForLB()
@@ -233,11 +286,10 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         mock_task._network_driver.neutron_client.delete_port.assert_called_with(DEL_PORT_ID)
 
     def test_TagInterfaceForMember_create_vlan_ve_with_dhcp(self):
-        self.conf.register_opts(config_options.A10_HARDWARE_THUNDER_OPTS,
-                                group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION)
-        devices_str = json.dumps([RACK_DEVICE])
-        self.conf.config(group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION,
-                         devices=devices_str)
+        intf = a10_utils.convert_interface_to_data_model(ETHERNET_INTERFACE)
+        device1_network_map = a10_data_models.DeviceNetworkMap(vcs_device_id=1,
+                                                               ethernet_interfaces=[intf])
+        VTHUNDER.device_network_map = [device1_network_map]
         member = self._mock_member()
         mock_task = task.TagInterfaceForMember()
         self._mock_tag_task(mock_task)
@@ -258,6 +310,20 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         fixed_ip = port['fixed_ips'][0]
         self.assertEqual(VE_IP, fixed_ip['ip_address'])
 
+    def test_TagInterfaceForMember_create_vlan_ve_with_neutron_exception(self):
+        intf = a10_utils.convert_interface_to_data_model(ETHERNET_INTERFACE)
+        device1_network_map = a10_data_models.DeviceNetworkMap(vcs_device_id=1,
+                                                               ethernet_interfaces=[intf])
+        VTHUNDER.device_network_map = [device1_network_map]
+        member = self._mock_member()
+        mock_task = task.TagInterfaceForMember()
+        self._mock_tag_task(mock_task)
+        self.client_mock.interface.ethernet.get.return_value = ETH_DATA
+        self.client_mock.vlan.exists.return_value = False
+        mock_task._network_driver.neutron_client.create_port = mock.Mock()
+        mock_task._network_driver.neutron_client.create_port.side_effect = Exception
+        self.assertRaises(Exception, lambda: mock_task.execute(member, VTHUNDER))
+
     def test_TagInterfaceForMember_revert_created_vlan(self):
         member = self._mock_member()
         mock_task = task.TagInterfaceForMember()
@@ -272,11 +338,10 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         mock_task._network_driver.neutron_client.delete_port.assert_called_with(DEL_PORT_ID)
 
     def test_DeleteInterfaceTagIfNotInUseForLB_execute_delete_vlan(self):
-        self.conf.register_opts(config_options.A10_HARDWARE_THUNDER_OPTS,
-                                group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION)
-        devices_str = json.dumps([RACK_DEVICE])
-        self.conf.config(group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION,
-                         devices=devices_str)
+        intf = a10_utils.convert_interface_to_data_model(ETHERNET_INTERFACE)
+        device1_network_map = a10_data_models.DeviceNetworkMap(vcs_device_id=1,
+                                                               ethernet_interfaces=[intf])
+        VTHUNDER.device_network_map = [device1_network_map]
         lb = self._mock_lb()
         mock_task = task.DeleteInterfaceTagIfNotInUseForLB()
         self._mock_tag_task(mock_task)
@@ -290,11 +355,10 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         mock_task._network_driver.neutron_client.delete_port.assert_called_with(DEL_PORT_ID)
 
     def test_DeleteInterfaceTagIfNotInUseForMember_execute_delete_vlan(self):
-        self.conf.register_opts(config_options.A10_HARDWARE_THUNDER_OPTS,
-                                group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION)
-        devices_str = json.dumps([RACK_DEVICE])
-        self.conf.config(group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION,
-                         devices=devices_str)
+        intf = a10_utils.convert_interface_to_data_model(ETHERNET_INTERFACE)
+        device1_network_map = a10_data_models.DeviceNetworkMap(vcs_device_id=1,
+                                                               ethernet_interfaces=[intf])
+        VTHUNDER.device_network_map = [device1_network_map]
         member = self._mock_member()
         mock_task = task.DeleteInterfaceTagIfNotInUseForMember()
         self._mock_tag_task(mock_task)
@@ -306,3 +370,49 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         mock_task.execute(member, VTHUNDER)
         self.client_mock.vlan.delete.assert_called_with(VLAN_ID)
         mock_task._network_driver.neutron_client.delete_port.assert_called_with(DEL_PORT_ID)
+
+    def test_SetupDeviceNetworkMap_execute_vcs_disabled(self):
+        self.conf.register_opts(config_options.A10_HARDWARE_THUNDER_OPTS,
+                                group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION)
+        devices_str = json.dumps([RACK_DEVICE])
+        self.conf.config(group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION,
+                         devices=devices_str)
+        mock_task = task.SetupDeviceNetworkMap()
+        self._mock_tag_task(mock_task)
+        mock_task.axapi_client.system.action.get_vcs_summary_oper.return_value = VCS_DISABLED
+        vthunder = mock_task.execute(VTHUNDER)
+        self.assertEqual(len(vthunder.device_network_map), 1)
+        self.assertEqual(vthunder.device_network_map[0].vcs_device_id, 1)
+
+    def test_SetupDeviceNetworkMap_execute_vcs_master_vblade(self):
+        self.conf.register_opts(config_options.A10_HARDWARE_THUNDER_OPTS,
+                                group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION)
+        devices_str = json.dumps([RACK_DEVICE_VCS])
+        self.conf.config(group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION,
+                         devices=devices_str)
+        mock_task = task.SetupDeviceNetworkMap()
+        self._mock_tag_task(mock_task)
+        mock_task.axapi_client.system.action.get_vcs_summary_oper.return_value = VCS_MASTER_VBLADE
+        vthunder = mock_task.execute(VTHUNDER)
+        self.assertEqual(len(vthunder.device_network_map), 2)
+        self.assertEqual(vthunder.device_network_map[0].vcs_device_id, 1)
+        self.assertEqual(vthunder.device_network_map[0].state, "Master")
+        self.assertEqual(vthunder.device_network_map[0].mgmt_ip_address, DEVICE1_MGMT_IP)
+        self.assertEqual(vthunder.device_network_map[1].vcs_device_id, 2)
+        self.assertEqual(vthunder.device_network_map[1].state, "vBlade")
+        self.assertEqual(vthunder.device_network_map[1].mgmt_ip_address, DEVICE2_MGMT_IP)
+
+    def test_SetupDeviceNetworkMap_execute_vcs_device1_failed(self):
+        self.conf.register_opts(config_options.A10_HARDWARE_THUNDER_OPTS,
+                                group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION)
+        devices_str = json.dumps([RACK_DEVICE_VCS])
+        self.conf.config(group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION,
+                         devices=devices_str)
+        mock_task = task.SetupDeviceNetworkMap()
+        self._mock_tag_task(mock_task)
+        mock_task.axapi_client.system.action.get_vcs_summary_oper.return_value = VCS_DEVICE1_FAILED
+        vthunder = mock_task.execute(VTHUNDER)
+        self.assertEqual(len(vthunder.device_network_map), 1)
+        self.assertEqual(vthunder.device_network_map[0].vcs_device_id, 2)
+        self.assertEqual(vthunder.device_network_map[0].state, "Master")
+        self.assertEqual(vthunder.device_network_map[0].mgmt_ip_address, DEVICE2_MGMT_IP)


### PR DESCRIPTION
## Description
a) In the VRRP-A High Availability & aVCS environment if one of the device in the cluster goes down then the configuration changes are handled gracefully without erring out. When the other device of the cluster comes up, the configurations to the device that came up can be pushed through update calls.
b) DCHP -> Static & Static -> DHCP config changes fail. Neutron ports are created, updated and deleted according to config.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1375
https://a10networks.atlassian.net/browse/STACK-1376
https://a10networks.atlassian.net/browse/STACK-1377
[STACK-1347](https://a10networks.atlassian.net/browse/STACK-1347)
[STACK-1349](https://a10networks.atlassian.net/browse/STACK-1349)



## Technical Approach
a)A new task SetupDeviceNetworkMap is introduced to setup device_network_map in vthunder to contain only vcs devices with known states and have Master device object at index 0. The vcs-summary information is obtained from the Master and used to determine the device status in the cluster. Later the TagInterface* tasks act upon only up devices.

b) Updation Approach
- Since ACOS client api `interface.ve.update()` doesn't seem to work in case of static ve_ip to dhcp updation. It throws error 
`DHCP address has to be the first configured under an interface.`

Hence used approach of first `interface.ve.delete()` then `interface.ve.create()`.

## Config Changes
<pre>
[a10_global]
network_type = "vlan"

[hardware_thunder]
devices=[
 {
 "project_id": "9b990719b64a4b2897d378ba56bba78d",
 "ip_address": "10.0.0.99",
 "device_name": "rack_vthunder",
 "username": "admin",
 "password": "a10",
 "interface_vlan_map": {
  "device_1": {
   "vcs_device_id": 1,
   <b>"mgmt_ip_address": "10.0.0.74",</b>
   "ethernet_interfaces": [{
    "interface_num": 2,
    "vlan_map": [
     {"vlan_id": 12, "ve_ip": ".10"}
    ]
   }],
   "trunk_interfaces": [{
    "interface_num": 1,
    "vlan_map": [
     {"vlan_id": 13, "ve_ip" : ".10"},
     {"vlan_id": 14, "ve_ip": ".10"}
    ]
   }],
  },
  "device_2": {
   "vcs_device_id": 2,
   <b>"mgmt_ip_address": "10.0.0.47",</b>
   "ethernet_interfaces": [{
    "interface_num": 2,
    "vlan_map": [
     {"vlan_id": 12, "ve_ip": ".20"}
    ]
   }],
   "trunk_interfaces": [{
    "interface_num": 1,
    "vlan_map": [
     {"vlan_id": 13, "ve_ip" : ".20"},
     {"vlan_id": 14, "ve_ip": ".20"}
    ]
   }],
  }
 }
 }]
</pre>

## Test Cases
a) Unit test cases changes contain positive and negative test cases.
b) **_For ve_ip creates, updates and delete_**
CREATION on vThunder and openstack neutron ports
- if a static `ve_ip` is configured in `ethernet_interfaces` -> CREATED
- if `use_dhcp` set as `True` in `ethernet_interfaces` -> CREATED
- if static `ve_ip` is configured in `trunk_interfaces` -> CREATED
- if `use_dhcp` set as `True` in `trunk_interfaces` -> CREATED


UPDATION on vThunder and openstack neutron ports
- if existing static `ve_ip` is changed to new `ve_ip` in `ethernet_interfaces` -> UPDATED
- if existing static `ve_ip` is changed to dhcp setting in `ethernet_interfaces` -> UPDATED
- if existing dhcp is changed to static ve_ip in `ethernet_interfaces` -> UPDATED
- if existing static `ve_ip` is changed to new `ve_ip` in `trunk_interfaces` -> UPDATED
- if existing static `ve_ip` is changed to dhcp setting in `trunk_interfaces` -> UPDATED
- if existing dhcp is changed to static ve_ip in `trunk_interfaces` -> UPDATED

DELETION on vThunder and openstack neutron ports
- if member is deleted, corresponding vlan, ve/trunk ve_ip configs are deleted 

## Manual Testing

a) device 1 and device 2 testing
1) State device-1: Master and device-2: vBlade
   1a) Add/Update/Delete Loadbalancer, check applies to both devices.
       $ openstack loadbalancer create --provider=a10 --name a10lb1 --vip-subnet-id provider-vlan-12-subnet --project 9b990719b64a4b2897d378ba56bba78d
       # Update VLAN 12 device-1 ve_ip: ".11" and device_2 ve_ip: ".21"
       # sudo systemctl restart a10-controller-worker.service
       $ openstack loadbalancer set a10lb1
       $ openstack loadbalancer delete a10lb1
   1b) Add/Update/Delete Member, check applies to both devices
       $ openstack loadbalancer create --provider=a10 --name a10lb1 --vip-subnet-id provider-vlan-12-subnet --project 9b990719b64a4b2897d378ba56bba78d
       $ openstack loadbalancer listener create --name listener1 --protocol HTTP --protocol-port 80 a10lb1
       $ openstack loadbalancer pool create --name pool1 --lb-algorithm ROUND_ROBIN --listener listener1 --protocol HTTP
       $ openstack loadbalancer member create --subnet-id provider-vlan-13-subnet --address  10.0.13.110 --protocol-port 80 pool1
       # Update VLAN 13 device-1 ve_ip: ".11" and device_2 ve_ip: ".21"
       # sudo systemctl restart a10-controller-worker.service
       $ openstack loadbalancer member set pool1 f30d983d-e488-4afe-ad45-8b6f49b2d217
       $ openstack loadbalancer member delete pool1 f30d983d-e488-4afe-ad45-8b6f49b2d217
       $ openstack loadbalancer pool delete pool1
       $ openstack loadbalancer listener delete listener1
       $ openstack loadbalancer delete a10lb1

2) Make device-2 down(link down). State device-1: Master and device-2: Unknown
   $ sudo ip link set vnet5 down
   2a) Add/Update/Delete Loadbalancer, check applies to one device.
       #commands same as "1a"
   2b) Add/Update Member, check applies to one device.
       #commands same as "1b" without deletes
       $ openstack loadbalancer member set pool1 ad2094db-8ccb-40bb-ab7f-1c45fe20352a

3) Bring device-2 up State device-1: Master and device-2: vBlade
   $ sudo ip link set vnet5 up
   3a) Update LB and Member, check device-1 config is synced to device-2
       $ openstack loadbalancer set a10lb1
       $ openstack loadbalancer member set pool1 ad2094db-8ccb-40bb-ab7f-1c45fe20352a

4) Make device-1 down(Reload) State device-1: Unknown and device-2: Master
   4a) Add one more Member on device-2
       $ openstack loadbalancer member create --subnet-id provider-vlan-14-subnet --address  10.0.14.110 --protocol-port 80 pool1

5) Bring device-1 up State device-1: vBlade and device-2: Master
   5a) Update Member, check device-2 config is synced to device-1
       $ openstack loadbalancer member set pool1 c29147a2-21ac-4348-856a-6c1b5bd9964f
   5b) Add one more member and check config
       $ openstack loadbalancer member create --subnet-id provider-vlan-14-subnet --address  10.0.14.111 --protocol-port 80 pool1
   5c) Delete all config
       $ openstack loadbalancer member delete pool1 01d1e537-b399-42a4-97a0-4e982526b493
       $ openstack loadbalancer member delete pool1 c29147a2-21ac-4348-856a-6c1b5bd9964f
       $ openstack loadbalancer member delete pool1 ad2094db-8ccb-40bb-ab7f-1c45fe20352a
       $ openstack loadbalancer pool delete pool1
       $ openstack loadbalancer listener delete listener1
       $ openstack loadbalancer delete a10lb1

b) Prerequisite : 
- Use `install-a10-octavia` to install vlan setup.
- Have required ovs-vsctl setting. eg creating bonds etc.
- On aVCS setup, in vthunders, have set up vrid floating ip
- In `a10-octavia.conf`, include `vrid_floating_ip` and `standby_ip_address` setting.

STEP 1: Configure required ve_ip/dhcp setting for `ethernet_interfaces` or/and `trunk_interfaces` in `a10-octavia.conf`
STEP 2: Restart `a10-controller-worker.service` service
STEP 3: Create loadbalancer, listener, pool and member. 
STEP 4: Check on vThunder, if proper ve/trunk ips are configured.
STEP 5: Check on openstack UI for neutron port created with same ve_ip addresses.