### PR TITLE
STACK-1612: Handled case for None description while creating lb

### DIFF
--- a/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
@@ -36,9 +36,11 @@ class LoadBalancerParent(object):
         vip_meta = utils.meta(loadbalancer, 'virtual_server', {})
         arp_disable = CONF.slb.arp_disable
         vrid = CONF.slb.default_virtual_server_vrid
-        description = str(loadbalancer.description) if loadbalancer.description else ""
-        if description.isspace():
-            description = ""
+        description = loadbalancer.description
+        if not loadbalancer.description:
+            description = None
+        else:
+            description = loadbalancer.description.strip()
 
         set_method(
             loadbalancer.id,

--- a/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
@@ -36,17 +36,14 @@ class LoadBalancerParent(object):
         vip_meta = utils.meta(loadbalancer, 'virtual_server', {})
         arp_disable = CONF.slb.arp_disable
         vrid = CONF.slb.default_virtual_server_vrid
-        description = loadbalancer.description
-        if not loadbalancer.description:
-            description = None
-        else:
-            description = loadbalancer.description.strip()
+        desc = loadbalancer.description
+        desc = desc.strip() if desc and desc.strip() else None
 
         set_method(
             loadbalancer.id,
             loadbalancer.vip.ip_address,
             arp_disable=arp_disable,
-            description=description,
+            description=desc,
             status=status, vrid=vrid,
             axapi_body=vip_meta)
 

--- a/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
@@ -36,12 +36,15 @@ class LoadBalancerParent(object):
         vip_meta = utils.meta(loadbalancer, 'virtual_server', {})
         arp_disable = CONF.slb.arp_disable
         vrid = CONF.slb.default_virtual_server_vrid
+        description = str(loadbalancer.description) if loadbalancer.description else ""
+        if description.isspace():
+            description = ""
 
         set_method(
             loadbalancer.id,
             loadbalancer.vip.ip_address,
             arp_disable=arp_disable,
-            description=loadbalancer.description.strip(),
+            description=description,
             status=status, vrid=vrid,
             axapi_body=vip_meta)
 


### PR DESCRIPTION
## Description
Resolved the issue facing while creating a loadbalancer without giving description

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1612

## Technical Approach
- Setting description to "" when it contains only spaces in it or when it is not provided.

## Related PR
https://github.com/a10networks/acos-client/pull/294

## Manual Testing
Following are the results for the steps mentioned in the bug by referring lb1 as lb2 and lb2 as lb3 here

1. 
![image](https://user-images.githubusercontent.com/58077446/93973142-57012700-fd91-11ea-8de6-94eb629231a7.png)

2. 
![image](https://user-images.githubusercontent.com/58077446/93973168-5ff1f880-fd91-11ea-9341-2bb14a091dac.png)

3. 
![image](https://user-images.githubusercontent.com/58077446/93973189-67190680-fd91-11ea-9a1c-0d5dbf458fe4.png)

4.
![image](https://user-images.githubusercontent.com/58077446/93973202-6d0ee780-fd91-11ea-9a22-efd7b3fe181d.png)

5. openstack loadbalancer set lb3 --description lblb3
![image](https://user-images.githubusercontent.com/58077446/93973273-8adc4c80-fd91-11ea-92ff-50348f320643.png)

6. openstack loadbalancer set lb2 --description test
![image](https://user-images.githubusercontent.com/58077446/93973306-9d568600-fd91-11ea-9bc9-e357fb12bfa1.png)


7.  openstack loadbalancer set lb2 --description ""
![image](https://user-images.githubusercontent.com/58077446/93973776-67fe6800-fd92-11ea-8cbe-2298a9651d5e.png)




 
