### PR TITLE
[STACK-1445]: Unit test constant values are being overwritten

### DIFF
--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -388,7 +388,6 @@ class SetupDeviceNetworkMap(VThunderBaseTask):
     @axapi_client_decorator
     def execute(self, vthunder):
         if vthunder and vthunder.project_id in CONF.hardware_thunder.devices:
-            vthunder.device_network_map = []
             vthunder_conf = CONF.hardware_thunder.devices[vthunder.project_id]
             device_network_map = vthunder_conf.device_network_map
 

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -183,7 +183,8 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         intf = a10_utils.convert_interface_to_data_model(ETHERNET_INTERFACE)
         device1_network_map = a10_data_models.DeviceNetworkMap(vcs_device_id=1,
                                                                ethernet_interfaces=[intf])
-        VTHUNDER.device_network_map = [device1_network_map]
+        mock_thunder = copy.deepcopy(VTHUNDER)
+        mock_thunder.device_network_map = [device1_network_map]
         lb = self._mock_lb()
         mock_task = task.TagInterfaceForLB()
         self._mock_tag_task(mock_task)
@@ -195,7 +196,7 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         mock_task._network_driver.get_network.return_value = NETWORK_11
         mock_task._network_driver.list_networks = mock.Mock()
         mock_task._network_driver.list_networks.return_value = [NETWORK_11]
-        mock_task.execute(lb, VTHUNDER)
+        mock_task.execute(lb, mock_thunder)
         self.client_mock.vlan.create.assert_called_with(VLAN_ID,
                                                         tagged_eths=[TAG_INTERFACE],
                                                         veth=True)
@@ -209,7 +210,8 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         intf = a10_utils.convert_interface_to_data_model(ETHERNET_INTERFACE)
         device1_network_map = a10_data_models.DeviceNetworkMap(vcs_device_id=1,
                                                                ethernet_interfaces=[intf])
-        VTHUNDER.device_network_map = [device1_network_map]
+        mock_thunder = copy.deepcopy(VTHUNDER)
+        mock_thunder.device_network_map = [device1_network_map]
         lb = self._mock_lb()
         mock_task = task.TagInterfaceForLB()
         self._mock_tag_task(mock_task)
@@ -224,7 +226,7 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         mock_task._network_driver.get_network.return_value = NETWORK_12
         mock_task._network_driver.list_networks = mock.Mock()
         mock_task._network_driver.list_networks.return_value = [NETWORK_12]
-        mock_task.execute(lb, VTHUNDER)
+        mock_task.execute(lb, mock_thunder)
         self.client_mock.vlan.create.assert_called_with(VE_IP_VLAN_ID,
                                                         tagged_eths=[TAG_INTERFACE],
                                                         veth=True)
@@ -237,7 +239,8 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         intf = a10_utils.convert_interface_to_data_model(TRUNK_INTERFACE)
         device1_network_map = a10_data_models.DeviceNetworkMap(vcs_device_id=1,
                                                                trunk_interfaces=[intf])
-        VTHUNDER.device_network_map = [device1_network_map]
+        mock_thunder = copy.deepcopy(VTHUNDER)
+        mock_thunder.device_network_map = [device1_network_map]
         lb = self._mock_lb()
         mock_task = task.TagInterfaceForLB()
         self._mock_tag_task(mock_task)
@@ -252,7 +255,7 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         mock_task._network_driver.get_network.return_value = NETWORK_12
         mock_task._network_driver.list_networks = mock.Mock()
         mock_task._network_driver.list_networks.return_value = [NETWORK_12]
-        mock_task.execute(lb, VTHUNDER)
+        mock_task.execute(lb, mock_thunder)
         self.client_mock.vlan.create.assert_called_with(VE_IP_VLAN_ID,
                                                         tagged_trunks=[TAG_TRUNK_INTERFACE],
                                                         veth=True)
@@ -265,15 +268,21 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         intf = a10_utils.convert_interface_to_data_model(ETHERNET_INTERFACE)
         device1_network_map = a10_data_models.DeviceNetworkMap(vcs_device_id=1,
                                                                ethernet_interfaces=[intf])
-        VTHUNDER.device_network_map = [device1_network_map]
+        mock_thunder = copy.deepcopy(VTHUNDER)
+        mock_thunder.device_network_map = [device1_network_map]
         lb = self._mock_lb()
         mock_task = task.TagInterfaceForLB()
         self._mock_tag_task(mock_task)
         self.client_mock.interface.ethernet.get.return_value = ETH_DATA
         self.client_mock.vlan.exists.side_effect = Exception
-        self.assertRaises(Exception, lambda: mock_task.execute(lb, VTHUNDER))
+        self.assertRaises(Exception, lambda: mock_task.execute(lb, mock_thunder))
 
     def test_TagInterfaceForLB_revert_created_vlan(self):
+        intf = a10_utils.convert_interface_to_data_model(ETHERNET_INTERFACE)
+        device1_network_map = a10_data_models.DeviceNetworkMap(vcs_device_id=1,
+                                                               ethernet_interfaces=[intf])
+        mock_thunder = copy.deepcopy(VTHUNDER)
+        mock_thunder.device_network_map = [device1_network_map]
         lb = self._mock_lb()
         mock_task = task.TagInterfaceForLB()
         self._mock_tag_task(mock_task)
@@ -282,7 +291,7 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         mock_task._network_driver.get_port_id_from_ip = mock.Mock()
         mock_task._network_driver.neutron_client.delete_port = mock.Mock()
         mock_task._network_driver.get_port_id_from_ip.return_value = DEL_PORT_ID
-        mock_task.revert(lb, VTHUNDER)
+        mock_task.revert(lb, mock_thunder)
         self.client_mock.vlan.delete.assert_called_with(VLAN_ID)
         mock_task._network_driver.neutron_client.delete_port.assert_called_with(DEL_PORT_ID)
 
@@ -290,7 +299,8 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         intf = a10_utils.convert_interface_to_data_model(ETHERNET_INTERFACE)
         device1_network_map = a10_data_models.DeviceNetworkMap(vcs_device_id=1,
                                                                ethernet_interfaces=[intf])
-        VTHUNDER.device_network_map = [device1_network_map]
+        mock_thunder = copy.deepcopy(VTHUNDER)
+        mock_thunder.device_network_map = [device1_network_map]
         member = self._mock_member()
         mock_task = task.TagInterfaceForMember()
         self._mock_tag_task(mock_task)
@@ -301,7 +311,7 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         mock_task._network_driver.get_network.return_value = NETWORK_11
         mock_task._network_driver.list_networks = mock.Mock()
         mock_task._network_driver.list_networks.return_value = [NETWORK_11]
-        mock_task.execute(member, VTHUNDER)
+        mock_task.execute(member, mock_thunder)
         self.client_mock.vlan.create.assert_called_with(VLAN_ID,
                                                         tagged_eths=[TAG_INTERFACE],
                                                         veth=True)
@@ -315,7 +325,8 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         intf = a10_utils.convert_interface_to_data_model(ETHERNET_INTERFACE)
         device1_network_map = a10_data_models.DeviceNetworkMap(vcs_device_id=1,
                                                                ethernet_interfaces=[intf])
-        VTHUNDER.device_network_map = [device1_network_map]
+        mock_thunder = copy.deepcopy(VTHUNDER)
+        mock_thunder.device_network_map = [device1_network_map]
         member = self._mock_member()
         mock_task = task.TagInterfaceForMember()
         self._mock_tag_task(mock_task)
@@ -323,9 +334,14 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         self.client_mock.vlan.exists.return_value = False
         mock_task._network_driver.neutron_client.create_port = mock.Mock()
         mock_task._network_driver.neutron_client.create_port.side_effect = Exception
-        self.assertRaises(Exception, lambda: mock_task.execute(member, VTHUNDER))
+        self.assertRaises(Exception, lambda: mock_task.execute(member, mock_thunder))
 
     def test_TagInterfaceForMember_revert_created_vlan(self):
+        intf = a10_utils.convert_interface_to_data_model(ETHERNET_INTERFACE)
+        device1_network_map = a10_data_models.DeviceNetworkMap(vcs_device_id=1,
+                                                               ethernet_interfaces=[intf])
+        mock_thunder = copy.deepcopy(VTHUNDER)
+        mock_thunder.device_network_map = [device1_network_map]
         member = self._mock_member()
         mock_task = task.TagInterfaceForMember()
         self._mock_tag_task(mock_task)
@@ -334,7 +350,7 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         mock_task._network_driver.get_port_id_from_ip = mock.Mock()
         mock_task._network_driver.neutron_client.delete_port = mock.Mock()
         mock_task._network_driver.get_port_id_from_ip.return_value = DEL_PORT_ID
-        mock_task.revert(member, VTHUNDER)
+        mock_task.revert(member, mock_thunder)
         self.client_mock.vlan.delete.assert_called_with(VLAN_ID)
         mock_task._network_driver.neutron_client.delete_port.assert_called_with(DEL_PORT_ID)
 
@@ -342,7 +358,8 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         intf = a10_utils.convert_interface_to_data_model(ETHERNET_INTERFACE)
         device1_network_map = a10_data_models.DeviceNetworkMap(vcs_device_id=1,
                                                                ethernet_interfaces=[intf])
-        VTHUNDER.device_network_map = [device1_network_map]
+        mock_thunder = copy.deepcopy(VTHUNDER)
+        mock_thunder.device_network_map = [device1_network_map]
         lb = self._mock_lb()
         mock_task = task.DeleteInterfaceTagIfNotInUseForLB()
         self._mock_tag_task(mock_task)
@@ -351,7 +368,7 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         mock_task._network_driver.get_port_id_from_ip = mock.Mock()
         mock_task._network_driver.neutron_client.delete_port = mock.Mock()
         mock_task._network_driver.get_port_id_from_ip.return_value = DEL_PORT_ID
-        mock_task.execute(lb, VTHUNDER)
+        mock_task.execute(lb, mock_thunder)
         self.client_mock.vlan.delete.assert_called_with(VLAN_ID)
         mock_task._network_driver.neutron_client.delete_port.assert_called_with(DEL_PORT_ID)
 
@@ -359,7 +376,8 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         intf = a10_utils.convert_interface_to_data_model(ETHERNET_INTERFACE)
         device1_network_map = a10_data_models.DeviceNetworkMap(vcs_device_id=1,
                                                                ethernet_interfaces=[intf])
-        VTHUNDER.device_network_map = [device1_network_map]
+        mock_thunder = copy.deepcopy(VTHUNDER)
+        mock_thunder.device_network_map = [device1_network_map]
         member = self._mock_member()
         mock_task = task.DeleteInterfaceTagIfNotInUseForMember()
         self._mock_tag_task(mock_task)
@@ -368,7 +386,7 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         mock_task._network_driver.get_port_id_from_ip = mock.Mock()
         mock_task._network_driver.neutron_client.delete_port = mock.Mock()
         mock_task._network_driver.get_port_id_from_ip.return_value = DEL_PORT_ID
-        mock_task.execute(member, VTHUNDER)
+        mock_task.execute(member, mock_thunder)
         self.client_mock.vlan.delete.assert_called_with(VLAN_ID)
         mock_task._network_driver.neutron_client.delete_port.assert_called_with(DEL_PORT_ID)
 
@@ -381,9 +399,10 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         mock_task = task.SetupDeviceNetworkMap()
         self._mock_tag_task(mock_task)
         mock_task.axapi_client.system.action.get_vcs_summary_oper.return_value = VCS_DISABLED
-        vthunder = mock_task.execute(VTHUNDER)
-        self.assertEqual(len(vthunder.device_network_map), 1)
-        self.assertEqual(vthunder.device_network_map[0].vcs_device_id, 1)
+        mock_thunder = copy.deepcopy(VTHUNDER)
+        thunder = mock_task.execute(mock_thunder)
+        self.assertEqual(len(thunder.device_network_map), 1)
+        self.assertEqual(thunder.device_network_map[0].vcs_device_id, 1)
 
     def test_SetupDeviceNetworkMap_execute_vcs_master_vblade(self):
         self.conf.register_opts(config_options.A10_HARDWARE_THUNDER_OPTS,
@@ -395,14 +414,15 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         mock_task = task.SetupDeviceNetworkMap()
         self._mock_tag_task(mock_task)
         mock_task.axapi_client.system.action.get_vcs_summary_oper.return_value = VCS_MASTER_VBLADE
-        vthunder = mock_task.execute(VTHUNDER)
-        self.assertEqual(len(vthunder.device_network_map), 2)
-        self.assertEqual(vthunder.device_network_map[0].vcs_device_id, 1)
-        self.assertEqual(vthunder.device_network_map[0].state, "Master")
-        self.assertEqual(vthunder.device_network_map[0].mgmt_ip_address, DEVICE1_MGMT_IP)
-        self.assertEqual(vthunder.device_network_map[1].vcs_device_id, 2)
-        self.assertEqual(vthunder.device_network_map[1].state, "vBlade")
-        self.assertEqual(vthunder.device_network_map[1].mgmt_ip_address, DEVICE2_MGMT_IP)
+        mock_thunder = copy.deepcopy(VTHUNDER)
+        thunder = mock_task.execute(mock_thunder)
+        self.assertEqual(len(thunder.device_network_map), 2)
+        self.assertEqual(thunder.device_network_map[0].vcs_device_id, 1)
+        self.assertEqual(thunder.device_network_map[0].state, "Master")
+        self.assertEqual(thunder.device_network_map[0].mgmt_ip_address, DEVICE1_MGMT_IP)
+        self.assertEqual(thunder.device_network_map[1].vcs_device_id, 2)
+        self.assertEqual(thunder.device_network_map[1].state, "vBlade")
+        self.assertEqual(thunder.device_network_map[1].mgmt_ip_address, DEVICE2_MGMT_IP)
 
     def test_SetupDeviceNetworkMap_execute_vcs_device1_failed(self):
         self.conf.register_opts(config_options.A10_HARDWARE_THUNDER_OPTS,
@@ -413,11 +433,12 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         mock_task = task.SetupDeviceNetworkMap()
         self._mock_tag_task(mock_task)
         mock_task.axapi_client.system.action.get_vcs_summary_oper.return_value = VCS_DEVICE1_FAILED
-        vthunder = mock_task.execute(VTHUNDER)
-        self.assertEqual(len(vthunder.device_network_map), 1)
-        self.assertEqual(vthunder.device_network_map[0].vcs_device_id, 2)
-        self.assertEqual(vthunder.device_network_map[0].state, "Master")
-        self.assertEqual(vthunder.device_network_map[0].mgmt_ip_address, DEVICE2_MGMT_IP)
+        mock_thunder = copy.deepcopy(VTHUNDER)
+        thunder = mock_task.execute(mock_thunder)
+        self.assertEqual(len(thunder.device_network_map), 1)
+        self.assertEqual(thunder.device_network_map[0].vcs_device_id, 2)
+        self.assertEqual(thunder.device_network_map[0].state, "Master")
+        self.assertEqual(thunder.device_network_map[0].mgmt_ip_address, DEVICE2_MGMT_IP)
 
     def test_SetupDeviceNetworkMap_execute_delete_flow_after_error_no_fail(self):
         ret_val = task.SetupDeviceNetworkMap().execute(vthunder=None)


### PR DESCRIPTION


## Description
Severity Level: Low

Test leaks were causing a need for `vthunder.device_network_map = []` to be set in the SetupDeviceNetworkMap task. These leaks covered up requirements in other tests and could cause further unintended consequences down the line.

## Jira Ticket
[STACK-1445](https://a10networks.atlassian.net/browse/STACK-1445)

## Technical Approach
Implemented deepcopying of constant required for testing.

## Config Changes
N/A

## Test Cases
N/A

## Manual Testing
*Note: Example data such as IPs and project_ids may be altered*

```
[a10_controller_worker]
network_driver = a10_octavia_neutron_driver
loadbalancer_topology = SINGLE

[a10_global]
network_type = vlan

[hardware_thunder]
devices = [ 
                    {   
                     "project_id":"4426bfb28d81417e8bb0747af919cb31",
                     "ip_address":"10.0.0.105",
                     "username":"admin",
                     "password":"a10",
                     "device_name":"thunder_1",
                     "interface_vlan_map": {
                     "device_1": {
                       "vcs_device_id": 1,
                       "mgmt_ip_address": "10.0.0.41",
                       "ethernet_interfaces": [
                          {   
                             "interface_num": 1,
                             "vlan_map": [
                                 {"vlan_id": 11, "use_dhcp": "True"}
                              ]   
                           },  
                          {   
                             "interface_num": 2,
                             "vlan_map": [
                                 {"vlan_id": 12, "use_dhcp": "True"}
                              ]   
                           }   
                         ]   
                      },  
                     "device_2": {
                       "vcs_device_id": 2,
                       "mgmt_ip_address": "10.0.0.54",
                       "ethernet_interfaces": [
                          {   
                             "interface_num": 1,
                             "vlan_map": [
                                 {"vlan_id": 11, "use_dhcp": "True"}
                              ]   
                           },  
                          {   
                             "interface_num": 2,
                             "vlan_map": [
                                 {"vlan_id": 12, "use_dhcp": "True"}
                              ]   
                           }   
                         ]   
                      }   
                    }   
                }   
           ]
```

The above configuration file was used in testing with deployment done via [network demo script](https://github.com/a10networks/a10-octavia/blob/master/a10_octavia/contrib/scripts/a10_setup_provider_vlan_poc).

The following commands were run to test the `SetupDeviceNetworkMap` task used in creation flows (loadbalancer and member are of particular interest):
```
    openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name lb1 --project demo
    openstack loadbalancer listener create --protocol HTTP --protocol-port 8080 --name l1 lb1 
    sleep 8
    openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener l1 --name pool1
    sleep 8
    openstack loadbalancer member create --subnet-id provider-vlan-12-subnet --address 10.0.12.130 --protocol-port 80 --name mem1 pool1
    sleep 8
    openstack loadbalancer member create --subnet-id provider-vlan-12-subnet --address 10.0.12.198 --protocol-port 80 --name mem2 pool1
```

It's expected that VE's are created for VLAN 11 and 12 across **both devices in the cluster**. It's also expected that these are assigned IPs via dchp (though static is fine to use). The following is the expected output::
```
$ show run
vlan 1/11 
  tagged ethernet 1
  router-interface ve 11 
!       
vlan 1/12 
  tagged ethernet 2
  router-interface ve 12 
!       
vlan 2/11 
  tagged ethernet 1
  router-interface ve 11 
!       
vlan 2/12 
  tagged ethernet 2
  router-interface ve 12 
!  

Device 1 $: show int br

Port    Link  Dupl  Speed  Trunk Vlan MAC             IP Address          IPs  Name
------------------------------------------------------------------------------------
mgmt    Up    auto  auto   N/A   N/A  5254.00f8.32de  10.0.0.41/24          1
1       Up    Full  10000  none  Tag  5254.0082.1d40  0.0.0.0/0             0
2       Up    Full  10000  none  Tag  5254.00ef.ec30  0.0.0.0/0             0
3       Disb  None  None   none  1    5254.00b8.5c29  0.0.0.0/0             0
4       Disb  None  None   none  1    5254.005a.4860  0.0.0.0/0             0
ve11    Up    N/A   N/A    N/A   11   5254.0082.1d40  10.0.11.84/24         1
ve12    Up    N/A   N/A    N/A   12   5254.00ef.ec30  10.0.12.59/24         1

Device 2 $: show int br

Port    Link  Dupl  Speed  Trunk Vlan MAC             IP Address          IPs  Name
------------------------------------------------------------------------------------
mgmt    Up    auto  auto   N/A   N/A  5254.004a.d5d8  10.0.0.54/24          1
1       Up    Full  10000  none  Tag  5254.0050.68e3  0.0.0.0/0             0
2       Up    Full  10000  none  Tag  5254.003e.9c44  0.0.0.0/0             0
3       Disb  None  None   none  1    5254.0005.fa21  0.0.0.0/0             0
4       Disb  None  None   none  1    5254.0059.ede6  0.0.0.0/0             0
ve11    Up    N/A   N/A    N/A   11   5254.0050.68e3  10.0.11.64/24         1
ve12    Up    N/A   N/A    N/A   12   5254.003e.9c44  10.0.12.56/24         1
```

To test against the altered `SetupDeviceNetworkMap` task is used in delete flows the following commands are executed:
```
    openstack loadbalancer member delete pool1 mem1
    openstack loadbalancer member delete pool1 mem2
    openstack loadbalancer pool delete pool1
    openstack loadbalancer listener delete l1
    openstack loadbalancer delete lb1
```

It's expected that slb nouns cleared as well as ve interfaces. The following is the expected output:

```
Device 1$: show int br

Port    Link  Dupl  Speed  Trunk Vlan MAC             IP Address          IPs  Name
------------------------------------------------------------------------------------
mgmt    Up    auto  auto   N/A   N/A  5254.00f8.32de  10.0.0.41/24          1
1       Up    Full  10000  none  1    5254.0082.1d40  0.0.0.0/0             0
2       Up    Full  10000  none  1    5254.00ef.ec30  0.0.0.0/0             0
3       Disb  None  None   none  1    5254.00b8.5c29  0.0.0.0/0             0
4       Disb  None  None   none  1    5254.005a.4860  0.0.0.0/0             0

Device 2$: show int br

Port    Link  Dupl  Speed  Trunk Vlan MAC             IP Address          IPs  Name
------------------------------------------------------------------------------------
mgmt    Up    auto  auto   N/A   N/A  5254.004a.d5d8  10.0.0.54/24          1
1       Up    Full  10000  none  1    5254.0050.68e3  0.0.0.0/0             0
2       Up    Full  10000  none  1    5254.003e.9c44  0.0.0.0/0             0
3       Disb  None  None   none  1    5254.0005.fa21  0.0.0.0/0             0
4       Disb  None  None   none  1    5254.0059.ede6  0.0.0.0/0             0
```