### PR TITLE
[STACK-1488] Removed partition deletion on revert

### DIFF
--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -362,19 +362,9 @@ class HandleACOSPartitionChange(VThunderBaseTask):
                 axapi_client.system.partition.create(vthunder.partition_name)
                 axapi_client.system.action.write_memory(partition="shared")
                 LOG.info("Partition %s created", vthunder.partition_name)
-        except acos_errors.Exists:
-            pass
         except Exception as e:
             LOG.exception("Failed to create parition on vThunder: %s", str(e))
-            raise
-
-    def revert(self, vthunder, *args, **kwargs):
-        try:
-            axapi_client = a10_utils.get_axapi_client(vthunder)
-            axapi_client.system.partition.delete(vthunder.partition_name)
-        except Exception as e:
-            LOG.exception("Failed to revert partition create : %s", str(e))
-            raise
+            raise e
 
 
 class SetupDeviceNetworkMap(VThunderBaseTask):


### PR DESCRIPTION
## Description

Severity Level: Critical
During reverts of load balancer create flows, the partition is deleted. This causes 2 issues:
1.  Side effect of deleting a fully configured partition
2. The loadbalancer is placed in error state. Delete's end on write memory tasks, but the partition does not exist causing a separate error to occur.

This PR also removes the check for the `Exists` error being thrown as the `if not axapi_client.system.partition.exists(vthunder.partition_name):` will handle this already.

## Jira Ticket
[STACK-1488](https://a10networks.atlassian.net/browse/STACK-1488)

## Technical Approach
Removed HandleACOSPartitionChange revert function 

## Config Changes
N/A

## Test Cases
N/A

## Manual Testing
Add a `raise` expression to any task after HandleACOSPartition task in the loadbalancer create flow. Then attempt to delete the load balancer in error state. The partition should remain (so long as it has been created)