### PR TITLE
STACK-1314: Add write mem to end of flows

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
@@ -50,7 +50,8 @@ class HealthMonitorFlows(object):
             requires=constants.POOL))
         create_hm_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-
+        create_hm_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return create_hm_flow
 
     def get_delete_health_monitor_flow(self):
@@ -85,7 +86,8 @@ class HealthMonitorFlows(object):
             requires=constants.POOL))
         delete_hm_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-
+        delete_hm_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return delete_hm_flow
 
     def get_update_health_monitor_flow(self):
@@ -114,5 +116,6 @@ class HealthMonitorFlows(object):
             requires=constants.POOL))
         update_hm_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-
+        update_hm_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return update_hm_flow

--- a/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
@@ -23,6 +23,7 @@ from octavia.controller.worker.tasks import model_tasks
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks
 from a10_octavia.controller.worker.tasks import health_monitor_tasks
+from a10_octavia.controller.worker.tasks import vthunder_tasks
 
 
 class HealthMonitorFlows(object):
@@ -50,7 +51,7 @@ class HealthMonitorFlows(object):
             requires=constants.POOL))
         create_hm_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        create_hm_flow.add(virtual_server_tasks.WriteMemory(
+        create_hm_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return create_hm_flow
 
@@ -86,7 +87,7 @@ class HealthMonitorFlows(object):
             requires=constants.POOL))
         delete_hm_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        delete_hm_flow.add(virtual_server_tasks.WriteMemory(
+        delete_hm_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return delete_hm_flow
 
@@ -116,6 +117,6 @@ class HealthMonitorFlows(object):
             requires=constants.POOL))
         update_hm_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        update_hm_flow.add(virtual_server_tasks.WriteMemory(
+        update_hm_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return update_hm_flow

--- a/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
@@ -22,6 +22,7 @@ from octavia.controller.worker.tasks import model_tasks
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks
 from a10_octavia.controller.worker.tasks import l7policy_tasks
+from a10_octavia.controller.worker.tasks import vthunder_tasks
 
 
 class L7PolicyFlows(object):
@@ -47,7 +48,7 @@ class L7PolicyFlows(object):
             requires=constants.L7POLICY))
         create_l7policy_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        create_l7policy_flow.add(virtual_server_tasks.WriteMemory(
+        create_l7policy_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return create_l7policy_flow
 
@@ -74,7 +75,7 @@ class L7PolicyFlows(object):
             requires=constants.L7POLICY))
         delete_l7policy_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        delete_l7policy_flow.add(virtual_server_tasks.WriteMemory(
+        delete_l7policy_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return delete_l7policy_flow
 
@@ -106,6 +107,6 @@ class L7PolicyFlows(object):
             requires=constants.L7POLICY))
         update_l7policy_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        update_l7policy_flow.add(virtual_server_tasks.WriteMemory(
+        update_l7policy_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return update_l7policy_flow

--- a/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
@@ -47,7 +47,8 @@ class L7PolicyFlows(object):
             requires=constants.L7POLICY))
         create_l7policy_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-
+        create_l7policy_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return create_l7policy_flow
 
     def get_delete_l7policy_flow(self):
@@ -73,7 +74,8 @@ class L7PolicyFlows(object):
             requires=constants.L7POLICY))
         delete_l7policy_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-
+        delete_l7policy_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return delete_l7policy_flow
 
     def get_update_l7policy_flow(self):
@@ -104,5 +106,6 @@ class L7PolicyFlows(object):
             requires=constants.L7POLICY))
         update_l7policy_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-
+        update_l7policy_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return update_l7policy_flow

--- a/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
@@ -22,6 +22,7 @@ from octavia.controller.worker.tasks import model_tasks
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks
 from a10_octavia.controller.worker.tasks import l7rule_tasks
+from a10_octavia.controller.worker.tasks import vthunder_tasks
 
 
 class L7RuleFlows(object):
@@ -48,7 +49,7 @@ class L7RuleFlows(object):
             requires=constants.L7POLICY))
         create_l7rule_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        create_l7rule_flow.add(virtual_server_tasks.WriteMemory(
+        create_l7rule_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return create_l7rule_flow
 
@@ -75,7 +76,7 @@ class L7RuleFlows(object):
             requires=constants.L7POLICY))
         delete_l7rule_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        delete_l7rule_flow.add(virtual_server_tasks.WriteMemory(
+        delete_l7rule_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return delete_l7rule_flow
 
@@ -108,6 +109,6 @@ class L7RuleFlows(object):
             requires=constants.L7POLICY))
         update_l7rule_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        update_l7rule_flow.add(virtual_server_tasks.WriteMemory(
+        update_l7rule_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return update_l7rule_flow

--- a/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
@@ -48,7 +48,8 @@ class L7RuleFlows(object):
             requires=constants.L7POLICY))
         create_l7rule_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-
+        create_l7rule_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return create_l7rule_flow
 
     def get_delete_l7rule_flow(self):
@@ -74,7 +75,8 @@ class L7RuleFlows(object):
             requires=constants.L7POLICY))
         delete_l7rule_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-
+        delete_l7rule_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return delete_l7rule_flow
 
     def get_update_l7rule_flow(self):
@@ -106,5 +108,6 @@ class L7RuleFlows(object):
             requires=constants.L7POLICY))
         update_l7rule_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-
+        update_l7rule_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return update_l7rule_flow

--- a/a10_octavia/controller/worker/flows/a10_listener_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_listener_flows.py
@@ -69,7 +69,7 @@ class ListenerFlows(object):
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
         create_all_listeners_flow.add(network_tasks.UpdateVIP(
             requires=constants.LOADBALANCER))
-        create_all_listener_flow.add(vthunder_tasks.WriteMemory(
+        create_all_listeners_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return create_all_listeners_flow
 

--- a/a10_octavia/controller/worker/flows/a10_listener_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_listener_flows.py
@@ -46,6 +46,8 @@ class ListenerFlows(object):
                                  MarkLBAndListenersActiveInDB(
                                      requires=[constants.LOADBALANCER,
                                                constants.LISTENERS]))
+        create_listener_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return create_listener_flow
 
     def get_create_all_listeners_flow(self):
@@ -66,6 +68,8 @@ class ListenerFlows(object):
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
         create_all_listeners_flow.add(network_tasks.UpdateVIP(
             requires=constants.LOADBALANCER))
+        create_all_listener_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return create_all_listeners_flow
 
     def get_delete_listener_flow(self):
@@ -89,7 +93,8 @@ class ListenerFlows(object):
             requires=constants.LISTENER))
         delete_listener_flow.add(database_tasks.MarkLBActiveInDB(
             requires=constants.LOADBALANCER))
-
+        delete_listener_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return delete_listener_flow
 
     def get_delete_rack_listener_flow(self):
@@ -111,7 +116,8 @@ class ListenerFlows(object):
             requires=constants.LISTENER))
         delete_listener_flow.add(database_tasks.MarkLBActiveInDB(
             requires=constants.LOADBALANCER))
-
+        delete_listener_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return delete_listener_flow
 
     def get_delete_listener_internal_flow(self, listener_name):
@@ -157,7 +163,8 @@ class ListenerFlows(object):
                                  MarkLBAndListenersActiveInDB(
                                      requires=[constants.LOADBALANCER,
                                                constants.LISTENERS]))
-
+        update_listener_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return update_listener_flow
 
     def get_rack_vthunder_create_listener_flow(self, project_id):
@@ -180,4 +187,6 @@ class ListenerFlows(object):
                                  MarkLBAndListenersActiveInDB(
                                      requires=[constants.LOADBALANCER,
                                                constants.LISTENERS]))
+        create_listener_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return create_listener_flow

--- a/a10_octavia/controller/worker/flows/a10_listener_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_listener_flows.py
@@ -23,6 +23,7 @@ from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks
 from a10_octavia.controller.worker.tasks import a10_network_tasks
 from a10_octavia.controller.worker.tasks import virtual_port_tasks
+from a10_octavia.controller.worker.tasks import vthunder_tasks
 
 
 class ListenerFlows(object):
@@ -46,7 +47,7 @@ class ListenerFlows(object):
                                  MarkLBAndListenersActiveInDB(
                                      requires=[constants.LOADBALANCER,
                                                constants.LISTENERS]))
-        create_listener_flow.add(virtual_server_tasks.WriteMemory(
+        create_listener_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return create_listener_flow
 
@@ -68,7 +69,7 @@ class ListenerFlows(object):
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
         create_all_listeners_flow.add(network_tasks.UpdateVIP(
             requires=constants.LOADBALANCER))
-        create_all_listener_flow.add(virtual_server_tasks.WriteMemory(
+        create_all_listener_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return create_all_listeners_flow
 
@@ -93,7 +94,7 @@ class ListenerFlows(object):
             requires=constants.LISTENER))
         delete_listener_flow.add(database_tasks.MarkLBActiveInDB(
             requires=constants.LOADBALANCER))
-        delete_listener_flow.add(virtual_server_tasks.WriteMemory(
+        delete_listener_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return delete_listener_flow
 
@@ -116,7 +117,7 @@ class ListenerFlows(object):
             requires=constants.LISTENER))
         delete_listener_flow.add(database_tasks.MarkLBActiveInDB(
             requires=constants.LOADBALANCER))
-        delete_listener_flow.add(virtual_server_tasks.WriteMemory(
+        delete_listener_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return delete_listener_flow
 
@@ -163,7 +164,7 @@ class ListenerFlows(object):
                                  MarkLBAndListenersActiveInDB(
                                      requires=[constants.LOADBALANCER,
                                                constants.LISTENERS]))
-        update_listener_flow.add(virtual_server_tasks.WriteMemory(
+        update_listener_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return update_listener_flow
 
@@ -187,6 +188,6 @@ class ListenerFlows(object):
                                  MarkLBAndListenersActiveInDB(
                                      requires=[constants.LOADBALANCER,
                                                constants.LISTENERS]))
-        create_listener_flow.add(virtual_server_tasks.WriteMemory(
+        create_listener_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return create_listener_flow

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -81,7 +81,7 @@ class LoadBalancerFlows(object):
         lb_create_flow.add(virtual_server_tasks.CreateVirtualServerTask(
             requires=(constants.LOADBALANCER,
                            a10constants.VTHUNDER)))
-        lb_create_flow.add(virtual_server_tasks.WriteMemory(
+        lb_create_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return lb_create_flow
 
@@ -208,7 +208,7 @@ class LoadBalancerFlows(object):
             requires=constants.LOADBALANCER))
         delete_LB_flow.add(database_tasks.DecrementLoadBalancerQuota(
             requires=constants.LOADBALANCER))
-        delete_LB_flow.add(virtual_server_tasks.WriteMemory(
+        delete_LB_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return (delete_LB_flow, store)
 
@@ -299,7 +299,7 @@ class LoadBalancerFlows(object):
                           a10constants.VTHUNDER]))
         update_LB_flow.add(database_tasks.MarkLBActiveInDB(
             requires=constants.LOADBALANCER))
-        update_LB_flow.add(virtual_server_tasks.WriteMemory(
+        update_LB_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return update_LB_flow
 
@@ -327,7 +327,7 @@ class LoadBalancerFlows(object):
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
             provides=a10constants.STATUS))
 
-        lb_create_flow.add(virtual_server_tasks.WriteMemory(
+        lb_create_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return lb_create_flow
 

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -81,7 +81,8 @@ class LoadBalancerFlows(object):
         lb_create_flow.add(virtual_server_tasks.CreateVirtualServerTask(
             requires=(constants.LOADBALANCER,
                            a10constants.VTHUNDER)))
-
+        lb_create_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return lb_create_flow
 
     def _create_single_topology(self):
@@ -207,7 +208,8 @@ class LoadBalancerFlows(object):
             requires=constants.LOADBALANCER))
         delete_LB_flow.add(database_tasks.DecrementLoadBalancerQuota(
             requires=constants.LOADBALANCER))
-
+        delete_LB_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return (delete_LB_flow, store)
 
     def get_new_lb_networking_subflow(self, topology):
@@ -297,6 +299,8 @@ class LoadBalancerFlows(object):
                           a10constants.VTHUNDER]))
         update_LB_flow.add(database_tasks.MarkLBActiveInDB(
             requires=constants.LOADBALANCER))
+        update_LB_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return update_LB_flow
 
     def get_create_rack_vthunder_load_balancer_flow(self, vthunder_conf, topology, listeners=None):
@@ -323,6 +327,8 @@ class LoadBalancerFlows(object):
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
             provides=a10constants.STATUS))
 
+        lb_create_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return lb_create_flow
 
     def get_post_lb_rack_vthunder_association_flow(self, prefix, topology,

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -97,7 +97,8 @@ class MemberFlows(object):
                                MarkLBAndListenersActiveInDB(
                                    requires=(constants.LOADBALANCER,
                                              constants.LISTENERS)))
-
+        create_member_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return create_member_flow
 
     def get_delete_member_flow(self):
@@ -150,7 +151,8 @@ class MemberFlows(object):
             provides=a10constants.DELETE_VRID))
         delete_member_flow.add(a10_database_tasks.DeleteVRIDEntry(
             requires=[a10constants.VRID, a10constants.DELETE_VRID]))
-
+        delete_member_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return delete_member_flow
 
     def get_update_member_flow(self):
@@ -197,7 +199,8 @@ class MemberFlows(object):
                                MarkLBAndListenersActiveInDB(
                                    requires=[constants.LOADBALANCER,
                                              constants.LISTENERS]))
-
+        update_member_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return update_member_flow
 
     def get_batch_update_members_flow(self, old_members, new_members,
@@ -286,7 +289,8 @@ class MemberFlows(object):
             database_tasks.MarkLBAndListenersActiveInDB(
                 requires=(constants.LOADBALANCER,
                           constants.LISTENERS)))
-
+        batch_update_members_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return batch_update_members_flow
 
     def get_rack_vthunder_create_member_flow(self):
@@ -330,4 +334,6 @@ class MemberFlows(object):
                                MarkLBAndListenersActiveInDB(
                                    requires=(constants.LOADBALANCER,
                                              constants.LISTENERS)))
+        create_member_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         return create_member_flow

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -97,7 +97,7 @@ class MemberFlows(object):
                                MarkLBAndListenersActiveInDB(
                                    requires=(constants.LOADBALANCER,
                                              constants.LISTENERS)))
-        create_member_flow.add(virtual_server_tasks.WriteMemory(
+        create_member_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return create_member_flow
 
@@ -151,7 +151,7 @@ class MemberFlows(object):
             provides=a10constants.DELETE_VRID))
         delete_member_flow.add(a10_database_tasks.DeleteVRIDEntry(
             requires=[a10constants.VRID, a10constants.DELETE_VRID]))
-        delete_member_flow.add(virtual_server_tasks.WriteMemory(
+        delete_member_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return delete_member_flow
 
@@ -199,7 +199,7 @@ class MemberFlows(object):
                                MarkLBAndListenersActiveInDB(
                                    requires=[constants.LOADBALANCER,
                                              constants.LISTENERS]))
-        update_member_flow.add(virtual_server_tasks.WriteMemory(
+        update_member_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return update_member_flow
 
@@ -289,7 +289,7 @@ class MemberFlows(object):
             database_tasks.MarkLBAndListenersActiveInDB(
                 requires=(constants.LOADBALANCER,
                           constants.LISTENERS)))
-        batch_update_members_flow.add(virtual_server_tasks.WriteMemory(
+        batch_update_members_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return batch_update_members_flow
 
@@ -334,6 +334,6 @@ class MemberFlows(object):
                                MarkLBAndListenersActiveInDB(
                                    requires=(constants.LOADBALANCER,
                                              constants.LISTENERS)))
-        create_member_flow.add(virtual_server_tasks.WriteMemory(
+        create_member_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         return create_member_flow

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -54,7 +54,7 @@ class PoolFlows(object):
             requires=constants.POOL))
         create_pool_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        create_pool_flow.add(virtual_server_tasks.WriteMemory(
+        create_pool_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
 
         return create_pool_flow
@@ -91,7 +91,7 @@ class PoolFlows(object):
             requires=[constants.POOL, constants.POOL_CHILD_COUNT]))
         delete_pool_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        delete_pool_flow.add(virtual_server_tasks.WriteMemory(
+        delete_pool_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
 
         return delete_pool_flow
@@ -154,7 +154,7 @@ class PoolFlows(object):
             requires=constants.POOL))
         update_pool_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        update_pool_flow.add(virtual_server_tasks.WriteMemory(
+        update_pool_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
 
         return update_pool_flow

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -25,6 +25,7 @@ from a10_octavia.controller.worker.tasks import a10_database_tasks
 from a10_octavia.controller.worker.tasks import persist_tasks
 from a10_octavia.controller.worker.tasks import service_group_tasks
 from a10_octavia.controller.worker.tasks import virtual_port_tasks
+from a10_octavia.controller.worker.tasks import vthunder_tasks
 
 
 class PoolFlows(object):

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -54,6 +54,8 @@ class PoolFlows(object):
             requires=constants.POOL))
         create_pool_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
+        create_pool_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
 
         return create_pool_flow
 
@@ -89,6 +91,8 @@ class PoolFlows(object):
             requires=[constants.POOL, constants.POOL_CHILD_COUNT]))
         delete_pool_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
+        delete_pool_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
 
         return delete_pool_flow
 
@@ -150,6 +154,8 @@ class PoolFlows(object):
             requires=constants.POOL))
         update_pool_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
+        update_pool_flow.add(virtual_server_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
 
         return update_pool_flow
 

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -744,20 +744,24 @@ class DeleteInterfaceTagIfNotInUseForMember(TagInterfaceBaseTask):
             LOG.exception("Failed to delete VLAN on vThunder: %s", str(e))
 
 
-class WriteMemory(task.Task):
+class WriteMemory(VThunderBaseTask):
 
     """Task to write memory of the Thunder device"""
 
-
     @device_context_switch_decorator
     def write_device_mem(self, partition_name, device_id=None, default_device_id=None):
-        self.axap_client.v3.acion.write_memory(partition=partition_name)
+        self.axapi_client.v3.action.write_memory(partition=partition_name)
 
     @axapi_client_decorator
     def execute(self, vthunder):
-        default_device_id = self.axapi_client.system.action.get_vrrp_device_id()
-        if vthunder_conf.device_network_map:
-            for device_obj in vthunder_conf.device_network_map:
+        default_device_id = None
+        if vthunder.project_id in CONF.hardware_thunder.devices:
+            thunder_conf = CONF.hardware_thunder.devices[vthunder.project_id]
+            if len(thunder_conf.device_network_map) > 1:
+                default_device_id = self.axapi_client.system.action.get_vrrp_device_id()
+
+        if default_device_id:
+            for device_obj in thunder_conf.device_network_map:
                 self.write_device_mem(vthunder.partition_name, device_obj.vcs_device_id, default_device_id)
         else:
             self.write_device_mem(vthunder.partition_name)

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -750,7 +750,7 @@ class WriteMemory(VThunderBaseTask):
 
     @device_context_switch_decorator
     def write_device_mem(self, partition_name, device_id=None, default_device_id=None):
-        self.axapi_client.v3.action.write_memory(partition=partition_name)
+        self.axapi_client.system.action.write_memory(partition=partition_name)
 
     @axapi_client_decorator
     def execute(self, vthunder):

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -742,3 +742,22 @@ class DeleteInterfaceTagIfNotInUseForMember(TagInterfaceBaseTask):
                                                 master_device_id=master_device_id)
         except Exception as e:
             LOG.exception("Failed to delete VLAN on vThunder: %s", str(e))
+
+
+class WriteMemory(task.Task):
+
+    """Task to write memory of the Thunder device"""
+
+
+    @device_context_switch_decorator
+    def write_device_mem(self, partition_name, device_id=None, default_device_id=None):
+        self.axap_client.v3.acion.write_memory(partition=partition_name)
+
+    @axapi_client_decorator
+    def execute(self, vthunder):
+        default_device_id = self.axapi_client.system.action.get_vrrp_device_id()
+        if vthunder_conf.device_network_map:
+            for device_obj in vthunder_conf.device_network_map:
+                self.write_device_mem(vthunder.partition_name, device_obj.vcs_device_id, default_device_id)
+        else:
+            self.write_device_mem(vthunder.partition_name)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -419,58 +419,17 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         self.assertEqual(vthunder.device_network_map[0].mgmt_ip_address, DEVICE2_MGMT_IP)
 
     def test_WriteMemory_execute_save_shared_mem(self):
-        self.conf.register_opts(config_options.A10_HARDWARE_THUNDER_OPTS,
-                                group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION)
         mock_task = task.WriteMemory()
         mock_task.axapi_client = self.client_mock
         mock_task.execute(VTHUNDER)
-        self.client_mock.v3.action.write_memory.assert_called()
+        self.client_mock.system.action.write_memory.assert_called_with(partition='shared')
 
-    def test_WriteMemory_execute_save_shared_mem(self):
-        self.conf.register_opts(config_options.A10_HARDWARE_THUNDER_OPTS,
-                                group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION)
-        thunder = copy.deepcopy(VTHUNDER) 
+    def test_WriteMemory_execute_save_specific_partition_mem(self):
+        thunder = copy.deepcopy(VTHUNDER)
         thunder.partition_name = "testPartition"
         mock_task = task.WriteMemory()
         mock_task.axapi_client = self.client_mock
         mock_task.execute(thunder)
-        self.client_mock.v3.action.write_memory.assert_called_with(partition="testPartition")
-
-    def test_WriteMemroy_execute_save_mem_hardware_deployment(self):
-        self.conf.register_opts(config_options.A10_HARDWARE_THUNDER_OPTS,
-                                group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION)
-        devices_str = json.dumps([RACK_DEVICE])
-        self.conf.config(group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION,
-                         devices=devices_str)
-        mock_task = task.WriteMemory()
-        mock_task.write_device_mem = mock.Mock()
-        mock_task.axapi_client = self.client_mock
-        thunder = copy.deepcopy(VTHUNDER)
-        thunder.project_id = "project-rack-vthunder"
-
-        mock_task.execute(thunder)
-        self.client_mock.system.action.get_vrrp_device_id.assert_not_called()
-        mock_task.write_device_mem.assert_called()
-
-    def test_WriteMemroy_execute_save_mem_hardware_deployment_ha(self):
-        self.conf.register_opts(config_options.A10_HARDWARE_THUNDER_OPTS,
-                                group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION)
-        ha_rack = copy.copy(RACK_DEVICE)
-        ha_rack['interface_vlan_map']['device_2'] = RACK_DEVICE_TRUNK_INTERFACE['interface_vlan_map']['device_1']
-        ha_rack['interface_vlan_map']['device_2']['vcs_device_id'] = 2
-        devices_str = json.dumps([ha_rack])
-        self.conf.config(group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION,
-                         devices=devices_str)
-
-        mock_task = task.WriteMemory()
-        mock_task.write_device_mem = mock.Mock()
-        mock_task.axapi_client = self.client_mock
-        mock_task.axapi_client.system.action.get_vrrp_device_id.return_value = 1
-        thunder = copy.deepcopy(VTHUNDER)
-        thunder.project_id = "project-rack-vthunder"
-        thunder.partition_name = "shared"
-        mock_task.execute(thunder)
-
-        self.client_mock.system.action.get_vrrp_device_id.assert_called()
-        write_mem_calls = [mock.call("shared", 1, 1), mock.call("shared", 2, 1)]
-        mock_task.write_device_mem.assert_has_calls(write_mem_calls, any_order=True)
+        self.client_mock.system.action.write_memory.assert_called_with(
+            partition='specified',
+            specified_partition='testPartition')

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -13,6 +13,7 @@
 #    under the License.
 
 
+import copy
 import imp
 import json
 try:
@@ -416,3 +417,60 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         self.assertEqual(vthunder.device_network_map[0].vcs_device_id, 2)
         self.assertEqual(vthunder.device_network_map[0].state, "Master")
         self.assertEqual(vthunder.device_network_map[0].mgmt_ip_address, DEVICE2_MGMT_IP)
+
+    def test_WriteMemory_execute_save_shared_mem(self):
+        self.conf.register_opts(config_options.A10_HARDWARE_THUNDER_OPTS,
+                                group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION)
+        mock_task = task.WriteMemory()
+        mock_task.axapi_client = self.client_mock
+        mock_task.execute(VTHUNDER)
+        self.client_mock.v3.action.write_memory.assert_called()
+
+    def test_WriteMemory_execute_save_shared_mem(self):
+        self.conf.register_opts(config_options.A10_HARDWARE_THUNDER_OPTS,
+                                group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION)
+        thunder = copy.deepcopy(VTHUNDER) 
+        thunder.partition_name = "testPartition"
+        mock_task = task.WriteMemory()
+        mock_task.axapi_client = self.client_mock
+        mock_task.execute(thunder)
+        self.client_mock.v3.action.write_memory.assert_called_with(partition="testPartition")
+
+    def test_WriteMemroy_execute_save_mem_hardware_deployment(self):
+        self.conf.register_opts(config_options.A10_HARDWARE_THUNDER_OPTS,
+                                group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION)
+        devices_str = json.dumps([RACK_DEVICE])
+        self.conf.config(group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION,
+                         devices=devices_str)
+        mock_task = task.WriteMemory()
+        mock_task.write_device_mem = mock.Mock()
+        mock_task.axapi_client = self.client_mock
+        thunder = copy.deepcopy(VTHUNDER)
+        thunder.project_id = "project-rack-vthunder"
+
+        mock_task.execute(thunder)
+        self.client_mock.system.action.get_vrrp_device_id.assert_not_called()
+        mock_task.write_device_mem.assert_called()
+
+    def test_WriteMemroy_execute_save_mem_hardware_deployment_ha(self):
+        self.conf.register_opts(config_options.A10_HARDWARE_THUNDER_OPTS,
+                                group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION)
+        ha_rack = copy.copy(RACK_DEVICE)
+        ha_rack['interface_vlan_map']['device_2'] = RACK_DEVICE_TRUNK_INTERFACE['interface_vlan_map']['device_1']
+        ha_rack['interface_vlan_map']['device_2']['vcs_device_id'] = 2
+        devices_str = json.dumps([ha_rack])
+        self.conf.config(group=a10constants.A10_HARDWARE_THUNDER_CONF_SECTION,
+                         devices=devices_str)
+
+        mock_task = task.WriteMemory()
+        mock_task.write_device_mem = mock.Mock()
+        mock_task.axapi_client = self.client_mock
+        mock_task.axapi_client.system.action.get_vrrp_device_id.return_value = 1
+        thunder = copy.deepcopy(VTHUNDER)
+        thunder.project_id = "project-rack-vthunder"
+        thunder.partition_name = "shared"
+        mock_task.execute(thunder)
+
+        self.client_mock.system.action.get_vrrp_device_id.assert_called()
+        write_mem_calls = [mock.call("shared", 1, 1), mock.call("shared", 2, 1)]
+        mock_task.write_device_mem.assert_has_calls(write_mem_calls, any_order=True)


### PR DESCRIPTION
## Description
Writes device memory at the end of each flow

## Linked PR
https://github.com/a10networks/acos-client/pull/281

## Jira Ticket
[STACK-1314](https://a10networks.atlassian.net/browse/STACK-1314)

## Technical Approach
- Required: Overview of approach taken to solve the problem
- Optional: List of tasks completed w/ links 

## Test Cases
- Write to the shared partition calls client
- Write to a given partition calls client with partition name

## Manual Testing
- Execute against each flow
- Check that taking down the active doesn't affect write memory of the standby
- Check that taking down the standby doesn't affect write memory of the active
- Ensure that in active-standby mode memory is saved on both devices