### PR TITLE
[BUG][STACK-1650][STACK-1652]: Added a new task for handling Pool delete and create in case of shared templates feature.

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -55,7 +55,7 @@ class PoolFlows(object):
             requires=[constants.POOL, a10constants.VTHUNDER],
             provides=constants.POOL)
         create_pool_flow.add(*self._get_sess_pers_subflow(create_pool))
-        create_pool_flow.add(virtual_port_tasks.ListenerUpdate(
+        create_pool_flow.add(virtual_port_tasks.ListenerUpdateForPoolDelete(
             requires=[constants.LOADBALANCER, constants.LISTENER, a10constants.VTHUNDER]))
         create_pool_flow.add(database_tasks.MarkPoolActiveInDB(
             requires=constants.POOL))
@@ -86,7 +86,7 @@ class PoolFlows(object):
         delete_pool_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
-        delete_pool_flow.add(virtual_port_tasks.ListenerUpdate(
+        delete_pool_flow.add(virtual_port_tasks.ListenerUpdateForPoolDelete(
             requires=[constants.LOADBALANCER, constants.LISTENER, a10constants.VTHUNDER]))
         delete_pool_flow.add(persist_tasks.DeleteSessionPersistence(
             requires=[a10constants.VTHUNDER, constants.POOL]))

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -55,7 +55,7 @@ class PoolFlows(object):
             requires=[constants.POOL, a10constants.VTHUNDER],
             provides=constants.POOL)
         create_pool_flow.add(*self._get_sess_pers_subflow(create_pool))
-        create_pool_flow.add(virtual_port_tasks.ListenerUpdateForPoolDelete(
+        create_pool_flow.add(virtual_port_tasks.ListenerUpdateForPool(
             requires=[constants.LOADBALANCER, constants.LISTENER, a10constants.VTHUNDER]))
         create_pool_flow.add(database_tasks.MarkPoolActiveInDB(
             requires=constants.POOL))
@@ -86,7 +86,7 @@ class PoolFlows(object):
         delete_pool_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
-        delete_pool_flow.add(virtual_port_tasks.ListenerUpdateForPoolDelete(
+        delete_pool_flow.add(virtual_port_tasks.ListenerUpdateForPool(
             requires=[constants.LOADBALANCER, constants.LISTENER, a10constants.VTHUNDER]))
         delete_pool_flow.add(persist_tasks.DeleteSessionPersistence(
             requires=[a10constants.VTHUNDER, constants.POOL]))

--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -175,6 +175,39 @@ class ListenerUpdate(ListenersParent, task.Task):
             raise e
 
 
+class ListenerUpdateForPoolDelete(ListenersParent, task.Task):
+    """Task to update listener while pool delete"""
+
+    @axapi_client_decorator
+    def execute(self, loadbalancer, listener, vthunder):
+        try:
+            vport_templates = {}
+            if listener:
+                old_listener = self.axapi_client.slb.virtual_server.vport.get(
+                    loadbalancer.id,
+                    listener.id,
+                    listener.protocol,
+                    listener.protocol_port)
+                templates = ["template-virtual-port-shared", "template-http-shared",
+                             "template-tcp-shared", "template-policy-shared",
+                             "template-virtual-port", "template-http",
+                             "template-tcp", "template-policy"]
+                for template_key in templates:
+                    if template_key in old_listener['port']:
+                        vport_templates[template_key] = old_listener['port'][template_key]
+                self.axapi_client.slb.virtual_server.vport.update(
+                    loadbalancer.id,
+                    listener.id,
+                    listener.protocol,
+                    listener.protocol_port,
+                    listener.default_pool_id,
+                    virtual_port_templates=vport_templates)
+                LOG.debug("Successfully updated listener: %s", listener.id)
+        except (acos_errors.ACOSException, ConnectionError) as e:
+            LOG.exception("Failed to update listener: %s", listener.id)
+            raise e
+
+
 class ListenerDelete(ListenersParent, task.Task):
     """Task to delete the listener"""
 

--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -175,7 +175,7 @@ class ListenerUpdate(ListenersParent, task.Task):
             raise e
 
 
-class ListenerUpdateForPoolDelete(ListenersParent, task.Task):
+class ListenerUpdateForPool(ListenersParent, task.Task):
     """Task to update listener while pool delete"""
 
     @axapi_client_decorator

--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -183,25 +183,13 @@ class ListenerUpdateForPoolDelete(ListenersParent, task.Task):
         try:
             vport_templates = {}
             if listener:
-                old_listener = self.axapi_client.slb.virtual_server.vport.get(
-                    loadbalancer.id,
-                    listener.id,
-                    listener.protocol,
-                    listener.protocol_port)
-                templates = ["template-virtual-port-shared", "template-http-shared",
-                             "template-tcp-shared", "template-policy-shared",
-                             "template-virtual-port", "template-http",
-                             "template-tcp", "template-policy"]
-                for template_key in templates:
-                    if template_key in old_listener['port']:
-                        vport_templates[template_key] = old_listener['port'][template_key]
+                listener.default_pool_id = None
                 self.axapi_client.slb.virtual_server.vport.update(
                     loadbalancer.id,
                     listener.id,
                     listener.protocol,
                     listener.protocol_port,
-                    listener.default_pool_id,
-                    virtual_port_templates=vport_templates)
+                    listener.default_pool_id)
                 LOG.debug("Successfully updated listener: %s", listener.id)
         except (acos_errors.ACOSException, ConnectionError) as e:
             LOG.exception("Failed to update listener: %s", listener.id)

--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -181,7 +181,6 @@ class ListenerUpdateForPoolDelete(ListenersParent, task.Task):
     @axapi_client_decorator
     def execute(self, loadbalancer, listener, vthunder):
         try:
-            vport_templates = {}
             if listener:
                 listener.default_pool_id = None
                 self.axapi_client.slb.virtual_server.vport.update(


### PR DESCRIPTION
## Description
- Severity Level: Medium
- When a listener and pool are created by enabling `use_shared_for_template_lookup` flag and then pool is deleted by disabling `use_shared_for_template_lookup`, it was throwing error due to ListenerUpdate task.
- When a listener is created by enabling `use_shared_for_template_lookup` and pool is created by disabling `use_shared_for_template_lookup`, then the shared templates attached to listener were getting replaced by the l3v templates due to ListenerUpdate after disabling the flag.
- So for resolving above 2 bugs, a new task **ListenerUpdateForPool** is added here.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1650
https://a10networks.atlassian.net/browse/STACK-1652

## Technical Approach
- Added a new task **ListenerUpdateForPool** for updating listener only when creating and deleting a Pool
- In that task, Listener will not be affected due to any config changes done while Pool creation or deletion. 
Only default_pool_id will be set to None.

## Manual Testing
**1. For STACK-1650:**
Step1: Set use_shared_for_template_lookup=True and create a listener with attaching shared templates to it.

![image](https://user-images.githubusercontent.com/58077446/95069861-eceb6900-0724-11eb-80b8-015a9f7d464f.png)

Step2: Set use_shared_for_template_lookup=False and create a pool with attaching l3v templates to it.

![image](https://user-images.githubusercontent.com/58077446/95070413-b3672d80-0725-11eb-96bb-1e549b921af5.png)

**2. For STACK-1652:**
Step1: Set use_shared_for_template_lookup=True and create a listener with attaching shared templates to it.

![image](https://user-images.githubusercontent.com/58077446/95069861-eceb6900-0724-11eb-80b8-015a9f7d464f.png)

Step2: Set use_shared_for_template_lookup=True and create a pool with attaching shared templates to it.

![image](https://user-images.githubusercontent.com/58077446/95070963-90894900-0726-11eb-9501-5ad67ab8a36f.png)

Step3: Set use_shared_for_template_lookup=False and delete the pool

![image](https://user-images.githubusercontent.com/58077446/95071182-e65df100-0726-11eb-9420-b8b915c2e014.png)
