### PR TITLE
[STACK-1493] Quick correction in revert of virtual port

### DIFF
--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -113,8 +113,6 @@ class ListenerCreate(ListenersParent, task.Task):
     @axapi_client_decorator
     def revert(self, loadbalancer, listener, vthunder, *args, **kwargs):
         LOG.warning("Reverting creation of listener: %s", listener.id)
-        listener.protocol = openstack_mappings.virtual_port_protocol(self.axapi_client,
-                                                                     listener.protocol)
         try:
             self.axapi_client.slb.virtual_server.vport.delete(
                 loadbalancer.id, listener.id, listener.protocol,


### PR DESCRIPTION
## Issue Description

Remove re-conversion of protocol type call from revert 

## Technical Approach 

We are in-place converting listener protocol to acos compatible in execute function
Same listener object is passed in case of ACOSExceptionError to Revert function
We can skip, re-conversion of protocol in revert

## Manual test case
Create a virtual port with ipinip and snat auto setting (To raise ACOSException)
Make sure correct API is called.
