### PR TITLE
[Bug][STACK-1470]: Added ha_conn_mirror support for Listeners

### DIFF
--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -36,6 +36,7 @@ class ListenersParent(object):
         autosnat = CONF.listener.autosnat
         conn_limit = CONF.listener.conn_limit
         use_rcv_hop = CONF.listener.use_rcv_hop_for_resp
+        ha_conn_mirror = CONF.listener.ha_conn_mirror
 
         virtual_port_templates = {}
         template_virtual_port = CONF.listener.template_virtual_port
@@ -67,6 +68,8 @@ class ListenersParent(object):
             listener.protocol = listener.protocol.lower()
             virtual_port_template = CONF.listener.template_http
             virtual_port_templates['template-http'] = virtual_port_template
+            ha_conn_mirror = None
+            LOG.warning("'ha_conn_mirror' is not allowed for HTTP, TERMINATED_HTTPS listener.")
         else:
             virtual_port_template = CONF.listener.template_tcp
             virtual_port_templates['template-tcp'] = virtual_port_template
@@ -90,7 +93,7 @@ class ListenersParent(object):
                    status=status, no_dest_nat=no_dest_nat,
                    autosnat=autosnat, ipinip=ipinip,
                    # TODO(hthompson6) resolve in acos client
-                   # ha_conn_mirror=ha_conn_mirror,
+                   ha_conn_mirror=ha_conn_mirror,
                    use_rcv_hop=use_rcv_hop,
                    conn_limit=conn_limit,
                    virtual_port_templates=virtual_port_templates,


### PR DESCRIPTION
## Description
- Severity Level : **Critical**
- `ha_conn_mirror` configuration in `a10-octavia.conf` is not supported on listeners at all. It should be supported for TCP and UDP protocol Listeners

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1470

## Technical Approach
- Added argument for accepting `ha-conn-mirror` in listeners api read from `a10-octavia.conf` under `[listener]` section.
- Since for `TERMINATED_HTTPS` and `HTTP` openstack mapping , `ha_conn_mirror` is **not** supported, hence raised a `LOG.warning` related to same and set it as `None`.

**Note**
Since the Openstack_mapping on vthunder is as follows:

- TERMINATED_HTTPS ---> HTTPS
- HTTPS--------------------> TCP

Hence it will be observed, that `ha_conn_mirror` will not be applicable for `TERMINATED_HTTPS` but will be applicable for `HTTPS` openstack protocol.

## Config Changes
None

## Test Cases
- Create listener with `--protocol` as `UDP`, `TCP`, `HTTP`, `HTTPS' passed as cli arguments.

## Manual Testing
Did testing with following config in `a10-octavia.conf`
```
[listener]
autosnat=True
conn_limit=1000
ha_conn_mirror=True
```

a) **TCP**
- `openstack loadbalancer listener create --name listener1 --protocol TCP --protocol-port 8081 SLB1`
Result on VThunder: 
```
slb virtual-server c793b2cc-85d6-41fa-9b19-19e0e3f3342c 192.168.8.169
  port 8081 tcp
    name 5b5e0189-89d0-4a8f-b962-313df552c445
    conn-limit 1000
    ha-conn-mirror
    extended-stats
    source-nat auto
```

b) **UDP**
- `openstack loadbalancer listener create --name listener2 --protocol UDP --protocol-port 8082 SLB1`
```
slb virtual-server c793b2cc-85d6-41fa-9b19-19e0e3f3342c 192.168.8.169
  port 8082 udp
    name 00f4bf85-1a67-4647-837f-07c984638bc4
    conn-limit 1000
    ha-conn-mirror
    extended-stats
    source-nat auto
```

c) **HTTP** -----  `ha_conn_mirror` not applicable
- `openstack loadbalancer listener create --name listener0 --protocol HTTP --protocol-port 8080 SLB1`
```
slb virtual-server c793b2cc-85d6-41fa-9b19-19e0e3f3342c 192.168.8.169
  port 8080 http
    name c1b52b6d-1d6a-4673-8bca-275ada839908
    conn-limit 1000
    extended-stats
    source-nat auto
```

d) **HTTPS** --- `ha_conn_mirror` applicable because of openstack mapping `HTTPS` to `tcp` on vThunder.
- `openstack loadbalancer listener create --name listener3 --protocol HTTPS --protocol-port 8083 SLB1`
```
slb virtual-server c793b2cc-85d6-41fa-9b19-19e0e3f3342c 192.168.8.169
  port 8083 tcp
    name 7a708edf-f4de-4d36-b891-6ff21042d583
    conn-limit 1000
    ha-conn-mirror
    extended-stats
    source-nat auto
```
