### PR TITLE
[BUG][STACK-1645]: Adding current partition check while using "use_shared_for_template_lookup" flag for attaching shared templates

### DIFF
--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -168,7 +168,7 @@ class ListenerUpdate(ListenersParent, task.Task):
         try:
             if listener:
                 self.set(self.axapi_client.slb.virtual_server.vport.update,
-                         loadbalancer, listener)
+                         loadbalancer, listener, vthunder)
                 LOG.debug("Successfully updated listener: %s", listener.id)
         except (acos_errors.ACOSException, ConnectionError) as e:
             LOG.exception("Failed to update listener: %s", listener.id)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_service_group_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_service_group_tasks.py
@@ -13,6 +13,7 @@
 #    under the License.
 
 
+import copy
 import imp
 try:
     from unittest import mock
@@ -113,6 +114,8 @@ class TestHandlerServiceGroupTasks(BaseTaskTestCase):
     @mock.patch('a10_octavia.common.openstack_mappings.service_group_protocol', mock.Mock())
     @mock.patch('a10_octavia.common.openstack_mappings.service_group_lb_method', mock.Mock())
     def test_PoolCreate_execute_create_with_l3v_local_policy_template(self):
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.partition_name = "my_partition"
         service_group_task = self._create_service_group_task_with_template(
             {'template_policy': 'my_policy_template'})
         self.conf.config(group=a10constants.A10_GLOBAL_CONF_SECTION,
@@ -124,7 +127,7 @@ class TestHandlerServiceGroupTasks(BaseTaskTestCase):
         }
         }
         service_group_task.axapi_client.slb.template.templates.get.return_value = device_templates
-        service_group_task.execute(POOL, VTHUNDER)
+        service_group_task.execute(POOL, vthunder)
         args, kwargs = self.client_mock.slb.service_group.create.call_args
         self.assertIn('template-policy-shared', kwargs['service_group_templates'])
         self.assertEqual(kwargs['service_group_templates']
@@ -133,6 +136,8 @@ class TestHandlerServiceGroupTasks(BaseTaskTestCase):
     @mock.patch('a10_octavia.common.openstack_mappings.service_group_protocol', mock.Mock())
     @mock.patch('a10_octavia.common.openstack_mappings.service_group_lb_method', mock.Mock())
     def test_PoolCreate_execute_create_with_shared_policy_template(self):
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.partition_name = "shared"
         service_group_task = self._create_service_group_task_with_template(
             {'template_policy': 'my_policy_template_other'})
         self.conf.config(group=a10constants.A10_GLOBAL_CONF_SECTION,
@@ -144,11 +149,11 @@ class TestHandlerServiceGroupTasks(BaseTaskTestCase):
         }
         }
         service_group_task.axapi_client.slb.template.templates.get.return_value = device_templates
-        service_group_task.execute(POOL, VTHUNDER)
+        service_group_task.execute(POOL, vthunder)
         args, kwargs = self.client_mock.slb.service_group.create.call_args
-        self.assertIn('template-policy-shared', kwargs['service_group_templates'])
+        self.assertIn('template-policy', kwargs['service_group_templates'])
         self.assertEqual(kwargs['service_group_templates']
-                         ['template-policy-shared'], 'my_policy_template_other')
+                         ['template-policy'], 'my_policy_template_other')
 
     def test_revert_pool_create_task(self):
         mock_pool = task.PoolCreate()

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
@@ -12,6 +12,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import copy
 import imp
 try:
     from unittest import mock
@@ -81,38 +82,90 @@ class TestHandlerVirtualPortTasks(base.BaseTaskTestCase):
     @mock.patch('a10_octavia.controller.worker.tasks.utils.shared_template_modifier')
     @mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol')
     def test_create_listener_with_template_http_shared(self, mock_protocol, mock_templates):
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.partition_name = "my_partition"
         listener_task, listener = self._create_shared_template(
             'http', {'template_http': 'temp1'}, mock_protocol, mock_templates)
-        listener_task.execute(LB, listener, VTHUNDER)
+        listener_task.execute(LB, listener, vthunder)
         args, kwargs = self.client_mock.slb.virtual_server.vport.create.call_args
         self.assertIn('template-http-shared', kwargs['virtual_port_templates'])
 
     @mock.patch('a10_octavia.controller.worker.tasks.utils.shared_template_modifier')
     @mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol')
     def test_create_listener_with_template_tcp_shared(self, mock_protocol, mock_templates):
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.partition_name = "my_partition"
         listener_task, listener = self._create_shared_template(
             'tcp', {'template_tcp': 'temp1'}, mock_protocol, mock_templates)
-        listener_task.execute(LB, listener, VTHUNDER)
+        listener_task.execute(LB, listener, vthunder)
         args, kwargs = self.client_mock.slb.virtual_server.vport.create.call_args
         self.assertIn('template-tcp-shared', kwargs['virtual_port_templates'])
 
     @mock.patch('a10_octavia.controller.worker.tasks.utils.shared_template_modifier')
     @mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol')
     def test_create_listener_with_template_policy_shared(self, mock_protocol, mock_templates):
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.partition_name = "my_partition"
         listener_task, listener = self._create_shared_template(
             'policy', {'template_policy': 'temp1'}, mock_protocol, mock_templates)
-        listener_task.execute(LB, listener, VTHUNDER)
+        listener_task.execute(LB, listener, vthunder)
         args, kwargs = self.client_mock.slb.virtual_server.vport.create.call_args
         self.assertIn('template-policy-shared', kwargs['virtual_port_templates'])
 
     @mock.patch('a10_octavia.controller.worker.tasks.utils.shared_template_modifier')
     @mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol')
     def test_create_listener_with_template_virtual_port_shared(self, mock_protocol, mock_templates):
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.partition_name = "my_partition"
         listener_task, listener = self._create_shared_template(
             'virtual-port', {'template_virtual_port': 'temp1'}, mock_protocol, mock_templates)
-        listener_task.execute(LB, listener, VTHUNDER)
+        listener_task.execute(LB, listener, vthunder)
         args, kwargs = self.client_mock.slb.virtual_server.vport.create.call_args
         self.assertIn('template-virtual-port-shared', kwargs['virtual_port_templates'])
+
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.shared_template_modifier')
+    @mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol')
+    def test_create_listener_with_template_http(self, mock_protocol, mock_templates):
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.partition_name = "shared"
+        listener_task, listener = self._create_shared_template(
+            'http', {'template_http': 'temp1'}, mock_protocol, mock_templates)
+        listener_task.execute(LB, listener, vthunder)
+        args, kwargs = self.client_mock.slb.virtual_server.vport.create.call_args
+        self.assertIn('template-http', kwargs['virtual_port_templates'])
+
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.shared_template_modifier')
+    @mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol')
+    def test_create_listener_with_template_tcp(self, mock_protocol, mock_templates):
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.partition_name = "shared"
+        listener_task, listener = self._create_shared_template(
+            'tcp', {'template_tcp': 'temp1'}, mock_protocol, mock_templates)
+        listener_task.execute(LB, listener, vthunder)
+        args, kwargs = self.client_mock.slb.virtual_server.vport.create.call_args
+        self.assertIn('template-tcp', kwargs['virtual_port_templates'])
+
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.shared_template_modifier')
+    @mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol')
+    def test_create_listener_with_template_policy(self, mock_protocol, mock_templates):
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.partition_name = "shared"
+        listener_task, listener = self._create_shared_template(
+            'policy', {'template_policy': 'temp1'}, mock_protocol, mock_templates)
+        listener_task.execute(LB, listener, vthunder)
+        args, kwargs = self.client_mock.slb.virtual_server.vport.create.call_args
+        self.assertIn('template-policy', kwargs['virtual_port_templates'])
+
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.shared_template_modifier')
+    @mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol')
+    def test_create_listener_with_template_virtual_port(self, mock_protocol, mock_templates):
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.partition_name = "shared"
+        listener_task, listener = self._create_shared_template(
+            'virtual-port', {'template_virtual_port': 'temp1'}, mock_protocol, mock_templates)
+        listener_task.execute(LB, listener, vthunder)
+        args, kwargs = self.client_mock.slb.virtual_server.vport.create.call_args
+        self.assertIn('template-virtual-port', kwargs['virtual_port_templates'])
 
     def test_create_http_virtual_port_use_rcv_hop(self):
         listener = self._mock_listener('HTTP', 1000)


### PR DESCRIPTION
## Description
- Severity Level : Medium
- When `use_shared_for_template_lookup` flag is set **True** while doing configs on shared partition, it was giving error for shared-templates' fields.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1645

## Technical Approach
- When `use_shared_for_template_lookup` is to be enabled, there is a check to verify if the current partition is not shared.
- If current partition is not shared, then template_key is set to respective "{template_type}-shared" by shared_template_modifier().
- If current partition is shared, then template_key is used as it is declared before.

## Test Cases
1. For listener:
When use_shared_for_template_lookup = True with current active partition as **l3v partition**, then:
- For template "template-virtual-port", template-virtual-port-shared is getting attached
- For template "template-http", template-http-shared is getting attached
- For template "template-tcp", template-tcp-shared is getting attached
- For template "template-policy", template-policy-shared is getting attached

When use_shared_for_template_lookup = True with current active partition as **shared partition**, then:
- For template "template-virtual-port", template-virtual-port is getting attached
- For template "template-http", template-http is getting attached
- For template "template-tcp", template-tcp is getting attached
- For template "template-policy", template-policy is getting attached

2.For pool:
When use_shared_for_template_lookup = True with current active partition as **l3v partition**, then:
- For template "template-policy", template-policy-shared is getting attached
- For template "template-server", Error is raised with respective Warning message
- For template "template-port", Error is raised with respective Warning message

When use_shared_for_template_lookup = True with current active partition as **shared partition**, then:
- For template "template-policy", template-policy is getting attached
- For template "template-server", template-policy is getting attached
- For template "template-port", template-port is getting attached

## Manual Testing
Test cases from the BUG.
