### PR TITLE
[STACK-1475] Resolved merge issue, added condition to check listeners

### DIFF
--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -512,7 +512,9 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             raise db_exceptions.NoResultFound
 
         listeners = pool.listeners
-        default_listener = pool.listeners[0]
+        default_listener = None
+        if listeners:
+            default_listener = pool.listeners[0]
         load_balancer = pool.load_balancer
 
         create_pool_tf = self._taskflow_load(self._pool_flows.
@@ -539,7 +541,9 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         load_balancer = pool.load_balancer
         listeners = pool.listeners
-
+        default_listener = None
+        if listeners:
+            default_listener = pool.listeners[0]
         members = pool.members
         health_monitor = pool.health_monitor
         mem_count = self._member_repo.get_member_count(
@@ -547,6 +551,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             project_id=pool.project_id)
         mem_count = mem_count - len(members) + 1
         store = {constants.POOL: pool, constants.LISTENERS: listeners,
+                 constants.LISTENER: default_listener,
                  constants.LOADBALANCER: load_balancer,
                  constants.HEALTH_MON: health_monitor,
                  a10constants.MEMBER_COUNT: mem_count}
@@ -581,7 +586,9 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             pool = e.last_attempt.result()
 
         listeners = pool.listeners
-        default_listener = pool.listeners[0]
+        default_listener = None
+        if listeners:
+            default_listener = pool.listeners[0]
         load_balancer = pool.load_balancer
 
         update_pool_tf = self._taskflow_load(self._pool_flows.

--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -133,9 +133,10 @@ class ListenerUpdate(ListenersParent, task.Task):
     @axapi_client_decorator
     def execute(self, loadbalancer, listener, vthunder):
         try:
-            self.set(self.axapi_client.slb.virtual_server.vport.update,
-                     loadbalancer, listener)
-            LOG.debug("Successfully updated listener: %s", listener.id)
+            if listener:
+                self.set(self.axapi_client.slb.virtual_server.vport.update,
+                         loadbalancer, listener)
+                LOG.debug("Successfully updated listener: %s", listener.id)
         except (acos_errors.ACOSException, ConnectionError) as e:
             LOG.exception("Failed to update listener: %s", listener.id)
             raise e


### PR DESCRIPTION
## Issue Description
1. Resolve an issue occurred during merge process of STACK-1426: Review and correct flow & tasks for ListenerDONE with master
2. If pool doesnt have a listener(default listener) the pool create/delete/update fails

##  Severity Level
Critical

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1475

## Technical Approach
For first part, due to unexpected merge, a line to pass single listener was missing added that one.
While testing, created a pool with no listener and code failed, Added if listeners array is greater than 0 and added check in task if listener is None.


## Test Cases
- Create a pool with no listener, Try to delete the pool 

## Manual Testing
- Created a pool passing slb name as para
openstack loadbalancer pool create --loadbalancer slb1 --lb-algorithm ROUND_ROBIN --protocol TCP
- delete the pool
openstack loadbalancer pool delete 75e637f3-ffc9-4847-ba39-fbe523398e8c