### PR TITLE
[BUG][STACK-1648]: Resolved an issue occurred during creating Terminated HTTPS listener.

### DIFF
--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -80,7 +80,7 @@ class ListenersParent(object):
         template_args = {}
         if listener.protocol == 'https' and listener.tls_certificate_id:
             # Adding TERMINATED_HTTPS SSL cert, created in previous task
-            template_args[template_key] = listener.id
+            template_args["template_client_ssl"] = listener.id
 
         elif listener.protocol.upper() in a10constants.HTTP_TYPE:
             template_http = CONF.listener.template_http


### PR DESCRIPTION
## Description
- Severity Level: High
Modified template key for terminated https listener sothat no terminated https listeners can be created without any issue.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1648

## Technical Approach
- Changed the key of template_args for HTTPS listener from `template_key` to `template_client_ssl`, 
As we are not supporting shared template feature in this case, template_key is not expected to be here.

## Manual Testing
Test Case from the bug.
Created TERMINATED_HTTPS listener without getting the error specified in the bug.