### PR TITLE
[Bug][STACK-1502]Modified default value for ha_conn_mirror to None

### DIFF
--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -78,7 +78,7 @@ A10_LISTENER_OPTS = [
                 default=False,
                 help=_('Disable destination NAT')),
     cfg.BoolOpt('ha_conn_mirror',
-                default=False,
+                default=None,
                 help=_('Enable for HA Conn sync')),
     cfg.StrOpt('template_virtual_port',
                default=None,

--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -68,8 +68,9 @@ class ListenersParent(object):
             listener.protocol = listener.protocol.lower()
             virtual_port_template = CONF.listener.template_http
             virtual_port_templates['template-http'] = virtual_port_template
-            ha_conn_mirror = None
-            LOG.warning("'ha_conn_mirror' is not allowed for HTTP, TERMINATED_HTTPS listener.")
+            if ha_conn_mirror is not None:
+                ha_conn_mirror = None
+                LOG.warning("'ha_conn_mirror' is not allowed for HTTP, TERMINATED_HTTPS listener.")
         else:
             virtual_port_template = CONF.listener.template_tcp
             virtual_port_templates['template-tcp'] = virtual_port_template


### PR DESCRIPTION
## Description
- Severity Level : Critical
- Default value for `ha_conn_mirror` should not be False for all protocols as `ha_conn_mirror` is not applicable for `HTTP` and `TERMINATED_HTTPS`  listener protocols.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1502

## Technical Approach
- Modified default value to `None` instead of `False`
- Added check for disabling `ha_conn_mirror` for HTTP and TERMINATED_HTTPS protocol type of listeners. In this case, if at all `ha_conn_mirror` setting is given anything (`TRUE/FALSE`) , it will throw warning and `ha_conn_mirror` will be set to None.

## Config Changes
None

## Test Cases
- Create listener with `--protocol` as `UDP`, `TCP`, `HTTP`, `HTTPS' passed as cli arguments, **_without_** `ha_conn_mirror` setting in `[listener]`

## Manual Testing
- Did testing with following config in `a10-octavia.conf`
```
[listener]
autosnat=True
conn_limit=1000
#ha_conn_mirror=True
```
a)  **HTTP** -----  `ha_conn_mirror` not applicable
- `openstack loadbalancer listener create --name listener0 --protocol HTTP --protocol-port 8080 SLB1`
```
slb virtual-server c793b2cc-85d6-41fa-9b19-19e0e3f3342c 192.168.8.169
  port 8080 http
    name c1b52b6d-1d6a-4673-8bca-275ada839908
    conn-limit 1000
    extended-stats
    source-nat auto
```

b) If any setting is given for `ha_conn_mirror`, warning is thrown.

![image](https://user-images.githubusercontent.com/52992745/88551131-21b1b480-d040-11ea-965a-4beab30b33c3.png)

