### PR TITLE
[Stack 1435] - Cannot delete loadbalancers in error state; Write memory for shared partition incorrect

### DIFF
--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -43,7 +43,6 @@ SP_OBJ_DICT = {
 HTTP_TYPE = ['HTTP', 'HTTPS']
 PERS_TYPE = ['cookie_persistence', 'src_ip_persistence']
 NO_DEST_NAT_SUPPORTED_PROTOCOL = ['tcp', 'udp']
-SHARED_PARTITION = 'shared'
 PORT = 'port'
 MEMBER_COUNT = 'member_count'
 DELETE_VRID = 'delete_vrid'

--- a/a10_octavia/common/data_models.py
+++ b/a10_octavia/common/data_models.py
@@ -137,7 +137,7 @@ class Thunder(BaseDataModel):
                  password=None, axapi_version=None, undercloud=None,
                  loadbalancer_id=None, project_id=None, compute_id=None,
                  topology="STANDALONE", role="MASTER", last_udp_update=None, status="ACTIVE",
-                 created_at=datetime.utcnow(), updated_at=datetime.utcnow(), partition_name=None,
+                 created_at=datetime.utcnow(), updated_at=datetime.utcnow(), partition_name="shared",
                  hierarchical_multitenancy=None, vrid_floating_ip=None,
                  device_network_map=None):
         self.id = id

--- a/a10_octavia/common/data_models.py
+++ b/a10_octavia/common/data_models.py
@@ -137,9 +137,9 @@ class Thunder(BaseDataModel):
                  password=None, axapi_version=None, undercloud=None,
                  loadbalancer_id=None, project_id=None, compute_id=None,
                  topology="STANDALONE", role="MASTER", last_udp_update=None, status="ACTIVE",
-                 created_at=datetime.utcnow(), updated_at=datetime.utcnow(), partition_name="shared",
-                 hierarchical_multitenancy=None, vrid_floating_ip=None,
-                 device_network_map=None):
+                 created_at=datetime.utcnow(), updated_at=datetime.utcnow(),
+                 partition_name="shared", hierarchical_multitenancy=None,
+                 vrid_floating_ip=None, device_network_map=None):
         self.id = id
         self.vthunder_id = vthunder_id
         self.amphora_id = amphora_id

--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -28,7 +28,6 @@ from keystoneclient.v3 import client as keystone_client
 from octavia.common import keystone
 from stevedore import driver as stevedore_driver
 
-from a10_octavia.common import a10constants
 from a10_octavia.common import data_models
 from a10_octavia.common import exceptions
 
@@ -56,8 +55,8 @@ def validate_partial_ipv4(address):
 
 
 def validate_partition(hardware_device):
-    partition_name = hardware_device.get('partition_name')
-    elif len(partition_name) > 14:
+    partition_name = hardware_device.get('partition_name', '')
+    if len(partition_name) > 14:
         raise ValueError("Supplied partition value '%s' exceeds maximum length 14" %
                          (partition_name))
     return hardware_device

--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -57,8 +57,6 @@ def validate_partial_ipv4(address):
 
 def validate_partition(hardware_device):
     partition_name = hardware_device.get('partition_name')
-    if not partition_name:
-        hardware_device['partition_name'] = a10constants.SHARED_PARTITION
     elif len(partition_name) > 14:
         raise ValueError("Supplied partition value '%s' exceeds maximum length 14" %
                          (partition_name))

--- a/a10_octavia/controller/worker/tasks/decorators.py
+++ b/a10_octavia/controller/worker/tasks/decorators.py
@@ -18,8 +18,6 @@ from oslo_config import cfg
 from oslo_log import log as logging
 from requests.exceptions import ConnectionError
 
-from a10_octavia.common import a10constants
-
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
 
@@ -42,7 +40,7 @@ def axapi_client_decorator(func):
                                                    vthunder.username, vthunder.password,
                                                    timeout=30)
 
-            if vthunder.partition_name != a10constants.SHARED_PARTITION:
+            if vthunder.partition_name != "shared":
                 activate_partition(self.axapi_client, vthunder.partition_name)
 
         else:

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -388,6 +388,7 @@ class SetupDeviceNetworkMap(VThunderBaseTask):
     @axapi_client_decorator
     def execute(self, vthunder):
         if vthunder and vthunder.project_id in CONF.hardware_thunder.devices:
+            vthunder.device_network_map = []
             vthunder_conf = CONF.hardware_thunder.devices[vthunder.project_id]
             device_network_map = vthunder_conf.device_network_map
 
@@ -756,9 +757,10 @@ class WriteMemory(VThunderBaseTask):
 
     @axapi_client_decorator
     def execute(self, vthunder):
-        if vthunder and vthunder.partition_name != "shared":
-            self.axapi_client.system.action.write_memory(
-                partition="specified",
-                specified_partition=vthunder.partition_name)
-        else:
-            self.axapi_client.system.action.write_memory(partition="shared")
+        if vthunder:
+            if vthunder.partition_name != "shared":
+                self.axapi_client.system.action.write_memory(
+                    partition="specified",
+                    specified_partition=vthunder.partition_name)
+            else:
+                self.axapi_client.system.action.write_memory(partition="shared")

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -387,8 +387,7 @@ class SetupDeviceNetworkMap(VThunderBaseTask):
 
     @axapi_client_decorator
     def execute(self, vthunder):
-        vthunder.device_network_map = []
-        if vthunder.project_id in CONF.hardware_thunder.devices:
+        if vthunder and vthunder.project_id in CONF.hardware_thunder.devices:
             vthunder_conf = CONF.hardware_thunder.devices[vthunder.project_id]
             device_network_map = vthunder_conf.device_network_map
 
@@ -757,7 +756,7 @@ class WriteMemory(VThunderBaseTask):
 
     @axapi_client_decorator
     def execute(self, vthunder):
-        if vthunder.partition_name:
+        if vthunder and vthunder.partition_name != "shared":
             self.axapi_client.system.action.write_memory(
                 partition="specified",
                 specified_partition=vthunder.partition_name)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -419,10 +419,15 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         self.assertEqual(vthunder.device_network_map[0].state, "Master")
         self.assertEqual(vthunder.device_network_map[0].mgmt_ip_address, DEVICE2_MGMT_IP)
 
+    def test_SetupDeviceNetworkMap_execute_delete_flow_after_error_no_fail(self):
+        ret_val = task.SetupDeviceNetworkMap().execute(vthunder=None)
+        self.assertIsNone(ret_val)
+
     def test_WriteMemory_execute_save_shared_mem(self):
+        mock_thunder = copy.deepcopy(VTHUNDER)
         mock_task = task.WriteMemory()
         mock_task.axapi_client = self.client_mock
-        mock_task.execute(VTHUNDER)
+        mock_task.execute(mock_thunder)
         self.client_mock.system.action.write_memory.assert_called_with(partition='shared')
 
     def test_WriteMemory_execute_save_specific_partition_mem(self):
@@ -434,3 +439,7 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         self.client_mock.system.action.write_memory.assert_called_with(
             partition='specified',
             specified_partition='testPartition')
+
+    def test_WriteMemory_execute_delete_flow_after_error_no_fail(self):
+        ret_val = task.WriteMemory().execute(vthunder=None)
+        self.assertIsNone(ret_val)


### PR DESCRIPTION
## Description
Severity Level:  Critical

Cannot delete load balancers placed in error state as calls were being made to `vthunder` object when it could be of type `None`.

A second bug was uncovered during testing this fix involving the write memory partition. The `if vthunder.partition_name` call would always equate to true after enforcing that `partition_name` defaulted to `"shared"` in the data model.

## Jira Ticket
[STACK-1435](https://a10networks.atlassian.net/browse/STACK-1435)

## Technical Approach
- Added check on if the vthunder != None before all other checks in the SetupDeviceNetworkMap task
- Added check on if the vthunder != None before all other checks in the WriteMemory task
- Removed `SHARED_PARTITION` constant
- Removed logic to turn `partition_name` to `shared` in the event it's `None` from the validators

## Config Changes
N/A

## Test Cases
- Added a test against the SetupDeviceNetworkMap for when no vthunder exists in the db during a delete flow. This occurs because of a prior error state obtained during a failed create flow.
- Added a test against the WriteMemory for when no vthunder exists in the db during a delete flow. This occurs because of a prior error state obtained during a failed create flow.

## Manual Testing
1. To elicit an error state in the load balancer create flow:
   - Ensure no `amphora_image_id` or `amphora_tag_id` exists in `a10-octavia.conf`
   - Create a load balancer with `--project <project_id` optional argument set to one not listed in the `devices` data structure of the `a10-octavia.conf` file under the `[hardware_thunder]` group.
2. Attempt to delete the load balancer in error state