### PR TITLE
[BUG][STACK-1546]: Corrected PartitionNotActiveError error message

### DIFF
--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -180,7 +180,8 @@ class PartitionNotActiveError(acos_errors.ACOSException):
     """ Occurs when the partition has been unloaded, but not deleted """
 
     def __init__(self, partition_name, device_ip):
-        msg = 'Partition {0} on device {1} is set to Not-Active'
+        msg = ('Partition {0} on device {1} is set to Not-Active').format(partition_name,
+                                                                          device_ip)
         super(PartitionNotActiveError, self).__init__(msg=msg)
 
 


### PR DESCRIPTION
## Description
- Severity Level : Low
- Corrected error message to display arguments like partition_name and device_ip correctly.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1546

## Technical Approach
- Passed in arguments to string message, which was initially missing

## Config Changes
None

## Test Cases
- When hmt is enabled and intended partition has been manually deleted from vthunder and not completely, on api invoking throws Error - `PartitionNotActiveError`

## Manual Testing
1) hierarchical_multitenancy": "enable"

2) create lb1, the project_id partition will be created, and then lb1 will be created in it as expected

3) from openstack delete lb1 successfully

4) on thunder, “no partition xxx id xx” to remove the partition, but not delete it completely from the system

5) create lb1, failed and get error message : 
```
Exception during message handling: PartitionNotActiveError: 1 Partition partition-A on device 10.0.0.54 is set to Not-Active
```

