### PR TITLE
STACK-1557: Added CentOS Support for a10-octavia

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ mysql> DELETE FROM alembic_version;
 With `a10-octavia` installed, run the following command to register the services
 
 ```shell
-$ install-a10-octavia
+$ install-a10-octavia-dev
 ```
 
 This will install systemd services with names - `a10-controller-worker.service`, `a10-health-manager.service` and `a10-house-keeper.service`.

--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ mysql> DELETE FROM alembic_version;
 With `a10-octavia` installed, run the following command to register the services
 
 ```shell
-$ install-a10-octavia-dev
+$ /path/to/a10-octavia/a10_octavia/install/install-a10-octavia-dev
 ```
 
 This will install systemd services with names - `a10-controller-worker.service`, `a10-health-manager.service` and `a10-house-keeper.service`.

--- a/a10_octavia/install/a10-controller-worker.service
+++ b/a10_octavia/install/a10-controller-worker.service
@@ -6,7 +6,7 @@ ExecReload = /bin/kill -HUP $MAINPID
 TimeoutStopSec = 300
 KillMode = process
 ExecStart = /usr/local/bin/a10-octavia-worker  --config-dir=/etc/octavia/ --config-file=/etc/a10/a10-octavia.conf
-User = stack
+User = root
 
 [Install]
 WantedBy = multi-user.target

--- a/a10_octavia/install/a10-controller-worker.service
+++ b/a10_octavia/install/a10-controller-worker.service
@@ -6,7 +6,7 @@ ExecReload = /bin/kill -HUP $MAINPID
 TimeoutStopSec = 300
 KillMode = process
 ExecStart = /usr/local/bin/a10-octavia-worker  --config-dir=/etc/octavia/ --config-file=/etc/a10/a10-octavia.conf
-User = root
+User = octavia
 
 [Install]
 WantedBy = multi-user.target

--- a/a10_octavia/install/a10-controller-worker.service
+++ b/a10_octavia/install/a10-controller-worker.service
@@ -6,7 +6,7 @@ ExecReload = /bin/kill -HUP $MAINPID
 TimeoutStopSec = 300
 KillMode = process
 ExecStart = /usr/local/bin/a10-octavia-worker  --config-dir=/etc/octavia/ --config-file=/etc/a10/a10-octavia.conf
-User = octavia
+User = %user%
 
 [Install]
 WantedBy = multi-user.target

--- a/a10_octavia/install/a10-health-manager.service
+++ b/a10_octavia/install/a10-health-manager.service
@@ -6,7 +6,7 @@ ExecReload = /bin/kill -HUP $MAINPID
 TimeoutStopSec = 300
 KillMode = process
 ExecStart = /usr/local/bin/a10-health-manager  --config-dir=/etc/octavia/ --config-file=/etc/a10/a10-octavia.conf
-User = root
+User = octavia
 
 [Install]
 WantedBy = multi-user.target

--- a/a10_octavia/install/a10-health-manager.service
+++ b/a10_octavia/install/a10-health-manager.service
@@ -6,7 +6,7 @@ ExecReload = /bin/kill -HUP $MAINPID
 TimeoutStopSec = 300
 KillMode = process
 ExecStart = /usr/local/bin/a10-health-manager  --config-dir=/etc/octavia/ --config-file=/etc/a10/a10-octavia.conf
-User = stack
+User = root
 
 [Install]
 WantedBy = multi-user.target

--- a/a10_octavia/install/a10-health-manager.service
+++ b/a10_octavia/install/a10-health-manager.service
@@ -6,7 +6,7 @@ ExecReload = /bin/kill -HUP $MAINPID
 TimeoutStopSec = 300
 KillMode = process
 ExecStart = /usr/local/bin/a10-health-manager  --config-dir=/etc/octavia/ --config-file=/etc/a10/a10-octavia.conf
-User = octavia
+User = %user%
 
 [Install]
 WantedBy = multi-user.target

--- a/a10_octavia/install/a10-house-keeper.service
+++ b/a10_octavia/install/a10-house-keeper.service
@@ -6,7 +6,7 @@ ExecReload = /bin/kill -HUP $MAINPID
 TimeoutStopSec = 300
 KillMode = process
 ExecStart = /usr/local/bin/a10-house-keeper  --config-dir=/etc/octavia/ --config-file=/etc/a10/a10-octavia.conf
-User = octavia
+User = %user%
 
 [Install]
 WantedBy = multi-user.target

--- a/a10_octavia/install/a10-house-keeper.service
+++ b/a10_octavia/install/a10-house-keeper.service
@@ -6,7 +6,7 @@ ExecReload = /bin/kill -HUP $MAINPID
 TimeoutStopSec = 300
 KillMode = process
 ExecStart = /usr/local/bin/a10-house-keeper  --config-dir=/etc/octavia/ --config-file=/etc/a10/a10-octavia.conf
-User = stack
+User = root
 
 [Install]
 WantedBy = multi-user.target

--- a/a10_octavia/install/a10-house-keeper.service
+++ b/a10_octavia/install/a10-house-keeper.service
@@ -6,7 +6,7 @@ ExecReload = /bin/kill -HUP $MAINPID
 TimeoutStopSec = 300
 KillMode = process
 ExecStart = /usr/local/bin/a10-house-keeper  --config-dir=/etc/octavia/ --config-file=/etc/a10/a10-octavia.conf
-User = root
+User = octavia
 
 [Install]
 WantedBy = multi-user.target

--- a/a10_octavia/install/install-a10-octavia
+++ b/a10_octavia/install/install-a10-octavia
@@ -14,6 +14,21 @@ HEALTHMANAGER="a10-health-manager.service"
 
 SERVICES=("$CONTROLLER" "$HOUSEKEEPER" "$HEALTHMANAGER")
 
+FILE1=/usr/bin/a10-octavia-worker
+if [ -f "$FILE1" ]; then
+    ln -s /usr/bin/a10-octavia-worker /usr/local/bin/a10-octavia-worker
+fi
+
+FILE2=/usr/bin/a10-health-manager
+if [ -f "$FILE2" ]; then
+    ln -s /usr/bin/a10-health-manager /usr/local/bin/a10-health-manager
+fi
+
+FILE3=/usr/bin/a10-house-keeper
+if [ -f "$FILE3" ]; then
+    ln -s /usr/bin/a10-house-keeper /usr/local/bin/a10-house-keeper
+fi
+
 echo "[+] Installing a10-controller-worker"
 echo "[+] Installing a10-house-keeper"
 echo "[+] Installing a10-health-manager"

--- a/a10_octavia/install/install-a10-octavia
+++ b/a10_octavia/install/install-a10-octavia
@@ -16,6 +16,9 @@ else
    alias pip='pip3'
 fi
 
+SYSTEMD_SCRIPT_DIR=$(pip show a10-octavia | grep Location | awk '{print $2}')
+SYSTEMD_SCRIPT_DIR="${SYSTEMD_SCRIPT_DIR}/a10_octavia/install"
+
 CONTROLLER="a10-controller-worker.service"
 HOUSEKEEPER="a10-house-keeper.service"
 HEALTHMANAGER="a10-health-manager.service"
@@ -24,14 +27,11 @@ SERVICES=("$CONTROLLER" "$HOUSEKEEPER" "$HEALTHMANAGER")
 
 for service in ${SERVICES[@]}; do
         if id "octavia" >/dev/null 2>&1; then
-            sed -i 's/%user%/octavia/' ${service}
+            sed -i 's/%user%/octavia/' "${SYSTEMD_SCRIPT_DIR}/${service}"
         else
-            sed -i 's/%user%/root/' ${service}
+            sed -i 's/%user%/root/' "${SYSTEMD_SCRIPT_DIR}/${service}"
         fi
 done
-
-SYSTEMD_SCRIPT_DIR=$(pip show a10-octavia | grep Location | awk '{print $2}')
-SYSTEMD_SCRIPT_DIR="${SYSTEMD_SCRIPT_DIR}/a10_octavia/install"
 
 FILE1=/usr/bin/a10-octavia-worker
 if [ -f "$FILE1" ]; then

--- a/a10_octavia/install/install-a10-octavia
+++ b/a10_octavia/install/install-a10-octavia
@@ -16,14 +16,22 @@ else
    alias pip='pip3'
 fi
 
-SYSTEMD_SCRIPT_DIR=$(pip show a10-octavia | grep Location | awk '{print $2}')
-SYSTEMD_SCRIPT_DIR="${SYSTEMD_SCRIPT_DIR}/a10_octavia/install"
-
 CONTROLLER="a10-controller-worker.service"
 HOUSEKEEPER="a10-house-keeper.service"
 HEALTHMANAGER="a10-health-manager.service"
 
 SERVICES=("$CONTROLLER" "$HOUSEKEEPER" "$HEALTHMANAGER")
+
+for service in ${SERVICES[@]}; do
+        if id "octavia" >/dev/null 2>&1; then
+            sed -i 's/%user%/octavia/' ${service}
+        else
+            sed -i 's/%user%/root/' ${service}
+        fi
+done
+
+SYSTEMD_SCRIPT_DIR=$(pip show a10-octavia | grep Location | awk '{print $2}')
+SYSTEMD_SCRIPT_DIR="${SYSTEMD_SCRIPT_DIR}/a10_octavia/install"
 
 FILE1=/usr/bin/a10-octavia-worker
 if [ -f "$FILE1" ]; then

--- a/a10_octavia/install/install-a10-octavia
+++ b/a10_octavia/install/install-a10-octavia
@@ -1,8 +1,19 @@
 #!/bin/bash
 
+# To bring support for alias
+shopt -s expand_aliases
+
 if [ "$EUID" -ne 0 ]
     then echo "Please run as root"
     exit
+fi
+
+# Figuring out correct pip version
+pip2 -V
+if [ $? -eq 0 ]; then
+   alias pip='pip2'
+else
+   alias pip='pip3'
 fi
 
 SYSTEMD_SCRIPT_DIR=$(pip show a10-octavia | grep Location | awk '{print $2}')

--- a/a10_octavia/install/install-a10-octavia-dev
+++ b/a10_octavia/install/install-a10-octavia-dev
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# To bring support for alias
+shopt -s expand_aliases
+
+if [ "$EUID" -ne 0 ]
+    then echo "Please run as root"
+    exit
+fi
+
+# Figuring out correct pip version
+pip2 -V
+if [ $? -eq 0 ]; then
+   alias pip='pip2'
+else
+   alias pip='pip3'
+fi
+
+SYSTEMD_SCRIPT_DIR=$(pip show a10-octavia | grep Location | awk '{print $2}')
+SYSTEMD_SCRIPT_DIR="${SYSTEMD_SCRIPT_DIR}/a10_octavia/install"
+
+CONTROLLER="a10-controller-worker.service"
+HOUSEKEEPER="a10-house-keeper.service"
+HEALTHMANAGER="a10-health-manager.service"
+
+SERVICES=("$CONTROLLER" "$HOUSEKEEPER" "$HEALTHMANAGER")
+
+for service in ${SERVICES[@]}; do
+        if id "octavia" >/dev/null 2>&1; then
+            sed -i 's/%user%/octavia/' "${SYSTEMD_SCRIPT_DIR}/${service}"
+        else
+            sed -i 's/%user%/stack/' "${SYSTEMD_SCRIPT_DIR}/${service}"
+        fi
+done
+
+FILE1=/usr/bin/a10-octavia-worker
+if [ -f "$FILE1" ]; then
+    ln -s /usr/bin/a10-octavia-worker /usr/local/bin/a10-octavia-worker
+fi
+
+FILE2=/usr/bin/a10-health-manager
+if [ -f "$FILE2" ]; then
+    ln -s /usr/bin/a10-health-manager /usr/local/bin/a10-health-manager
+fi
+
+FILE3=/usr/bin/a10-house-keeper
+if [ -f "$FILE3" ]; then
+    ln -s /usr/bin/a10-house-keeper /usr/local/bin/a10-house-keeper
+fi
+
+echo "[+] Installing a10-controller-worker"
+echo "[+] Installing a10-house-keeper"
+echo "[+] Installing a10-health-manager"
+
+for i in ${SERVICES[@]}; do
+	cp -f "$SYSTEMD_SCRIPT_DIR/${i}" /etc/systemd/system/
+	chown root:root /etc/systemd/system/${i}
+done
+
+echo "[=] Reloading systemd" 
+systemctl daemon-reload
+
+for j in ${SERVICES[@]}; do
+	echo "[=] Enabling ${j}"
+        systemctl enable ${j}
+        echo "[=] Starting ${j}"
+        systemctl start ${j}
+done
+
+echo "Completed installation a10-controller-worker, a10-house-keeper and a10-health-manager service"

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ scripts =
         a10_octavia/install/a10-house-keeper
         a10_octavia/install/a10-health-manager
         a10_octavia/install/install-a10-octavia
+        a10_octavia/install/install-a10-octavia-dev
 
 [wheel]
 universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ scripts =
         a10_octavia/install/a10-house-keeper
         a10_octavia/install/a10-health-manager
         a10_octavia/install/install-a10-octavia
-        a10_octavia/install/install-a10-octavia-dev
 
 [wheel]
 universal = 1


### PR DESCRIPTION
## Description
**STACK-1557**
Adding CentOS Support for a10-octavia sothat it can be installed successfully on CentOS with Packstack setup.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1557

## Technical Approach
- For CentOS, as all the 3 services are getting installed in `/usr/bin` by default instead of `/usr/local/bin`, getting those installed services from `/usr/bin` to` /usr/local/bin` using symlink logic.
- Added logic for setting User in `a10-controller-worker.service`, `a10-health-manager.service` and `a10-house-keeper.service` to **octavia** if it exists in the system otherwise to **root** if octavia user does not exist.
- Brought support for aliases through the install script and set pip to pip2 or pip3 by it, depending on the underlying system environment.

## Test Cases
1. Install packstack and octavia manually in a fresh CentOS7, then install a10-octavia in the system by referring steps in the README.
2. Install packstack and octavia manually in a fresh CentOS8, then install a10-octavia in the system by referring steps in the README.
3. Install devstack in a fresh Ubuntu18, then install a10-octavia in the system by referring steps in the README.

## Manual Testing
**Step1:**
- Boot a CentOS7 and install packstack and octavia in it manually.
- Clone the a10-octavia repository and install it by following the all the installation steps in README.
- Register and start a10-octavia services by executing `install-a10-octavia` with a10-octavia already installed.
- Make sure the services are up by running `systemctl status a10-controller-worker.service a10-health-manager.service a10-house-keeper.service`

**Step2:**
- Boot a CentOS8 and install packstack and octavia in it manually.
- Clone the a10-octavia repository and install it by following the all the installation steps in README.
- Register and start a10-octavia services by executing `install-a10-octavia` with a10-octavia already installed.
- Make sure the services are up by running `systemctl status a10-controller-worker.service a10-health-manager.service a10-house-keeper.service`

**Step3:**
- Boot an Ubuntu18 and install devstack in it.
- Clone the a10-octavia repository and install it by following the all the installation steps in README.
- Register and start a10-octavia services by executing `install-a10-octavia` with a10-octavia already installed.
- Make sure the services are up by running `systemctl status a10-controller-worker.service a10-health-manager.service a10-house-keeper.service`