### PR TITLE
[STACK-1478]: Removed check on vrid_floating_ip

### DIFF
--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -59,7 +59,6 @@ def validate_partition(hardware_device):
     if len(partition_name) > 14:
         raise ValueError("Supplied partition value '%s' exceeds maximum length 14" %
                          (partition_name))
-    return hardware_device
 
 
 def validate_params(hardware_info):
@@ -69,10 +68,7 @@ def validate_params(hardware_info):
         if all(hardware_info[x] is not None for x in ('project_id', 'ip_address',
                                                       'username', 'password', 'device_name')):
             validate_ipv4(hardware_info['ip_address'])
-            hardware_info = validate_partition(hardware_info)
-            if 'vrid_floating_ip' in hardware_info:
-                if hardware_info['vrid_floating_ip'].lower() != 'dhcp':
-                    validate_ipv4(hardware_info['vrid_floating_ip'])
+            validate_partition(hardware_info)
             return hardware_info
     raise cfg.ConfigFileValueError('Please check your configuration. The params `project_id`, '
                                    '`ip_address`, `username`, `password` and `device_name` '


### PR DESCRIPTION
## Description

Severity Level: Low

Partial IP addresses were not being handled as expected due to generic ipv4 validation being preformed on them

## Jira Ticket
[STACK-1478]

## Technical Approach
Removed unnecessary validation

## Config Changes
N/A

## Test Cases
N/A

## Manual Testing
The following config file was used for testing. The important section is `vrid_floating_ip` which should contain a partial IP address such as `.17` or `6.17`

```
[a10_controller_worker]
network_driver = a10_octavia_neutron_driver

[hardware_thunder]
devices = [ 
                    {   
                     "project_id": "4426bfb28d81417e8bb0747af919cb31",
                     "ip_address":"10.0.0.105",
                     "username":"admin",
                     "password":"password",
                     "device_name":"thunder_1",
                     "partition_name": "PartitionD",
                     "vrid_floating_ip": ".17"
                    }
]
```

The VRID floating IP is not associated until a member is created. Before creating the member the lb, listener, and pool must be created such as the below example
```
    openstack loadbalancer create --vip-subnet provider-vlan-11-subnet --name lb1 --project demo
    openstack loadbalancer listener create --protocol HTTP --protocol-port 8080 --name l1 lb1
    openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener l1 --name pool1
```

Now to configure the VRID floating IP issue the member create command

```
openstack loadbalancer member create --address 10.0.12.130 --subnet-id provider-vlan-12-subnet --protocol-port 80 --name mem2 pool1
```

The subnet in this case has a cidr of `10.0.12.0/24` thus the VRID IP should be `10.0.12.17` and present in `PartitionD`. The follow would be print in the `show run` output

```
!
active-partition PartitionD
!       
vrrp-a vrid 0 
  floating-ip 10.0.12.17
```

[STACK-1478]: https://a10networks.atlassian.net/browse/STACK-1478