### PR TITLE
[Stack-1634][Stack-1661] Added VE IP configuration support at device level.

### DIFF
--- a/a10_octavia/common/data_models.py
+++ b/a10_octavia/common/data_models.py
@@ -208,9 +208,10 @@ class Interface(BaseDataModel):
 class DeviceNetworkMap(BaseDataModel):
 
     def __init__(self, vcs_device_id=None, mgmt_ip_address=None, ethernet_interfaces=None,
-                 trunk_interfaces=None):
+                 trunk_interfaces=None, ve_ip_address=None):
         self.vcs_device_id = vcs_device_id
         self.mgmt_ip_address = mgmt_ip_address
         self.ethernet_interfaces = ethernet_interfaces or []
         self.trunk_interfaces = trunk_interfaces or []
         self.state = 'Unknown'
+        self.ve_ip_address = ve_ip_address

--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -200,6 +200,7 @@ def validate_vcs_device_info(device_network_map):
                 raise exceptions.MissingMgmtIpConfigError(device_id)
             else:
                 validate_ipv4(device_obj.mgmt_ip_address)
+                validate_partial_ipv4(device_obj.ve_ip_address)
 
 
 def convert_interface_to_data_model(interface_obj):
@@ -241,6 +242,8 @@ def validate_interface_vlan_map(hardware_device):
     device_network_map = []
     for device_id, device_obj in hardware_device.get('interface_vlan_map').items():
         device_map = data_models.DeviceNetworkMap(device_obj.get('vcs_device_id'))
+        if device_obj.get('ve_ip_address'):
+            data_map.ve_ip = device_obj.get('ve_ip_address')
         if device_obj.get('ethernet_interfaces'):
             for eth in device_obj.get('ethernet_interfaces'):
                 device_map.ethernet_interfaces.append(convert_interface_to_data_model(eth))


### PR DESCRIPTION
## Description
**Feature**
- Added config support for `ve_ip_address` at device level under `[hardware_thunder]`.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1634
https://a10networks.atlassian.net/browse/STACK-1661

## Technical Approach
- Added `ve_ip_address` param to `DeviceNetworkMap` data model
- Supported `ve_ip_address` in `utils.py` and validated the partial octets. 


## Config Changes
<pre>
[hardware_vthunder]

devices=[
 {
 "project_id": "fake_uuid",
 "username" : "username",
 "password" : "password",
 "ip_address" : "X.X.X.X",
 "device_name" : "rack_1",
 "interface_vlan_map": {
  "device_1": {
   "vcs_device_id": 1,
   "mgmt_ip_address": "10.0.0.81",
     <b>"ve_ip_address": ".10",</b>
     "ethernet_interfaces": [
     {
      "interface_num": 1,
      "vlan_map": [
       {"vlan_id": 12, "ve_ip" : ".23"}
      ]
     }]
 }}]
</pre>

## Test Cases
- `[hardware_thunder]` now accepts `ve_ip_address`

## Manual Testing
None
