### PR TITLE
[BUG][STACK-1446] - Relational Operator is wrong when config l7rule with --compare-type REGEX and --type FILE_TYPE

### DIFF
--- a/a10_octavia/controller/worker/tasks/policy.py
+++ b/a10_octavia/controller/worker/tasks/policy.py
@@ -75,7 +75,10 @@ class PolicyUtil(object):
 
         # rule string static - required for file type rules only
         if l7rule.type == "FILE_TYPE":
-            ruleString = "([HTTP::uri] ends_with"
+            if l7rule.compare_type == "REGEX":
+                ruleString = "([HTTP::uri] matches_regex"
+            else:
+                ruleString = "([HTTP::uri] ends_with"
 
         # value
         value_string = l7rule.value


### PR DESCRIPTION
## Description
When comparison type is provided as REGEX and type as file type, aflex policy was created with ends_with Comparision and with regular expression as value. 

If Bug Fix:
Severity Level: Medium
Issue Description: Relational Operator is wrong when config l7rule with --compare-type REGEX and --type FILE_TYPE

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1446

## Technical Approach
- Added code REGEX equivalent aflex script for the comparison type regex.


## Manual Testing
- Created l7rule with comparison type as REGEX and type as FILE_TYPE, value is regular expression, Checked aflex script in Thunder
` openstack loadbalancer l7rule create --compare-type REGEX --value "abc" --type FILE_TYPE policy1`

- Created l7policy with comparison type as equals_to and type FILE_TYPE, checked aflex script.
`openstack loadbalancer l7rule create --compare-type EQUAL_TO --type FILE_TYPE --value '.txt' policy1 `
  