### PR TITLE
Stack 1402 - VE/VLAN branch not working with single device

### DIFF
--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -400,9 +400,8 @@ class SetupDeviceNetworkMap(VThunderBaseTask):
             except Exception as e:
                 LOG.exception("Failed to get vcs summary oper: %s", str(e))
                 raise
+
             if resp and 'vcs-summary' in resp and 'oper' in resp['vcs-summary']:
-                vthunder_conf = CONF.hardware_thunder.devices[vthunder.project_id]
-                device_network_map = vthunder_conf.device_network_map
                 oper = resp['vcs-summary']['oper']
                 if oper.get('vcs-enabled') != 'Yes':
                     if len(device_network_map) == 1:

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -388,6 +388,13 @@ class SetupDeviceNetworkMap(VThunderBaseTask):
     def execute(self, vthunder):
         vthunder.device_network_map = []
         if vthunder.project_id in CONF.hardware_thunder.devices:
+            vthunder_conf = CONF.hardware_thunder.devices[vthunder.project_id]
+            device_network_map = vthunder_conf.device_network_map
+
+            # Case when device network map is not provided/length is 0
+            if not device_network_map:
+                return vthunder
+
             try:
                 resp = self.axapi_client.system.action.get_vcs_summary_oper()
             except Exception as e:


### PR DESCRIPTION
## Description

Issue Description:
The aVCS config is not working with single device setup due to missing network device map check.


Severity Level: Critical


## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1402

## Technical Approach
Added a condition that checks that device network map is provided.

## Test Cases
Environment in which both single and clustered setup co-exists.
Project1 must be aVCS configured and project2 must be a single rack device.
Create LB in both projects, both gets created successfully.

## Manual Testing
Created a project, associated proper users.
In config added a device as rack device for project.
For other project, in config added a aVCS cluster floating IP and configuration.
Booted LBs in both project.