### PR TITLE
[BUG][STACK-1549]: [member] will see wrong value for option: conn-resume when created member.

### DIFF
--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -126,7 +126,7 @@ A10_SERVER_OPTS = [
                default=64000000,
                help=_('Connection Limit')),
     cfg.IntOpt('conn_resume', min=1, max=1000000,
-               default=1,
+               default=None,
                help=_('Connection Resume')),
     cfg.StrOpt('template_server',
                default=None,


### PR DESCRIPTION
## Description
When conn-resume not provided, a member is created with value as 1. As per documentation, by default, it should not get set for the member.   

Severity Level: Highest

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1549

## Technical Approach
- Changed the default value for conn-resume from 1 to None

## Manual Testing
- Tested creation of member with conn-resume not provided.
- Tested creation of member with provided some value to the conn-resume attribute.
