### PR TITLE
STACK-1559: Allow templates to be used from the Shared Partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,8 @@ These settings are added to the `a10-octavia.conf` file. They allow the operator
 ```shell
 [a10_global]
 network_type = vlan
-use_parent_partition = True 
+use_parent_partition = True
+use_shared_for_template_lookup = True
 ```
 #### Loadbalancer/virtual server config example
 ```shell

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ These settings are added to the `a10-octavia.conf` file. They allow the operator
 network_type = vlan
 use_parent_partition = True
 
-<!-- Use this for allowing templates to be used from shared partition for attaching them to components in l3v partition -->
+[NOTE: Use this flag for allowing templates to be used from shared partition for attaching them to components in l3v partition]
 use_shared_for_template_lookup = True
 ```
 #### Loadbalancer/virtual server config example

--- a/README.md
+++ b/README.md
@@ -404,6 +404,8 @@ These settings are added to the `a10-octavia.conf` file. They allow the operator
 [a10_global]
 network_type = vlan
 use_parent_partition = True
+
+<!-- Use this for allowing templates to be used from shared partition for attaching them to components in l3v partition -->
 use_shared_for_template_lookup = True
 ```
 #### Loadbalancer/virtual server config example

--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -45,6 +45,9 @@ A10_GLOBAL_OPTS = [
                default=a10constants.FLAT,
                choices=a10constants.SUPPORTED_NETWORK_TYPE,
                help=_('Neutron ML2 Tenent Network Type')),
+    cfg.BoolOpt('use_shared_for_template_lookup',
+                default=False,
+                help=_('Use shared for template')),
 ]
 
 A10_VTHUNDER_OPTS = [

--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -192,3 +192,12 @@ class ParentProjectNotFound(keystone_exceptions.Error):
         msg = ('The project {0} does not have a parent or has default project'
                ' as parent. ').format(project_id)
         super(ParentProjectNotFound, self).__init__(message=msg)
+
+
+class SharedPartitionTemplateNotSupported(acos_errors.FeatureNotSupported):
+    """ Occurs when shared partition lookup for templates is not supported on acos client"""
+
+    def __init__(self, resource, template_key):
+        msg = ('Shared partition template lookup for [{0}] is not supported'
+               ' on template `{1}`').format(resource, template_key)
+        super(SharedPartitionTemplateNotSupported, self).__init__(code=505, msg=msg)

--- a/a10_octavia/controller/worker/tasks/server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/server_tasks.py
@@ -40,14 +40,13 @@ class MemberCreate(task.Task):
         server_args['conn-resume'] = CONF.server.conn_resume
         server_args = {'server': server_args}
 
+        server_temp = {}
         template_server = CONF.server.template_server
-        if template_server and template_server.lower() == 'none':
-            template_server = None
-        if CONF.a10_global.use_shared_for_template_lookup:
-            if template_server:
+        if template_server and template_server.lower() != 'none':
+            if CONF.a10_global.use_shared_for_template_lookup:
                 LOG.warning('Shared partition template lookup for `[server]`'
                             ' is not supported on template `template-server`')
-        server_temp = {'template-server': template_server}
+            server_temp = {'template-server': template_server}
 
         if not member.enabled:
             status = False

--- a/a10_octavia/controller/worker/tasks/server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/server_tasks.py
@@ -20,6 +20,7 @@ from taskflow import task
 import acos_client.errors as acos_errors
 
 from a10_octavia.common import openstack_mappings
+from a10_octavia.common import exceptions as a10exp
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
 from a10_octavia.controller.worker.tasks import utils
 
@@ -42,6 +43,10 @@ class MemberCreate(task.Task):
         template_server = CONF.server.template_server
         if template_server and template_server.lower() == 'none':
             template_server = None
+        if CONF.a10_global.use_shared_for_template_lookup:
+            if template_server:
+                raise a10exp.SharedPartitionTemplateNotSupported(resource='server',
+                                                                 template_key='template-server')
         server_temp = {'template-server': template_server}
 
         if not member.enabled:

--- a/a10_octavia/controller/worker/tasks/server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/server_tasks.py
@@ -45,8 +45,8 @@ class MemberCreate(task.Task):
             template_server = None
         if CONF.a10_global.use_shared_for_template_lookup:
             if template_server:
-                raise a10exp.SharedPartitionTemplateNotSupported(resource='server',
-                                                                 template_key='template-server')
+                LOG.warning('Shared partition template lookup for `[server]`'
+                            ' is not supported on template `template-server`')
         server_temp = {'template-server': template_server}
 
         if not member.enabled:

--- a/a10_octavia/controller/worker/tasks/service_group_tasks.py
+++ b/a10_octavia/controller/worker/tasks/service_group_tasks.py
@@ -22,6 +22,7 @@ from octavia.common import exceptions
 
 import acos_client.errors as acos_errors
 
+from a10_octavia.common import exceptions as a10exp
 from a10_octavia.common import openstack_mappings
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
 from a10_octavia.controller.worker.tasks import utils
@@ -41,11 +42,19 @@ class PoolParent(object):
         template_server = CONF.service_group.template_server
         if template_server and template_server.lower() == 'none':
             template_server = None
+        if CONF.a10_global.use_shared_for_template_lookup:
+            if template_server:
+                raise a10exp.SharedPartitionTemplateNotSupported(resource='service-group',
+                                                                 template_key='template-server')
         service_group_temp['template-server'] = template_server
 
         template_port = CONF.service_group.template_port
         if template_port and template_port.lower() == 'none':
             template_port = None
+        if CONF.a10_global.use_shared_for_template_lookup:
+            if template_port:
+                raise a10exp.SharedPartitionTemplateNotSupported(resource='service-group',
+                                                                 template_key='template-port')
         service_group_temp['template-port'] = template_port
 
         template_policy = CONF.service_group.template_policy

--- a/a10_octavia/controller/worker/tasks/service_group_tasks.py
+++ b/a10_octavia/controller/worker/tasks/service_group_tasks.py
@@ -39,22 +39,18 @@ class PoolParent(object):
 
         service_group_temp = {}
         template_server = CONF.service_group.template_server
-        if template_server and template_server.lower() == 'none':
-            template_server = None
-        if CONF.a10_global.use_shared_for_template_lookup:
-            if template_server:
+        if template_server and template_server.lower() != 'none':
+            if CONF.a10_global.use_shared_for_template_lookup:
                 LOG.warning('Shared partition template lookup for `[service-group]`'
                             ' is not supported on template `template-server`')
-        service_group_temp['template-server'] = template_server
+            service_group_temp['template-server'] = template_server
 
         template_port = CONF.service_group.template_port
-        if template_port and template_port.lower() == 'none':
-            template_port = None
-        if CONF.a10_global.use_shared_for_template_lookup:
-            if template_port:
+        if template_port and template_port.lower() != 'none':
+            if CONF.a10_global.use_shared_for_template_lookup:
                 LOG.warning('Shared partition template lookup for `[service-group]`'
                             ' is not supported on template `template-port`')
-        service_group_temp['template-port'] = template_port
+            service_group_temp['template-port'] = template_port
 
         template_policy = CONF.service_group.template_policy
         if template_policy and template_policy.lower() != 'none':

--- a/a10_octavia/controller/worker/tasks/service_group_tasks.py
+++ b/a10_octavia/controller/worker/tasks/service_group_tasks.py
@@ -22,7 +22,6 @@ from octavia.common import exceptions
 
 import acos_client.errors as acos_errors
 
-from a10_octavia.common import exceptions as a10exp
 from a10_octavia.common import openstack_mappings
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
 from a10_octavia.controller.worker.tasks import utils
@@ -44,8 +43,8 @@ class PoolParent(object):
             template_server = None
         if CONF.a10_global.use_shared_for_template_lookup:
             if template_server:
-                raise a10exp.SharedPartitionTemplateNotSupported(resource='service-group',
-                                                                 template_key='template-server')
+                LOG.warning('Shared partition template lookup for `[service-group]`'
+                            ' is not supported on template `template-server`')
         service_group_temp['template-server'] = template_server
 
         template_port = CONF.service_group.template_port
@@ -53,8 +52,8 @@ class PoolParent(object):
             template_port = None
         if CONF.a10_global.use_shared_for_template_lookup:
             if template_port:
-                raise a10exp.SharedPartitionTemplateNotSupported(resource='service-group',
-                                                                 template_key='template-port')
+                LOG.warning('Shared partition template lookup for `[service-group]`'
+                            ' is not supported on template `template-port`')
         service_group_temp['template-port'] = template_port
 
         template_policy = CONF.service_group.template_policy

--- a/a10_octavia/controller/worker/tasks/utils.py
+++ b/a10_octavia/controller/worker/tasks/utils.py
@@ -12,6 +12,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import copy
 import json
 import logging
 
@@ -60,29 +61,13 @@ def meta(lbaas_obj, key, default):
         return default
     return meta_json.get(key, default)
 
-
-def handle_virtual_port_templates(templates, acos_client):
-        if CONF.a10_global.use_shared_for_template_lookup:
-                existing_templates_list = acos_client.slb.template.templates.get()
-		# HTTP Template
-                if template['template-http']:
-                    if existing_templates_list[]:
-                        template['template-http-shared'] =  template['template-http']
-                        template['shared-partition-http-template'] = True
-			del template['template-http']
-
-		# TCP Template
-		if template['template-tcp']:
-                    if existing_templates_list[]:
-                        template['template-tcp-shared'] =  template['template-tcp']
-                        template['shared-partition-tcp-template'] = True
-                        del template['template-tcp']
-
-                # Template Policy
-                if template['template-policy']:
-                    if existing_templates_list[]:
-                        template['template-tcp-shared'] =  template['template-policy']
-                        template['shared-partition-policy-template'] = True
-                        del template['template-policy']
-        else:
-            return template
+def shared_template_modifier(template_type, template_name, device_templates):
+    resource_list_key = "{0}-list".format(template_type)
+    if resource_list_key in device_templates:
+        for device_template in device_templates[resource_list_key]:
+            resouce_type = device_template.keys()[0]
+            device_template_name = device_template[resouce_type].get("name")
+            if template_name == device_template_name
+                break
+            template_type = "shared-partition-{0}".format(template_type)
+    return template_type

--- a/a10_octavia/controller/worker/tasks/utils.py
+++ b/a10_octavia/controller/worker/tasks/utils.py
@@ -62,11 +62,11 @@ def meta(lbaas_obj, key, default):
     return meta_json.get(key, default)
 
 def shared_template_modifier(template_type, template_name, device_templates):
-    resource_list_key = "{0}-list".format(template_type)
-    if resource_list_key in device_templates:
-        for device_template in device_templates[resource_list_key]:
-            resouce_type = device_template.keys()[0]
-            device_template_name = device_template[resouce_type].get("name")
+    resource_type = template_type.split('-', 1)[1]
+    resource_list_key = "{0}-list".format(resource_type)
+    if resource_list_key in device_templates['template']:
+        for device_template in device_templates['template'][resource_list_key]:
+            device_template_name = device_template[resource_type].get("name")
             if template_name == device_template_name:
                 break
             template_type = "{0}-shared".format(template_type)

--- a/a10_octavia/controller/worker/tasks/utils.py
+++ b/a10_octavia/controller/worker/tasks/utils.py
@@ -67,7 +67,9 @@ def shared_template_modifier(template_type, template_name, device_templates):
         for device_template in device_templates[resource_list_key]:
             resouce_type = device_template.keys()[0]
             device_template_name = device_template[resouce_type].get("name")
-            if template_name == device_template_name
+            if template_name == device_template_name:
                 break
-            template_type = "shared-partition-{0}".format(template_type)
+            template_type = "{0}-shared".format(template_type)
+    else:
+        template_type = "{0}-shared".format(template_type)
     return template_type

--- a/a10_octavia/controller/worker/tasks/utils.py
+++ b/a10_octavia/controller/worker/tasks/utils.py
@@ -59,3 +59,30 @@ def meta(lbaas_obj, key, default):
     except Exception:
         return default
     return meta_json.get(key, default)
+
+
+def handle_virtual_port_templates(templates, acos_client):
+        if CONF.a10_global.use_shared_for_template_lookup:
+                existing_templates_list = acos_client.slb.template.templates.get()
+		# HTTP Template
+                if template['template-http']:
+                    if existing_templates_list[]:
+                        template['template-http-shared'] =  template['template-http']
+                        template['shared-partition-http-template'] = True
+			del template['template-http']
+
+		# TCP Template
+		if template['template-tcp']:
+                    if existing_templates_list[]:
+                        template['template-tcp-shared'] =  template['template-tcp']
+                        template['shared-partition-tcp-template'] = True
+                        del template['template-tcp']
+
+                # Template Policy
+                if template['template-policy']:
+                    if existing_templates_list[]:
+                        template['template-tcp-shared'] =  template['template-policy']
+                        template['shared-partition-policy-template'] = True
+                        del template['template-policy']
+        else:
+            return template

--- a/a10_octavia/controller/worker/tasks/utils.py
+++ b/a10_octavia/controller/worker/tasks/utils.py
@@ -64,7 +64,7 @@ def meta(lbaas_obj, key, default):
 def shared_template_modifier(template_type, template_name, device_templates):
     resource_type = template_type.split('-', 1)[1]
     resource_list_key = "{0}-list".format(resource_type)
-    if resource_list_key in device_templates['template']:
+    if resource_list_key in device_templates:
         for device_template in device_templates['template'][resource_list_key]:
             device_template_name = device_template[resource_type].get("name")
             if template_name == device_template_name:

--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -87,6 +87,8 @@ class ListenersParent(object):
             template_policy = None
         vport_templates['template-policy'] = template_policy
 
+	vport_templates = utils.handle_virtual_port_templates(vport_templates, self.acos_client)
+
         # Add all config filters here
         if no_dest_nat and (
                 listener.protocol.lower()

--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -38,7 +38,7 @@ class ListenersParent(object):
         ipinip = CONF.listener.ipinip
         use_rcv_hop = CONF.listener.use_rcv_hop_for_resp
         ha_conn_mirror = CONF.listener.ha_conn_mirror
-        
+
         status = self.axapi_client.slb.UP
         if not listener.enabled:
             self.axapi_client.slb.DOWN
@@ -86,7 +86,7 @@ class ListenersParent(object):
                                                               listener.id,
                                                               device_templates)
             template_args[template_key] = listener.id
-        elif listener.protocol in a10constants.HTTP_TYPE.lower():
+        elif listener.protocol.upper() in a10constants.HTTP_TYPE:
             template_http = CONF.listener.template_http
             if template_http and template_http.lower() != 'none':
                 template_key = 'template-http'
@@ -104,7 +104,7 @@ class ListenersParent(object):
                 template_key = 'template-tcp'
                 if CONF.a10_global.use_shared_for_template_lookup:
                     template_key = utils.shared_template_modifier(template_key,
-                                                                  template_http,
+                                                                  template_tcp,
                                                                   device_templates)
                 vport_templates[template_key] = template_tcp
 
@@ -113,8 +113,8 @@ class ListenersParent(object):
             template_key = 'template-policy'
             if CONF.a10_global.use_shared_for_template_lookup:
                 template_key = utils.shared_template_modifier(template_key,
-                                                  template_http,
-                                                  device_templates)
+                                                              template_policy,
+                                                              device_templates)
             vport_templates[template_key] = template_policy
 
         set_method(loadbalancer.id, listener.id,

--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -70,24 +70,30 @@ class ListenersParent(object):
         vport_templates = {}
         template_vport = CONF.listener.template_virtual_port
         if template_vport and template_vport.lower() != 'none':
-            template_key = utils.shared_template_modifier('template-virtual-port',
-                                                          template_vport,
-                                                          device_templates)
+            template_key = 'template-virtual-port'
+            if CONF.a10_global.use_shared_for_template_lookup:
+                template_key = utils.shared_template_modifier(template_key,
+                                                              template_vport,
+                                                              device_templates)
             vport_templates[template_key] = template_vport
 
         template_args = {}
         if listener.protocol == 'https' and listener.tls_certificate_id:
             # Adding TERMINATED_HTTPS SSL cert, created in previous task
-            template_key = utils.shared_template_modifier('template-client-ssl',
-                                                          listener.id,
-                                                          device_templates)
+            template_key = 'template-client-ssl'
+            if CONF.a10_global.use_shared_for_template_lookup:
+                template_key = utils.shared_template_modifier(template_key,
+                                                              listener.id,
+                                                              device_templates)
             template_args[template_key] = listener.id
         elif listener.protocol in a10constants.HTTP_TYPE.lower():
             template_http = CONF.listener.template_http
             if template_http and template_http.lower() != 'none':
-                template_key = utils.shared_template_modifier('template-http',
-                                                              template_http,
-                                                              device_templates)
+                template_key = 'template-http'
+                if CONF.a10_global.use_shared_for_template_lookup:
+                    template_key = utils.shared_template_modifier(template_key,
+                                                                  template_http,
+                                                                  device_templates)
                 vport_templates[template_key] = template_http
             if ha_conn_mirror is not None:
                 ha_conn_mirror = None
@@ -95,16 +101,20 @@ class ListenersParent(object):
         elif listener.protocol == 'tcp':
             template_tcp = CONF.listener.template_tcp
             if template_tcp and template_tcp.lower() != 'none':
-                template_key = utils.shared_template_modifier('template-tcp',
-                                                              template_http,
-                                                              device_templates)
+                template_key = 'template-tcp'
+                if CONF.a10_global.use_shared_for_template_lookup:
+                    template_key = utils.shared_template_modifier(template_key,
+                                                                  template_http,
+                                                                  device_templates)
                 vport_templates[template_key] = template_tcp
 
         template_policy = CONF.listener.template_policy
         if template_policy and template_policy.lower() != 'none':
-            template_key = utils.shared_template_modifier('template-policy',
-                                              template_http,
-                                              device_templates)
+            template_key = 'template-policy'
+            if CONF.a10_global.use_shared_for_template_lookup:
+                template_key = utils.shared_template_modifier(template_key,
+                                                  template_http,
+                                                  device_templates)
             vport_templates[template_key] = template_policy
 
         set_method(loadbalancer.id, listener.id,

--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -80,12 +80,8 @@ class ListenersParent(object):
         template_args = {}
         if listener.protocol == 'https' and listener.tls_certificate_id:
             # Adding TERMINATED_HTTPS SSL cert, created in previous task
-            template_key = 'template-client-ssl'
-            if CONF.a10_global.use_shared_for_template_lookup:
-                template_key = utils.shared_template_modifier(template_key,
-                                                              listener.id,
-                                                              device_templates)
             template_args[template_key] = listener.id
+
         elif listener.protocol.upper() in a10constants.HTTP_TYPE:
             template_http = CONF.listener.template_http
             if template_http and template_http.lower() != 'none':

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_service_group_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_service_group_tasks.py
@@ -117,8 +117,8 @@ class TestHandlerServiceGroupTasks(BaseTaskTestCase):
         service_group_task.axapi_client.slb.template.templates.get.return_value = device_templates
         service_group_task.execute(POOL, VTHUNDER)
         args, kwargs = self.client_mock.slb.service_group.create.call_args
-        self.assertIn('template-policy', kwargs['service_group_templates'])
-        self.assertEqual(kwargs['service_group_templates']['template-policy'], 'my_policy_template')
+        self.assertIn('template-policy-shared', kwargs['service_group_templates'])
+        self.assertEqual(kwargs['service_group_templates']['template-policy-shared'], 'my_policy_template')
 
     @mock.patch('a10_octavia.common.openstack_mappings.service_group_protocol', mock.Mock())
     @mock.patch('a10_octavia.common.openstack_mappings.service_group_lb_method', mock.Mock())

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_utils.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_utils.py
@@ -40,7 +40,7 @@ class TestUtils(base.TestCase):
         template_type = utils.shared_template_modifier('template-tcp',
                                                        'my_tcp_temp',
                                                        device_templates)
-        self.assertEqual('template-tcp', template_type)
+        self.assertEqual('template-tcp-shared', template_type)
 
     def test_shared_template_modifier_resource_found_name_not_found(self):
         device_templates = self._get_device_templates('tcp', 'my_secondary_tcp')

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_utils.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_utils.py
@@ -1,0 +1,50 @@
+#    Copyright 2020, A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.]
+
+from octavia.tests.unit import base
+
+from a10_octavia.controller.worker.tasks import utils
+
+
+class TestUtils(base.TestCase):
+
+    def _get_device_templates(self, template_type, template_name):
+        device_templates = {"template": {
+                                "{}-list".format(template_type): [{
+                                        template_type: {"name": template_name}
+                                    }]
+                                }
+                            }
+        return device_templates
+
+    def test_shared_template_modifier_resource_not_found(self):
+        device_templates = self._get_device_templates('http', 'my_http_temp')
+        template_type = utils.shared_template_modifier('template-tcp',
+                                                       'my_tcp_temp',
+                                                       device_templates)
+        self.assertEqual('template-tcp-shared', template_type)
+
+    def test_shared_template_modifier_resource_found_name_found(self):
+        device_templates = self._get_device_templates('tcp', 'my_tcp_temp')
+        template_type = utils.shared_template_modifier('template-tcp',
+                                                       'my_tcp_temp',
+                                                       device_templates)
+        self.assertEqual('template-tcp', template_type)
+
+    def test_shared_template_modifier_resource_found_name_not_found(self):
+        device_templates = self._get_device_templates('tcp', 'my_secondary_tcp')
+        template_type = utils.shared_template_modifier('template-tcp',
+                                                       'my_tcp_temp',
+                                                       device_templates)
+        self.assertEqual('template-tcp-shared', template_type)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
@@ -55,29 +55,58 @@ class TestHandlerVirtualPortTasks(base.BaseTaskTestCase):
         listener.connection_limit = conn_limit
         return listener
 
-    @mock.patch('a10_octavia.controller.worker.tasks.utils.shared_template_modifier')
-    @mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol')
-    def _create_shared_template(self, template_protocol, template_config, mock_protocol, mock_templates):
-        template_protocol = template_protocol.lower()
-        shared_template_type = 'template-{}-shared'.format(template_protocol)
-        mock_templates.return_value = shared_template_type
-        listener = self._mock_listener(template_protocol.upper(), 1000)
+    def _create_shared_template(self, template_type, template_config, mock_protocol, mock_templates):
+        template_type = template_type.lower()
+        mock_templates.return_value = 'template-{}-shared'.format(template_type)
+        listener = self._mock_listener(template_type.upper(), 1000)
         mock_protocol.return_value = listener.protocol
 
         listener_task = task.ListenerCreate()
         listener_task.axapi_client = self.client_mock
         self.conf.config(group=a10constants.A10_GLOBAL_CONF_SECTION, use_shared_for_template_lookup=True)
-        self.conf.config(group=a10constants.LISTENER_CONF_SECTION,
-                         **template_config)
+        self.conf.config(group=a10constants.LISTENER_CONF_SECTION, **template_config)
         listener_task.CONF = self.conf
-        device_templates = {"template": {"{}-list".format(template_protocol): [{template_protocol: {"name": "temp1"}}]}}
+        
+        device_templates = {"template": {
+                                "{}-list".format(template_type): [{
+                                        template_type: {"name": template_config.values()[0]}
+                                    }]
+                                }
+                            }
         listener_task.axapi_client.slb.template.templates.get.return_value = device_templates
+        return listener_task, listener
+
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.shared_template_modifier')
+    @mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol')
+    def test_create_listener_with_template_http_shared(self, mock_protocol, mock_templates):
+        listener_task, listener = self._create_shared_template('http', {'template_http': 'temp1'}, mock_protocol, mock_templates)
         listener_task.execute(LB, listener, VTHUNDER)
-
         args, kwargs = self.client_mock.slb.virtual_server.vport.create.call_args
-        self.assertIn(shared_template_type, kwargs['virtual_port_templates'])
-        self.assertTrue(kwargs['virtual_port_templates'])
+        self.assertIn('template-http-shared', kwargs['virtual_port_templates'])
 
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.shared_template_modifier')
+    @mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol')
+    def test_create_listener_with_template_tcp_shared(self, mock_protocol, mock_templates):
+        listener_task, listener = self._create_shared_template('tcp', {'template_tcp': 'temp1'}, mock_protocol, mock_templates)
+        listener_task.execute(LB, listener, VTHUNDER)
+        args, kwargs = self.client_mock.slb.virtual_server.vport.create.call_args
+        self.assertIn('template-tcp-shared', kwargs['virtual_port_templates'])
+
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.shared_template_modifier')
+    @mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol')
+    def test_create_listener_with_template_policy_shared(self, mock_protocol, mock_templates):
+        listener_task, listener = self._create_shared_template('policy', {'template_policy': 'temp1'}, mock_protocol, mock_templates)
+        listener_task.execute(LB, listener, VTHUNDER)
+        args, kwargs = self.client_mock.slb.virtual_server.vport.create.call_args
+        self.assertIn('template-policy-shared', kwargs['virtual_port_templates'])
+
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.shared_template_modifier')
+    @mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol')
+    def test_create_listener_with_template_virtual_port_shared(self, mock_protocol, mock_templates):
+        listener_task, listener = self._create_shared_template('virtual-port', {'template_virtual_port': 'temp1'}, mock_protocol, mock_templates)
+        listener_task.execute(LB, listener, VTHUNDER)
+        args, kwargs = self.client_mock.slb.virtual_server.vport.create.call_args
+        self.assertIn('template-virtual-port-shared', kwargs['virtual_port_templates'])
 
     def test_create_http_virtual_port_use_rcv_hop(self):
         listener = self._mock_listener('HTTP', 1000)


### PR DESCRIPTION
*Credit to @NehaKembalkarA10 for PR info. This was pulled from the following [Feature Branch PR](https://github.com/a10networks/a10-octavia/pull/181)*

## Description
**STACK-1559**
It was not possible to attach a template from shared partition to a listener, member and pool in a l3v partition.
So now by this implementation, we can attach supported templates from shared partition to listener, member and pool in our l3v partition.
## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1559
## Technical Approach
Added support for a flag variable `use_shared_for_template_lookup` in config file sothat when user tries to attach a template from shared partition to his desired components of his local partition by setting the flag to **True**, then it will get possible to do so.
**1. For listener (virtual-port):**
It supports template_virtual_port, template_tcp, template_policy and template_http from Shared partition to be attached to the listener of l3v partition
a) When `use_shared_for_template_lookup = True`, and `template_virtual_port` from shared partition is assigned there in config file, then vport_templates[template_virtual_port_shared] will get the value of the provided virtual-port-template and it will get attached to the listener.
b) When `use_shared_for_template_lookup = True`, and `template_tcp` from shared partition is assigned there in config file, then vport_templates[template_tcp_shared] will get the value of the provided tcp-template and it will get attached to the listener.
c) When `use_shared_for_template_lookup = True`, and `template_policy` from shared partition is assigned there in config file, then vport_templates[template_policy_shared] will get the value of the provided policy-template and it will get attached to the listener.
d) When `use_shared_for_template_lookup = True`, and `template_http` from shared partition is assigned there in config file, then vport_templates[template_http_shared] will get the value of the provided http-template and it will get attached to the listener.

**2. For pool (service-group):**
It supports only template_policy from Shared partition to be attached to the pool of l3v partition. And for template_server and template_port, it will give a warning of not supporting them from shared partition lookup.
a) When `use_shared_for_template_lookup = True`, and `template_policy` from shared partition is assigned there in config file, then service_group_templates[template_policy_shared] will get the value of the provided template-policy and it will get attached to the pool.
b) When `use_shared_for_template_lookup = True`, and `template_server` from shared partition is assigned there in config file,
then this will show a warning of not supporting Shared partition template lookup for template_server and the pool will go in Error.
c) When `use_shared_for_template_lookup = True`, and `template_port` from shared partition is assigned there in config file,
then this will show a warning of not supporting Shared partition template lookup for template_port and the pool will go in Error.

**3. For member (server):**
It does not support template_server from shared partition to be attached to a member in a l3v partition.
When `use_shared_for_template_lookup = True`, and `template_server` from shared partition is assigned there in config file,
then this will show a warning of not supporting Shared partition template lookup for template_server and the member will go in Error.

## Related PRs
https://github.com/a10networks/acos-client/pull/293

## Config Changes
[a10_global]
network_type = vlan
use_parent_partition = True
**use_shared_for_template_lookup = True**

## Test Cases
Below test-cases need to be tested by setting `use_shared_for_template_lookup = True` in config file.
1. For listener: 
- Given a template_virtual_port of shared partition to get attached to a listener in l3v partition, it is getting attached.
- Given a template_tcp of shared partition to get attached to a listener in l3v partition, it is getting attached.
- Given a template_policy of shared partition to get attached to a listener in l3v partition, it is getting attached.
- Given a template_http of shared partition to get attached to a listener in l3v partition, it is getting attached.

2. For pool:
- Given a template_policy of shared partition to get attached to a pool in l3v partition, it is getting attached.
- Given a template_server of shared partition to get attached to a pool in l3v partition, it is giving warning.
- Given a template_server of shared partition to get attached to a pool in l3v partition, it is giving warning.

3. For member:
Given a template_server of shared partition to get attached to a member in l3v partition, it is giving warning.

## Manual Testing
**1. For listener:** 

_Case1: Attaching http-template of shared partition_
Step1: Use following config:
```
[a10_global]
enable_hierarchical_multitenancy = True
network_type = "flat"
use_shared_for_template_lookup = True
[listener]
conn_limit = 4444
autosnat = True
use_rcv_hop_for_resp = False
template_http = temp1
[hardware_thunder]
devices=[
 {
 "project_id": "eccaddd60f404477a7c32270267729d4",
 "username" : "admin",
 "password" : "a10",
 "ip_address" : "10.43.12.122",
 "device_name" : "rack_1",
 "partition_name" : "PartitionC"}]
```
Step2: Create a listener
openstack loadbalancer listener create --protocol HTTP --protocol-port 90 lb1

Result:
![image](https://user-images.githubusercontent.com/58077446/93327221-a72f3500-f837-11ea-8d78-210747b9e5cf.png)

_Case2: Attaching tcp-template of shared partition_
Step1: Use following config:
```
[a10_global]
enable_hierarchical_multitenancy = True
network_type = "flat"
use_shared_for_template_lookup = True

[listener]
conn_limit = 4444
autosnat = True
use_rcv_hop_for_resp = False
template_tcp = temp2
[hardware_thunder]
devices=[
 {
 "project_id": "eccaddd60f404477a7c32270267729d4",
 "username" : "admin",
 "password" : "a10",
 "ip_address" : "10.43.12.122",
 "device_name" : "rack_1",
 "partition_name" : "PartitionC"}]
```
Step2: Create a listener
openstack loadbalancer listener create --protocol TCP --protocol-port 90 lb1

Result:
![image](https://user-images.githubusercontent.com/58077446/93328957-160d8d80-f83a-11ea-8f10-cdf61fafa17c.png)

_Case3: Attaching policy-template and virtual-port-template of shared partition_
Step1: Use following config:
```
[a10_global]
enable_hierarchical_multitenancy = True
network_type = "flat"
use_shared_for_template_lookup = True

[listener]
conn_limit = 4444
autosnat = True
use_rcv_hop_for_resp = False
template_policy = temp_policy1
template_virtual_port = vport_temp1
[hardware_thunder]
devices=[
 {
 "project_id": "eccaddd60f404477a7c32270267729d4",
 "username" : "admin",
 "password" : "a10",
 "ip_address" : "10.43.12.122",
 "device_name" : "rack_1",
 "partition_name" : "PartitionC"}]
```
Step2: Create a listener
openstack loadbalancer listener create --protocol TCP --protocol-port 90 lb1

Result:
![image](https://user-images.githubusercontent.com/58077446/93329841-718c4b00-f83b-11ea-8e96-55730b196bc9.png)

**2. For Pool:**

_Case1: Attaching policy-template of shared partition_
Step1: Use following config:
```
[a10_global]
enable_hierarchical_multitenancy = True
network_type = "flat"
use_shared_for_template_lookup = True
[service_group]
template_policy = "temp_policy1"
[hardware_thunder]
devices=[
 {
 "project_id": "eccaddd60f404477a7c32270267729d4",
 "username" : "admin",
 "password" : "a10",
 "ip_address" : "10.43.12.122",
 "device_name" : "rack_1",
 "partition_name" : "PartitionC"}]
```
Step2: Create a pool
openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener e2cf2cbb-401a-4b04-8a35-eb42e2474309 --name pool1

Result:
![image](https://user-images.githubusercontent.com/58077446/93330374-51a95700-f83c-11ea-8e6e-0d4a884f2d6a.png)

_Case2: Attaching server-template of shared partition_
Step1: Use following config:
```
[a10_global]
enable_hierarchical_multitenancy = True
network_type = "flat"
use_shared_for_template_lookup = True
[service_group]
template_server = "temp_server1"
[hardware_thunder]
devices=[
 {
 "project_id": "eccaddd60f404477a7c32270267729d4",
 "username" : "admin",
 "password" : "a10",
 "ip_address" : "10.43.12.122",
 "device_name" : "rack_1",
 "partition_name" : "PartitionC"}]
```
Step2: Create a pool
openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener e2cf2cbb-401a-4b04-8a35-eb42e2474309 --name pool1

Result:
![image](https://user-images.githubusercontent.com/58077446/93334589-cd0e0700-f842-11ea-8fdf-28bc870b409f.png)

_Case3: Attaching template-port of shared partition_
Step1: Use following config:
```
[a10_global]
enable_hierarchical_multitenancy = True
network_type = "flat"
use_shared_for_template_lookup = True
[service_group]
template_port = "temp_port1"
[hardware_thunder]
devices=[
 {
 "project_id": "eccaddd60f404477a7c32270267729d4",
 "username" : "admin",
 "password" : "a10",
 "ip_address" : "10.43.12.122",
 "device_name" : "rack_1",
 "partition_name" : "PartitionC"}]
```
Step2: Create a pool
openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener e2cf2cbb-401a-4b04-8a35-eb42e2474309 --name pool1

Result:
![image](https://user-images.githubusercontent.com/58077446/93334703-ff1f6900-f842-11ea-8177-10d7c6aea71b.png)

**3. For Member:**

_Case2: Attaching server-template of shared partition_
Step1: Use following config:
```
[a10_global]
enable_hierarchical_multitenancy = True
network_type = "flat"
use_shared_for_template_lookup = True
[server]
conn_limit=20000
conn_resume=20000
template_server = "temp_server1"
[hardware_thunder]
devices=[
 {
 "project_id": "eccaddd60f404477a7c32270267729d4",
 "username" : "admin",
 "password" : "a10",
 "ip_address" : "10.43.12.122",
 "device_name" : "rack_1",
 "partition_name" : "PartitionC"}]
```
Step2: Create a pool
openstack loadbalancer member create --address 10.10.10.10 --protocol-port 80 --name member1 pool1

Result:
![image](https://user-images.githubusercontent.com/58077446/93335163-a9978c00-f843-11ea-856d-a6a2bf9caad1.png)