### PR TITLE
[BUG][STACK-1461]: Modified help description of template related configurations of a10-octavia.conf

### DIFF
--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -83,15 +83,18 @@ A10_LISTENER_OPTS = [
     cfg.StrOpt('template_virtual_port',
                default=None,
                max_length=127,
-               help=_('Virtual port template (Virtual port template name)')),
+               help=_('Provide an existing Virtual port template name on VThunder '
+                      'to associate with virtual port')),
     cfg.StrOpt('template_tcp',
                default=None,
                max_length=127,
-               help=_('TCP Proxy Template name')),
+               help=_('Provide an existing TCP template name on VThunder '
+                      'to associate with virtual port')),
     cfg.StrOpt('template_policy',
                default=None,
                max_length=127,
-               help=_('Policy Template (Policy template name).')),
+               help=_('Provide an existing Policy template name on VThunder '
+                      'to associate with virtual port')),
     cfg.BoolOpt('autosnat', default=False,
                 help=_('Enable autosnat')),
     cfg.IntOpt('conn_limit', min=1, max=64000000,
@@ -100,7 +103,8 @@ A10_LISTENER_OPTS = [
     cfg.StrOpt('template_http',
                default=None,
                max_length=127,
-               help=_('HTTP Template Name')),
+               help=_('Provide an existing HTTP template name on VThunder '
+                      'to associate with virtual port')),
     cfg.BoolOpt('use_rcv_hop_for_resp',
                 default=False,
                 help=_('Use receive hop for response to client')),
@@ -109,13 +113,16 @@ A10_LISTENER_OPTS = [
 A10_SERVICE_GROUP_OPTS = [
     cfg.StrOpt('template_server',
                default=None,
-               help=_('Service Group Server Template')),
+               help=_('Provide an existing Service Group Server template name on VThunder '
+                      'to associate with service group')),
     cfg.StrOpt('template_port',
                default=None,
-               help=_('Service Group Port Template')),
+               help=_('Provide an existing Service Group Port template name on VThunder '
+                      'to associate with service group')),
     cfg.StrOpt('template_policy',
                default=None,
-               help=_('Service Group Policy Template')),
+               help=_('Provide an existing Service Group Policy template name on VThunder '
+                      'to associate with service group')),
 ]
 
 A10_SERVER_OPTS = [
@@ -127,7 +134,8 @@ A10_SERVER_OPTS = [
                help=_('Connection Resume')),
     cfg.StrOpt('template_server',
                default=None,
-               help=_('Template Server')),
+               help=_('Provide an existing Server template name on VThunder '
+                      'to associate with server')),
 ]
 
 A10_HARDWARE_THUNDER_OPTS = [


### PR DESCRIPTION
## Description
- Severity Level :**Low**
- All the template_* related configuration on a10-octavia.conf under different sections requires an existing template* name that is  present on the vthunder. Since the help() description is misleading, editing it to indicate properly.


## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1461

## Technical Approach
- Modified the description for all template related configs for `listener`  `service-group` and `server` sections for a10-octavia.conf.

## Config Changes
None

## Test Cases
None

## Manual Testing
None