### PR TITLE
[BUG][STACK-1580] : LB should not be created in parent partition with use_parent_partition False and hmt enabled.

### DIFF
--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from keystone import exception as keystone_exceptions
 from oslo_config import cfg
 
 from octavia.common import exceptions
@@ -181,3 +182,12 @@ class PartitionNotActiveError(acos_errors.ACOSException):
     def __init__(self, partition_name, device_ip):
         msg = 'Partition {0} on device {1} is set to Not-Active'
         super(PartitionNotActiveError, self).__init__(msg=msg)
+
+
+class ParentProjectNotFound(keystone_exceptions.Error):
+    """Occurs if no parent project found."""
+
+    def __init__(self, project_id):
+        msg = ('The project {0} does not have a parent or has default project'
+               ' as parent. ').format(project_id)
+        super(ParentProjectNotFound, self).__init__(message=msg)

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -195,6 +195,10 @@ class GetVThunderByLoadBalancer(BaseDatabaseTask):
                         vthunder.project_id)
                     if parent_project_id:
                         vthunder.partition_name = parent_project_id[:14]
+                    else:   ## TODO Should be handled via new db architechture
+                        LOG.warning("The parent project for project %s does not exist. "
+                                    "Configuration will be applied in project partition itself. ",
+                                    vthunder.project_id)
                 else:
                     LOG.warning("Hierarchical multitenancy is disabled, use_parent_partition "
                                 "configuration will not be applied for loadbalancer: %s",

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -21,6 +21,7 @@ from oslo_config import cfg
 from oslo_log import log as logging
 from oslo_utils import uuidutils
 from taskflow import task
+from taskflow.types import failure
 
 from octavia.common import constants
 from octavia.db import api as db_apis
@@ -195,10 +196,10 @@ class GetVThunderByLoadBalancer(BaseDatabaseTask):
                         vthunder.project_id)
                     if parent_project_id:
                         vthunder.partition_name = parent_project_id[:14]
-                    else:   ## TODO Should be handled via new db architechture
-                        LOG.warning("The parent project for project %s does not exist. "
-                                    "Configuration will be applied in project partition itself. ",
-                                    vthunder.project_id)
+                    else:
+                        LOG.error("The parent project for project %s does not exist. ",
+                                  vthunder.project_id)
+                        raise exceptions.ParentProjectNotFound(vthunder.project_id)
                 else:
                     LOG.warning("Hierarchical multitenancy is disabled, use_parent_partition "
                                 "configuration will not be applied for loadbalancer: %s",
@@ -306,6 +307,19 @@ class CreateRackVthunderEntry(BaseDatabaseTask):
             LOG.error('Failed to create vThunder entry in db for load balancer: %s.',
                       loadbalancer.id)
             raise e
+
+    def revert(self, result, loadbalancer, vthunder_config, *args, **kwargs):
+        if isinstance(result, failure.Failure):
+            # This task's execute failed, so nothing needed to be done to
+            # revert
+            return
+
+        LOG.warning('Reverting create Rack VThunder in DB for load balancer: %s', loadbalancer.id)
+        try:
+            self.vthunder_repo.delete(
+                db_apis.get_session(), loadbalancer_id=loadbalancer.id)
+        except Exception as e:
+            LOG.error("Failed to delete vThunder entry for load balancer: %s", loadbalancer.id)
 
 
 class CreateVThunderHealthEntry(BaseDatabaseTask):

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -189,15 +189,16 @@ class GetVThunderByLoadBalancer(BaseDatabaseTask):
             return None
         if vthunder.undercloud:
             use_parent_part = CONF.a10_global.use_parent_partition
-            if use_parent_part and not vthunder.hierarchical_multitenancy:
-                LOG.warning("Hierarchical multitenancy is disabled, use_parent_partition "
-                            "configuration will not be applied for loadbalancer: %s",
-                            loadbalancer.id)
-            elif use_parent_part and vthunder.hierarchical_multitenancy:
-                parent_project_id = utils.get_parent_project(
-                    vthunder.project_id)
-                if parent_project_id:
-                    vthunder.partition_name = parent_project_id[:14]
+            if use_parent_part:
+                if vthunder.hierarchical_multitenancy == 'enable':
+                    parent_project_id = utils.get_parent_project(
+                        vthunder.project_id)
+                    if parent_project_id:
+                        vthunder.partition_name = parent_project_id[:14]
+                else:
+                    LOG.warning("Hierarchical multitenancy is disabled, use_parent_partition "
+                                "configuration will not be applied for loadbalancer: %s",
+                                loadbalancer.id)
         return vthunder
 
 


### PR DESCRIPTION
## Description
- Severity Level : **High**
- When we create LB with `use_parent_partition` flag as `False` and `hierarchical_multitenancy` (hmt) as `enable` n `a10-octavia.conf`, it should get created in project partition/ shared partition and not in parent partition.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1580

## Technical Approach
- By default, `hierarchical_multitenancy` (hmt) is `disable`, if not set.
- Changed if condition to be more specific, to check if hmt is set to `enable` and `use_parent_partition` as True, then only Parent partition is to be used. Otherwise for all other conditions, partition used will be either `partition_name` or `shared` (if `partition_name` is not mentioned).

_**Update**_: 
- Added log error for project having no parent or default as parent when all parent partition settings are enabled.

![image](https://user-images.githubusercontent.com/52992745/92874919-19fa7380-f426-11ea-9552-19c2748788bb.png)

- Also added `revert` for `CreateRackVthunderEntry`, to delete vthunder entry during reverts of taskflow.


## Config Changes
None

## Test Cases


SR No | hierarchical_multitenancy | use_parent_partition | partition_name | Result (Partition used) | LOGS/Warning
-- | -- | -- | -- | -- | --
  |   |   |   |   |  
1 | disable | FALSE | partitionA | partitionA |  -
2 | disable | FALSE | - | shared |  -
3 | disable | TRUE | partitionA | partitionA | *Warning
4 | disable | TRUE | - | shared | *Warning
5 | enable | FALSE | partitionA | existing project id [:14] |  -
6 | enable | FALSE | - | existing project id [:14] |  -
7 | enable | TRUE | partitionA (project has parent) | parent partition [:14] | - 
8 | enable | TRUE | - (project has parent)| parent partition [:14] |  -
Updated testcases
  |   |   |   |   |  
9 | enable | TRUE | partitionA (project does not have parent) | existing project id [:14] | **Error
10 | enable | TRUE | - (project does not have parent) | existing project id [:14] | **Error


*Warning 
![image](https://user-images.githubusercontent.com/52992745/92471227-35326c80-f1f5-11ea-8249-3b68c3162124.png)

**Error
![image](https://user-images.githubusercontent.com/52992745/92729401-e53bdd00-f38f-11ea-89a0-2be05c1c01de.png)
![image](https://user-images.githubusercontent.com/52992745/92874879-1109a200-f426-11ea-855a-37f7e8e4428e.png)



## Manual Testing
_Note :  `39acc1192457418ab2f5623e2e372344` is child project of `b572164adbcb489082dc4cfe0ad1d7e9`_ 
**_Below is test case 6 from above_**
Steps:
1) Set `a10-octavia.conf` with following configurations:
<pre>
[a10_global]
<b>use_parent_partition = False </b>

[hardware_thunder]
devices=[
{
 "project_id": "39acc1192457418ab2f5623e2e372344",   -------------------> child project 
 "ip_address": "10.0.0.XX",
 "device_name": "rack_vthunder",
 "username": "XX",
 "password": "XX",
 <b>"hierarchical_multitenancy": "enable"</b>
 }
]
</pre>
2) Restart the `a10-controller-worker.service`
3) Create LB in child project as follows : 
`openstack loadbalancer create --vip-subnet-id fd8effcf-f85c-498b-9bae-7ba36db4c01b --name SLB1 --project 39acc1192457418ab2f5623e2e372344`

4) Check on VThunder and openstack cli. It is created in child project partition.
![image](https://user-images.githubusercontent.com/52992745/92469922-45494c80-f1f3-11ea-9a10-02d23383adf9.png)

![image](https://user-images.githubusercontent.com/52992745/92469958-55f9c280-f1f3-11ea-83e6-82220e9436df.png)

** Above steps can be repeated for all the test cases mentioned above with different configurations

