### PR TITLE
[BUG][STACK-1498][STACK-1524][STACK-1525]: VRID and VRID Floating IP proper delete and update in db

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -105,7 +105,8 @@ class CreateVThunderEntry(BaseDatabaseTask):
             self.vthunder_repo.delete(
                 db_apis.get_session(), loadbalancer_id=loadbalancer.id)
         except NoResultFound:
-            LOG.error("Failed to delete vThunder entry for load balancer: %s", loadbalancer.id)
+            LOG.error(
+                "Failed to delete vThunder entry for load balancer: %s", loadbalancer.id)
 
 
 class CheckExistingProjectPartitionEntry(BaseDatabaseTask):
@@ -120,7 +121,8 @@ class CheckExistingProjectPartitionEntry(BaseDatabaseTask):
             project_id=loadbalancer.project_id)
         if vthunder is None:
             return
-        existing_ip_addr_partition = '{}:{}'.format(vthunder.ip_address, vthunder.partition_name)
+        existing_ip_addr_partition = '{}:{}'.format(
+            vthunder.ip_address, vthunder.partition_name)
         config_ip_addr_partition = '{}:{}'.format(vthunder_config.ip_address,
                                                   vthunder_config.partition_name)
         if existing_ip_addr_partition != config_ip_addr_partition:
@@ -158,7 +160,8 @@ class GetVThunderByLoadBalancer(BaseDatabaseTask):
                             "configuration will not be applied for loadbalancer: %s",
                             loadbalancer.id)
             elif use_parent_part and vthunder.hierarchical_multitenancy:
-                parent_project_id = utils.get_parent_project(vthunder.project_id)
+                parent_project_id = utils.get_parent_project(
+                    vthunder.project_id)
                 if parent_project_id:
                     vthunder.partition_name = parent_project_id[:14]
         return vthunder
@@ -224,7 +227,8 @@ class MapLoadbalancerToAmphora(BaseDatabaseTask):
 
         if vthunder is None:
             # Check for spare vthunder
-            vthunder = self.vthunder_repo.get_spare_vthunder(db_apis.get_session())
+            vthunder = self.vthunder_repo.get_spare_vthunder(
+                db_apis.get_session())
             if vthunder is None:
                 LOG.debug("No Amphora available for load balancer with id %s",
                           loadbalancer.id)
@@ -338,6 +342,7 @@ class GetVRIDForProjectMember(BaseDatabaseTask):
 class UpdateVRIDForProjectMember(BaseDatabaseTask):
 
     def execute(self, member, vrid, port):
+        vrid_value = CONF.a10_global.vrid
         if port:
             if vrid:
                 try:
@@ -345,7 +350,8 @@ class UpdateVRIDForProjectMember(BaseDatabaseTask):
                         db_apis.get_session(),
                         vrid.id,
                         vrid_floating_ip=port.fixed_ips[0].ip_address,
-                        vrid_port_id=port.id)
+                        vrid_port_id=port.id,
+                        vrid=vrid_value)
                     LOG.debug("Successfully updated DB vrid %s entry for member %s",
                               vrid.id, member.id)
                 except Exception as e:
@@ -358,11 +364,26 @@ class UpdateVRIDForProjectMember(BaseDatabaseTask):
                     self.vrid_repo.create(db_apis.get_session(),
                                           project_id=member.project_id,
                                           vrid_floating_ip=port.fixed_ips[0].ip_address,
-                                          vrid_port_id=port.id)
+                                          vrid_port_id=port.id,
+                                          vrid=vrid_value)
                     LOG.debug("Successfully created DB entry for vrid for member %s",
                               member.id)
                 except Exception as e:
                     LOG.error("Failed to create vrid DB entry due to: %s", str(e))
+                    raise e
+        else:
+            conf_floating_ip = utils.get_vrid_floating_ip_for_project(
+                member.project_id)
+            if vrid and not conf_floating_ip:
+                try:
+                    self.vrid_repo.delete(
+                        db_apis.get_session(), id=vrid.id)
+                    LOG.debug("Successfully deleted DB vrid %s entry for member %s",
+                              vrid.id, member.id)
+                except Exception as e:
+                    LOG.error("Failed to delete vrid %(vrid)s "
+                              "DB entry due to: %(except)s",
+                              {'vrid': vrid.id, 'except': e})
                     raise e
 
 
@@ -373,7 +394,8 @@ class CountMembersInProject(BaseDatabaseTask):
                 db_apis.get_session(),
                 project_id=member.project_id)
         except Exception as e:
-            LOG.exception("Failed to get count of members in given project: %s", str(e))
+            LOG.exception(
+                "Failed to get count of members in given project: %s", str(e))
             raise e
 
 
@@ -383,7 +405,8 @@ class DeleteVRIDEntry(BaseDatabaseTask):
             try:
                 self.vrid_repo.delete(db_apis.get_session(), id=vrid.id)
             except Exception as e:
-                LOG.exception("Failed to delete VRID entry from vrid table: %s", str(e))
+                LOG.exception(
+                    "Failed to delete VRID entry from vrid table: %s", str(e))
                 raise e
 
 


### PR DESCRIPTION
## Description
**_STACK-1498_**
- Severity Level: **High**
- VRID floating IP was not getting reconfigured when we set it in config, then remove it and then again set it.

**_STACK-1524_**
- Severity Level: **High**
- VRID floating ip was configured wrongly for vrid 1  when setting member  or creating new member. Setting member did not change floating-ip for vrid 1 but sets a new floating-ip under vrid 0. 

**_STACK-1525_**
- Severity Level: **High**
- VRID floating ip was not deleted for vrid=1 after delete all members and pool.


## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1498
https://a10networks.atlassian.net/browse/STACK-1524
https://a10networks.atlassian.net/browse/STACK-1525

## Technical Approach
- Added delete api call in `UpdateVRIDForProjectMember`  in case `vrid_floating_ip config` is removed.
- Added updated vrid table entry by reading `CONF.a10_global.vrid` in db.
- Some pep8 changes.


## Config Changes
None

## Test Cases
STACK-1498 : 
a) CREATE `vrid_floating_ip`:
- Give `vrid_floating_ip` as any static ip - SUCCESS
- Give `vrid_floating_ip` as any  "dhcp" - SUCCESS
- No config for `vrid_floating_ip` - SUCCESS

b) UPDATE `vrid_floating_ip`:
- Earlier no ip --> now static ip 
- Earlier no ip --> now dhcp
- Earlier static --> now dhcp
- Earlier dhcp  --> now static ip
- Earlier static ip --> now new static ip
- Earlier static ip --> remove config completely
- Earlier dhcp --> remove config completely

c) DELETE `vrid_floating_ip`
- Given `vrid_floating_ip` as static ip  
RESULT : deleted vrid records,  corresponding neutron ports in Openstack UI gets deleted, Vthunder vrid floating ip also gets deleted
- Given `vrid_floating_ip` as  dhcp
RESULT : deleted vrid records,  corresponding neutron ports in Openstack UI gets deleted, Vthunder vrid floating ip also gets deleted

STACK-1524:
- Set `vrid` as 1 in `[a10_global]` and created a member --> Successfully created a member with vrid as 1 on vthunder.

STACK-1525: 
- Given a member with set `vrid` as 1 in `[a10_global]` on vthunder, if we delete it/ or delete pool --> Successfully deletes  member and vrid configuration also gets deleted from vthunder.

## Manual Testing

STACK-1498 : 
**Step 1:** :  Give/Set `vrid_floating_ip` in `[a10_global]` or `[hardware_thunder]` as static/dhcp and restart service
**Step 2:** : Create a member
**Step 3:** :Check on vthunder if `vrid_floating_ip` is configured and  neutron port is created on Openstack Network. Check db entry for vrid table.
**Step 4:** : Remove  `vrid_floating_ip` from `[a10_global]` or `[hardware_thunder]`  and restart service
**Step 5:** : Set member. Then Check on vthunder if `vrid_floating_ip` is removed and  neutron port is removed on Openstack Network. Check db entry for vrid table is removed.
**Step 6:** : Add any `vrid_floating_ip` from `[a10_global]` or `[hardware_thunder]`  and restart service. Perform set operation on member
**Step 7:** : Check again on vthunder if `vrid_floating_ip` is configured and  neutron port is created on Openstack Network. Check db entry for vrid table.

STACK-1524 : 
**Step 1:** :  Add `vrid` in `[a10_global]`  as 1 and restart service
**Step 2:** : Create a member
**Step 3:**: Check again on vthunder if `vrid_floating_ip` is configured and  neutron port is created on Openstack Network. Check db entry for vrid table.

STACK-1525 : 
**Step 1:** :  Add `vrid` in `[a10_global]`  as 1 and restart service
**Step 2:** : Create a member
**Step 4:** : Delete member / pool
**Step 3:**: Check again on vthunder if `vrid_floating_ip` config is deleted and  neutron port is deleted on Openstack Network. Check db entry for vrid table is removed.


 
