### PR TITLE
[BUG][STACK-1612]: Handled validations of loadbalancer description

### DIFF
--- a/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
@@ -36,14 +36,12 @@ class LoadBalancerParent(object):
         vip_meta = utils.meta(loadbalancer, 'virtual_server', {})
         arp_disable = CONF.slb.arp_disable
         vrid = CONF.slb.default_virtual_server_vrid
-        if loadbalancer.description == " ":
-            loadbalancer.description = loadbalancer.description.strip()
 
         set_method(
             loadbalancer.id,
             loadbalancer.vip.ip_address,
             arp_disable=arp_disable,
-            description=loadbalancer.description,
+            description=loadbalancer.description.strip(),
             status=status, vrid=vrid,
             axapi_body=vip_meta)
 

--- a/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
@@ -36,6 +36,8 @@ class LoadBalancerParent(object):
         vip_meta = utils.meta(loadbalancer, 'virtual_server', {})
         arp_disable = CONF.slb.arp_disable
         vrid = CONF.slb.default_virtual_server_vrid
+        if loadbalancer.description == " ":
+            loadbalancer.description = loadbalancer.description.strip()
 
         set_method(
             loadbalancer.id,


### PR DESCRIPTION
## Description
- Severity level: Medium
- When we set loadbalancer description to "" or " ", then the description parameter should not get attached to it i.e it should set to be **None** for the loadbalancer instead of throwing `ACOSException: 1023459374 Input string exceeds permitted length`.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1612

## Related PR:
https://github.com/a10networks/acos-client/pull/294

## Technical Approach
- Trimming the description given by user and then validating it.
- If description is "" or " ", then it is set to None

## Test Cases
- Given description as "", when an lb is updated with it, the description attaching to the lb is None.
- Given description as " ", when an lb is updated with it, the description attaching to the lb is None.

## Manual Testing
Step1: Update an existing lb1 with description from "lblb1" to ""
Before update:
![image](https://user-images.githubusercontent.com/58077446/93602952-fcf31100-f9e0-11ea-9b74-5adfb0de26f0.png)

After update:
`> openstack loadbalancer set lb1 --description ""`

![image](https://user-images.githubusercontent.com/58077446/93603100-29a72880-f9e1-11ea-8d5c-b03c87a4ac1d.png)

Step2: Update an existing lb2 with description from "lblb1" to " "
Before update:
![image](https://user-images.githubusercontent.com/58077446/93603288-6f63f100-f9e1-11ea-901e-acb71b46328a.png)

After update:
`> openstack loadbalancer set lb2 --description " "`

![image](https://user-images.githubusercontent.com/58077446/93603377-8c98bf80-f9e1-11ea-8ce2-3167499ecc8a.png)

