### PR TITLE
[BUG][STACK-1667]: Added ListenerUpdateForPool task in pool-update flow to fix the issue.

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -147,7 +147,7 @@ class PoolFlows(object):
             requires=[constants.POOL, a10constants.VTHUNDER, constants.UPDATE_DICT],
             provides=constants.POOL)
         update_pool_flow.add(*self._get_sess_pers_subflow(update_pool))
-        update_pool_flow.add(virtual_port_tasks.ListenerUpdate(
+        update_pool_flow.add(virtual_port_tasks.ListenerUpdateForPool(
             requires=[constants.LOADBALANCER, constants.LISTENER, a10constants.VTHUNDER]))
         update_pool_flow.add(database_tasks.UpdatePoolInDB(
             requires=[constants.POOL, constants.UPDATE_DICT]))

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
@@ -201,15 +201,15 @@ class TestHandlerVirtualPortTasks(base.BaseTaskTestCase):
         self.assertIn('use_rcv_hop', kwargs)
         self.assertFalse(kwargs.get('use_rcv_hop'))
 
-    def test_listener_update_for_pool_with_http_protocol(self):
+    @mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol')
+    def test_listener_update_for_pool_with_http_protocol(self, mock_protocol):
         listener = self._mock_listener('HTTP', 1000)
+        mock_protocol.return_value = listener.protocol
 
         listener_task = task.ListenerUpdateForPool()
         listener_task.axapi_client = self.client_mock
 
-        with mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol',
-                        return_value=listener.protocol):
-            listener_task.execute(LB, listener, VTHUNDER)
+        listener_task.execute(LB, listener, VTHUNDER)
         self.client_mock.slb.virtual_server.vport.update.assert_called_with(LB.id,
                                                                             listener.id,
                                                                             listener.protocol,
@@ -217,15 +217,15 @@ class TestHandlerVirtualPortTasks(base.BaseTaskTestCase):
                                                                             listener.default_pool_id
                                                                             )
 
-    def test_listener_update_for_pool_with_https_protocol(self):
+    @mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol')
+    def test_listener_update_for_pool_with_https_protocol(self, mock_protocol):
         listener = self._mock_listener('HTTPS', 1000)
+        mock_protocol.return_value = listener.protocol
 
         listener_task = task.ListenerUpdateForPool()
         listener_task.axapi_client = self.client_mock
 
-        with mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol',
-                        return_value=listener.protocol):
-            listener_task.execute(LB, listener, VTHUNDER)
+        listener_task.execute(LB, listener, VTHUNDER)
         self.client_mock.slb.virtual_server.vport.update.assert_called_with(LB.id,
                                                                             listener.id,
                                                                             listener.protocol,
@@ -233,15 +233,15 @@ class TestHandlerVirtualPortTasks(base.BaseTaskTestCase):
                                                                             listener.default_pool_id
                                                                             )
 
-    def test_listener_update_for_pool_with_tcp_protocol(self):
+    @mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol')
+    def test_listener_update_for_pool_with_tcp_protocol(self, mock_protocol):
         listener = self._mock_listener('TCP', 1000)
+        mock_protocol.return_value = listener.protocol
 
         listener_task = task.ListenerUpdateForPool()
         listener_task.axapi_client = self.client_mock
 
-        with mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol',
-                        return_value=listener.protocol):
-            listener_task.execute(LB, listener, VTHUNDER)
+        listener_task.execute(LB, listener, VTHUNDER)
         self.client_mock.slb.virtual_server.vport.update.assert_called_with(LB.id,
                                                                             listener.id,
                                                                             listener.protocol,

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
@@ -200,3 +200,51 @@ class TestHandlerVirtualPortTasks(base.BaseTaskTestCase):
         args, kwargs = self.client_mock.slb.virtual_server.vport.update.call_args
         self.assertIn('use_rcv_hop', kwargs)
         self.assertFalse(kwargs.get('use_rcv_hop'))
+
+    def test_listener_update_for_pool_with_http_protocol(self):
+        listener = self._mock_listener('HTTP', 1000)
+
+        listener_task = task.ListenerUpdateForPool()
+        listener_task.axapi_client = self.client_mock
+
+        with mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol',
+                        return_value=listener.protocol):
+            listener_task.execute(LB, listener, VTHUNDER)
+        self.client_mock.slb.virtual_server.vport.update.assert_called_with(LB.id,
+                                                                            listener.id,
+                                                                            listener.protocol,
+                                                                            listener.protocol_port,
+                                                                            listener.default_pool_id
+                                                                            )
+
+    def test_listener_update_for_pool_with_https_protocol(self):
+        listener = self._mock_listener('HTTPS', 1000)
+
+        listener_task = task.ListenerUpdateForPool()
+        listener_task.axapi_client = self.client_mock
+
+        with mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol',
+                        return_value=listener.protocol):
+            listener_task.execute(LB, listener, VTHUNDER)
+        self.client_mock.slb.virtual_server.vport.update.assert_called_with(LB.id,
+                                                                            listener.id,
+                                                                            listener.protocol,
+                                                                            listener.protocol_port,
+                                                                            listener.default_pool_id
+                                                                            )
+
+    def test_listener_update_for_pool_with_tcp_protocol(self):
+        listener = self._mock_listener('TCP', 1000)
+
+        listener_task = task.ListenerUpdateForPool()
+        listener_task.axapi_client = self.client_mock
+
+        with mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol',
+                        return_value=listener.protocol):
+            listener_task.execute(LB, listener, VTHUNDER)
+        self.client_mock.slb.virtual_server.vport.update.assert_called_with(LB.id,
+                                                                            listener.id,
+                                                                            listener.protocol,
+                                                                            listener.protocol_port,
+                                                                            listener.default_pool_id
+                                                                            )


### PR DESCRIPTION
## Description
- Severity Level: Medium
- While updating pool with l3v templates, listener's shared templates were also getting updated with l3v ones because of disabling use_shared_for_template_lookup flag while ListenerUpdate.
So added the new task ListenerUpdateForPool in pool update flow to resolve this issue.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1667

## Technical Approach
- Added a new task ListenerUpdateForPool for updating listener only when updating a Pool
- By this task, Listener will not be affected due to any config changes done while Pool update.
- Added unit tests for the newly added ListenerUpdateForPool task.

## Manual Testing
- Tested the test-cases specified in the bug.
