### PR TITLE
[BUG][STACK-1448]: failed to create listener with protocol UDP when config file included :template_tcp=1

### DIFF
--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -76,7 +76,7 @@ class ListenersParent(object):
             if ha_conn_mirror is not None:
                 ha_conn_mirror = None
                 LOG.warning("'ha_conn_mirror' is not allowed for HTTP, TERMINATED_HTTPS listener.")
-        else:
+        elif listener.protocol == 'TCP':
             template_tcp = CONF.listener.template_tcp
             if template_tcp and template_tcp.lower() == 'none':
                 template_tcp = None


### PR DESCRIPTION
## Description
When creating a UDP protocol type listener, flow is trying to use template_tcp and its configuration. 

If Bug Fix:
Severity Level: High

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1448

## Technical Approach
- Added an explicit condition in creating and update listener task to check whether listener protocol type is TCP.

## Manual Testing
- Creating a listener of UDP protocol type with template-tcp added in a10-octavia.conf.
- Created listener of TCP protocol type.
