### PR TITLE
[BUG][STACK-1548]: Removed 'is' from Error Message of InvalidVCSDeviceCount

### DIFF
--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -137,7 +137,7 @@ class MissingMgmtIpConfigError(cfg.ConfigFileValueError):
 class InvalidVCSDeviceCount(cfg.ConfigFileValueError):
 
     def __init__(self, device_count):
-        msg = ('Number of devices in config is should be 1 when VCS is not enabled, ' +
+        msg = ('Number of devices in config should be 1 when VCS is not enabled, ' +
                'provided {0}').format(device_count)
         super(InvalidVCSDeviceCount, self).__init__(msg=msg)
 


### PR DESCRIPTION
## Description
-  Severity Level: **High**
- Cosmetic changes needed for error message of `InvalidVCSDeviceCount`
- `"Number of devices in config is should be 1 when VCS is not enabled, provided 2"` ==> remove `“is"`

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1548

## Technical Approach
- Corrected Error message for `InvalidVCSDeviceCount`. Removed unnecessary `is`.

## Config Changes
None

## Test Cases
- On non-vcs setup, while creating an lb, we get an `InvalidVCSDeviceCount` error message properly.

## Manual Testing
**Step1:** Set  `a10-octavia.conf` as follows. The 2 vthunders that are added are **NOT** on vcs mode
```
[a10_global]
vrid_floating_ip = ".104"
use_parent_partition = False
network_type = 'vlan'

[hardware_thunder]
devices=[
 {
 "project_id": "b8a9e31710ef4babb8189a5c3d92abc7",
 "ip_address": "10.0.0.91",    
 "device_name": "rack_vthunder",
 "username": "admin",
 "password": "a10",
 "interface_vlan_map": {
  "device_1": {
   "vcs_device_id": 1,
   "mgmt_ip_address": "10.0.0.57",
   "ethernet_interfaces": [
     {
      "interface_num": 1,
      "vlan_map": [
       {"vlan_id": 12, "ve_ip" : ".23"}
      ]
     },
     {
      "interface_num": 2,
      "vlan_map": [
       {"vlan_id": 12, "ve_ip" : ".25"}
      ]
     }
   ],
   "trunk_interfaces": [{
    "interface_num": 1,
    "vlan_map": [
     {"vlan_id": 14, "ve_ip": ".21"}
    ]
   }],
  },
  "device_2": {
   "vcs_device_id": 2,
   "mgmt_ip_address": "10.0.0.47",
   "ethernet_interfaces": [{
    "interface_num": 2,
    "vlan_map": [
    {"vlan_id": 12, "ve_ip" : ".17"}
    ]
   }],
   "trunk_interfaces": [{
    "interface_num": 1,
    "vlan_map": [
     {"vlan_id": 13, "use_dhcp" : "True"}
    ]
   }],
  }
 }
 }]
```
**Step2:** Make sure the vthunders are on non-vcs  mode
```
AX2500-35-Active(config)#show vcs summary
VCS is not active.
AX2500-35-Active(config)#

```

**Step3:** Create LB.
**Result :** We get _corrected_ Error message on logs.   
![image](https://user-images.githubusercontent.com/52992745/92075797-e04abc80-edd6-11ea-80ca-4db221fd2e22.png)

and LB goes to `ERROR` state
