### PR TITLE
[BUG][STACK-1484, 1491] Ensured Sticky Partitions for Hardware Thunder config

### DIFF
--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -144,10 +144,10 @@ class InvalidVCSDeviceCount(cfg.ConfigFileValueError):
 
 class IpAddressPartitionCollisionInProjectError(cfg.ConfigFileValueError):
 
-    def __init__(self, given_ip_part_config, existing_ip_part_config, project_id):
+    def __init__(self, config_ip_part, existing_ip_part, project_id):
         msg = ('Given IPAddress:Partition `{0}` in a10-octavia.conf is invalid. '
                'There is an existing IPAddress:Partition `{1}` in use for project {2}.').format(
-            given_ip_part_config, existing_ip_part_config, project_id)
+            config_ip_part, existing_ip_part, project_id)
         super(IpAddressPartitionCollisionInProjectError, self).__init__(msg=msg)
 
 

--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -142,6 +142,15 @@ class InvalidVCSDeviceCount(cfg.ConfigFileValueError):
         super(InvalidVCSDeviceCount, self).__init__(msg=msg)
 
 
+class IpAddressPartitionCollisionInProjectError(cfg.ConfigFileValueError):
+
+    def __init__(self, given_ip_part_config, existing_ip_part_config, project_id):
+        msg = ('Given IPAddress:Partition `{0}` in a10-octavia.conf is invalid. '
+               'There is an existing IPAddress:Partition `{1}` in use for project {2}.').format(
+            given_ip_part_config, existing_ip_part_config, project_id)
+        super(IpAddressPartitionCollisionInProjectError, self).__init__(msg=msg)
+
+
 class MissingVCSDeviceConfig(base.NetworkException):
     def __init__(self, device_ids):
         msg = ('Device ids {0} provided in config are not present in VCS' +

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -283,6 +283,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             constants.TOPOLOGY: topology
         }
         if lb.project_id in CONF.hardware_thunder.devices:
+            store.update({constants.LOADBALANCER: lb})
             create_lb_flow = self._lb_flows.get_create_rack_vthunder_load_balancer_flow(
                 vthunder_conf=CONF.hardware_thunder.devices[lb.project_id],
                 topology=topology, listeners=lb.listeners)

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -283,7 +283,6 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             constants.TOPOLOGY: topology
         }
         if lb.project_id in CONF.hardware_thunder.devices:
-            store.update({constants.LOADBALANCER: lb})
             create_lb_flow = self._lb_flows.get_create_rack_vthunder_load_balancer_flow(
                 vthunder_conf=CONF.hardware_thunder.devices[lb.project_id],
                 topology=topology, listeners=lb.listeners)

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -289,7 +289,9 @@ class LoadBalancerFlows(object):
 
         lb_create_flow.add(lifecycle_tasks.LoadBalancerIDToErrorOnRevertTask(
             requires=constants.LOADBALANCER_ID))
-
+        lb_create_flow.add(a10_database_tasks.CheckExistingProjectPartitionEntry(
+            inject={a10constants.VTHUNDER_CONFIG: vthunder_conf},
+            requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG)))
         lb_create_flow.add(self.vthunder_flows.get_rack_vthunder_for_lb_subflow(
             vthunder_conf=vthunder_conf,
             prefix=constants.ROLE_STANDALONE,

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -289,6 +289,10 @@ class LoadBalancerFlows(object):
 
         lb_create_flow.add(lifecycle_tasks.LoadBalancerIDToErrorOnRevertTask(
             requires=constants.LOADBALANCER_ID))
+        lb_create_flow.add(database_tasks.ReloadLoadBalancer(
+            name=f_name + '-' + 'reload_loadbalancer',
+            requires=constants.LOADBALANCER_ID,
+            provides=constants.LOADBALANCER))
         lb_create_flow.add(a10_database_tasks.CheckExistingProjectPartitionEntry(
             inject={a10constants.VTHUNDER_CONFIG: vthunder_conf},
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG)))

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -290,7 +290,6 @@ class LoadBalancerFlows(object):
         lb_create_flow.add(lifecycle_tasks.LoadBalancerIDToErrorOnRevertTask(
             requires=constants.LOADBALANCER_ID))
         lb_create_flow.add(database_tasks.ReloadLoadBalancer(
-            name=f_name + '-' + 'reload_loadbalancer',
             requires=constants.LOADBALANCER_ID,
             provides=constants.LOADBALANCER))
         lb_create_flow.add(a10_database_tasks.CheckExistingProjectPartitionEntry(

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -355,10 +355,6 @@ class VThunderFlows(object):
 
         amp_for_lb_flow = linear_flow.Flow(sf_name)
 
-        amp_for_lb_flow.add(database_tasks.ReloadLoadBalancer(
-            name=sf_name + '-' + 'reload_loadbalancer',
-            requires=constants.LOADBALANCER_ID,
-            provides=constants.LOADBALANCER))
         amp_for_lb_flow.add(a10_database_tasks.CreateRackVthunderEntry(
             name=sf_name + '-' + 'create_rack_vThunder_entry_in_database',
             inject={a10constants.VTHUNDER_CONFIG: vthunder_conf},

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -114,19 +114,18 @@ class CheckExistingProjectPartitionEntry(BaseDatabaseTask):
         is used to configure, otherwise Raise ConfigValueError"""
 
     def execute(self, loadbalancer, vthunder_config):
-        project_id = loadbalancer.project_id
         vthunder = self.vthunder_repo.get_vthunder_by_project_id(
             db_apis.get_session(),
             project_id=loadbalancer.project_id)
         if vthunder is None:
             return
         existing_ip_addr_partition = '{}:{}'.format(vthunder.ip_address, vthunder.partition_name)
-        given_ip_addr_partition = '{}:{}'.format(
-            vthunder_config.ip_address, vthunder_config.partition_name)
-        if existing_ip_addr_partition != given_ip_addr_partition:
-            raise exceptions.IpAddressPartitionCollisionInProjectError(given_ip_addr_partition,
+        config_ip_addr_partition = '{}:{}'.format(vthunder_config.ip_address,
+                                                  vthunder_config.partition_name)
+        if existing_ip_addr_partition != config_ip_addr_partition:
+            raise exceptions.IpAddressPartitionCollisionInProjectError(config_ip_addr_partition,
                                                                        existing_ip_addr_partition,
-                                                                       project_id)
+                                                                       loadbalancer.project_id)
 
 
 class DeleteVThunderEntry(BaseDatabaseTask):

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -111,7 +111,8 @@ class CreateVThunderEntry(BaseDatabaseTask):
 class CheckExistingProjectPartitionEntry(BaseDatabaseTask):
     """ Check existing Thunder entry with same project id.
         If exists, ensure the existing IPAddress:Partition
-        is used to configure, otherwise Raise ConfigValueError"""
+        is used to configure, otherwise Raise ConfigValueError
+    """
 
     def execute(self, loadbalancer, vthunder_config):
         vthunder = self.vthunder_repo.get_vthunder_by_project_id(

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -27,6 +27,7 @@ from octavia.db import api as db_apis
 from octavia.db import repositories as repo
 
 from a10_octavia.common import a10constants
+from a10_octavia.common import exceptions
 from a10_octavia.common import utils
 from a10_octavia.db import repositories as a10_repo
 
@@ -105,6 +106,27 @@ class CreateVThunderEntry(BaseDatabaseTask):
                 db_apis.get_session(), loadbalancer_id=loadbalancer.id)
         except NoResultFound:
             LOG.error("Failed to delete vThunder entry for load balancer: %s", loadbalancer.id)
+
+
+class CheckExistingProjectPartitionEntry(BaseDatabaseTask):
+    """ Check existing Thunder entry with same project id.
+        If exists, ensure the existing IPAddress:Partition
+        is used to configure, otherwise Raise ConfigValueError"""
+
+    def execute(self, loadbalancer, vthunder_config):
+        project_id = loadbalancer.project_id
+        vthunder = self.vthunder_repo.get_vthunder_by_project_id(
+            db_apis.get_session(),
+            project_id=loadbalancer.project_id)
+        if vthunder is None:
+            return
+        existing_ip_addr_partition = '{}:{}'.format(vthunder.ip_address, vthunder.partition_name)
+        given_ip_addr_partition = '{}:{}'.format(
+            vthunder_config.ip_address, vthunder_config.partition_name)
+        if existing_ip_addr_partition != given_ip_addr_partition:
+            raise exceptions.IpAddressPartitionCollisionInProjectError(given_ip_addr_partition,
+                                                                       existing_ip_addr_partition,
+                                                                       project_id)
 
 
 class DeleteVThunderEntry(BaseDatabaseTask):

--- a/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
@@ -75,12 +75,13 @@ class DeleteVirtualServerTask(task.Task):
 
     @axapi_client_decorator
     def execute(self, loadbalancer, vthunder):
-        try:
-            self.axapi_client.slb.virtual_server.delete(loadbalancer.id)
-            LOG.debug("Successfully deleted load balancer: %s", loadbalancer.id)
-        except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
-            LOG.exception("Failed to delete load balancer: %s", loadbalancer.id)
-            raise e
+        if vthunder:
+            try:
+                self.axapi_client.slb.virtual_server.delete(loadbalancer.id)
+                LOG.debug("Successfully deleted load balancer: %s", loadbalancer.id)
+            except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
+                LOG.exception("Failed to delete load balancer: %s", loadbalancer.id)
+                raise e
 
 
 class UpdateVirtualServerTask(LoadBalancerParent, task.Task):


### PR DESCRIPTION
## Description

- Severity Level : **Critical**
- Given a `project_id`, it should not be bound to multiple thunders when configure with one already in `a10-octavia.conf` and on  updation in `a10-octavia.conf` with different `ip_address`/ `partition_name`, it should throw Config error.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1484
https://a10networks.atlassian.net/browse/STACK-1491


## Technical Approach
- Added Task to check if there is an existing VThunder entry of the given `project_id`. 
- If yes, checking if the configured `ip_address` and `partition_name` are different than the ones associated with existing VThunder. 
- If No, raises an Config Value exception with appropriate message.
- Also while trying to delete Error'ed LBs with no vthunder entry, was facing issue mentioned like in [STACK-1509](https://a10networks.atlassian.net/browse/STACK-1509) - Resolved this also by adding `None` check for vthunder.


## Config Changes
None

## Test Cases
With at least one LB already configured within a given project_id and a given set of `ip_address` and `partition_name`, if again in `a10-octavia.conf`, we
- Change only `ip_address` ->  restart the service ->  create another LB ---> Error 
- Change only `partition_name` -> restart the service -> create another LB ---> Error 

## Manual Testing
**Step 1:**
Create a LB named `SLB1` with below `[hardware_thunder]` configuration in `a10-octavia.conf`
```
{
 "project_id": "project_1",
 "username" : "****",
 "password" : "****",
 "ip_address" : "10.43.12.122",
 "device_name" : "rack_1",
 "partition_name" : "PartitionB"
} 
```
**_Result:_**: `SLB1` is created.

**Step 2:**
Change the `ip_address` to `10.43.12.137` in **Step1** config, restart `a10-controller-worker.service`. Create another LB named `SLB2`.
_**Result**_: Error is raised in LOGs, `SLB2` is in `ERROR` state
![image](https://user-images.githubusercontent.com/52992745/89191506-a6f91400-d5c0-11ea-93a3-15f59a0c04da.png)

**Step 3:**
Now Change only `partition_name` to `PartitionC` in **Step1** config, restart `a10-controller-worker.service`. Create another LB named `SLB3`.
_**Result**_: Error is raised in LOGs, `SLB3` goes in `ERROR` state

![image](https://user-images.githubusercontent.com/52992745/89191763-06efba80-d5c1-11ea-861b-45f600e2d4ad.png)

- `openstack loadbalancer list`
![image](https://user-images.githubusercontent.com/52992745/89191836-20910200-d5c1-11ea-903f-2f534a9a1963.png)
