### PR TITLE
[STACK-1510][STACK-1620] : Fixed hierarchical multitenancy logic when use_parent_partition is True or False

### DIFF
--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -99,9 +99,7 @@ def convert_to_hardware_thunder_conf(hardware_list):
             hardware_device['device_network_map'] = validate_interface_vlan_map(hardware_device)
             del hardware_device['interface_vlan_map']
         hierarchical_mt = hardware_device.get('hierarchical_multitenancy')
-        if hierarchical_mt == "enable":
-            hardware_device["partition_name"] = project_id[0:14]
-        elif hierarchical_mt != "disable" and hierarchical_mt is not None:
+        if hierarchical_mt and hierarchical_mt not in ('enable', 'disable'):
             raise cfg.ConfigFileValueError('Option `hierarchical_multitenancy` specified '
                                            'under project id {} only accepts "enable" and '
                                            '"disable"'.format(project_id))
@@ -231,14 +229,14 @@ def convert_interface_to_data_model(interface_obj):
             raise exceptions.InvalidVlanIdConfigError(vlan_id)
         if vlan_id in interface_dm.tags:
             raise exceptions.DuplicateVlanTagsConfigError(interface_num, vlan_id)
-        if vlan_map.get('use_dhcp'):
-            if not vlan_map.get('use_dhcp') in ("True", "False"):
+        if vlan_map.get('use_dhcp') and vlan_map.get('use_dhcp') not in ("True", "False"):
                 raise exceptions.InvalidUseDhcpConfigError(vlan_map.get('use_dhcp'))
+        if vlan_map.get('use_dhcp') == 'True':
             if vlan_map.get('ve_ip'):
                 raise exceptions.VirtEthCollisionConfigError(interface_num, vlan_id)
             else:
                 interface_dm.ve_ips.append('dhcp')
-        else:
+        if not vlan_map.get('use_dhcp') or vlan_map.get('use_dhcp') == 'False':
             if not vlan_map.get('ve_ip'):
                 raise exceptions.VirtEthMissingConfigError(interface_num, vlan_id)
             interface_dm.ve_ips.append(validate_partial_ipv4(vlan_map.get('ve_ip')))

--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -230,7 +230,7 @@ def convert_interface_to_data_model(interface_obj):
         if vlan_id in interface_dm.tags:
             raise exceptions.DuplicateVlanTagsConfigError(interface_num, vlan_id)
         if vlan_map.get('use_dhcp') and vlan_map.get('use_dhcp') not in ("True", "False"):
-                raise exceptions.InvalidUseDhcpConfigError(vlan_map.get('use_dhcp'))
+            raise exceptions.InvalidUseDhcpConfigError(vlan_map.get('use_dhcp'))
         if vlan_map.get('use_dhcp') == 'True':
             if vlan_map.get('ve_ip'):
                 raise exceptions.VirtEthCollisionConfigError(interface_num, vlan_id)

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -194,44 +194,26 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             raise db_exceptions.NoResultFound
 
         load_balancer = listener.load_balancer
+        parent_project_list = utils.get_parent_project_list()
+        listener_parent_proj = utils.get_parent_project(listener.project_id)
 
-        if CONF.a10_global.use_parent_partition:
-            parent_project_list = utils.get_parent_project_list()
-            listener_parent_proj = utils.get_parent_project(
-                listener.project_id)
-            if (listener.project_id in parent_project_list or
-                    (listener_parent_proj and listener_parent_proj in parent_project_list)
-                    or listener.project_id in CONF.hardware_thunder.devices):
-                create_listener_tf = self._taskflow_load(self._listener_flows.
-                                                         get_rack_vthunder_create_listener_flow(
-                                                             listener.project_id),
-                                                         store={constants.LOADBALANCER:
-                                                                load_balancer,
-                                                                constants.LISTENER:
-                                                                listener})
-            else:
-                create_listener_tf = self._taskflow_load(self._listener_flows.
-                                                         get_create_listener_flow(),
-                                                         store={constants.LOADBALANCER:
-                                                                load_balancer,
-                                                                constants.LISTENER:
-                                                                listener})
+        if (listener.project_id in parent_project_list or
+                (listener_parent_proj and listener_parent_proj in parent_project_list)
+                or listener.project_id in CONF.hardware_thunder.devices):
+            create_listener_tf = self._taskflow_load(self._listener_flows.
+                                                     get_rack_vthunder_create_listener_flow(
+                                                         listener.project_id),
+                                                     store={constants.LOADBALANCER:
+                                                            load_balancer,
+                                                            constants.LISTENER:
+                                                            listener})
         else:
-            if listener.project_id in CONF.hardware_thunder.devices:
-                create_listener_tf = self._taskflow_load(self._listener_flows.
-                                                         get_rack_vthunder_create_listener_flow(
-                                                             listener.project_id),
-                                                         store={constants.LOADBALANCER:
-                                                                load_balancer,
-                                                                constants.LISTENER:
-                                                                listener})
-            else:
-                create_listener_tf = self._taskflow_load(self._listener_flows.
-                                                         get_create_listener_flow(),
-                                                         store={constants.LOADBALANCER:
-                                                                load_balancer,
-                                                                constants.LISTENER:
-                                                                listener})
+            create_listener_tf = self._taskflow_load(self._listener_flows.
+                                                     get_create_listener_flow(),
+                                                     store={constants.LOADBALANCER:
+                                                            load_balancer,
+                                                            constants.LISTENER:
+                                                            listener})
 
         with tf_logging.DynamicLoggingListener(create_listener_tf,
                                                log=LOG):
@@ -401,50 +383,30 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         load_balancer = pool.load_balancer
 
         topology = CONF.a10_controller_worker.loadbalancer_topology
+        parent_project_list = utils.get_parent_project_list()
+        member_parent_proj = utils.get_parent_project(
+            member.project_id)
 
-        if CONF.a10_global.use_parent_partition:
-            parent_project_list = utils.get_parent_project_list()
-            member_parent_proj = utils.get_parent_project(
-                member.project_id)
-            if (member.project_id in parent_project_list or
-                    (member_parent_proj and member_parent_proj in parent_project_list)
-                    or member.project_id in CONF.hardware_thunder.devices):
-                create_member_tf = self._taskflow_load(
-                    self._member_flows.get_rack_vthunder_create_member_flow(),
-                    store={
-                        constants.MEMBER: member,
-                        constants.LISTENERS: listeners,
-                        constants.LOADBALANCER: load_balancer,
-                        constants.POOL: pool})
-            else:
-                create_member_tf = self._taskflow_load(self._member_flows.
-                                                       get_create_member_flow(
-                                                           topology=topology),
-                                                       store={constants.MEMBER: member,
-                                                              constants.LISTENERS:
-                                                              listeners,
-                                                              constants.LOADBALANCER:
-                                                              load_balancer,
-                                                              constants.POOL: pool})
+        if (member.project_id in parent_project_list or
+                (member_parent_proj and member_parent_proj in parent_project_list)
+                or member.project_id in CONF.hardware_thunder.devices):
+            create_member_tf = self._taskflow_load(
+                self._member_flows.get_rack_vthunder_create_member_flow(),
+                store={
+                    constants.MEMBER: member,
+                    constants.LISTENERS: listeners,
+                    constants.LOADBALANCER: load_balancer,
+                    constants.POOL: pool})
         else:
-            if member.project_id in CONF.hardware_thunder.devices:
-                create_member_tf = self._taskflow_load(
-                    self._member_flows.get_rack_vthunder_create_member_flow(),
-                    store={
-                        constants.MEMBER: member,
-                        constants.LISTENERS: listeners,
-                        constants.LOADBALANCER: load_balancer,
-                        constants.POOL: pool})
-            else:
-                create_member_tf = self._taskflow_load(self._member_flows.
-                                                       get_create_member_flow(
-                                                           topology=topology),
-                                                       store={constants.MEMBER: member,
-                                                              constants.LISTENERS:
-                                                              listeners,
-                                                              constants.LOADBALANCER:
-                                                              load_balancer,
-                                                              constants.POOL: pool})
+            create_member_tf = self._taskflow_load(self._member_flows.
+                                                   get_create_member_flow(
+                                                       topology=topology),
+                                                   store={constants.MEMBER: member,
+                                                          constants.LISTENERS:
+                                                          listeners,
+                                                          constants.LOADBALANCER:
+                                                          load_balancer,
+                                                          constants.POOL: pool})
 
         with tf_logging.DynamicLoggingListener(create_member_tf,
                                                log=LOG):

--- a/a10_octavia/tests/unit/common/test_config_types.py
+++ b/a10_octavia/tests/unit/common/test_config_types.py
@@ -36,7 +36,7 @@ RACK_DEVICE_1 = {
     "interface_vlan_map": {
         "device_1": {
             "ethernet_interfaces": [{
-                "interface_num": "5",
+                "interface_num": 5,
                 "vlan_map": [
                     {"vlan_id": 11, "use_dhcp": "True"},
                     {"vlan_id": 12, "ve_ip": ".10"}
@@ -59,7 +59,7 @@ VTHUNDER_1 = data_models.HardwareThunder(project_id="project-1", device_name="ra
                                          undercloud=True, username="abc", password="abc",
                                          ip_address="10.0.0.1", partition_name="shared",
                                          device_network_map='"device_1":{"ethernet_interfaces":'
-                                         '[{"interface_num": "5", "vlan_map": ['
+                                         '[{"interface_num": 5, "vlan_map": ['
                                          '{"vlan_id": 11, "use_dhcp": "True"},'
                                          '{"vlan_id": 12, "ve_ip": ".10"}]}]}}')
 VTHUNDER_2 = data_models.HardwareThunder(project_id="project-2", device_name="rack_thunder_2",

--- a/a10_octavia/tests/unit/common/test_utils.py
+++ b/a10_octavia/tests/unit/common/test_utils.py
@@ -85,7 +85,7 @@ RESULT_HARDWARE_DEVICE_LIST = {'project-1': VTHUNDER_1,
 INTERFACE_CONF = {"interface_num": 1,
                   "vlan_map": [
                       {"vlan_id": 11, "ve_ip": "10.20"},
-                      {"vlan_id": 12, "use_dhcp": True},
+                      {"vlan_id": 12, "use_dhcp": "True"},
                       {"vlan_id": 13, "ve_ip": "10.30"}]
                   }
 INTERFACE = data_models.Interface(interface_num=1, tags=[11, 12, 13], ve_ips=[
@@ -140,9 +140,9 @@ class TestUtils(base.BaseTaskTestCase):
         self.assertRaises(cfg.ConfigFileValueError, utils.validate_partial_ipv4, '10.333.11.10')
 
     def test_validate_partition_valid(self):
-        self.assertEqual(utils.validate_partition(HARDWARE_DEVICE), HARDWARE_DEVICE)
+        self.assertEqual(utils.validate_partition(HARDWARE_DEVICE), None)
         empty_hardware_device = {}
-        self.assertEqual(utils.validate_partition(empty_hardware_device), SHARED_HARDWARE_DEVICE)
+        self.assertEqual(utils.validate_partition(empty_hardware_device), None)
 
     def test_validate_partition_invalid(self):
         long_partition_hardware_device = copy.deepcopy(HARDWARE_DEVICE)
@@ -151,7 +151,6 @@ class TestUtils(base.BaseTaskTestCase):
 
     def test_validate_params_valid(self):
         shared_hardware_info = copy.deepcopy(HARDWARE_INFO)
-        shared_hardware_info['partition_name'] = 'shared'
         self.assertEqual(utils.validate_params(HARDWARE_INFO), shared_hardware_info)
 
     def test_validate_params_invalid(self):
@@ -326,18 +325,18 @@ class TestUtils(base.BaseTaskTestCase):
                           utils.convert_interface_to_data_model, missing_ve_ip_in_iface_obj)
         ve_ips_collision_in_iface_obj = {"interface_num": 1,
                                          "vlan_map": [
-                                             {"vlan_id": 11, "use_dhcp": True, "ve_ip": "10.30"}]}
+                                             {"vlan_id": 11, "use_dhcp": "True", "ve_ip": "10.30"}]}
         self.assertRaises(exceptions.VirtEthCollisionConfigError,
                           utils.convert_interface_to_data_model, ve_ips_collision_in_iface_obj)
         missing_ve_ip_in_iface_obj = {"interface_num": 1,
                                       "vlan_map": [
-                                          {"vlan_id": 11, "use_dhcp": False}]}
+                                          {"vlan_id": 11, "use_dhcp": "False"}]}
         self.assertRaises(exceptions.VirtEthMissingConfigError,
                           utils.convert_interface_to_data_model, missing_ve_ip_in_iface_obj)
         duplicate_vlan_ids_in_iface_obj = {"interface_num": 1,
                                            "vlan_map": [
                                                {"vlan_id": 11, "ve_ip": "10.20"},
-                                               {"vlan_id": 11, "use_dhcp": True}]}
+                                               {"vlan_id": 11, "use_dhcp": "True"}]}
         self.assertRaises(exceptions.DuplicateVlanTagsConfigError,
                           utils.convert_interface_to_data_model, duplicate_vlan_ids_in_iface_obj)
 

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -106,8 +106,7 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         mock_vthunder.partition_name = a10constants.MOCK_PARENT_PROJECT_ID[:14]
         mock_create_vthunder.vthunder_repo.create.return_value = mock_vthunder
         vthunder = mock_create_vthunder.execute(mock_lb, mock_vthunder_config)
-        self.assertEquals(vthunder.partition_name,
-                          a10constants.MOCK_PARENT_PROJECT_ID[:14])
+        self.assertEqual(vthunder.partition_name, a10constants.MOCK_PARENT_PROJECT_ID[:14])
 
     @mock.patch('a10_octavia.common.utils.get_parent_project',
                 return_value=None)


### PR DESCRIPTION
## Description
**Bug**
- Severity Level :**Critical**
- Fixed hmt logic for LB and its sub resources. 
- Delete was showing issues, as api calls were made to wrong partitions.
- LB sub-resources should be created in LB partition regardless of use_parent_partition flag.

 
## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1510
https://a10networks.atlassian.net/browse/STACK-1620

## Technical Approach
- Shifted hmt logic from task `GetVThunderByLoadBalancer` to db task `CreateRackVthunderEntry` ensuring correct partition_name is stored in `vthunders` table.
- Added return value to `CreateRackVthunderEntry` for writing test cases for them.
- Refactored `utils.py` module for hmt logic, modified hmt conditions
- Shifted UTs of `GetVThunderByLoadBalancer` to call `CreateRackVthunderEntry` for partitions.
- Removed `CONF.a10_global.use_parent_partition` check from `create_listener` and `create_member` api call, as subresources do not depend on `use_parent_partition`

**_Some Unrelated changes apart from BUG while doing pytest:_**
- Fixed Failing UTs and implementation for `use_dhcp`. 

## Config Changes
None

## Test Cases
a) **LOADBALANCER** 
- For _**upp= True, hmt = disable / upp= False, hmt = disable**_

Config(input) | Resource(input) | Vthunder partition(output) | Error description
-- | -- | -- | --
admin | LB | own partition |  
child1 | LB --project child1 | own partition |  
child2 | LB --project child2 | own partition |  
Invalid | LB --project some_random_invalid_id | Error |  

- For _**upp= False, hmt = enable**_  
 
Config(input) | Resource(input) | Vthunder partition(output) | Error description
-- | -- | -- | --
admin | LB | own partition | WARNING Hierarchical multitenancy is disabled
child1 | LB --project child1 | own partition | WARNING Hierarchical multitenancy is disabled
child2 | LB --project child2 | own partition | WARNING Hierarchical multitenancy is disabled
Invalid | LB --project some_random_invalid_id | Error |  



- For  **_upp= False, hmt = disable_**


Config(input) | Resource(input) | Vthunder partition(output) | Error description
-- | -- | -- | --
admin | LB | own partition |  
child1 | LB --project child1 | own partition |  
child2 | LB --project child2 | own partition |  
Invalid | LB --project some_random_invalid_id | Error |  


b) **Listener/ member/ pool/ hm ( any LB subresource)**

- For **_upp=True, hmt= enable_**  

Parent Resouce(Existing) | Residing in Partition (Existing) | Config(input) | Resource(input) | Vthunder partition(output) | Error description
-- | -- | -- | -- | -- | --
LB --project admin | admin | child1/child2/admin | Listener create | admin |  
LB --project child1 | admin | child1/child2/admin | Listener create | admin |  
LB --project child2 | admin | child1/child2/admin | Listener create | admin |  
LB --project child1 | child1 | child1 | Listener create | child1 |  
LB --project child2 | child2 | child2 | Listener create | child2 |  


- For **_upp=True, hmt= disable_**    
 

Parent Resouce(Existing) | Residing in Partition (Existing) | Config(input) | Resource(input) | Vthunder partition(output) | Error description
-- | -- | -- | -- | -- | --
LB --project admin | admin | admin | Listener create | admin |  
LB --project child1 | child1 | child1 | Listener create | child1 |  
LB --project child2 | child2 | child2 | Listener create | child2 |  


- For **_upp=False, hmt= enable_**

Parent Resouce(Existing) | Residing in Partition (Existing) | Config(input) | Resource(input) | Vthunder partition(output) | Error description
-- | -- | -- | -- | -- | --
LB --project admin | admin | admin | Listener create | admin | WARNING Hierarchical multitenancy is disabled
LB --project child1 | child1 | child1 | Listener create | child1 | WARNING Hierarchical multitenancy is disabled
LB --project child2 | child2 | child2 | Listener create | child2 | WARNING Hierarchical multitenancy is disabled





## Manual Testing
Steps are mentioned in details [STACK-1620](https://a10networks.atlassian.net/browse/STACK-1620) description