### PR TITLE
[STACK-1402] Corrected avcs status check

### DIFF
--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -393,7 +393,8 @@ class SetupDeviceNetworkMap(VThunderBaseTask):
             except Exception as e:
                 LOG.exception("Failed to get vcs summary oper: %s", str(e))
                 raise
-            if resp and 'vcs-summary' in resp and 'oper' in resp['vcs-summary']:
+            if resp and 'vcs-summary' in resp and 'oper' in resp['vcs-summary'] and (
+                    resp['vcs-summary']['oper']['vcs-enabled'] == 'Yes'):
                 vthunder_conf = CONF.hardware_thunder.devices[vthunder.project_id]
                 device_network_map = vthunder_conf.device_network_map
                 oper = resp['vcs-summary']['oper']


### PR DESCRIPTION
## Description

Issue Description:
The aVCS config is not working with single device setup due to invalid aVCS status check condition.


Severity Level: Critical


## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1402

## Technical Approach
Added a condition that checks aVCS current status. As `vcs-enabled` is always available in both positive and negetive test cases. No need of checking its existence.

## Test Cases
Environment in which both single and clustered setup co-exists.
Project1 must be aVCS configured and project2 must be a single rack device.
Create LB in both projects, both gets created successfully.

## Manual Testing
Created a project, associated proper users.
In config added a device as rack device for project.
For other project, in config added a aVCS cluster floating IP and configuration.
Booted LBs in both project.