### PR TITLE
[BUG][STACK-1512] Failed to delete an ERROR'ed LB with no associated vThunder 

### DIFF
--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -590,7 +590,7 @@ class TagInterfaceBaseTask(VThunderBaseTask):
                         str(create_vlan_id))
 
     def tag_interfaces(self, vthunder, create_vlan_id):
-        if vthunder.device_network_map:
+        if vthunder and vthunder.device_network_map:
             network_list = self.network_driver.list_networks()
             vlan_subnet_id_dict = {}
             for network in network_list:
@@ -652,7 +652,7 @@ class TagInterfaceForLB(TagInterfaceBaseTask):
     @axapi_client_decorator
     def revert(self, loadbalancer, vthunder, *args, **kwargs):
         try:
-            if vthunder.device_network_map:
+            if vthunder and vthunder.device_network_map:
                 vlan_id = self.get_vlan_id(loadbalancer.vip.subnet_id, False)
                 if self.is_vlan_deletable():
                     LOG.warning("Revert TagInterfaceForLB with VLAN id %s", vlan_id)
@@ -695,7 +695,7 @@ class TagInterfaceForMember(TagInterfaceBaseTask):
                         "Skipping TagInterfaceForMember task", member.id)
             return
         try:
-            if vthunder.device_network_map:
+            if vthunder and vthunder.device_network_map:
                 vlan_id = self.get_vlan_id(member.subnet_id, False)
                 if self.is_vlan_deletable():
                     LOG.warning("Reverting tag interface for member with VLAN id %s", vlan_id)
@@ -716,7 +716,7 @@ class DeleteInterfaceTagIfNotInUseForLB(TagInterfaceBaseTask):
     @axapi_client_decorator
     def execute(self, loadbalancer, vthunder):
         try:
-            if vthunder.device_network_map:
+            if vthunder and vthunder.device_network_map:
                 vlan_id = self.get_vlan_id(loadbalancer.vip.subnet_id, False)
                 if self.is_vlan_deletable():
                     master_device_id = vthunder.device_network_map[0].vcs_device_id
@@ -740,7 +740,7 @@ class DeleteInterfaceTagIfNotInUseForMember(TagInterfaceBaseTask):
                         "Skipping DeleteInterfaceTagIfNotInUseForMember task", member.id)
             return
         try:
-            if vthunder.device_network_map:
+            if vthunder and vthunder.device_network_map:
                 vlan_id = self.get_vlan_id(member.subnet_id, False)
                 if self.is_vlan_deletable():
                     master_device_id = vthunder.device_network_map[0].vcs_device_id


### PR DESCRIPTION
## Description
- Severity Level:  **Critical**
- Issue Description: In VLAN env, we were unable to delete an LB completely that has gone into ERROR state for some reason and has no corresponding vthunder entry in db. We get following error on stack trace,

**AttributeError: 'NoneType' object has no attribute 'device_network_map'** 

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1512

## Technical Approach
- Before we try to access `vthunder.device_network_map`, we need to check if `vthunder` exist or not. Hence added them at places where `vthunder.device_network_map` is called.

## Config Changes
None

## Test Cases
- Normal environment : Deleting LB with status `ERROR` with no associated vthunder entry  will be successful without any error.
- VLAN Enviroment :  Deleting LB with status `ERROR` with no associated vthunder entry  will be successful without any error.

## Manual Testing
- Follow the steps given in Ticket [1512](https://a10networks.atlassian.net/browse/STACK-1512)
