### PR TITLE
[BUG][STACK-1670]: Set partition name to current project partition when hierarchical multitenancy is enabled

### DIFF
--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -99,6 +99,8 @@ def convert_to_hardware_thunder_conf(hardware_list):
             hardware_device['device_network_map'] = validate_interface_vlan_map(hardware_device)
             del hardware_device['interface_vlan_map']
         hierarchical_mt = hardware_device.get('hierarchical_multitenancy')
+        if hierarchical_mt == "enable":
+            hardware_device["partition_name"] = project_id[0:14]
         if hierarchical_mt and hierarchical_mt not in ('enable', 'disable'):
             raise cfg.ConfigFileValueError('Option `hierarchical_multitenancy` specified '
                                            'under project id {} only accepts "enable" and '

--- a/a10_octavia/tests/common/a10constants.py
+++ b/a10_octavia/tests/common/a10constants.py
@@ -43,6 +43,7 @@ A10_GLOBAL_OPTS = 'a10_global'
 MOCK_PARENT_PROJECT_ID = 'parent_project_id_with_length_32'
 MOCK_CHILD_PART = 'child_part'
 MOCK_CHILD_PROJECT_ID = '_child_project_id_with_length_32'
+MOCK_CHILD_PARTITION = '_child_project'
 MOCK_PROJECT_ID = 'mock-project-id'
 
 A10_GLOBAL_CONF_SECTION = 'a10_global'

--- a/a10_octavia/tests/unit/common/test_utils.py
+++ b/a10_octavia/tests/unit/common/test_utils.py
@@ -59,7 +59,7 @@ DUP_PARTITION_HARDWARE_INFO = {
     'password': 'abc'}
 
 HARDWARE_INFO_WITH_HMT_ENABLED = [{
-    'project_id': '5fef4dab3190438a875d057ddc7af567',
+    'project_id': a10constants.MOCK_CHILD_PROJECT_ID,
     'ip_address': '13.13.13.13',
     'device_name': 'rack_thunder_3',
     'username': 'usr',
@@ -74,11 +74,12 @@ VTHUNDER_1 = data_models.HardwareThunder(project_id="project-1", device_name="ra
 VTHUNDER_2 = data_models.HardwareThunder(project_id="project-2", device_name="rack_thunder_2",
                                          undercloud=True, username="def", password="def",
                                          ip_address="12.12.12.12", partition_name="def-sample")
-VTHUNDER_3 = data_models.HardwareThunder(project_id="5fef4dab3190438a875d057ddc7af567",
+VTHUNDER_3 = data_models.HardwareThunder(project_id=a10constants.MOCK_CHILD_PROJECT_ID,
                                          device_name="rack_thunder_3",
                                          undercloud=True, username="usr", password="pwd",
                                          hierarchical_multitenancy='enable',
-                                         ip_address="13.13.13.13", partition_name="5fef4dab319043")
+                                         ip_address="13.13.13.13",
+                                         partition_name=a10constants.MOCK_CHILD_PARTITION)
 
 DUPLICATE_DICT = {'project_1': VTHUNDER_1,
                   'project_2': VTHUNDER_1}
@@ -97,7 +98,8 @@ DUPLICATE_PARTITION_HARDWARE_DEVICE_LIST = [DUP_PARTITION_HARDWARE_INFO, HARDWAR
 RESULT_HARDWARE_DEVICE_LIST = {'project-1': VTHUNDER_1,
                                'project-2': VTHUNDER_2}
 
-RESULT_HMT_HARDWARE_DEVICE_LIST = {'5fef4dab3190438a875d057ddc7af567': VTHUNDER_3}
+RESULT_HMT_HARDWARE_DEVICE_LIST = {a10constants.MOCK_CHILD_PROJECT_ID: VTHUNDER_3}
+
 INTERFACE_CONF = {"interface_num": 1,
                   "vlan_map": [
                       {"vlan_id": 11, "ve_ip": "10.20"},

--- a/a10_octavia/tests/unit/common/test_utils.py
+++ b/a10_octavia/tests/unit/common/test_utils.py
@@ -58,12 +58,27 @@ DUP_PARTITION_HARDWARE_INFO = {
     'username': 'abc',
     'password': 'abc'}
 
+HARDWARE_INFO_WITH_HMT_ENABLED = [{
+    'project_id': '5fef4dab3190438a875d057ddc7af567',
+    'ip_address': '13.13.13.13',
+    'device_name': 'rack_thunder_3',
+    'username': 'usr',
+    'password': 'pwd',
+    'hierarchical_multitenancy': 'enable',
+    'partition_name': 'shared'
+}]
+
 VTHUNDER_1 = data_models.HardwareThunder(project_id="project-1", device_name="rack_thunder_1",
                                          undercloud=True, username="abc", password="abc",
                                          ip_address="10.10.10.10", partition_name="shared")
 VTHUNDER_2 = data_models.HardwareThunder(project_id="project-2", device_name="rack_thunder_2",
                                          undercloud=True, username="def", password="def",
                                          ip_address="12.12.12.12", partition_name="def-sample")
+VTHUNDER_3 = data_models.HardwareThunder(project_id="5fef4dab3190438a875d057ddc7af567",
+                                         device_name="rack_thunder_3",
+                                         undercloud=True, username="usr", password="pwd",
+                                         hierarchical_multitenancy='enable',
+                                         ip_address="13.13.13.13", partition_name="5fef4dab319043")
 
 DUPLICATE_DICT = {'project_1': VTHUNDER_1,
                   'project_2': VTHUNDER_1}
@@ -82,6 +97,7 @@ DUPLICATE_PARTITION_HARDWARE_DEVICE_LIST = [DUP_PARTITION_HARDWARE_INFO, HARDWAR
 RESULT_HARDWARE_DEVICE_LIST = {'project-1': VTHUNDER_1,
                                'project-2': VTHUNDER_2}
 
+RESULT_HMT_HARDWARE_DEVICE_LIST = {'5fef4dab3190438a875d057ddc7af567': VTHUNDER_3}
 INTERFACE_CONF = {"interface_num": 1,
                   "vlan_map": [
                       {"vlan_id": 11, "ve_ip": "10.20"},
@@ -177,6 +193,10 @@ class TestUtils(base.BaseTaskTestCase):
                           DUPLICATE_PROJECT_HARDWARE_DEVICE_LIST)
         self.assertRaises(cfg.ConfigFileValueError, utils.convert_to_hardware_thunder_conf,
                           DUPLICATE_PARTITION_HARDWARE_DEVICE_LIST)
+
+    def test_convert_to_hardware_thunder_conf_with_hmt(self):
+        self.assertEqual(utils.convert_to_hardware_thunder_conf(HARDWARE_INFO_WITH_HMT_ENABLED),
+                         RESULT_HMT_HARDWARE_DEVICE_LIST)
 
     @mock.patch('octavia.common.keystone.KeystoneSession')
     @mock.patch('a10_octavia.common.utils.keystone_client.Client')


### PR DESCRIPTION
## Description
- Severity Level: Medium
- If hierarchical-multitenancy is enabled, the partition should be set to the current project partition specified in config file instead of setting it to "shared".

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1670

## Technical Approach
- If hierarchical-multitenancy is enabled, set vthunder partition name to the first 14 digits of project_id present in config file.

## Test Cases
- If hierarchical-multitenancy is enabled, partition_name of vThunder should be the first 14 digits of the project_id specified in config file.

## Manual Testing
admin has child project child2_admin.
**Step1**: Set **use_parent_partition=True** & **"hierarchical_multitenancy": "enable"**, **project_id: project_id of child2_admin**

**Step2**: Create a loadbalancer lcc1 with project child2_admin
stack@neha:~$ openstack loadbalancer create --name lcc1 --vip-subnet-id vip_subnet --project child2_admin
lcc1 is created under admin project id partition as expected

**Step3**: Modify config with setting **use_parent_partition=False** and restart service

**Step4**: Create a loadbalancer lccs1 with project child2_admin
stack@neha:~$ openstack loadbalancer create --name lccs1 --vip-subnet-id vip_subnet --project child2_admin

**Result**: Getting expected Error with child2_admin project_id partition instead of shared.
![image](https://user-images.githubusercontent.com/58077446/95568651-216f6580-0a42-11eb-9046-263f232b72f4.png)
