### PR TITLE
[BUG][STACK-1612]: Removed the existing strip logic added for loadbalancer's description

### DIFF
--- a/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
@@ -37,7 +37,7 @@ class LoadBalancerParent(object):
         arp_disable = CONF.slb.arp_disable
         vrid = CONF.slb.default_virtual_server_vrid
         desc = loadbalancer.description
-        desc = desc.strip() if desc and desc.strip() else None
+        desc = "" if str(desc).isspace() else desc
 
         set_method(
             loadbalancer.id,


### PR DESCRIPTION
## Description
- Severity Level: Medium
- Removing the existing strip logic of description sothat description should not get stripped through the `virtual_server_task.py` code for now.
- Note: Even if stripping logic is removed from here, description with leading and trailing spaces are getting stripped on vThunder side as it's getting handled from somewhere else.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1612

## Related PR:
https://github.com/a10networks/acos-client/pull/294

## Technical Approach
- Setting description to "" if it is arrives as multiple spaces.
- Otherwise setting it to as it is arriving.

## Manual Testing
All the testcases from the bug.
Refer https://github.com/a10networks/a10-octavia/pull/191 for detailed testcases.
