### PR TITLE
[BUG][STACK-1510]: When ohm is enabled, child project resources gets created in parent partition of vthunder

### DIFF
--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -28,6 +28,7 @@ from octavia.db import api as db_apis
 from octavia.db import repositories as repo
 
 from a10_octavia.common import a10constants
+from a10_octavia.common import utils
 from a10_octavia.controller.worker.flows import a10_health_monitor_flows
 from a10_octavia.controller.worker.flows import a10_l7policy_flows
 from a10_octavia.controller.worker.flows import a10_l7rule_flows
@@ -190,7 +191,12 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             raise db_exceptions.NoResultFound
 
         load_balancer = listener.load_balancer
-        if listener.project_id in CONF.hardware_thunder.devices:
+        if CONF.a10_global.use_parent_partition:
+            listener_parent_proj = utils.get_parent_project(listener.project_id)
+            parent_project_list = utils.get_parent_project_list()
+
+        if any([any([proj in parent_project_list for proj in (listener_parent_proj,
+                listener.project_id)]), listener.project_id in CONF.hardware_thunder.devices]):
             create_listener_tf = self._taskflow_load(self._listener_flows.
                                                      get_rack_vthunder_create_listener_flow(
                                                          listener.project_id),
@@ -216,6 +222,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         listener = self._listener_repo.get(db_apis.get_session(),
                                            id=listener_id)
         load_balancer = listener.load_balancer
+
         if listener.project_id in CONF.hardware_thunder.devices:
             delete_listener_tf = self._taskflow_load(
                 self._listener_flows.get_delete_rack_listener_flow(),
@@ -282,6 +289,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         store[constants.UPDATE_DICT] = {
             constants.TOPOLOGY: topology
         }
+
         if lb.project_id in CONF.hardware_thunder.devices:
             create_lb_flow = self._lb_flows.get_create_rack_vthunder_load_balancer_flow(
                 vthunder_conf=CONF.hardware_thunder.devices[lb.project_id],
@@ -372,7 +380,13 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         load_balancer = pool.load_balancer
 
         topology = CONF.a10_controller_worker.loadbalancer_topology
-        if member.project_id in CONF.hardware_thunder.devices:
+
+        if CONF.a10_global.use_parent_partition:
+            member_parent_proj = utils.get_parent_project(member.project_id)
+            parent_project_list = utils.get_parent_project_list()
+
+        if any([any([proj in parent_project_list for proj in (member_parent_proj,
+                member.project_id)]), member.project_id in CONF.hardware_thunder.devices]):
             create_member_tf = self._taskflow_load(
                 self._member_flows.get_rack_vthunder_create_member_flow(),
                 store={

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -192,23 +192,42 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         load_balancer = listener.load_balancer
 
-        if any([any([proj in utils.get_parent_project_list() for proj in (listener.project_id,
-                utils.get_parent_project(listener.project_id))
-                if CONF.a10_global.use_parent_partition]),
-                listener.project_id in CONF.hardware_thunder.devices]):
-            create_listener_tf = self._taskflow_load(self._listener_flows.
-                                                     get_rack_vthunder_create_listener_flow(
-                                                         listener.project_id),
-                                                     store={constants.LOADBALANCER:
-                                                            load_balancer,
-                                                            constants.LISTENER:
+        if CONF.a10_global.use_parent_partition:
+            parent_project_list = utils.get_parent_project_list()
+            listener_parent_proj = utils.get_parent_project(
+                listener.project_id)
+            if (listener.project_id in parent_project_list or
+                    (listener_parent_proj and listener_parent_proj in parent_project_list)
+                    or listener.project_id in CONF.hardware_thunder.devices):
+                create_listener_tf = self._taskflow_load(self._listener_flows.
+                                                         get_rack_vthunder_create_listener_flow(
+                                                             listener.project_id),
+                                                         store={constants.LOADBALANCER:
+                                                                load_balancer,
+                                                                constants.LISTENER:
+                                                                listener})
+            else:
+                create_listener_tf = self._taskflow_load(self._listener_flows.
+                                                         get_create_listener_flow(),
+                                                         store={constants.LOADBALANCER:
+                                                                load_balancer,
+                                                                constants.LISTENER:
                                                                 listener})
         else:
-            create_listener_tf = self._taskflow_load(self._listener_flows.
-                                                     get_create_listener_flow(),
-                                                     store={constants.LOADBALANCER:
-                                                            load_balancer,
-                                                            constants.LISTENER:
+            if listener.project_id in CONF.hardware_thunder.devices:
+                create_listener_tf = self._taskflow_load(self._listener_flows.
+                                                         get_rack_vthunder_create_listener_flow(
+                                                             listener.project_id),
+                                                         store={constants.LOADBALANCER:
+                                                                load_balancer,
+                                                                constants.LISTENER:
+                                                                listener})
+            else:
+                create_listener_tf = self._taskflow_load(self._listener_flows.
+                                                         get_create_listener_flow(),
+                                                         store={constants.LOADBALANCER:
+                                                                load_balancer,
+                                                                constants.LISTENER:
                                                                 listener})
 
         with tf_logging.DynamicLoggingListener(create_listener_tf,
@@ -380,26 +399,49 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         topology = CONF.a10_controller_worker.loadbalancer_topology
 
-        if any([any([proj in utils.get_parent_project_list() for proj in (member.project_id,
-                utils.get_parent_project(member.project_id))
-                if CONF.a10_global.use_parent_partition]),
-                member.project_id in CONF.hardware_thunder.devices]):
-            create_member_tf = self._taskflow_load(
-                self._member_flows.get_rack_vthunder_create_member_flow(),
-                store={
-                    constants.MEMBER: member,
-                    constants.LISTENERS: listeners,
-                    constants.LOADBALANCER: load_balancer,
-                    constants.POOL: pool})
+        if CONF.a10_global.use_parent_partition:
+            parent_project_list = utils.get_parent_project_list()
+            member_parent_proj = utils.get_parent_project(
+                member.project_id)
+            if (member.project_id in parent_project_list or
+                    (member_parent_proj and member_parent_proj in parent_project_list)
+                    or member.project_id in CONF.hardware_thunder.devices):
+                create_member_tf = self._taskflow_load(
+                    self._member_flows.get_rack_vthunder_create_member_flow(),
+                    store={
+                        constants.MEMBER: member,
+                        constants.LISTENERS: listeners,
+                        constants.LOADBALANCER: load_balancer,
+                        constants.POOL: pool})
+            else:
+                create_member_tf = self._taskflow_load(self._member_flows.
+                                                       get_create_member_flow(
+                                                           topology=topology),
+                                                       store={constants.MEMBER: member,
+                                                              constants.LISTENERS:
+                                                              listeners,
+                                                              constants.LOADBALANCER:
+                                                              load_balancer,
+                                                              constants.POOL: pool})
         else:
-            create_member_tf = self._taskflow_load(self._member_flows.
-                                                   get_create_member_flow(topology=topology),
-                                                   store={constants.MEMBER: member,
-                                                          constants.LISTENERS:
-                                                          listeners,
-                                                          constants.LOADBALANCER:
-                                                          load_balancer,
-                                                          constants.POOL: pool})
+            if member.project_id in CONF.hardware_thunder.devices:
+                create_member_tf = self._taskflow_load(
+                    self._member_flows.get_rack_vthunder_create_member_flow(),
+                    store={
+                        constants.MEMBER: member,
+                        constants.LISTENERS: listeners,
+                        constants.LOADBALANCER: load_balancer,
+                        constants.POOL: pool})
+            else:
+                create_member_tf = self._taskflow_load(self._member_flows.
+                                                       get_create_member_flow(
+                                                           topology=topology),
+                                                       store={constants.MEMBER: member,
+                                                              constants.LISTENERS:
+                                                              listeners,
+                                                              constants.LOADBALANCER:
+                                                              load_balancer,
+                                                              constants.POOL: pool})
 
         with tf_logging.DynamicLoggingListener(create_member_tf,
                                                log=LOG):

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -380,9 +380,6 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         topology = CONF.a10_controller_worker.loadbalancer_topology
 
-        if CONF.a10_global.use_parent_partition:
-            member_parent_proj = utils.get_parent_project(member.project_id)
-            parent_project_list = utils.get_parent_project_list()
         if any([any([proj in utils.get_parent_project_list() for proj in (member.project_id,
                 utils.get_parent_project(member.project_id))
                 if CONF.a10_global.use_parent_partition]),

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -191,12 +191,11 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             raise db_exceptions.NoResultFound
 
         load_balancer = listener.load_balancer
-        if CONF.a10_global.use_parent_partition:
-            listener_parent_proj = utils.get_parent_project(listener.project_id)
-            parent_project_list = utils.get_parent_project_list()
 
-        if any([any([proj in parent_project_list for proj in (listener_parent_proj,
-                listener.project_id)]), listener.project_id in CONF.hardware_thunder.devices]):
+        if any([any([proj in utils.get_parent_project_list() for proj in (listener.project_id,
+                utils.get_parent_project(listener.project_id))
+                if CONF.a10_global.use_parent_partition]),
+                listener.project_id in CONF.hardware_thunder.devices]):
             create_listener_tf = self._taskflow_load(self._listener_flows.
                                                      get_rack_vthunder_create_listener_flow(
                                                          listener.project_id),
@@ -384,9 +383,10 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         if CONF.a10_global.use_parent_partition:
             member_parent_proj = utils.get_parent_project(member.project_id)
             parent_project_list = utils.get_parent_project_list()
-
-        if any([any([proj in parent_project_list for proj in (member_parent_proj,
-                member.project_id)]), member.project_id in CONF.hardware_thunder.devices]):
+        if any([any([proj in utils.get_parent_project_list() for proj in (member.project_id,
+                utils.get_parent_project(member.project_id))
+                if CONF.a10_global.use_parent_partition]),
+                member.project_id in CONF.hardware_thunder.devices]):
             create_member_tf = self._taskflow_load(
                 self._member_flows.get_rack_vthunder_create_member_flow(),
                 store={


### PR DESCRIPTION
## Description
**STACK-1510**
- Severity Level: **High**
- If `use_parent_partition` is True, listener cannot be created under the previous loadbalancer if modify the `project_id` in `a10-octavia.conf`
- In other words, `Child2` project's listener was not getting created in parent partition when `use_parent_partition` is True, and LB is created from `Child1` project.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1510

## Technical Approach
_(The setup tested for : there is an `admin` project and `child1` and `child2` project are its children.)_
- It was found that the listener's `project_id` comes from the LB's `project_id` it is attached to and **not** on the sourced project.
- When use_parent_partition is `True`, keeping `hmt` - enabled, when listener intended from `child2` project is fired to get attached to LB of `child1` project, error occurs.
- It was failing at the **_if_** condition at `controller_worker` level, and going over to _non-rack_ flow. Eventually it leads to `MissingSecurityGroup` Error.

- Hence, more conditions on above **if** statement were added to also match parent projects like: 
 (a) Fetch parent projects of all the projects mentioned in config. 
 (b) Check if `listener.project_id`  exist in above list (a). [in case listener create openstack cmd is fired from `child1` project attached to an LB belonging to `admin` project]
 (c) Check if parent project id of `listener.project_id`  in above list (a).[in case listener create openstack cmd is fired from `child2` project attached to an LB belonging to `child1` project]

- If while getting parent project_id, if given config `project_id` is invalid/doesn't exist, we return None.

## Config Changes
None

## Test Cases

- If `use_parent_partition` = True and `hierarchical_multitenancy` is `enable`:

Configured project | Parent Resource (existing) | Resource(to create) | Vthunder partition (Result)
-- | -- | -- | --
admin | LB(admin) | Listener | admin
child1 | LB(admin) | Listener | admin
child2 | LB(admin) | Listener | admin
  |   |   |  
child1 | LB(child1) | Listener | admin
  |   |   |  
child2 | LB(child1) | Listener | admin
child2 | LB(child2) | Listener | admin
  |   |   |  
Invalid | LB(admin) | Listener | -- (Goes to non-RACK flow, throw error)
Invalid | LB(child1) | Listener | -- (Goes to non-RACK flow, throw error)
Invalid | LB(child2) | Listener | -- (Goes to non-RACK flow, throw error)

-  When `use_parent_partition` = False and `hierarchical_multitenancy` is `disable`:

Configured project | Parent Resource (existing) | Resource(to create) | Vthunder partition (Result)
-- | -- | -- | --
admin | LB(admin) | Listener | admin
child1 | LB(admin) | Listener | -- (Goes to non-RACK flow, throw error)
child2 | LB(admin) | Listener | -- (Goes to non-RACK flow, throw error)
  |   |   |  
child1 | LB(child1) | Listener | child1
  |   |   |  
child2 | LB(child1) | Listener | -- (Goes to non-RACK flow, throw error)
child2 | LB(child2) | Listener | child2
  |   |   |  
Invalid | LB(admin) | Listener | -- (Goes to non-RACK flow, throw error)
Invalid | LB(child1) | Listener | -- (Goes to non-RACK flow, throw error)
Invalid | LB(child2) | Listener | -- (Goes to non-RACK flow, throw error)


** similar test cases are applicable for pool and member.


## Manual Testing
- One scenario is same as mentioned in Steps to reproduce of [STACK-1510](https://a10networks.atlassian.net/browse/STACK-1510)
