### PR TITLE
STACK-1430 - Checked pending state inconsistency and fixed issues.

### DIFF
--- a/a10_octavia/controller/worker/tasks/l7policy_tasks.py
+++ b/a10_octavia/controller/worker/tasks/l7policy_tasks.py
@@ -18,9 +18,9 @@ from requests.exceptions import ConnectionError
 from taskflow import task
 
 from a10_octavia.common import openstack_mappings
-from a10_octavia.controller.worker.tasks import utils
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
 from a10_octavia.controller.worker.tasks.policy import PolicyUtil
+from a10_octavia.controller.worker.tasks import utils
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
@@ -73,7 +73,7 @@ class L7PolicyParent(object):
                 l7policy.id,
                 listener.id)
         except (acos_errors.ACOSException, ConnectionError) as e:
-            LOG.exception("Failed associated l7policy %s to listener %s", l7policy.id, listener.id)
+            LOG.exception("Failed to associate l7policy %s to listener %s", l7policy.id, listener.id)
             raise e
 
 
@@ -92,7 +92,7 @@ class CreateL7Policy(L7PolicyParent, task.Task):
             LOG.exception("Failed to connect A10 Thunder device: %s", vthunder.ip_address)
         except Exception as e:
             LOG.warning(
-                "Failed to revert creation of l7policy: %s due to %s",
+                "Failed to revert creation of l7policy %s due to %s",
                 l7policy.id, str(e))
 
 
@@ -145,7 +145,7 @@ class DeleteL7Policy(task.Task):
                 listener.id)
         except (acos_errors.ACOSException, ConnectionError) as e:
             LOG.exception(
-                "Failed to dissociated l7policy %s from listener %s",
+                "Failed to dissociate l7policy %s from listener %s",
                 l7policy.id,
                 listener.id)
             raise e

--- a/a10_octavia/controller/worker/tasks/l7policy_tasks.py
+++ b/a10_octavia/controller/worker/tasks/l7policy_tasks.py
@@ -14,6 +14,7 @@
 from acos_client import errors as acos_errors
 from oslo_config import cfg
 from oslo_log import log as logging
+from requests.exceptions import ConnectionError
 from taskflow import task
 
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator

--- a/a10_octavia/controller/worker/tasks/l7policy_tasks.py
+++ b/a10_octavia/controller/worker/tasks/l7policy_tasks.py
@@ -14,7 +14,7 @@
 from acos_client import errors as acos_errors
 from oslo_config import cfg
 from oslo_log import log as logging
-from requests.exceptions import ConnectionError
+from requests import exceptions
 from taskflow import task
 
 from a10_octavia.common import openstack_mappings
@@ -42,7 +42,7 @@ class L7PolicyParent(object):
             self.axapi_client.slb.aflex_policy.create(
                 file=filename, script=script, size=size, action="import")
             LOG.debug("Successfully created l7policy: %s", l7policy.id)
-        except (acos_errors.ACOSException, ConnectionError) as e:
+        except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception("Failed to create/update l7policy: %s", l7policy.id)
             raise e
 
@@ -51,7 +51,7 @@ class L7PolicyParent(object):
                 listener.load_balancer_id, listener.name,
                 listener.protocol, listener.protocol_port)
             LOG.debug("Successfully fetched listener %s for l7policy %s", listener.id, l7policy.id)
-        except (acos_errors.ACOSException, ConnectionError) as e:
+        except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception("Failed to get listener %s for l7policy: %s", listener.id, l7policy.id)
             raise e
 
@@ -72,7 +72,7 @@ class L7PolicyParent(object):
                 "Successfully associated l7policy %s to listener %s",
                 l7policy.id,
                 listener.id)
-        except (acos_errors.ACOSException, ConnectionError) as e:
+        except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception("Failed to associate l7policy %s to listener %s", l7policy.id, listener.id)
             raise e
 
@@ -88,7 +88,7 @@ class CreateL7Policy(L7PolicyParent, task.Task):
     def revert(self, l7policy, listeners, vthunder, *args, **kwargs):
         try:
             self.axapi_client.slb.aflex_policy.delete(l7policy.id)
-        except ConnectionError:
+        except exceptions.ConnectionError:
             LOG.exception("Failed to connect A10 Thunder device: %s", vthunder.ip_address)
         except Exception as e:
             LOG.warning(
@@ -121,7 +121,7 @@ class DeleteL7Policy(task.Task):
                 listener.load_balancer_id, listener.name,
                 listener.protocol, listener.protocol_port)
             LOG.debug("Successfully fetched listener %s for l7policy %s", listener.id, l7policy.id)
-        except (acos_errors.ACOSException, ConnectionError) as e:
+        except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception("Failed to get listener %s for l7policy: %s", listener.id, l7policy.id)
             raise e
 
@@ -143,7 +143,7 @@ class DeleteL7Policy(task.Task):
                 "Successfully dissociated l7policy %s from listener %s",
                 l7policy.id,
                 listener.id)
-        except (acos_errors.ACOSException, ConnectionError) as e:
+        except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception(
                 "Failed to dissociate l7policy %s from listener %s",
                 l7policy.id,
@@ -153,6 +153,6 @@ class DeleteL7Policy(task.Task):
         try:
             self.axapi_client.slb.aflex_policy.delete(l7policy.id)
             LOG.debug("Successfully deleted l7policy: %s", l7policy.id)
-        except (acos_errors.ACOSException, ConnectionError) as e:
+        except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception("Failed to delete l7policy: %s", l7policy.id)
             raise e

--- a/a10_octavia/controller/worker/tasks/l7policy_tasks.py
+++ b/a10_octavia/controller/worker/tasks/l7policy_tasks.py
@@ -11,8 +11,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-
-
+from acos_client import errors as acos_errors
 from oslo_config import cfg
 from oslo_log import log as logging
 from taskflow import task
@@ -35,30 +34,30 @@ class L7PolicyParent(object):
         listener = listeners[0]
         c_pers, s_pers = utils.get_sess_pers_templates(listener.default_pool)
         kargs = {}
-        get_listener = None
+
         try:
             self.axapi_client.slb.aflex_policy.create(
                 file=filename, script=script, size=size, action="import")
-            LOG.debug("l7policy created successfully: %s", l7policy.id)
-        except Exception as e:
-            LOG.exception("Failed to create/update l7policy: %s", str(e))
-            raise
+            LOG.debug("Successfully created l7policy: %s", l7policy.id)
+        except (acos_errors.ACOSException, ConnectionError) as e:
+            LOG.exception("Failed to create/update l7policy: %s", l7policy.id)
+            raise e
 
         try:
             get_listener = self.axapi_client.slb.virtual_server.vport.get(
                 listener.load_balancer_id, listener.name,
                 listener.protocol, listener.protocol_port)
-        except Exception as e:
-            LOG.exception("Failed to get listener for l7policy: %s", str(e))
-            raise
+            LOG.debug("Successfully fetched listener %s for l7policy %s", listener.id, l7policy.id)
+        except (acos_errors.ACOSException, ConnectionError) as e:
+            LOG.exception("Failed to get listener %s for l7policy: %s", listener.id, l7policy.id)
+            raise e
 
-        aflex_scripts = []
         if 'aflex-scripts' in get_listener['port']:
             aflex_scripts = get_listener['port']['aflex-scripts']
             aflex_scripts.append({"aflex": filename})
         else:
             aflex_scripts = [{"aflex": filename}]
-            kargs["aflex-scripts"] = aflex_scripts
+        kargs["aflex-scripts"] = aflex_scripts
 
         try:
             self.axapi_client.slb.virtual_server.vport.update(
@@ -66,10 +65,10 @@ class L7PolicyParent(object):
                 listener.protocol, listener.protocol_port,
                 listener.default_pool_id, s_pers,
                 c_pers, 1, **kargs)
-            LOG.debug("Listener updated successfully: %s", listener.id)
-        except Exception as e:
-            LOG.exception("Failed to update listener for l7policy: %s", str(e))
-            raise
+            LOG.debug("Successfully associated l7policy %s to listener %s", l7policy.id, listener.id)
+        except (acos_errors.ACOSException, ConnectionError) as e:
+            LOG.exception("Failed associated l7policy %s to listener %s", l7policy.id, listener.id)
+            raise e
 
 
 class CreateL7Policy(L7PolicyParent, task.Task):
@@ -79,13 +78,24 @@ class CreateL7Policy(L7PolicyParent, task.Task):
     def execute(self, l7policy, listeners, vthunder):
         self.set(l7policy, listeners)
 
+    @axapi_client_decorator
+    def revert(self, l7policy, listeners, vthunder):
+        try:
+            self.axapi_client.slb.aflex_policy.delete(l7policy.id)
+        except ConnectionError:
+            LOG.exception("Failed to connect A10 Thunder device: %s", vthunder.ip_address)
+        except Exception as e:
+            LOG.warning(
+                "Failed to revert creation of l7policy: %s due to %s",
+                l7policy.id, str(e))
+
 
 class UpdateL7Policy(L7PolicyParent, task.Task):
     """Task to update L7Policy"""
 
     @axapi_client_decorator
     def execute(self, l7policy, listeners, vthunder, update_dict):
-        l7policy.__dict__.update(update_dict)
+        l7policy.update(update_dict)
         self.set(l7policy, listeners)
 
 
@@ -98,15 +108,14 @@ class DeleteL7Policy(task.Task):
         c_pers, s_pers = utils.get_sess_pers_templates(
             listener.default_pool)
         kargs = {}
-        get_listener = None
-
         try:
             get_listener = self.axapi_client.slb.virtual_server.vport.get(
                 listener.load_balancer_id, listener.name,
                 listener.protocol, listener.protocol_port)
-        except Exception as e:
-            LOG.warning("Failed to get listener for l7policy: %s", str(e))
-            raise
+            LOG.debug("Successfully fetched listener %s for l7policy %s", listener.id, l7policy.id)
+        except (acos_errors.ACOSException, ConnectionError) as e:
+            LOG.exception("Failed to get listener %s for l7policy: %s", listener.id, l7policy.id)
+            raise e
 
         new_aflex_scripts = []
         if 'aflex-scripts' in get_listener['port']:
@@ -122,14 +131,14 @@ class DeleteL7Policy(task.Task):
                 listener.protocol, listener.protocol_port,
                 listener.default_pool_id,
                 s_pers, c_pers, 1, **kargs)
-            LOG.debug(
-                "l7policy %s detached from port %s successfully.", l7policy.id, listener.id)
-        except Exception as e:
-            LOG.warning("Failed to detach l7policy: %s", str(e))
-            raise
+            LOG.debug("Successfully dissociated l7policy %s from listener %s", l7policy.id, listener.id)
+        except (acos_errors.ACOSException, ConnectionError) as e:
+            LOG.exception("Failed to dissociated l7policy %s from listener %s", l7policy.id, listener.id)
+            raise e
 
         try:
             self.axapi_client.slb.aflex_policy.delete(l7policy.id)
-            LOG.debug("l7policy deleted successfully: %s", l7policy.id)
-        except Exception as e:
-            LOG.warning("Failed to delete l7policy: %s", str(e))
+            LOG.debug("Successfully deleted l7policy: %s", l7policy.id)
+        except (acos_errors.ACOSException, ConnectionError) as e:
+            LOG.exception("Failed to delete l7policy: %s", l7policy.id)
+            raise e

--- a/a10_octavia/controller/worker/tasks/l7policy_tasks.py
+++ b/a10_octavia/controller/worker/tasks/l7policy_tasks.py
@@ -66,7 +66,10 @@ class L7PolicyParent(object):
                 listener.protocol, listener.protocol_port,
                 listener.default_pool_id, s_pers,
                 c_pers, 1, **kargs)
-            LOG.debug("Successfully associated l7policy %s to listener %s", l7policy.id, listener.id)
+            LOG.debug(
+                "Successfully associated l7policy %s to listener %s",
+                l7policy.id,
+                listener.id)
         except (acos_errors.ACOSException, ConnectionError) as e:
             LOG.exception("Failed associated l7policy %s to listener %s", l7policy.id, listener.id)
             raise e
@@ -80,7 +83,7 @@ class CreateL7Policy(L7PolicyParent, task.Task):
         self.set(l7policy, listeners)
 
     @axapi_client_decorator
-    def revert(self, l7policy, listeners, vthunder):
+    def revert(self, l7policy, listeners, vthunder, *args, **kwargs):
         try:
             self.axapi_client.slb.aflex_policy.delete(l7policy.id)
         except ConnectionError:
@@ -132,9 +135,15 @@ class DeleteL7Policy(task.Task):
                 listener.protocol, listener.protocol_port,
                 listener.default_pool_id,
                 s_pers, c_pers, 1, **kargs)
-            LOG.debug("Successfully dissociated l7policy %s from listener %s", l7policy.id, listener.id)
+            LOG.debug(
+                "Successfully dissociated l7policy %s from listener %s",
+                l7policy.id,
+                listener.id)
         except (acos_errors.ACOSException, ConnectionError) as e:
-            LOG.exception("Failed to dissociated l7policy %s from listener %s", l7policy.id, listener.id)
+            LOG.exception(
+                "Failed to dissociated l7policy %s from listener %s",
+                l7policy.id,
+                listener.id)
             raise e
 
         try:

--- a/a10_octavia/controller/worker/tasks/l7rule_tasks.py
+++ b/a10_octavia/controller/worker/tasks/l7rule_tasks.py
@@ -14,7 +14,7 @@
 from acos_client import errors as acos_errors
 from oslo_config import cfg
 from oslo_log import log as logging
-from requests.exceptions import ConnectionError
+from requests import exceptions
 from taskflow import task
 
 from a10_octavia.common import openstack_mappings
@@ -43,7 +43,7 @@ class L7RuleParent(object):
             self.axapi_client.slb.aflex_policy.create(
                 file=filename, script=script, size=size, action="import")
             LOG.debug("Successfully created l7 rule: %s", l7rule.id)
-        except (acos_errors.ACOSException, ConnectionError) as e:
+        except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception("Failed to create/update l7rule: %s", l7rule.id)
             raise e
 
@@ -52,7 +52,7 @@ class L7RuleParent(object):
                 listener.load_balancer_id, listener.name,
                 listener.protocol, listener.protocol_port)
             LOG.debug("Successfully fetched listener %s for l7rule %s", listener.id, l7rule.id)
-        except (acos_errors.ACOSException, ConnectionError) as e:
+        except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception("Failed to get listener %s for l7rule: %s", listener.id, l7rule.id)
             raise e
 
@@ -70,7 +70,7 @@ class L7RuleParent(object):
                 listener.default_pool_id, s_pers,
                 c_pers, 1, **kargs)
             LOG.debug("Successfully associated l7rule %s to listener %s", l7rule.id, listener.id)
-        except (acos_errors.ACOSException, ConnectionError) as e:
+        except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception("Failed to associate l7rule %s to listener %s", l7rule.id, listener.id)
             raise e
 
@@ -120,7 +120,7 @@ class DeleteL7Rule(task.Task):
             self.axapi_client.slb.aflex_policy.create(
                 file=filename, script=script, size=size, action="import")
             LOG.debug("Successfully deleted l7rule: %s", l7rule.id)
-        except (acos_errors.ACOSException, ConnectionError) as e:
+        except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.warning("Failed to delete l7rule: %s", str(e))
             raise e
 
@@ -129,7 +129,7 @@ class DeleteL7Rule(task.Task):
                 listener.load_balancer_id, listener.name,
                 listener.protocol, listener.protocol_port)
             LOG.debug("Successfully fetched listener %s for l7rule %s", listener.id, l7rule.id)
-        except (acos_errors.ACOSException, ConnectionError) as e:
+        except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception("Failed to get listener %s for l7rule: %s", listener.id, l7rule.id)
             raise e
 
@@ -146,7 +146,7 @@ class DeleteL7Rule(task.Task):
                 listener.protocol, listener.protocol_port, listener.default_pool_id,
                 s_pers, c_pers, 1, **kargs)
             LOG.debug("Successfully dissociated l7rule %s from listener %s", l7rule.id, listener.id)
-        except (acos_errors.ACOSException, ConnectionError) as e:
+        except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception(
                 "Failed to dissociate l7rule %s from listener %s",
                 l7rule.id,

--- a/a10_octavia/controller/worker/tasks/l7rule_tasks.py
+++ b/a10_octavia/controller/worker/tasks/l7rule_tasks.py
@@ -14,6 +14,7 @@
 from acos_client import errors as acos_errors
 from oslo_config import cfg
 from oslo_log import log as logging
+from requests.exceptions import ConnectionError
 from taskflow import task
 
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator

--- a/a10_octavia/controller/worker/tasks/l7rule_tasks.py
+++ b/a10_octavia/controller/worker/tasks/l7rule_tasks.py
@@ -142,5 +142,8 @@ class DeleteL7Rule(task.Task):
                 s_pers, c_pers, 1, **kargs)
             LOG.debug("Successfully dissociated l7rule %s from listener %s", l7rule.id, listener.id)
         except (acos_errors.ACOSException, ConnectionError) as e:
-            LOG.exception("Failed to dissociated l7rule %s from listener %s", l7rule.id, listener.id)
+            LOG.exception(
+                "Failed to dissociated l7rule %s from listener %s",
+                l7rule.id,
+                listener.id)
             raise e

--- a/a10_octavia/controller/worker/tasks/l7rule_tasks.py
+++ b/a10_octavia/controller/worker/tasks/l7rule_tasks.py
@@ -71,7 +71,7 @@ class L7RuleParent(object):
                 c_pers, 1, **kargs)
             LOG.debug("Successfully associated l7rule %s to listener %s", l7rule.id, listener.id)
         except (acos_errors.ACOSException, ConnectionError) as e:
-            LOG.exception("Failed associated l7rule %s to listener %s", l7rule.id, listener.id)
+            LOG.exception("Failed to associate l7rule %s to listener %s", l7rule.id, listener.id)
             raise e
 
 
@@ -148,7 +148,7 @@ class DeleteL7Rule(task.Task):
             LOG.debug("Successfully dissociated l7rule %s from listener %s", l7rule.id, listener.id)
         except (acos_errors.ACOSException, ConnectionError) as e:
             LOG.exception(
-                "Failed to dissociated l7rule %s from listener %s",
+                "Failed to dissociate l7rule %s from listener %s",
                 l7rule.id,
                 listener.id)
             raise e


### PR DESCRIPTION
## Description
Checked for pending state issues for the related components of l7 policy, accordingly added an exception and revert for the creation of l7policy. Fixed issues related to an L7 policy

Severity Level:  High

ISSUES:
- while CREATING a new l7policy, this L7 policy doesn't get attached to the listener if the listener already has l7 policy attached to it.
- updation failing when we try to update l7policy with action "REDIRECT TO pool" from any other action type.
- When creating a listener  with HTTPS port it gets created with vthunder port, and then tried to fetch vport it was failing there.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1430
https://a10networks.atlassian.net/browse/STACK-1481

## Technical Approach
- Checked the l7policy, l7rule created flows and tasks.
- Derived test-cases on the basis of the glass box testing technique. 
- Resolved the bugs encountered through testing. 
- Added exceptions and revert to handle pending state inconsistency.

## Manual Testing
L7 policy
1. Revert check created l7policy with ERROR status and checked whether revert gets triggered.
2. Created 2 l7policy for the same listener with action redirect to pool to the same pool.
3. update l7 policy from action redirect to pool to REJECT  
4. Updated l7policy from action reject to redirect to pool and redirected to the independent pool(not associated with the listener).
5. Deleted the l7policy, checked listener if aflex policy relation is erased.

L7 rule tests:
1. Created an l7 policy for l7policy.
2. Deleted already created l7rule for an l7policy.
3. Updated l7rule and checked the changes reflected on vthunder device.
