### PR TITLE
[BUG][STACK-1520]: Ensure one to one mapping for Hardware Thunder IP_Address:Partition_name <-->Project_id

### DIFF
--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -142,13 +142,22 @@ class InvalidVCSDeviceCount(cfg.ConfigFileValueError):
         super(InvalidVCSDeviceCount, self).__init__(msg=msg)
 
 
-class IpAddressPartitionCollisionInProjectError(cfg.ConfigFileValueError):
+class ThunderInUseByExistingProjectError(cfg.ConfigFileValueError):
 
     def __init__(self, config_ip_part, existing_ip_part, project_id):
         msg = ('Given IPAddress:Partition `{0}` in a10-octavia.conf is invalid. '
-               'There is an existing IPAddress:Partition `{1}` in use for project {2}.').format(
+               'The project `{2}` is using IPAddress:Partition `{1}` already.').format(
             config_ip_part, existing_ip_part, project_id)
-        super(IpAddressPartitionCollisionInProjectError, self).__init__(msg=msg)
+        super(ThunderInUseByExistingProjectError, self).__init__(msg=msg)
+
+
+class ProjectInUseByExistingThunderError(cfg.ConfigFileValueError):
+
+    def __init__(self, config_ip_part, existing_project_id, project_id):
+        msg = ('Given project_id `{2}` in a10-octavia.conf is invalid. '
+               'The given IPAddress:Partition `{0}` is getting used for project {1} '
+               'already.').format(config_ip_part, existing_project_id, project_id)
+        super(ProjectInUseByExistingThunderError, self).__init__(msg=msg)
 
 
 class MissingVCSDeviceConfig(base.NetworkException):

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -292,7 +292,10 @@ class LoadBalancerFlows(object):
         lb_create_flow.add(database_tasks.ReloadLoadBalancer(
             requires=constants.LOADBALANCER_ID,
             provides=constants.LOADBALANCER))
-        lb_create_flow.add(a10_database_tasks.CheckExistingProjectPartitionEntry(
+        lb_create_flow.add(a10_database_tasks.CheckExistingProjectToThunderMappedEntries(
+            inject={a10constants.VTHUNDER_CONFIG: vthunder_conf},
+            requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG)))
+        lb_create_flow.add(a10_database_tasks.CheckExistingThunderToProjectMappedEntries(
             inject={a10constants.VTHUNDER_CONFIG: vthunder_conf},
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG)))
         lb_create_flow.add(self.vthunder_flows.get_rack_vthunder_for_lb_subflow(

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -228,6 +228,25 @@ class VThunderRepository(BaseRepository):
 
         return model.to_data_model()
 
+    def get_vthunders_by_project_id(self, session, project_id):
+        model_list = session.query(self.model_class).filter(
+            self.model_class.project_id == project_id).filter(
+                and_(self.model_class.status == "ACTIVE",
+                     or_(self.model_class.role == "STANDALONE",
+                         self.model_class.role == "MASTER")))
+        id_list = [model.id for model in model_list]
+        return id_list
+
+    def get_vthunders_by_ip_address(self, session, ip_address):
+        model_list = session.query(self.model_class).filter(
+            self.model_class.ip_address == ip_address).filter(
+                and_(self.model_class.status == "ACTIVE",
+                     or_(self.model_class.role == "STANDALONE",
+                         self.model_class.role == "MASTER")))
+
+        id_list = [model.id for model in model_list]
+        return id_list
+
     def get_delete_compute_flag(self, session, compute_id):
         if compute_id:
             count = session.query(self.model_class).filter(


### PR DESCRIPTION
## Description
- Severity Level : **High**
- To ensure one Partition maps to only one tenant logic at db level, following two cases occurs: 

_**Case a)**_  : Whether for a particular `project_id` there exist a `ip_address:partition_name` already in db (active). If there is, enforce user to use that, by raising an Error. - (Already resolved in https://github.com/a10networks/a10-octavia/pull/155)

_**Case b)**_ Another case is that whether for a particular `ip_address:partition_name`, there exist a `project_id` already in db (active). If there is, enforce user to use that, by raising an Error. - (**_Resolving in this PR_**)

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1520

## Technical Approach
- Resolves _**Case (b)**_
   Added new Task `CheckExistingThunderToProjectMappedEntries`, that does following : 
    i) Fetch all the existing vthunders from db filtered by given config  `ip_address`
    ii) For each vthunder, compare `ip_address:partition_name` with given config `ip_address:partition_name` to be equal
    iii) If they are Equal, compare vthunder’s `project_id` with given config `project_id`.
    iv) If they are Not equal then throw Error, otherwise continue. 

- Resolves **_Case (a)_**
   Modified existing `CheckExistingProjectPartitionEntry` -> `CheckExistingProjectToThunderMappedEntries`, that checks the reverse of above scenario.
- Added custom exceptions inheriting `ConfigFileValueError` with appropriate error message.

## Config Changes
None

## Test Cases
a) With at least one LB already configured within a given `project_id` and a given set of `ip_address` and `partition_name`, if again in `a10-octavia.conf`, we
- Change only `ip_address` ->  restart the service ->  create another LB ---> Error 
- Change only `partition_name` -> restart the service -> create another LB ---> Error 

b) With at least one LB already configured with a given set of `ip_address` and `partition_name` in a `project_id`, if again in `a10-octavia.conf`, we
- Change only `project_id` -> restart the service ->  create another LB ---> Error 

## Manual Testing

**Step 1:**
Create a LB named `SLB1` with below `[hardware_thunder]` configuration in `a10-octavia.conf`
```
{
 "project_id": "b8a9e31710ef4babb8189a5c3d92abc7",
 "username" : "****",
 "password" : "****",
 "ip_address" : "10.0.0.57",
 "device_name" : "rack_1",
 "partition_name" : "PartitionA"
} 
```

**_Result:_**: `SLB1` is created.

**Step 2:**
Change the `ip_address` to `10.0.0.56` in **Step1** config, restart `a10-controller-worker.service`. Create another LB named `SLB2`.

_**Result**_: Error is raised in LOGs, `SLB2` is in `ERROR` state
![InvalidVthunder_IP_addr_for_Project](https://user-images.githubusercontent.com/52992745/90389398-21d52b00-e0a7-11ea-96d4-e4202d7139e7.PNG)


**Step 3:**
Now Change only `partition_name` to `PartitionC` in **Step1** config, restart `a10-controller-worker.service`. Create another LB named `SLB3`.

_**Result**_: Error is raised in LOGs, `SLB3` goes in `ERROR` state
![InvalidVthunder_Partition_for_Project](https://user-images.githubusercontent.com/52992745/90389414-2bf72980-e0a7-11ea-8919-d3cadcbdcbbf.PNG)

**Step 4:**
Now Change only `project_id` to `b572164adbcb489082dc4cfe0ad1d7e9` in **Step1** config, restart `a10-controller-worker.service`. Create another LB named `SLB4`.
_**Result**_: Error is raised in LOGs, `SLB4` goes in `ERROR` state

![InvalidprojectID _for_vthunder](https://user-images.githubusercontent.com/52992745/90389516-5812aa80-e0a7-11ea-9f87-b17461f504ed.PNG)

