### PR TITLE
[STACK-1665]: HOTFIX for PR#199

### DIFF
--- a/a10_octavia/controller/worker/tasks/persist_tasks.py
+++ b/a10_octavia/controller/worker/tasks/persist_tasks.py
@@ -32,7 +32,6 @@ class HandleSessionPersistenceDelta(task.Task):
     def execute(self, vthunder, pool):
         sess_pers = pool.session_persistence
         if sess_pers and sess_pers.type in SP_OBJ_DICT:
-
             # Remove existing persistence template if any
             for sp_type in PERS_TYPE:
                 try:
@@ -63,9 +62,9 @@ class HandleSessionPersistenceDelta(task.Task):
     @axapi_client_decorator
     def revert(self, vthunder, pool, *args, **kwargs):
         LOG.warning("Reverting creation of session persistence for pool: %s", pool.id)
-        sp_template = getattr(self.axapi_client.slb.template,
-                              SP_OBJ_DICT[pool.session_persistence.type])
         try:
+            sp_template = getattr(self.axapi_client.slb.template,
+                                  SP_OBJ_DICT[pool.session_persistence.type])
             sp_template.delete(pool.id)
             LOG.debug("Successfully deleted session persistence template for pool: %s", pool.id)
         except acos_errors.NotFound:

--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -182,7 +182,8 @@ class ListenerUpdateForPool(ListenersParent, task.Task):
     def execute(self, loadbalancer, listener, vthunder):
         try:
             if listener:
-                listener.default_pool_id = None
+                listener.protocol = openstack_mappings.virtual_port_protocol(
+                    self.axapi_client, listener.protocol).lower()
                 self.axapi_client.slb.virtual_server.vport.update(
                     loadbalancer.id,
                     listener.id,


### PR DESCRIPTION
## Description
Severity Level: Critical

1. Terminated HTTPS was broken by PR#199 due to lack of protocol mapping

2. HandleSessionPersistenceDelta revert task tried to access session persistence even when it was confirmed to exist. Moving it inside of the try block allows failures to propogate

## Jira Ticket
[STACK-1665](https://a10networks.atlassian.net/browse/STACK-1665)

## Technical Approach
Leveraged protocol mapping to turn "TERMINATED_HTTPS" -> "https"

## Config Changes
N/A


## Test Cases
N/A

## Manual Testing

#### Pre-Req commands
```
openssl genrsa -des3 -out ca.key 1024 

openssl req -new -x509 -days 3650 -key ca.key -out ca.crt  

openssl x509  -in  ca.crt -out ca.pem 

openssl genrsa -des3 -out ca-int_encrypted.key 1024 

openssl rsa -in ca-int_encrypted.key -out ca-int.key 

openssl req -new -key ca-int.key -out ca-int.csr -subj "/CN=ca-int@acme.com" 

openssl x509 -req -days 3650 -in ca-int.csr -CA ca.crt -CAkey ca.key -set_serial 01 -out ca-int.crt 

openssl genrsa -des3 -out server_encrypted.key 1024 

openssl rsa -in server_encrypted.key -out server.key 

openssl req -new -key server.key -out server.csr -subj "/CN=server@acme.com" 

openssl x509 -req -days 3650 -in server.csr  -CA ca-int.crt -CAkey ca-int.key -set_serial 01 -out server.crt

openstack secret store --payload-content-type='text/plain' --name='certificate' --payload="$(cat server.crt)"

openstack secret store --payload-content-type='text/plain' --name='private_key' --payload="$(cat server.key)"

openstack secret container create --name='tls_container' --type='certificate' --secret="certificate=$(openstack secret list | awk '/ certificate / {print $2}')" --secret="private_key=$(openstack secret list | awk '/ private_key / {print $2}')"

openstack loadbalancer create --vip-subnet-id public-subnet --name myvip 
```

#### Test with HTTP
````
openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name mylist myvip

openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener mylist --name myvip
````

#### Test with Terminated HTTPS
```
openstack loadbalancer listener create --protocol TERMINATED_HTTPS --protocol-port 443 --default-tls-container-ref="$(openstack secret container list | awk '/ tls_container / {print $2}')" --name mylist myvip

 openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener mylist --name myvip
```

#### Test with HTTPS
````
openstack loadbalancer listener create --protocol HTTPS --protocol-port 443 --name mylist myvip

 openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener mylist --name myvip
````