### PR TITLE
[BUG][STACK-1618][member]: real port was not deleted when deleting a member with same port but different protocol

### DIFF
--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -104,5 +104,5 @@ LB_TO_VTHUNDER_SUBFLOW = 'lb-to-vthunder-subflow'
 
 # Member count with specific IP.
 MEMBER_COUNT_IP = 'member_count_ip'
-MEMBER_COUNT_IP_PORT = 'member_count_ip_port'
+MEMBER_COUNT_IP_PORT_PROTOCOL = 'member_count_ip_port_protocol'
 POOL_COUNT_IP = 'pool_count_ip'

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -123,11 +123,12 @@ class MemberFlows(object):
             provides=a10constants.VTHUNDER))
         delete_member_flow.add(a10_database_tasks.CountMembersWithIP(
             requires=constants.MEMBER, provides=a10constants.MEMBER_COUNT_IP))
-        delete_member_flow.add(a10_database_tasks.CountMembersWithIPPort(
-            requires=constants.MEMBER, provides=a10constants.MEMBER_COUNT_IP_PORT))
+        delete_member_flow.add(a10_database_tasks.CountMembersWithIPPortProtocol(
+            requires=(constants.MEMBER, constants.POOL),
+            provides=a10constants.MEMBER_COUNT_IP_PORT_PROTOCOL))
         delete_member_flow.add(server_tasks.MemberDelete(
             requires=(constants.MEMBER, a10constants.VTHUNDER, constants.POOL,
-                      a10constants.MEMBER_COUNT_IP, a10constants.MEMBER_COUNT_IP_PORT)))
+                      a10constants.MEMBER_COUNT_IP, a10constants.MEMBER_COUNT_IP_PORT_PROTOCOL)))
         delete_member_flow.add(database_tasks.DeleteMemberInDB(
             requires=constants.MEMBER))
         delete_member_flow.add(database_tasks.DecrementMemberQuota(
@@ -167,11 +168,12 @@ class MemberFlows(object):
             provides=a10constants.VTHUNDER))
         delete_member_flow.add(a10_database_tasks.CountMembersWithIP(
             requires=constants.MEMBER, provides=a10constants.MEMBER_COUNT_IP))
-        delete_member_flow.add(a10_database_tasks.CountMembersWithIPPort(
-            requires=constants.MEMBER, provides=a10constants.MEMBER_COUNT_IP_PORT))
+        delete_member_flow.add(a10_database_tasks.CountMembersWithIPPortProtocol(
+            requires=(constants.MEMBER, constants.POOL),
+            provides=a10constants.MEMBER_COUNT_IP_PORT_PROTOCOL))
         delete_member_flow.add(server_tasks.MemberDelete(
             requires=(constants.MEMBER, a10constants.VTHUNDER, constants.POOL,
-                      a10constants.MEMBER_COUNT_IP, a10constants.MEMBER_COUNT_IP_PORT)))
+                      a10constants.MEMBER_COUNT_IP, a10constants.MEMBER_COUNT_IP_PORT_PROTOCOL)))
         if CONF.a10_global.network_type == 'vlan':
             delete_member_flow.add(vthunder_tasks.DeleteInterfaceTagIfNotInUseForMember(
                 requires=[constants.MEMBER, a10constants.VTHUNDER]))
@@ -197,9 +199,10 @@ class MemberFlows(object):
             name='setup_device_network_map_' + member_id,
             requires=a10constants.VTHUNDER,
             provides=a10constants.VTHUNDER))
-        delete_member_thunder_subflow.add(a10_database_tasks.CountMembersWithIPPort(
+        delete_member_thunder_subflow.add(a10_database_tasks.CountMembersWithIPPortProtocol(
             name='count_members_ip_port_' + member_id,
-            requires=constants.MEMBER, provides=a10constants.MEMBER_COUNT_IP_PORT,
+            requires=(constants.MEMBER, constants.POOL),
+            provides=a10constants.MEMBER_COUNT_IP_PORT_PROTOCOL,
             rebind={constants.MEMBER: member_id}))
         delete_member_thunder_subflow.add(a10_database_tasks.PoolCountforIP(
             name='pool_count_for_ip_' + member_id,
@@ -208,7 +211,7 @@ class MemberFlows(object):
         delete_member_thunder_subflow.add(server_tasks.MemberDeletePool(
             name='delete_thunder_member_pool_' + member_id,
             requires=(constants.MEMBER, a10constants.VTHUNDER, constants.POOL,
-                      a10constants.POOL_COUNT_IP, a10constants.MEMBER_COUNT_IP_PORT),
+                      a10constants.POOL_COUNT_IP, a10constants.MEMBER_COUNT_IP_PORT_PROTOCOL),
             rebind={constants.MEMBER: member_id}))
         if CONF.a10_global.network_type == 'vlan':
             delete_member_thunder_subflow.add(vthunder_tasks.DeleteInterfaceTagIfNotInUseForMember(

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -556,12 +556,12 @@ class CountMembersWithIP(BaseDatabaseTask):
             raise e
 
 
-class CountMembersWithIPPort(BaseDatabaseTask):
-    def execute(self, member):
+class CountMembersWithIPPortProtocol(BaseDatabaseTask):
+    def execute(self, member, pool):
         try:
-            return self.member_repo.get_member_count_by_ip_address_port(
+            return self.member_repo.get_member_count_by_ip_address_port_protocol(
                 db_apis.get_session(), member.ip_address, member.project_id,
-                member.protocol_port)
+                member.protocol_port, pool.protocol)
         except Exception as e:
             LOG.exception(
                 "Failed to get count of members with given IP fnd port for a pool: %s",

--- a/a10_octavia/controller/worker/tasks/server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/server_tasks.py
@@ -90,7 +90,7 @@ class MemberDelete(task.Task):
     """Task to delete member"""
 
     @axapi_client_decorator
-    def execute(self, member, vthunder, pool, member_count_ip, member_count_ip_port):
+    def execute(self, member, vthunder, pool, member_count_ip, member_count_ip_port_protocol):
         server_name = '{}_{}'.format(member.project_id[:5], member.ip_address.replace('.', '_'))
         try:
             self.axapi_client.slb.service_group.member.delete(
@@ -105,7 +105,7 @@ class MemberDelete(task.Task):
             if member_count_ip <= 1:
                 self.axapi_client.slb.server.delete(server_name)
                 LOG.debug("Successfully deleted member %s from pool %s", member.id, pool.id)
-            elif member_count_ip_port <= 1:
+            elif member_count_ip_port_protocol <= 1:
                 protocol = openstack_mappings.service_group_protocol(
                     self.axapi_client, pool.protocol)
                 self.axapi_client.slb.server.port.delete(server_name, member.protocol_port,
@@ -152,13 +152,13 @@ class MemberDeletePool(task.Task):
     """Task to delete member"""
 
     @axapi_client_decorator
-    def execute(self, member, vthunder, pool, pool_count_ip, member_count_ip_port):
+    def execute(self, member, vthunder, pool, pool_count_ip, member_count_ip_port_protocol):
         try:
             server_name = '{}_{}'.format(member.project_id[:5], member.ip_address.replace('.', '_'))
             if pool_count_ip <= 1:
                 self.axapi_client.slb.server.delete(server_name)
                 LOG.debug("Successfully deleted member %s from pool %s", member.id, pool.id)
-            elif member_count_ip_port <= 1:
+            elif member_count_ip_port_protocol <= 1:
                 protocol = openstack_mappings.service_group_protocol(
                     self.axapi_client, pool.protocol)
                 self.axapi_client.slb.server.port.delete(server_name, member.protocol_port,

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -338,11 +338,11 @@ class MemberRepository(repo.MemberRepository):
 
     def get_member_count_by_ip_address_port_protocol(self, session, ip_address, project_id, port,
                                                      protocol):
-        return session.query(self.model_class).filter(
+        return session.query(self.model_class).join(base_models.Pool).filter(
             self.model_class.project_id == project_id).filter(
             and_(self.model_class.ip_address == ip_address,
                  self.model_class.protocol_port == port,
-                 self.model_class.pool.protocol == protocol,
+                 base_models.Pool.protocol == protocol,
                  or_(self.model_class.provisioning_status == consts.PENDING_DELETE,
                      self.model_class.provisioning_status == consts.ACTIVE))).count()
 

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -336,11 +336,13 @@ class MemberRepository(repo.MemberRepository):
                  or_(self.model_class.provisioning_status == consts.PENDING_DELETE,
                      self.model_class.provisioning_status == consts.ACTIVE))).count()
 
-    def get_member_count_by_ip_address_port(self, session, ip_address, project_id, port):
+    def get_member_count_by_ip_address_port_protocol(self, session, ip_address, project_id, port,
+                                                     protocol):
         return session.query(self.model_class).filter(
             self.model_class.project_id == project_id).filter(
             and_(self.model_class.ip_address == ip_address,
                  self.model_class.protocol_port == port,
+                 self.model_class.pool.protocol == protocol,
                  or_(self.model_class.provisioning_status == consts.PENDING_DELETE,
                      self.model_class.provisioning_status == consts.ACTIVE))).count()
 

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -201,9 +201,9 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
             protocol_port=t_constants.MOCK_PORT_ID,
             project_id=t_constants.MOCK_PROJECT_ID,
             ip_address=t_constants.MOCK_IP_ADDRESS)
-        mock_count_member = task.CountMembersWithIPPort()
-        mock_count_member.member_repo.get_member_count_by_ip_address_port = mock.Mock()
-        mock_count_member.member_repo.get_member_count_by_ip_address_port.return_value = 2
+        mock_count_member = task.CountMembersWithIPPortProtocol()
+        mock_count_member.member_repo.get_member_count_by_ip_address_port_protocol = mock.Mock()
+        mock_count_member.member_repo.get_member_count_by_ip_address_port_protocol.return_value = 2
         member_count = mock_count_member.execute(member_1)
         self.assertEqual(2, member_count)
 

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -198,11 +198,6 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
             protocol_port=t_constants.MOCK_PORT_ID,
             project_id=t_constants.MOCK_PROJECT_ID,
             ip_address=t_constants.MOCK_IP_ADDRESS)
-        member_2 = o_data_models.Member(
-            id=uuidutils.generate_uuid(),
-            protocol_port=t_constants.MOCK_PORT_ID,
-            project_id=t_constants.MOCK_PROJECT_ID,
-            ip_address=t_constants.MOCK_IP_ADDRESS)
         mock_count_member = task.CountMembersWithIPPortProtocol()
         mock_count_member.member_repo.get_member_count_by_ip_address_port_protocol = mock.Mock()
         mock_count_member.member_repo.get_member_count_by_ip_address_port_protocol.return_value = 2
@@ -214,12 +209,6 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
                                         project_id=t_constants.MOCK_PROJECT_ID,
                                         ip_address=t_constants.MOCK_IP_ADDRESS,
                                         pool_id=a10constants.MOCK_POOL_ID)
-        member_2 = o_data_models.Member(
-            id=uuidutils.generate_uuid(),
-            protocol_port=t_constants.MOCK_PORT_ID,
-            project_id=t_constants.MOCK_PROJECT_ID,
-            ip_address=t_constants.MOCK_IP_ADDRESS,
-            pool_id=a10constants.MOCK_POOL_ID_2)
         mock_count_pool = task.PoolCountforIP()
         mock_count_pool.member_repo.get_pool_count_by_ip = mock.Mock()
         mock_count_pool.member_repo.get_pool_count_by_ip.return_value = 2

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -45,6 +45,8 @@ VRID = data_models.VRID(id=uuidutils.generate_uuid(), project_id=a10constants.MO
 MEMBER_1 = o_data_models.Member(id=uuidutils.generate_uuid(),
                                 project_id=a10constants.MOCK_PROJECT_ID)
 
+POOL = o_data_models.Pool(id=a10constants.MOCK_POOL_ID)
+
 
 class TestA10DatabaseTasks(base.BaseTaskTestCase):
     def setUp(self):
@@ -190,7 +192,7 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         member_count = mock_count_member.execute(MEMBER_1)
         self.assertEqual(1, member_count)
 
-    def test_count_members_in_project_ip_port(self):
+    def test_count_members_in_project_ip_port_protocol(self):
         member_1 = o_data_models.Member(
             id=uuidutils.generate_uuid(),
             protocol_port=t_constants.MOCK_PORT_ID,
@@ -204,7 +206,7 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         mock_count_member = task.CountMembersWithIPPortProtocol()
         mock_count_member.member_repo.get_member_count_by_ip_address_port_protocol = mock.Mock()
         mock_count_member.member_repo.get_member_count_by_ip_address_port_protocol.return_value = 2
-        member_count = mock_count_member.execute(member_1)
+        member_count = mock_count_member.execute(member_1, POOL)
         self.assertEqual(2, member_count)
 
     def test_pool_count_accn_ip(self):


### PR DESCRIPTION
## Description
the real port was not deleted when deleting a member  with the same port and different protocol
if deleting a member with a different port and different same protocol,  the real port will be deleted, so looks like there is a little inconsistent.

Severity Level: high

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1618

## Technical Approach
- Changed the functionality of fetch member count using IP and port to IP, port and protocol.
- Changed the related variable. 

## Manual Testing
- Tested the case mentioned in bug report.
- Tested basic cases of deleting member and pool.