### PR TITLE
Stack 1429 - Review and correct flow & tasks for Health Monitor

### DIFF
--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -129,7 +129,3 @@ class MissingMgmtIpConfigError(cfg.ConfigFileValueError):
         msg = ('Missing `mgmt_ip_address` for vcs device with id {0}. ' +
                'Please provide management IP address').format(vcs_device_id)
         super(MissingMgmtIpConfigError, self).__init__(msg=msg)
-
-
-class GenericFlowException(exceptions.OctaviaException):
-    pass

--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -129,3 +129,7 @@ class MissingMgmtIpConfigError(cfg.ConfigFileValueError):
         msg = ('Missing `mgmt_ip_address` for vcs device with id {0}. ' +
                'Please provide management IP address').format(vcs_device_id)
         super(MissingMgmtIpConfigError, self).__init__(msg=msg)
+
+
+class GenericFlowException(exceptions.OctaviaException):
+    pass

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -16,6 +16,7 @@
 from acos_client import errors as acos_errors
 from oslo_config import cfg
 from oslo_log import log as logging
+from requests.exceptions import ConnectionError
 from taskflow import task
 
 from a10_octavia.common import a10constants

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -21,8 +21,8 @@ from taskflow import task
 
 from a10_octavia.common import a10constants
 from a10_octavia.common import openstack_mappings
-from a10_octavia.controller.worker.tasks import utils
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
+from a10_octavia.controller.worker.tasks import utils
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -72,7 +72,7 @@ class CreateAndAssociateHealthMonitor(task.Task):
     @axapi_client_decorator
     def revert(self, listeners, health_mon, vthunder, *args, **kwargs):
         try:
-            self.axapi_client.slb.hm.delete(health_mon.id[:5])
+            self.axapi_client.slb.hm.delete(health_mon.id)
         except ConnectionError:
             LOG.exception("Failed to connect A10 Thunder device: %s", vthunder.ip_address)
         except Exception as e:

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -51,7 +51,7 @@ class CreateAndAssociateHealthMonitor(task.Task):
                                             health_mon.rise_threshold, method=method,
                                             port=listeners[0].protocol_port, url=url,
                                             expect_code=expect_code, axapi_args=args)
-            LOG.debug("Health Monitor created successfully: %s", health_mon.id)
+            LOG.debug("Successfully created health monitor: %s", health_mon.id)
         except (acos_errors.ACOSException, ConnectionError) as e:
             LOG.exception("Failed to create health monitor: %s", health_mon.id)
             raise e
@@ -60,13 +60,12 @@ class CreateAndAssociateHealthMonitor(task.Task):
             self.axapi_client.slb.service_group.update(health_mon.pool_id,
                                                        health_monitor=health_mon.id,
                                                        health_check_disable=0)
-            LOG.debug("Health Monitor %s is associated to pool %s successfully.",
+            LOG.debug("Successfully associated health monitor %s to pool %s",
                       health_mon.id, health_mon.pool_id)
         except (acos_errors.ACOSException, ConnectionError) as e:
             LOG.exception(
-                "Failed to associate pool %s to Health Monitor: %s",
-                health_mon.pool_id,
-                health_mon.id)
+                "Failed to associate health monitor %s to pool %s",
+                health_mon.id, health_mon.pool_id)
             raise e
 
     @axapi_client_decorator
@@ -74,12 +73,11 @@ class CreateAndAssociateHealthMonitor(task.Task):
         try:
             self.axapi_client.slb.hm.delete(health_mon.id[:5])
         except ConnectionError:
-            LOG.exception("Failed to connect A10 Thunder device: %s", vthunder.ip)
+            LOG.exception("Failed to connect A10 Thunder device: %s", vthunder.ip_address)
         except Exception as e:
             LOG.warning(
                 "Failed to revert creation of health monitor: %s due to %s",
-                health_mon.id,
-                str(e))
+                health_mon.id, str(e))
 
 
 class DeleteHealthMonitor(task.Task):
@@ -91,18 +89,17 @@ class DeleteHealthMonitor(task.Task):
             self.axapi_client.slb.service_group.update(health_mon.pool_id,
                                                        health_monitor="",
                                                        health_check_disable=True)
-            LOG.debug("Health Monitor %s is dissociated from pool %s successfully.",
+            LOG.debug("Successfully dissociate health monitor %s from pool %s",
                       health_mon.id, health_mon.pool_id)
         except (acos_errors.ACOSException, ConnectionError) as e:
             LOG.exception(
-                "Failed to dissociate pool %s from health monitor: %s",
-                health_mon.pool_id,
-                health_mon.id)
+                "Failed to dissociate health monitor %s from pool %s",
+                health_mon.pool_id, health_mon.id)
             raise e
 
         try:
             self.axapi_client.slb.hm.delete(health_mon.id)
-            LOG.debug("Health Monitor deleted successfully: %s", health_mon.id)
+            LOG.debug("Successfully deleted health monitor: %s", health_mon.id)
         except (acos_errors.ACOSException, ConnectionError) as e:
             LOG.exception("Failed to delete health monitor: %s", health_mon.id)
             raise e
@@ -131,7 +128,7 @@ class UpdateHealthMonitor(task.Task):
                 health_mon.delay, health_mon.timeout, health_mon.rise_threshold,
                 method=method, url=url, expect_code=expect_code,
                 port=listeners[0].protocol_port, axapi_args=args)
-            LOG.debug("Health Monitor updated successfully: %s", health_mon.id)
+            LOG.debug("Successfully updated health monitor: %s", health_mon.id)
         except (acos_errors.ACOSException, ConnectionError) as e:
-            LOG.exception("Failed to update Health Monitor: %s", health_mon.id)
+            LOG.exception("Failed to update health monitor: %s", health_mon.id)
             raise e

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -90,7 +90,7 @@ class DeleteHealthMonitor(task.Task):
             self.axapi_client.slb.service_group.update(health_mon.pool_id,
                                                        health_monitor="",
                                                        health_check_disable=True)
-            LOG.debug("Successfully dissociate health monitor %s from pool %s",
+            LOG.debug("Successfully dissociated health monitor %s from pool %s",
                       health_mon.id, health_mon.pool_id)
         except (acos_errors.ACOSException, ConnectionError) as e:
             LOG.exception(

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -13,15 +13,15 @@
 #    under the License.
 
 
+from acos_client import errors as acos_errors
 from oslo_config import cfg
 from oslo_log import log as logging
 from taskflow import task
 
 from a10_octavia.common import a10constants
-from a10_octavia.common.exceptions import GenericFlowException
 from a10_octavia.common import openstack_mappings
-from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
 from a10_octavia.controller.worker.tasks import utils
+from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
@@ -51,10 +51,9 @@ class CreateAndAssociateHealthMonitor(task.Task):
                                             port=listeners[0].protocol_port, url=url,
                                             expect_code=expect_code, axapi_args=args)
             LOG.debug("Health Monitor created successfully: %s", health_mon.id)
-        except Exception as e:
-            msg = str(e)
-            LOG.exception("Failed to create Health Monitor: %s", msg)
-            raise GenericFlowException(msg)
+        except (acos_errors.ACOSException, ConnectionError) as e:
+            LOG.exception("Failed to create health monitor: %s", health_mon.id)
+            raise e
 
         try:
             self.axapi_client.slb.service_group.update(health_mon.pool_id,
@@ -62,17 +61,18 @@ class CreateAndAssociateHealthMonitor(task.Task):
                                                        health_check_disable=0)
             LOG.debug("Health Monitor %s is associated to pool %s successfully.",
                       health_mon.id, health_mon.pool_id)
-        except Exception as e:
-            msg = str(e)
-            LOG.exception("Failed to associate pool to Health Monitor: %s", msg)
-            raise GenericFlowException(msg)
+        except (acos_errors.ACOSException, ConnectionError) as e:
+            LOG.exception("Failed to associate pool %s to Health Monitor: %s", health_mon.pool_id, health_mon.id)
+            raise e
 
     @axapi_client_decorator
     def revert(self, listeners, health_mon, vthunder, *args, **kwargs):
         try:
             self.axapi_client.slb.hm.delete(health_mon.id[:5])
+        except ConnectionError:
+            LOG.exception("Failed to connect A10 Thunder device: %s", vthunder.ip)
         except Exception as e:
-            LOG.exception("Failed to delete health monitor: %s", str(e))
+            LOG.warning("Failed to revert creation of health monitor: %s due to %s", health_mon.id, str(e))
 
 
 class DeleteHealthMonitor(task.Task):
@@ -86,27 +86,16 @@ class DeleteHealthMonitor(task.Task):
                                                        health_check_disable=True)
             LOG.debug("Health Monitor %s is dissociated from pool %s successfully.",
                       health_mon.id, health_mon.pool_id)
-        except Exception as e:
-            msg = str(e)
-            LOG.exception("Failed to dissociate Health Monitor from pool: %s", msg)
-            raise GenericFlowException(msg)
+        except (acos_errors.ACOSException, ConnectionError) as e:
+            LOG.exception("Failed to dissociate pool %s from health monitor: %s", health_mon.pool_id, health_mon.id)
+            raise e
+
         try:
             self.axapi_client.slb.hm.delete(health_mon.id)
             LOG.debug("Health Monitor deleted successfully: %s", health_mon.id)
-        except Exception as e:
-            msg = str(e)
-            LOG.exception("Failed to delete health monitor: %s", msg)
-            raise GenericFlowException(msg)
-
-    @axapi_client_decorator
-    def revert(self, health_mon, vthunder, *args, **kwargs):
-        try:
-            self.axapi_client.slb.service_group.update(health_mon.pool_id,
-                                                       health_monitor=health_mon.id[:5],
-                                                       health_check_disable=0)
-
-        except Exception as e:
-            LOG.exception("Failed to revert delete Health Monitor operation: %s", str(e))
+        except (acos_errors.ACOSException, ConnectionError) as e:
+            LOG.exception("Failed to delete health monitor: %s", health_mon.id)
+            raise e
 
 
 class UpdateHealthMonitor(task.Task):
@@ -133,5 +122,6 @@ class UpdateHealthMonitor(task.Task):
                 method=method, url=url, expect_code=expect_code,
                 port=listeners[0].protocol_port, axapi_args=args)
             LOG.debug("Health Monitor updated successfully: %s", health_mon.id)
-        except Exception as e:
-            LOG.exception("Failed to update Health Monitor: %s", str(e))
+        except (acos_errors.ACOSException, ConnectionError) as e:
+            LOG.exception("Failed to update Health Monitor: %s", health_mon.id)
+            raise e

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -18,10 +18,10 @@ from oslo_log import log as logging
 from taskflow import task
 
 from a10_octavia.common import a10constants
-from a10_octavia.common import openstack_mappings
 from a10_octavia.common.exceptions import GenericFlowException
-from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
+from a10_octavia.common import openstack_mappings
 from a10_octavia.controller.worker.tasks import utils
+from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -63,7 +63,10 @@ class CreateAndAssociateHealthMonitor(task.Task):
             LOG.debug("Health Monitor %s is associated to pool %s successfully.",
                       health_mon.id, health_mon.pool_id)
         except (acos_errors.ACOSException, ConnectionError) as e:
-            LOG.exception("Failed to associate pool %s to Health Monitor: %s", health_mon.pool_id, health_mon.id)
+            LOG.exception(
+                "Failed to associate pool %s to Health Monitor: %s",
+                health_mon.pool_id,
+                health_mon.id)
             raise e
 
     @axapi_client_decorator
@@ -73,7 +76,10 @@ class CreateAndAssociateHealthMonitor(task.Task):
         except ConnectionError:
             LOG.exception("Failed to connect A10 Thunder device: %s", vthunder.ip)
         except Exception as e:
-            LOG.warning("Failed to revert creation of health monitor: %s due to %s", health_mon.id, str(e))
+            LOG.warning(
+                "Failed to revert creation of health monitor: %s due to %s",
+                health_mon.id,
+                str(e))
 
 
 class DeleteHealthMonitor(task.Task):
@@ -88,7 +94,10 @@ class DeleteHealthMonitor(task.Task):
             LOG.debug("Health Monitor %s is dissociated from pool %s successfully.",
                       health_mon.id, health_mon.pool_id)
         except (acos_errors.ACOSException, ConnectionError) as e:
-            LOG.exception("Failed to dissociate pool %s from health monitor: %s", health_mon.pool_id, health_mon.id)
+            LOG.exception(
+                "Failed to dissociate pool %s from health monitor: %s",
+                health_mon.pool_id,
+                health_mon.id)
             raise e
 
         try:

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -20,8 +20,8 @@ from taskflow import task
 from a10_octavia.common import a10constants
 from a10_octavia.common.exceptions import GenericFlowException
 from a10_octavia.common import openstack_mappings
-from a10_octavia.controller.worker.tasks import utils
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
+from a10_octavia.controller.worker.tasks import utils
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -87,27 +87,27 @@ class DeleteHealthMonitor(task.Task):
             LOG.debug("Health Monitor %s is dissociated from pool %s successfully.",
                       health_mon.id, health_mon.pool_id)
         except Exception as e:
-            msg=str(e)
+            msg = str(e)
             LOG.exception("Failed to dissociate Health Monitor from pool: %s", msg)
             raise GenericFlowException(msg)
         try:
             self.axapi_client.slb.hm.delete(health_mon.id)
             LOG.debug("Health Monitor deleted successfully: %s", health_mon.id)
         except Exception as e:
-            msg=str(e)
+            msg = str(e)
             LOG.exception("Failed to delete health monitor: %s", msg)
             raise GenericFlowException(msg)
-    
+
     @axapi_client_decorator
     def revert(self, health_mon, vthunder, *args, **kwargs):
         try:
             self.axapi_client.slb.service_group.update(health_mon.pool_id,
                                                        health_monitor=health_mon.id[:5],
                                                        health_check_disable=0)
-            
+
         except Exception as e:
             LOG.exception("Failed to revert delete Health Monitor operation: %s", str(e))
-            
+
 
 class UpdateHealthMonitor(task.Task):
     """Task to update Health Monitor"""

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -19,6 +19,7 @@ from taskflow import task
 
 from a10_octavia.common import a10constants
 from a10_octavia.common import openstack_mappings
+from a10_octavia.common.exceptions import GenericFlowException
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
 from a10_octavia.controller.worker.tasks import utils
 
@@ -51,8 +52,9 @@ class CreateAndAssociateHealthMonitor(task.Task):
                                             expect_code=expect_code, axapi_args=args)
             LOG.debug("Health Monitor created successfully: %s", health_mon.id)
         except Exception as e:
-            LOG.exception("Failed to create Health Monitor: %s", str(e))
-            raise
+            msg = str(e)
+            LOG.exception("Failed to create Health Monitor: %s", msg)
+            raise GenericFlowException(msg)
 
         try:
             self.axapi_client.slb.service_group.update(health_mon.pool_id,
@@ -61,8 +63,9 @@ class CreateAndAssociateHealthMonitor(task.Task):
             LOG.debug("Health Monitor %s is associated to pool %s successfully.",
                       health_mon.id, health_mon.pool_id)
         except Exception as e:
-            LOG.exception("Failed to associate pool to Health Monitor: %s", str(e))
-            raise
+            msg = str(e)
+            LOG.exception("Failed to associate pool to Health Monitor: %s", msg)
+            raise GenericFlowException(msg)
 
 
 class DeleteHealthMonitor(task.Task):


### PR DESCRIPTION
## Description
The creation and deletion of a health monitor operations were not atomic. Also, Checked if the act of creation and deletion causes any of load balancer, the listener. pool in the pending state.

If Bug Fix:
Severity Level: High
Issue Description: The creation and deletion of a health monitor operations were not atomic. Also, Checked if the act of creation and deletion causes any of load balancer, the listener. pool in the pending state.

## Jira Ticket
**This is optional if you are an external contributor**
- https://a10networks.atlassian.net/browse/STACK-1429

## Technical Approach
- Added revert for creating and deleting health monitor.

## Manual Testing
- Tested creation of health monitor for pool.
- Tested creation flow by raising an exception on the creation of HM, and checked whole tree(load balancer- listener-pool ) to validate if those objects in Active or pending state.
- Tested if revert specific to create hm task getting executed or not.
- Tested deletion of health monitor flow.
- Tested deletion flow by raising an exception on the deletion of HM, and checked whole tree(load balancer- listener-pool ) to validate if those objects in Active or pending state.
- Tested if revert specific to delete hm task getting executed or not.
- 