### PR TITLE
[STACK-1442]: Creating member without subnet id provided resulted in failure in vlan networks

### DIFF
--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -705,12 +705,12 @@ class TagInterfaceForMember(TagInterfaceBaseTask):
 
     @axapi_client_decorator
     def revert(self, member, vthunder, *args, **kwargs):
-         if not member.subnet_id:
-            LOG.warning("Subnet id argument was not specified during "
-                        "issuance of create command/API call for member %s. "
-                        "Skipping TagInterfaceForMember task", member.id)
-            return
-         try:
+        if not member.subnet_id:
+           LOG.warning("Subnet id argument was not specified during "
+                       "issuance of create command/API call for member %s. "
+                       "Skipping TagInterfaceForMember task", member.id)
+           return
+        try:
             if vthunder.device_network_map:
                 vlan_id = self.get_vlan_id(member.subnet_id, False)
                 if self.is_vlan_deletable():
@@ -749,12 +749,12 @@ class DeleteInterfaceTagIfNotInUseForMember(TagInterfaceBaseTask):
 
     @axapi_client_decorator
     def execute(self, member, vthunder):
-         if not member.subnet_id:
-            LOG.warning("Subnet id argument was not specified during "
-                        "issuance of create command/API call for member %s. "
-                        "Skipping DeleteInterfaceTagIfNotInUseForMember task", member.id)
-            return
-         try:
+        if not member.subnet_id:
+           LOG.warning("Subnet id argument was not specified during "
+                       "issuance of create command/API call for member %s. "
+                       "Skipping DeleteInterfaceTagIfNotInUseForMember task", member.id)
+           return
+        try:
             if vthunder.device_network_map:
                 vlan_id = self.get_vlan_id(member.subnet_id, False)
                 if self.is_vlan_deletable():

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -688,7 +688,6 @@ class TagInterfaceForMember(TagInterfaceBaseTask):
 
     """Task to tag Ethernet/Trunk Interface on a vThunder device from member subnet"""
 
-
     @axapi_client_decorator
     def execute(self, member, vthunder):
         if not member.subnet_id:
@@ -706,10 +705,10 @@ class TagInterfaceForMember(TagInterfaceBaseTask):
     @axapi_client_decorator
     def revert(self, member, vthunder, *args, **kwargs):
         if not member.subnet_id:
-           LOG.warning("Subnet id argument was not specified during "
-                       "issuance of create command/API call for member %s. "
-                       "Skipping TagInterfaceForMember task", member.id)
-           return
+            LOG.warning("Subnet id argument was not specified during "
+                        "issuance of create command/API call for member %s. "
+                        "Skipping TagInterfaceForMember task", member.id)
+            return
         try:
             if vthunder.device_network_map:
                 vlan_id = self.get_vlan_id(member.subnet_id, False)
@@ -750,10 +749,10 @@ class DeleteInterfaceTagIfNotInUseForMember(TagInterfaceBaseTask):
     @axapi_client_decorator
     def execute(self, member, vthunder):
         if not member.subnet_id:
-           LOG.warning("Subnet id argument was not specified during "
-                       "issuance of create command/API call for member %s. "
-                       "Skipping DeleteInterfaceTagIfNotInUseForMember task", member.id)
-           return
+            LOG.warning("Subnet id argument was not specified during "
+                        "issuance of create command/API call for member %s. "
+                        "Skipping DeleteInterfaceTagIfNotInUseForMember task", member.id)
+            return
         try:
             if vthunder.device_network_map:
                 vlan_id = self.get_vlan_id(member.subnet_id, False)

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -688,8 +688,14 @@ class TagInterfaceForMember(TagInterfaceBaseTask):
 
     """Task to tag Ethernet/Trunk Interface on a vThunder device from member subnet"""
 
+
     @axapi_client_decorator
     def execute(self, member, vthunder):
+        if not member.subnet_id:
+            LOG.warning("Subnet id argument was not specified during "
+                        "issuance of create command/API call for member %s. "
+                        "Skipping TagInterfaceForMember task", member.id)
+            return
         try:
             vlan_id = self.get_vlan_id(member.subnet_id, False)
             self.tag_interfaces(vthunder, vlan_id)
@@ -699,7 +705,12 @@ class TagInterfaceForMember(TagInterfaceBaseTask):
 
     @axapi_client_decorator
     def revert(self, member, vthunder, *args, **kwargs):
-        try:
+         if not member.subnet_id:
+            LOG.warning("Subnet id argument was not specified during "
+                        "issuance of create command/API call for member %s. "
+                        "Skipping TagInterfaceForMember task", member.id)
+            return
+         try:
             if vthunder.device_network_map:
                 vlan_id = self.get_vlan_id(member.subnet_id, False)
                 if self.is_vlan_deletable():
@@ -738,7 +749,12 @@ class DeleteInterfaceTagIfNotInUseForMember(TagInterfaceBaseTask):
 
     @axapi_client_decorator
     def execute(self, member, vthunder):
-        try:
+         if not member.subnet_id:
+            LOG.warning("Subnet id argument was not specified during "
+                        "issuance of create command/API call for member %s. "
+                        "Skipping DeleteInterfaceTagIfNotInUseForMember task", member.id)
+            return
+         try:
             if vthunder.device_network_map:
                 vlan_id = self.get_vlan_id(member.subnet_id, False)
                 if self.is_vlan_deletable():

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -16,7 +16,6 @@
 import copy
 import imp
 import json
-import logging
 try:
     from unittest import mock
 except ImportError:
@@ -339,14 +338,41 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         self.client_mock.vlan.delete.assert_called_with(VLAN_ID)
         mock_task._network_driver.neutron_client.delete_port.assert_called_with(DEL_PORT_ID)
 
-    def test_TagInterfaceForMember_log_warning_no_subnet_id(self):
+    @mock.patch('logging.Logger.warning')
+    def test_TagInterfaceForMember_execute_log_warning_no_subnet_id(self, mock_log):
         member = self._mock_member()
+        member.id = "1234"
         member.subnet_id = None
-        log_message = """Subnet id argument was not specified during 
-                      issuance of create command/API call for member %s. 
-                      Skipping TagInterfaceForMember task"""
+        log_message = str("Subnet id argument was not specified during "
+                          "issuance of create command/API call for member %s. "
+                          "Skipping TagInterfaceForMember task")
         mock_task = task.TagInterfaceForMember()
+        mock_task.execute(member, VTHUNDER)
+        mock_log.assert_called_with(log_message, member.id, extra=mock.ANY)
 
+    @mock.patch('logging.Logger.warning')
+    def test_TagInterfaceForMember_revert_log_warning_no_subnet_id(self, mock_log):
+        member = self._mock_member()
+        member.id = "1234"
+        member.subnet_id = None
+        log_message = str("Subnet id argument was not specified during "
+                          "issuance of create command/API call for member %s. "
+                          "Skipping TagInterfaceForMember task")
+        mock_task = task.TagInterfaceForMember()
+        mock_task.revert(member, VTHUNDER)
+        mock_log.assert_called_with(log_message, member.id, extra=mock.ANY)
+
+    @mock.patch('logging.Logger.warning')
+    def test_DeleteInterfaceTagIfNotInUseForMember_execute_log_warning_no_subnet_id(self, mock_log):
+        member = self._mock_member()
+        member.id = "1234"
+        member.subnet_id = None
+        log_message = str("Subnet id argument was not specified during "
+                          "issuance of create command/API call for member %s. "
+                          "Skipping DeleteInterfaceTagIfNotInUseForMember task")
+        mock_task = task.DeleteInterfaceTagIfNotInUseForMember()
+        mock_task.execute(member, VTHUNDER)
+        mock_log.assert_called_with(log_message, member.id, extra=mock.ANY)
 
     def test_DeleteInterfaceTagIfNotInUseForLB_execute_delete_vlan(self):
         intf = a10_utils.convert_interface_to_data_model(ETHERNET_INTERFACE)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -16,6 +16,7 @@
 import copy
 import imp
 import json
+import logging
 try:
     from unittest import mock
 except ImportError:
@@ -337,6 +338,15 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         mock_task.revert(member, VTHUNDER)
         self.client_mock.vlan.delete.assert_called_with(VLAN_ID)
         mock_task._network_driver.neutron_client.delete_port.assert_called_with(DEL_PORT_ID)
+
+    def test_TagInterfaceForMember_log_warning_no_subnet_id(self):
+        member = self._mock_member()
+        member.subnet_id = None
+        log_message = """Subnet id argument was not specified during 
+                      issuance of create command/API call for member %s. 
+                      Skipping TagInterfaceForMember task"""
+        mock_task = task.TagInterfaceForMember()
+
 
     def test_DeleteInterfaceTagIfNotInUseForLB_execute_delete_vlan(self):
         intf = a10_utils.convert_interface_to_data_model(ETHERNET_INTERFACE)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -338,41 +338,47 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         self.client_mock.vlan.delete.assert_called_with(VLAN_ID)
         mock_task._network_driver.neutron_client.delete_port.assert_called_with(DEL_PORT_ID)
 
-    @mock.patch('logging.Logger.warning')
-    def test_TagInterfaceForMember_execute_log_warning_no_subnet_id(self, mock_log):
+    def test_TagInterfaceForMember_execute_log_warning_no_subnet_id(self):
         member = self._mock_member()
         member.id = "1234"
         member.subnet_id = None
+        task_path = "a10_octavia.controller.worker.tasks.vthunder_tasks"
         log_message = str("Subnet id argument was not specified during "
                           "issuance of create command/API call for member %s. "
                           "Skipping TagInterfaceForMember task")
+        expected_log = ["WARNING:{}:{}".format(task_path, log_message % member.id)]
         mock_task = task.TagInterfaceForMember()
-        mock_task.execute(member, VTHUNDER)
-        mock_log.assert_called_with(log_message, member.id, extra=mock.ANY)
+        with self.assertLogs(task_path, level='WARN') as cm:
+            mock_task.execute(member, VTHUNDER)
+            self.assertEqual(expected_log, cm.output)
 
-    @mock.patch('logging.Logger.warning')
-    def test_TagInterfaceForMember_revert_log_warning_no_subnet_id(self, mock_log):
+    def test_TagInterfaceForMember_revert_log_warning_no_subnet_id(self):
         member = self._mock_member()
         member.id = "1234"
         member.subnet_id = None
+        task_path = "a10_octavia.controller.worker.tasks.vthunder_tasks"
         log_message = str("Subnet id argument was not specified during "
                           "issuance of create command/API call for member %s. "
                           "Skipping TagInterfaceForMember task")
+        expected_log = ["WARNING:{}:{}".format(task_path, log_message % member.id)]
         mock_task = task.TagInterfaceForMember()
-        mock_task.revert(member, VTHUNDER)
-        mock_log.assert_called_with(log_message, member.id, extra=mock.ANY)
+        with self.assertLogs(task_path, level='WARN') as cm:
+            mock_task.revert(member, VTHUNDER)
+            self.assertEqual(expected_log, cm.output)
 
-    @mock.patch('logging.Logger.warning')
-    def test_DeleteInterfaceTagIfNotInUseForMember_execute_log_warning_no_subnet_id(self, mock_log):
+    def test_DeleteInterfaceTagIfNotInUseForMember_execute_log_warning_no_subnet_id(self):
         member = self._mock_member()
         member.id = "1234"
         member.subnet_id = None
+        task_path = "a10_octavia.controller.worker.tasks.vthunder_tasks"
         log_message = str("Subnet id argument was not specified during "
                           "issuance of create command/API call for member %s. "
                           "Skipping DeleteInterfaceTagIfNotInUseForMember task")
+        expected_log = ["WARNING:{}:{}".format(task_path, log_message % member.id)]
         mock_task = task.DeleteInterfaceTagIfNotInUseForMember()
-        mock_task.execute(member, VTHUNDER)
-        mock_log.assert_called_with(log_message, member.id, extra=mock.ANY)
+        with self.assertLogs(task_path, level='WARN') as cm:
+            mock_task.execute(member, VTHUNDER)
+            self.assertEqual(expected_log, cm.output)
 
     def test_DeleteInterfaceTagIfNotInUseForLB_execute_delete_vlan(self):
         intf = a10_utils.convert_interface_to_data_model(ETHERNET_INTERFACE)


### PR DESCRIPTION
## Description

 Severity Level: High

```ERROR oslo_messaging.rpc.server SubnetNotFound: subnet not found (subnet id: None).```
The above error was raised when `--subnet-id` (an optional argument) was not specified when creating members in a vlan network.

This didn't show very well that the subnet_id (an optional argument) is actually required for our members when using VLAN networks.

I’ve been back and forth on the fix for this. There are 3 options were:
1. Resolve the IP address. And if not resolvable throw an error/warning
2. Log a warning and skip
3. Log and error

https://github.com/openstack/octavia/blob/master/octavia/controller/worker/v2/tasks/network_tasks.py#L76

The above link shows similar code completed upstream. This indicates a design decision of not trying to resolve the subnet’s of members based upon their IP address.

Due run-time considerations, concern of conflict with other code surrounding the member subnet information, and precedent I've gone with Option 2.

If the member doesn’t have a subnet id provided, a warning is logged and  networking tasks associated with the members are skipped

## Jira Ticket
[STACK-1442](https://a10networks.atlassian.net/browse/STACK-1442)

## Technical Approach
- Added warning logs for when `--subnet-id` is not specified during member operations

## Config Changes
N/A

## Test Cases
- Ensure TagInterfaceForMember execute logs warning message when `member.subnet_id` is `None`
- Ensure TagInterfaceForMember revert logs warning message when `member.subnet_id` is `None`
- Ensure DeleteInterfaceTagIfNotInUseForMember execute logs warning message when `member.subnet_id` is `None`

## Manual Testing

The following configuration file was used for testing purposes. 

```
[a10_controller_worker]
network_driver = a10_octavia_neutron_driver
loadbalancer_topology = SINGLE

[a10_global]
network_type = vlan

[hardware_thunder]
devices = [ 
                    {   
                     "project_id": "4426bfb28d81417e8bb0747af919cb31",
                     "ip_address":"10.0.0.41",
                     "username":"admin",
                     "password":"a10",
                     "device_name":"thunder_1",
                     "interface_vlan_map": {
                     "device_1": {
                       "vcs_device_id": 1,
                       "mgmt_ip_address": "10.0.0.41",
                       "ethernet_interfaces": [
                          {   
                             "interface_num": 1,
                             "vlan_map": [
                                 {"vlan_id": 11, "use_dhcp": "True"}
                              ]
                           },  
                          {  
                             "interface_num": 2,
                             "vlan_map": [
                                 {"vlan_id": 12, "use_dhcp": "True"}
                              ]
                           }
                         ]
                      }
                    }
                }
           ]
```

The following commands must be executed before running member create/delete:
```
$ openstack loadbalancer create --vip-subnet provider-vlan-11-subnet --name lb1 --project demo
$ openstack loadbalancer listener create --protocol HTTP --protocol-port 8080 --name l1 lb1 
$ openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener l1 --name pool1
```

**It's recommended to set `debug=False` in `/etc/a10/a10-octavia.conf`. This will make the warning logs easier to find**

#### Case 1: TagInterfaceForMember execute

```
$ openstack loadbalancer member create --address 10.0.0.3 --protocol-port 80 --name mem1 pool1
```

Expected Output:
```
$ journalctl -a --unit a10-controller-worker.service 

WARNING a10_octavia.controller.worker.tasks.vthunder_tasks [-] Subnet id argument was not specified during issuance of create command/API call for member 1afd4575-d452-4357-b014-f325e9668107. Skipping TagInterfaceForMember task
````

#### Case 2: TagInterfaceForMember revert
* Must inject a `raise` into the `TagInterfaceForMember` task's `execute` function first to ensure the member is placed into error state.

```
$ openstack loadbalancer member create --address 10.0.0.3 --protocol-port 80 --name mem1 pool1
```

Expected Output:
```
$ journalctl -a --unit a10-controller-worker.service 

WARNING a10_octavia.controller.worker.tasks.vthunder_tasks [-] Subnet id argument was not specified during issuance of create command/API call for member 1afd4575-d452-4357-b014-f325e9668107. Skipping TagInterfaceForMember task
````

#### Case 3: DeleteInterfaceTagIfNotInUseForMember execute
```
$ openstack loadbalancer member create --address 10.0.0.3 --protocol-port 80 --name mem1 pool1
$ openstack loadbalancer member delete mem1
```

Expected Output:
```
$ journalctl -a --unit a10-controller-worker.service 

WARNING a10_octavia.controller.worker.tasks.vthunder_tasks [-] Subnet id argument was not specified during issuance of create command/API call for member 1afd4575-d452-4357-b014-f325e9668107. Skipping DeleteInterfaceTagIfNotInUseForMember task
````