### PR TITLE
[BUG][STACK-1436, STACK-1465]: Removed slicing of hm.id for hm name and added UTs

### DIFF
--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -42,7 +42,7 @@ class CreateAndAssociateHealthMonitor(task.Task):
         args = utils.meta(health_mon, 'hm', {})
 
         try:
-            self.axapi_client.slb.hm.create(health_mon.id[0:5],
+            self.axapi_client.slb.hm.create(health_mon.id,
                                             openstack_mappings.hm_type(self.axapi_client,
                                                                        health_mon.type),
                                             health_mon.delay, health_mon.timeout,
@@ -56,7 +56,7 @@ class CreateAndAssociateHealthMonitor(task.Task):
 
         try:
             self.axapi_client.slb.service_group.update(health_mon.pool_id,
-                                                       health_monitor=health_mon.id[0:5],
+                                                       health_monitor=health_mon.id,
                                                        health_check_disable=0)
             LOG.debug("Health Monitor %s is associated to pool %s successfully.",
                       health_mon.id, health_mon.pool_id)
@@ -79,7 +79,7 @@ class DeleteHealthMonitor(task.Task):
         except Exception as e:
             LOG.warning("Failed to dissociate Health Monitor from pool: %s", str(e))
         try:
-            self.axapi_client.slb.hm.delete(health_mon.id[0:5])
+            self.axapi_client.slb.hm.delete(health_mon.id)
             LOG.debug("Health Monitor deleted successfully: %s", health_mon.id)
         except Exception as e:
             LOG.warning("Failed to delete health monitor: %s", str(e))
@@ -103,7 +103,7 @@ class UpdateHealthMonitor(task.Task):
         args = utils.meta(health_mon, 'hm', {})
         try:
             self.axapi_client.slb.hm.update(
-                health_mon.id[0:5],
+                health_mon.id,
                 openstack_mappings.hm_type(self.axapi_client, health_mon.type),
                 health_mon.delay, health_mon.timeout, health_mon.rise_threshold,
                 method=method, url=url, expect_code=expect_code,

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -92,7 +92,7 @@ class UpdateHealthMonitor(task.Task):
     def execute(self, listeners, health_mon, vthunder, update_dict):
         """ Execute update health monitor """
         # TODO(hthompson6) Length of name of healthmonitor for older vThunder devices
-        health_mon.__dict__.update(update_dict)
+        health_mon.update(update_dict)
         method = None
         url = None
         expect_code = None

--- a/a10_octavia/tests/common/a10constants.py
+++ b/a10_octavia/tests/common/a10constants.py
@@ -13,6 +13,7 @@
 #    under the License.
 
 
+MOCK_HM_ID = 'mock-hm-1'
 MOCK_POOL_ID = 'mock-pool-1'
 MOCK_MEMBER_ID = 'mock-member-1'
 MOCK_LOAD_BALANCER_ID = 'mock-lb-1'

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_health_monitor_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_health_monitor_tasks.py
@@ -1,0 +1,80 @@
+#    Copyright 2020, A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import imp
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from octavia.common import constants as o_constants
+from octavia.common import data_models as o_data_models
+
+from a10_octavia.common.data_models import VThunder
+import a10_octavia.controller.worker.tasks.health_monitor_tasks as task
+from a10_octavia.controller.worker.tasks import utils
+from a10_octavia.tests.common import a10constants
+from a10_octavia.tests.unit.base import BaseTaskTestCase
+
+VTHUNDER = VThunder()
+HM = o_data_models.HealthMonitor(id=a10constants.MOCK_HM_ID,
+                                 type=o_constants.HEALTH_MONITOR_TCP,
+                                 delay=o_constants.DELAY,
+                                 timeout=o_constants.TIMEOUT,
+                                 rise_threshold=o_constants.RISE_THRESHOLD,
+                                 http_method=o_constants.HTTP_METHOD,
+                                 url_path=o_constants.URL_PATH,
+                                 expected_codes=o_constants.EXPECTED_CODES)
+ARGS = utils.meta(HM, 'hm', {})
+LISTENERS = [o_data_models.Listener(id=a10constants.MOCK_LISTENER_ID, protocol_port=mock.ANY)]
+
+
+class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
+
+    def setUp(self):
+        super(TestHandlerHealthMonitorTasks, self).setUp()
+        imp.reload(task)
+        self.client_mock = mock.Mock()
+
+    def tearDown(self):
+        super(TestHandlerHealthMonitorTasks, self).tearDown()
+
+    def test_health_monitor_create_task(self):
+        mock_hm = task.CreateAndAssociateHealthMonitor()
+        mock_hm.axapi_client = self.client_mock
+        mock_hm.execute(LISTENERS, HM, VTHUNDER)
+        self.client_mock.slb.hm.create.assert_called_with(a10constants.MOCK_HM_ID,
+                                                          self.client_mock.slb.hm.TCP,
+                                                          HM.delay, HM.timeout,
+                                                          HM.rise_threshold, method=None,
+                                                          port=mock.ANY, url=None,
+                                                          expect_code=None, axapi_args=ARGS)
+
+    def test_health_monitor_update_task(self):
+        mock_hm = task.UpdateHealthMonitor()
+        mock_hm.axapi_client = self.client_mock
+        UPDATE_DICT = {'HM.delay': '10'}
+        mock_hm.execute(LISTENERS, HM, VTHUNDER, UPDATE_DICT)
+        self.client_mock.slb.hm.update.assert_called_with(a10constants.MOCK_HM_ID,
+                                                          self.client_mock.slb.hm.TCP,
+                                                          HM.delay, HM.timeout,
+                                                          HM.rise_threshold, method=None,
+                                                          port=mock.ANY, url=None,
+                                                          expect_code=None, axapi_args=ARGS)
+
+    def test_health_monitor_delete_task(self):
+        mock_hm = task.DeleteHealthMonitor()
+        mock_hm.axapi_client = self.client_mock
+        mock_hm.execute(HM, VTHUNDER)
+        self.client_mock.slb.hm.delete.assert_called_with(a10constants.MOCK_HM_ID)


### PR DESCRIPTION
## Description
- Severity Level : **Low**
- Creating a health monitor concatenates the id to 5 characters instead of the full id on VThunder cli.
- Need to remove the unnecessary data type conversion for hm during UpdateHealthMonitor task.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1436
https://a10networks.atlassian.net/browse/STACK-1465

## Technical Approach
- Removed Slicing of health monitor id before passing it as health monitor name, during create, update and delete
- Also added UTs for health monitor
- In UpdateHealthMonitor task, used `health_mon.update(update_dict)` instead of `health_mon.__dict__(update_dict)`.

## Config Changes
None

## Test Cases
-  **Create health monitor** 
 Successfully creates hm on Vthunder cli. Also gets attached to the pool with same id name.
![image](https://user-images.githubusercontent.com/52992745/87642373-0c4aa980-c767-11ea-9797-a7860b470283.png)
-  **Update health monitor**
 Successfully update hm on Vthunder cli.

- **Delete health monitor**
 Successfully delete hm on Vthunder cli.

## Manual Testing
- Create an slb tree
- Create an hm 
- on vthunder, do `show running-config health monitor` to see the output.

## Script used 
`openstack loadbalancer create --name SLB1 --vip-subnet-id 05facc48-be06-439c-917d-e223942a5bf4`
`openstack loadbalancer listener create --name listener1 --protocol  TCP --protocol-port 8080 SLB1`
`openstack loadbalancer pool create --protocol TCP --listener listener1 --lb-algorithm ROUND_ROBIN --name pool1
`
`openstack loadbalancer healthmonitor create --delay 10 --timeout 3 --max-retries 3 --type HTTP --name hm1 pool1`
