### PR TITLE
[DO NOT MERGE] Stack 1429 - Review and correct flow & tasks for Health Monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ $ journalctl -af --unit a10-house-keeper.service
 ### 2. Clone the repo from your fork
 
 ```shell
-$ git clone https://git@github.com:<username>/a10-octavia.git
+$ git clone git@github.com:<username>/a10-octavia.git
 ```
 
 ### 3. Run octavia install script 

--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -83,15 +83,18 @@ A10_LISTENER_OPTS = [
     cfg.StrOpt('template_virtual_port',
                default=None,
                max_length=127,
-               help=_('Virtual port template (Virtual port template name)')),
+               help=_('Provide an existing Virtual port template name on VThunder '
+                      'to associate with virtual port')),
     cfg.StrOpt('template_tcp',
                default=None,
                max_length=127,
-               help=_('TCP Proxy Template name')),
+               help=_('Provide an existing TCP template name on VThunder '
+                      'to associate with virtual port')),
     cfg.StrOpt('template_policy',
                default=None,
                max_length=127,
-               help=_('Policy Template (Policy template name).')),
+               help=_('Provide an existing Policy template name on VThunder '
+                      'to associate with virtual port')),
     cfg.BoolOpt('autosnat', default=False,
                 help=_('Enable autosnat')),
     cfg.IntOpt('conn_limit', min=1, max=64000000,
@@ -100,7 +103,8 @@ A10_LISTENER_OPTS = [
     cfg.StrOpt('template_http',
                default=None,
                max_length=127,
-               help=_('HTTP Template Name')),
+               help=_('Provide an existing HTTP template name on VThunder '
+                      'to associate with virtual port')),
     cfg.BoolOpt('use_rcv_hop_for_resp',
                 default=False,
                 help=_('Use receive hop for response to client')),
@@ -109,13 +113,16 @@ A10_LISTENER_OPTS = [
 A10_SERVICE_GROUP_OPTS = [
     cfg.StrOpt('template_server',
                default=None,
-               help=_('Service Group Server Template')),
+               help=_('Provide an existing Service Group Server template name on VThunder '
+                      'to associate with service group')),
     cfg.StrOpt('template_port',
                default=None,
-               help=_('Service Group Port Template')),
+               help=_('Provide an existing Service Group Port template name on VThunder '
+                      'to associate with service group')),
     cfg.StrOpt('template_policy',
                default=None,
-               help=_('Service Group Policy Template')),
+               help=_('Provide an existing Service Group Policy template name on VThunder '
+                      'to associate with service group')),
 ]
 
 A10_SERVER_OPTS = [
@@ -127,7 +134,8 @@ A10_SERVER_OPTS = [
                help=_('Connection Resume')),
     cfg.StrOpt('template_server',
                default=None,
-               help=_('Template Server')),
+               help=_('Provide an existing Server template name on VThunder '
+                      'to associate with server')),
 ]
 
 A10_HARDWARE_THUNDER_OPTS = [

--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -129,7 +129,3 @@ class MissingMgmtIpConfigError(cfg.ConfigFileValueError):
         msg = ('Missing `mgmt_ip_address` for vcs device with id {0}. ' +
                'Please provide management IP address').format(vcs_device_id)
         super(MissingMgmtIpConfigError, self).__init__(msg=msg)
-
-
-class GenericFlowException(exceptions.OctaviaException):
-    pass

--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -129,3 +129,7 @@ class MissingMgmtIpConfigError(cfg.ConfigFileValueError):
         msg = ('Missing `mgmt_ip_address` for vcs device with id {0}. ' +
                'Please provide management IP address').format(vcs_device_id)
         super(MissingMgmtIpConfigError, self).__init__(msg=msg)
+
+
+class GenericFlowException(exceptions.OctaviaException):
+    pass

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -42,7 +42,7 @@ class CreateAndAssociateHealthMonitor(task.Task):
         args = utils.meta(health_mon, 'hm', {})
 
         try:
-            self.axapi_client.slb.hm.create(health_mon.id[0:5],
+            self.axapi_client.slb.hm.create(health_mon.id,
                                             openstack_mappings.hm_type(self.axapi_client,
                                                                        health_mon.type),
                                             health_mon.delay, health_mon.timeout,
@@ -56,7 +56,7 @@ class CreateAndAssociateHealthMonitor(task.Task):
 
         try:
             self.axapi_client.slb.service_group.update(health_mon.pool_id,
-                                                       health_monitor=health_mon.id[0:5],
+                                                       health_monitor=health_mon.id,
                                                        health_check_disable=0)
             LOG.debug("Health Monitor %s is associated to pool %s successfully.",
                       health_mon.id, health_mon.pool_id)
@@ -79,7 +79,7 @@ class DeleteHealthMonitor(task.Task):
         except Exception as e:
             LOG.warning("Failed to dissociate Health Monitor from pool: %s", str(e))
         try:
-            self.axapi_client.slb.hm.delete(health_mon.id[0:5])
+            self.axapi_client.slb.hm.delete(health_mon.id)
             LOG.debug("Health Monitor deleted successfully: %s", health_mon.id)
         except Exception as e:
             LOG.warning("Failed to delete health monitor: %s", str(e))
@@ -92,7 +92,7 @@ class UpdateHealthMonitor(task.Task):
     def execute(self, listeners, health_mon, vthunder, update_dict):
         """ Execute update health monitor """
         # TODO(hthompson6) Length of name of healthmonitor for older vThunder devices
-        health_mon.__dict__.update(update_dict)
+        health_mon.update(update_dict)
         method = None
         url = None
         expect_code = None
@@ -103,7 +103,7 @@ class UpdateHealthMonitor(task.Task):
         args = utils.meta(health_mon, 'hm', {})
         try:
             self.axapi_client.slb.hm.update(
-                health_mon.id[0:5],
+                health_mon.id,
                 openstack_mappings.hm_type(self.axapi_client, health_mon.type),
                 health_mon.delay, health_mon.timeout, health_mon.rise_threshold,
                 method=method, url=url, expect_code=expect_code,

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -16,6 +16,7 @@
 from acos_client import errors as acos_errors
 from oslo_config import cfg
 from oslo_log import log as logging
+from requests.exceptions import ConnectionError
 from taskflow import task
 
 from a10_octavia.common import a10constants

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -21,8 +21,8 @@ from taskflow import task
 
 from a10_octavia.common import a10constants
 from a10_octavia.common import openstack_mappings
-from a10_octavia.controller.worker.tasks import utils
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
+from a10_octavia.controller.worker.tasks import utils
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -52,6 +52,7 @@ class CreateAndAssociateHealthMonitor(task.Task):
                                             port=listeners[0].protocol_port, url=url,
                                             expect_code=expect_code, axapi_args=args)
             LOG.debug("Successfully created health monitor: %s", health_mon.id)
+
         except (acos_errors.ACOSException, ConnectionError) as e:
             LOG.exception("Failed to create health monitor: %s", health_mon.id)
             raise e

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -51,7 +51,7 @@ class CreateAndAssociateHealthMonitor(task.Task):
                                             health_mon.rise_threshold, method=method,
                                             port=listeners[0].protocol_port, url=url,
                                             expect_code=expect_code, axapi_args=args)
-            LOG.debug("Health Monitor created successfully: %s", health_mon.id)
+            LOG.debug("Successfully created health monitor: %s", health_mon.id)
         except (acos_errors.ACOSException, ConnectionError) as e:
             LOG.exception("Failed to create health monitor: %s", health_mon.id)
             raise e
@@ -60,13 +60,12 @@ class CreateAndAssociateHealthMonitor(task.Task):
             self.axapi_client.slb.service_group.update(health_mon.pool_id,
                                                        health_monitor=health_mon.id,
                                                        health_check_disable=0)
-            LOG.debug("Health Monitor %s is associated to pool %s successfully.",
+            LOG.debug("Successfully associated health monitor %s to pool %s",
                       health_mon.id, health_mon.pool_id)
         except (acos_errors.ACOSException, ConnectionError) as e:
             LOG.exception(
-                "Failed to associate pool %s to Health Monitor: %s",
-                health_mon.pool_id,
-                health_mon.id)
+                "Failed to associate health monitor %s to pool %s",
+                health_mon.id, health_mon.pool_id)
             raise e
 
     @axapi_client_decorator
@@ -74,12 +73,11 @@ class CreateAndAssociateHealthMonitor(task.Task):
         try:
             self.axapi_client.slb.hm.delete(health_mon.id[:5])
         except ConnectionError:
-            LOG.exception("Failed to connect A10 Thunder device: %s", vthunder.ip)
+            LOG.exception("Failed to connect A10 Thunder device: %s", vthunder.ip_address)
         except Exception as e:
             LOG.warning(
                 "Failed to revert creation of health monitor: %s due to %s",
-                health_mon.id,
-                str(e))
+                health_mon.id, str(e))
 
 
 class DeleteHealthMonitor(task.Task):
@@ -91,18 +89,17 @@ class DeleteHealthMonitor(task.Task):
             self.axapi_client.slb.service_group.update(health_mon.pool_id,
                                                        health_monitor="",
                                                        health_check_disable=True)
-            LOG.debug("Health Monitor %s is dissociated from pool %s successfully.",
+            LOG.debug("Successfully dissociate health monitor %s from pool %s",
                       health_mon.id, health_mon.pool_id)
         except (acos_errors.ACOSException, ConnectionError) as e:
             LOG.exception(
-                "Failed to dissociate pool %s from health monitor: %s",
-                health_mon.pool_id,
-                health_mon.id)
+                "Failed to dissociate health monitor %s from pool %s",
+                health_mon.pool_id, health_mon.id)
             raise e
 
         try:
             self.axapi_client.slb.hm.delete(health_mon.id)
-            LOG.debug("Health Monitor deleted successfully: %s", health_mon.id)
+            LOG.debug("Successfully deleted health monitor: %s", health_mon.id)
         except (acos_errors.ACOSException, ConnectionError) as e:
             LOG.exception("Failed to delete health monitor: %s", health_mon.id)
             raise e
@@ -131,7 +128,7 @@ class UpdateHealthMonitor(task.Task):
                 health_mon.delay, health_mon.timeout, health_mon.rise_threshold,
                 method=method, url=url, expect_code=expect_code,
                 port=listeners[0].protocol_port, axapi_args=args)
-            LOG.debug("Health Monitor updated successfully: %s", health_mon.id)
+            LOG.debug("Successfully updated health monitor: %s", health_mon.id)
         except (acos_errors.ACOSException, ConnectionError) as e:
-            LOG.exception("Failed to update Health Monitor: %s", health_mon.id)
+            LOG.exception("Failed to update health monitor: %s", health_mon.id)
             raise e

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -13,15 +13,15 @@
 #    under the License.
 
 
+from acos_client import errors as acos_errors
 from oslo_config import cfg
 from oslo_log import log as logging
 from taskflow import task
 
 from a10_octavia.common import a10constants
-from a10_octavia.common.exceptions import GenericFlowException
 from a10_octavia.common import openstack_mappings
-from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
 from a10_octavia.controller.worker.tasks import utils
+from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
@@ -51,10 +51,9 @@ class CreateAndAssociateHealthMonitor(task.Task):
                                             port=listeners[0].protocol_port, url=url,
                                             expect_code=expect_code, axapi_args=args)
             LOG.debug("Health Monitor created successfully: %s", health_mon.id)
-        except Exception as e:
-            msg = str(e)
-            LOG.exception("Failed to create Health Monitor: %s", msg)
-            raise GenericFlowException(msg)
+        except (acos_errors.ACOSException, ConnectionError) as e:
+            LOG.exception("Failed to create health monitor: %s", health_mon.id)
+            raise e
 
         try:
             self.axapi_client.slb.service_group.update(health_mon.pool_id,
@@ -62,17 +61,18 @@ class CreateAndAssociateHealthMonitor(task.Task):
                                                        health_check_disable=0)
             LOG.debug("Health Monitor %s is associated to pool %s successfully.",
                       health_mon.id, health_mon.pool_id)
-        except Exception as e:
-            msg = str(e)
-            LOG.exception("Failed to associate pool to Health Monitor: %s", msg)
-            raise GenericFlowException(msg)
+        except (acos_errors.ACOSException, ConnectionError) as e:
+            LOG.exception("Failed to associate pool %s to Health Monitor: %s", health_mon.pool_id, health_mon.id)
+            raise e
 
     @axapi_client_decorator
     def revert(self, listeners, health_mon, vthunder, *args, **kwargs):
         try:
             self.axapi_client.slb.hm.delete(health_mon.id[:5])
+        except ConnectionError:
+            LOG.exception("Failed to connect A10 Thunder device: %s", vthunder.ip)
         except Exception as e:
-            LOG.exception("Failed to delete health monitor: %s", str(e))
+            LOG.warning("Failed to revert creation of health monitor: %s due to %s", health_mon.id, str(e))
 
 
 class DeleteHealthMonitor(task.Task):
@@ -86,27 +86,16 @@ class DeleteHealthMonitor(task.Task):
                                                        health_check_disable=True)
             LOG.debug("Health Monitor %s is dissociated from pool %s successfully.",
                       health_mon.id, health_mon.pool_id)
-        except Exception as e:
-            msg = str(e)
-            LOG.exception("Failed to dissociate Health Monitor from pool: %s", msg)
-            raise GenericFlowException(msg)
+        except (acos_errors.ACOSException, ConnectionError) as e:
+            LOG.exception("Failed to dissociate pool %s from health monitor: %s", health_mon.pool_id, health_mon.id)
+            raise e
+
         try:
             self.axapi_client.slb.hm.delete(health_mon.id)
             LOG.debug("Health Monitor deleted successfully: %s", health_mon.id)
-        except Exception as e:
-            msg = str(e)
-            LOG.exception("Failed to delete health monitor: %s", msg)
-            raise GenericFlowException(msg)
-
-    @axapi_client_decorator
-    def revert(self, health_mon, vthunder, *args, **kwargs):
-        try:
-            self.axapi_client.slb.service_group.update(health_mon.pool_id,
-                                                       health_monitor=health_mon.id[:5],
-                                                       health_check_disable=0)
-
-        except Exception as e:
-            LOG.exception("Failed to revert delete Health Monitor operation: %s", str(e))
+        except (acos_errors.ACOSException, ConnectionError) as e:
+            LOG.exception("Failed to delete health monitor: %s", health_mon.id)
+            raise e
 
 
 class UpdateHealthMonitor(task.Task):
@@ -133,5 +122,6 @@ class UpdateHealthMonitor(task.Task):
                 method=method, url=url, expect_code=expect_code,
                 port=listeners[0].protocol_port, axapi_args=args)
             LOG.debug("Health Monitor updated successfully: %s", health_mon.id)
-        except Exception as e:
-            LOG.exception("Failed to update Health Monitor: %s", str(e))
+        except (acos_errors.ACOSException, ConnectionError) as e:
+            LOG.exception("Failed to update Health Monitor: %s", health_mon.id)
+            raise e

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -18,10 +18,10 @@ from oslo_log import log as logging
 from taskflow import task
 
 from a10_octavia.common import a10constants
-from a10_octavia.common import openstack_mappings
 from a10_octavia.common.exceptions import GenericFlowException
-from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
+from a10_octavia.common import openstack_mappings
 from a10_octavia.controller.worker.tasks import utils
+from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -63,7 +63,10 @@ class CreateAndAssociateHealthMonitor(task.Task):
             LOG.debug("Health Monitor %s is associated to pool %s successfully.",
                       health_mon.id, health_mon.pool_id)
         except (acos_errors.ACOSException, ConnectionError) as e:
-            LOG.exception("Failed to associate pool %s to Health Monitor: %s", health_mon.pool_id, health_mon.id)
+            LOG.exception(
+                "Failed to associate pool %s to Health Monitor: %s",
+                health_mon.pool_id,
+                health_mon.id)
             raise e
 
     @axapi_client_decorator
@@ -73,7 +76,10 @@ class CreateAndAssociateHealthMonitor(task.Task):
         except ConnectionError:
             LOG.exception("Failed to connect A10 Thunder device: %s", vthunder.ip)
         except Exception as e:
-            LOG.warning("Failed to revert creation of health monitor: %s due to %s", health_mon.id, str(e))
+            LOG.warning(
+                "Failed to revert creation of health monitor: %s due to %s",
+                health_mon.id,
+                str(e))
 
 
 class DeleteHealthMonitor(task.Task):
@@ -88,7 +94,10 @@ class DeleteHealthMonitor(task.Task):
             LOG.debug("Health Monitor %s is dissociated from pool %s successfully.",
                       health_mon.id, health_mon.pool_id)
         except (acos_errors.ACOSException, ConnectionError) as e:
-            LOG.exception("Failed to dissociate pool %s from health monitor: %s", health_mon.pool_id, health_mon.id)
+            LOG.exception(
+                "Failed to dissociate pool %s from health monitor: %s",
+                health_mon.pool_id,
+                health_mon.id)
             raise e
 
         try:

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -20,8 +20,8 @@ from taskflow import task
 from a10_octavia.common import a10constants
 from a10_octavia.common.exceptions import GenericFlowException
 from a10_octavia.common import openstack_mappings
-from a10_octavia.controller.worker.tasks import utils
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
+from a10_octavia.controller.worker.tasks import utils
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -87,27 +87,27 @@ class DeleteHealthMonitor(task.Task):
             LOG.debug("Health Monitor %s is dissociated from pool %s successfully.",
                       health_mon.id, health_mon.pool_id)
         except Exception as e:
-            msg=str(e)
+            msg = str(e)
             LOG.exception("Failed to dissociate Health Monitor from pool: %s", msg)
             raise GenericFlowException(msg)
         try:
             self.axapi_client.slb.hm.delete(health_mon.id)
             LOG.debug("Health Monitor deleted successfully: %s", health_mon.id)
         except Exception as e:
-            msg=str(e)
+            msg = str(e)
             LOG.exception("Failed to delete health monitor: %s", msg)
             raise GenericFlowException(msg)
-    
+
     @axapi_client_decorator
     def revert(self, health_mon, vthunder, *args, **kwargs):
         try:
             self.axapi_client.slb.service_group.update(health_mon.pool_id,
                                                        health_monitor=health_mon.id[:5],
                                                        health_check_disable=0)
-            
+
         except Exception as e:
             LOG.exception("Failed to revert delete Health Monitor operation: %s", str(e))
-            
+
 
 class UpdateHealthMonitor(task.Task):
     """Task to update Health Monitor"""

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -19,6 +19,7 @@ from taskflow import task
 
 from a10_octavia.common import a10constants
 from a10_octavia.common import openstack_mappings
+from a10_octavia.common.exceptions import GenericFlowException
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
 from a10_octavia.controller.worker.tasks import utils
 
@@ -51,8 +52,9 @@ class CreateAndAssociateHealthMonitor(task.Task):
                                             expect_code=expect_code, axapi_args=args)
             LOG.debug("Health Monitor created successfully: %s", health_mon.id)
         except Exception as e:
-            LOG.exception("Failed to create Health Monitor: %s", str(e))
-            raise
+            msg = str(e)
+            LOG.exception("Failed to create Health Monitor: %s", msg)
+            raise GenericFlowException(msg)
 
         try:
             self.axapi_client.slb.service_group.update(health_mon.pool_id,
@@ -61,8 +63,9 @@ class CreateAndAssociateHealthMonitor(task.Task):
             LOG.debug("Health Monitor %s is associated to pool %s successfully.",
                       health_mon.id, health_mon.pool_id)
         except Exception as e:
-            LOG.exception("Failed to associate pool to Health Monitor: %s", str(e))
-            raise
+            msg = str(e)
+            LOG.exception("Failed to associate pool to Health Monitor: %s", msg)
+            raise GenericFlowException(msg)
 
 
 class DeleteHealthMonitor(task.Task):

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -689,6 +689,11 @@ class TagInterfaceForMember(TagInterfaceBaseTask):
 
     @axapi_client_decorator
     def execute(self, member, vthunder):
+        if not member.subnet_id:
+            LOG.warning("Subnet id argument was not specified during "
+                        "issuance of create command/API call for member %s. "
+                        "Skipping TagInterfaceForMember task", member.id)
+            return
         try:
             vlan_id = self.get_vlan_id(member.subnet_id, False)
             self.tag_interfaces(vthunder, vlan_id)
@@ -698,6 +703,11 @@ class TagInterfaceForMember(TagInterfaceBaseTask):
 
     @axapi_client_decorator
     def revert(self, member, vthunder, *args, **kwargs):
+        if not member.subnet_id:
+            LOG.warning("Subnet id argument was not specified during "
+                        "issuance of create command/API call for member %s. "
+                        "Skipping TagInterfaceForMember task", member.id)
+            return
         try:
             if vthunder.device_network_map:
                 vlan_id = self.get_vlan_id(member.subnet_id, False)
@@ -737,6 +747,11 @@ class DeleteInterfaceTagIfNotInUseForMember(TagInterfaceBaseTask):
 
     @axapi_client_decorator
     def execute(self, member, vthunder):
+        if not member.subnet_id:
+            LOG.warning("Subnet id argument was not specified during "
+                        "issuance of create command/API call for member %s. "
+                        "Skipping DeleteInterfaceTagIfNotInUseForMember task", member.id)
+            return
         try:
             if vthunder.device_network_map:
                 vlan_id = self.get_vlan_id(member.subnet_id, False)

--- a/a10_octavia/tests/common/a10constants.py
+++ b/a10_octavia/tests/common/a10constants.py
@@ -13,6 +13,7 @@
 #    under the License.
 
 
+MOCK_HM_ID = 'mock-hm-1'
 MOCK_POOL_ID = 'mock-pool-1'
 MOCK_MEMBER_ID = 'mock-member-1'
 MOCK_LOAD_BALANCER_ID = 'mock-lb-1'

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_health_monitor_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_health_monitor_tasks.py
@@ -1,0 +1,79 @@
+#    Copyright 2020, A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import copy
+import imp
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from octavia.common import data_models as o_data_models
+
+from a10_octavia.common.data_models import VThunder
+from a10_octavia.controller.worker.tasks import health_monitor_tasks as task
+from a10_octavia.controller.worker.tasks import utils
+from a10_octavia.tests.common import a10constants
+from a10_octavia.tests.unit.base import BaseTaskTestCase
+
+VTHUNDER = VThunder()
+HM = o_data_models.HealthMonitor(id=a10constants.MOCK_HM_ID,
+                                 type='TCP',
+                                 delay=7,
+                                 timeout=3,
+                                 rise_threshold=8,
+                                 http_method='GET')
+ARGS = utils.meta(HM, 'hm', {})
+LISTENERS = [o_data_models.Listener(id=a10constants.MOCK_LISTENER_ID, protocol_port=mock.ANY)]
+
+
+class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
+
+    def setUp(self):
+        super(TestHandlerHealthMonitorTasks, self).setUp()
+        imp.reload(task)
+        self.client_mock = mock.Mock()
+
+    def tearDown(self):
+        super(TestHandlerHealthMonitorTasks, self).tearDown()
+
+    def test_health_monitor_create_task(self):
+        mock_hm = task.CreateAndAssociateHealthMonitor()
+        mock_hm.axapi_client = self.client_mock
+        mock_hm.execute(LISTENERS, HM, VTHUNDER)
+        self.client_mock.slb.hm.create.assert_called_with(a10constants.MOCK_HM_ID,
+                                                          self.client_mock.slb.hm.TCP,
+                                                          HM.delay, HM.timeout,
+                                                          HM.rise_threshold, method=None,
+                                                          port=mock.ANY, url=None,
+                                                          expect_code=None, axapi_args=ARGS)
+
+    def test_health_monitor_update_task(self):
+        mock_hm = task.UpdateHealthMonitor()
+        mock_hm.axapi_client = self.client_mock
+        update_dict = {'delay': '10'}
+        hm = copy.deepcopy(HM)
+        mock_hm.execute(LISTENERS, hm, VTHUNDER, update_dict)
+        self.client_mock.slb.hm.update.assert_called_with(a10constants.MOCK_HM_ID,
+                                                          self.client_mock.slb.hm.TCP,
+                                                          hm.delay, hm.timeout,
+                                                          hm.rise_threshold, method=None,
+                                                          port=mock.ANY, url=None,
+                                                          expect_code=None, axapi_args=ARGS)
+
+    def test_health_monitor_delete_task(self):
+        mock_hm = task.DeleteHealthMonitor()
+        mock_hm.axapi_client = self.client_mock
+        mock_hm.execute(HM, VTHUNDER)
+        self.client_mock.slb.hm.delete.assert_called_with(a10constants.MOCK_HM_ID)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -354,6 +354,48 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         self.client_mock.vlan.delete.assert_called_with(VLAN_ID)
         mock_task._network_driver.neutron_client.delete_port.assert_called_with(DEL_PORT_ID)
 
+    def test_TagInterfaceForMember_execute_log_warning_no_subnet_id(self):
+        member = self._mock_member()
+        member.id = "1234"
+        member.subnet_id = None
+        task_path = "a10_octavia.controller.worker.tasks.vthunder_tasks"
+        log_message = str("Subnet id argument was not specified during "
+                          "issuance of create command/API call for member %s. "
+                          "Skipping TagInterfaceForMember task")
+        expected_log = ["WARNING:{}:{}".format(task_path, log_message % member.id)]
+        mock_task = task.TagInterfaceForMember()
+        with self.assertLogs(task_path, level='WARN') as cm:
+            mock_task.execute(member, VTHUNDER)
+            self.assertEqual(expected_log, cm.output)
+
+    def test_TagInterfaceForMember_revert_log_warning_no_subnet_id(self):
+        member = self._mock_member()
+        member.id = "1234"
+        member.subnet_id = None
+        task_path = "a10_octavia.controller.worker.tasks.vthunder_tasks"
+        log_message = str("Subnet id argument was not specified during "
+                          "issuance of create command/API call for member %s. "
+                          "Skipping TagInterfaceForMember task")
+        expected_log = ["WARNING:{}:{}".format(task_path, log_message % member.id)]
+        mock_task = task.TagInterfaceForMember()
+        with self.assertLogs(task_path, level='WARN') as cm:
+            mock_task.revert(member, VTHUNDER)
+            self.assertEqual(expected_log, cm.output)
+
+    def test_DeleteInterfaceTagIfNotInUseForMember_execute_log_warning_no_subnet_id(self):
+        member = self._mock_member()
+        member.id = "1234"
+        member.subnet_id = None
+        task_path = "a10_octavia.controller.worker.tasks.vthunder_tasks"
+        log_message = str("Subnet id argument was not specified during "
+                          "issuance of create command/API call for member %s. "
+                          "Skipping DeleteInterfaceTagIfNotInUseForMember task")
+        expected_log = ["WARNING:{}:{}".format(task_path, log_message % member.id)]
+        mock_task = task.DeleteInterfaceTagIfNotInUseForMember()
+        with self.assertLogs(task_path, level='WARN') as cm:
+            mock_task.execute(member, VTHUNDER)
+            self.assertEqual(expected_log, cm.output)
+
     def test_DeleteInterfaceTagIfNotInUseForLB_execute_delete_vlan(self):
         intf = a10_utils.convert_interface_to_data_model(ETHERNET_INTERFACE)
         device1_network_map = a10_data_models.DeviceNetworkMap(vcs_device_id=1,


### PR DESCRIPTION
## Description
The creation and deletion of a health monitor operations were not atomic. Also, Checked if the act of creation and deletion causes any of load balancer, the listener. pool in the pending state. 

If Bug Fix:
- Severity Level: High
- Issue Description: The creation and deletion of a health monitor operations were not atomic. Also, Checked if the act of creation and deletion causes any of load balancer, the listener. pool in pending state. 

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1429

## Technical Approach
- Added revert for creating and deleting health monitor.

## Manual Testing
- Tested creation of health monitor for pool.
- Tested creation flow by raising an exception on the creation of HM, and checked whole tree(load balancer- listener-pool ) to validate if those objects in Active or pending state.
- Tested if revert specific to create hm task getting executed or not.
- Tested deletion of health monitor flow.
- Tested deletion flow by raising an exception on the deletion of HM, and checked whole tree(load balancer- listener-pool ) to validate if those objects in Active or pending state.
- Tested if revert specific to delete hm task getting executed or not.