### PR TITLE
[Bug][STACK-1321]: Member isn't removed from Thunder if delete a pool from Octavia

### DIFF
--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -553,6 +553,10 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         load_balancer = pool.load_balancer
         listeners = pool.listeners
 
+        if pool.members:
+            for member in pool.members:
+                self.delete_member(member.id)
+
         delete_pool_tf = self._taskflow_load(
             self._pool_flows.get_delete_pool_flow(),
             store={constants.POOL: pool, constants.LISTENERS: listeners,


### PR DESCRIPTION
## Description
- Severity Level : Critical
- Delete a pool that has a member inside, will succeed in Octavia. But on Thunder, the server(member) is still there.

## Jira Ticket
[STACK-1321](https://a10networks.atlassian.net/browse/STACK-1321)

## Technical Approach
- When pool is deleted, the child members are deleted before that. 
- Added `delete_member` flow inside `delete_pool` flow of `controller_worker` module.

## Config Changes
None

## Test Cases
- When pool is deleted via openstack cli command, the members are also deleted from vthunder.

## Manual Testing
- `openstack loadbalancer pool delete pool1`
- Check vthunder, all the child members (servers) are deleted.