### PR TITLE
[STACK-1588A]: Update UpdateVRIDForLoadbalancerResource db task for updating multiple VRIDs fetched from HandleVRIDFloatingIP.

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -356,9 +356,9 @@ class LoadBalancerFlows(object):
         handle_vrid_for_lb_subflow.add(a10_network_tasks.HandleVRIDFloatingIP(
             requires=[a10constants.VTHUNDER, a10constants.VRID_LIST, constants.SUBNET],
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
-            provides=(a10constants.PORT, a10constants.VRID)))
+            provides= a10constants.VRID_LIST))
         handle_vrid_for_lb_subflow.add(a10_database_tasks.UpdateVRIDForLoadbalancerResource(
-            requires=[a10constants.VRID, a10constants.PORT, constants.SUBNET],
+            requires=a10constants.VRID_LIST,
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER}))
         return handle_vrid_for_lb_subflow
 

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -167,9 +167,11 @@ class LoadBalancerFlows(object):
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER)))
         delete_LB_flow.add(self.get_delete_lb_vrid_subflow())
         if CONF.a10_global.network_type == 'vlan':
-            delete_LB_flow.add(vthunder_tasks.DeleteInterfaceTagIfNotInUseForLB(
-                requires=[constants.LOADBALANCER,
-                          a10constants.VTHUNDER]))
+            delete_LB_flow.add(
+                vthunder_tasks.DeleteInterfaceTagIfNotInUseForLB(
+                    requires=[
+                        constants.LOADBALANCER,
+                        a10constants.VTHUNDER]))
 
         # delete_LB_flow.add(listeners_delete)
         # delete_LB_flow.add(network_tasks.UnplugVIP(
@@ -229,17 +231,21 @@ class LoadBalancerFlows(object):
             requires=a10constants.VTHUNDER,
             inject={a10constants.STATUS: constants.ACTIVE}))
         if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
-            new_LB_net_subflow.add(vthunder_tasks.CreateHealthMonitorOnVThunder(
-                name=a10constants.CREATE_HEALTH_MONITOR_ON_VTHUNDER_MASTER,
-                requires=a10constants.VTHUNDER))
-            new_LB_net_subflow.add(a10_database_tasks.GetBackupVThunderByLoadBalancer(
-                name=a10constants.GET_BACKUP_VTHUNDER_BY_LB,
-                requires=constants.LOADBALANCER,
-                provides=a10constants.BACKUP_VTHUNDER))
-            new_LB_net_subflow.add(vthunder_tasks.VThunderComputeConnectivityWait(
-                name=a10constants.BACKUP_CONNECTIVITY_WAIT,
-                rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-                requires=constants.AMPHORA))
+            new_LB_net_subflow.add(
+                vthunder_tasks.CreateHealthMonitorOnVThunder(
+                    name=a10constants.CREATE_HEALTH_MONITOR_ON_VTHUNDER_MASTER,
+                    requires=a10constants.VTHUNDER))
+            new_LB_net_subflow.add(
+                a10_database_tasks.GetBackupVThunderByLoadBalancer(
+                    name=a10constants.GET_BACKUP_VTHUNDER_BY_LB,
+                    requires=constants.LOADBALANCER,
+                    provides=a10constants.BACKUP_VTHUNDER))
+            new_LB_net_subflow.add(
+                vthunder_tasks.VThunderComputeConnectivityWait(
+                    name=a10constants.BACKUP_CONNECTIVITY_WAIT,
+                    rebind={
+                        a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
+                    requires=constants.AMPHORA))
             new_LB_net_subflow.add(vthunder_tasks.EnableInterface(
                 name=a10constants.BACKUP_ENABLE_INTERFACE,
                 rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
@@ -284,7 +290,8 @@ class LoadBalancerFlows(object):
             requires=a10constants.VTHUNDER))
         return update_LB_flow
 
-    def get_create_rack_vthunder_load_balancer_flow(self, vthunder_conf, topology, listeners=None):
+    def get_create_rack_vthunder_load_balancer_flow(
+            self, vthunder_conf, topology, listeners=None):
         """Flow to create rack load balancer"""
 
         f_name = constants.CREATE_LOADBALANCER_FLOW
@@ -295,16 +302,25 @@ class LoadBalancerFlows(object):
         lb_create_flow.add(database_tasks.ReloadLoadBalancer(
             requires=constants.LOADBALANCER_ID,
             provides=constants.LOADBALANCER))
-        lb_create_flow.add(a10_database_tasks.CheckExistingProjectToThunderMappedEntries(
-            inject={a10constants.VTHUNDER_CONFIG: vthunder_conf},
-            requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG)))
-        lb_create_flow.add(a10_database_tasks.CheckExistingThunderToProjectMappedEntries(
-            inject={a10constants.VTHUNDER_CONFIG: vthunder_conf},
-            requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG)))
-        lb_create_flow.add(self.vthunder_flows.get_rack_vthunder_for_lb_subflow(
-            vthunder_conf=vthunder_conf,
-            prefix=constants.ROLE_STANDALONE,
-            role=constants.ROLE_STANDALONE))
+        lb_create_flow.add(
+            a10_database_tasks.CheckExistingProjectToThunderMappedEntries(
+                inject={
+                    a10constants.VTHUNDER_CONFIG: vthunder_conf},
+                requires=(
+                    constants.LOADBALANCER,
+                    a10constants.VTHUNDER_CONFIG)))
+        lb_create_flow.add(
+            a10_database_tasks.CheckExistingThunderToProjectMappedEntries(
+                inject={
+                    a10constants.VTHUNDER_CONFIG: vthunder_conf},
+                requires=(
+                    constants.LOADBALANCER,
+                    a10constants.VTHUNDER_CONFIG)))
+        lb_create_flow.add(
+            self.vthunder_flows.get_rack_vthunder_for_lb_subflow(
+                vthunder_conf=vthunder_conf,
+                prefix=constants.ROLE_STANDALONE,
+                role=constants.ROLE_STANDALONE))
         post_amp_prefix = constants.POST_LB_AMP_ASSOCIATION_SUBFLOW
         lb_create_flow.add(
             self.get_post_lb_rack_vthunder_association_flow(
@@ -346,20 +362,29 @@ class LoadBalancerFlows(object):
         return post_create_lb_flow
 
     def handle_vrid_for_loadbalancer_subflow(self):
-        handle_vrid_for_lb_subflow = linear_flow.Flow(a10constants.HANDLE_VRID_LOADBALANCER_SUBFLOW)
+        handle_vrid_for_lb_subflow = linear_flow.Flow(
+            a10constants.HANDLE_VRID_LOADBALANCER_SUBFLOW)
         handle_vrid_for_lb_subflow.add(a10_network_tasks.GetLBResourceSubnet(
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
             provides=constants.SUBNET))
-        handle_vrid_for_lb_subflow.add(a10_database_tasks.GetVRIDForLoadbalancerResource(
-            rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
-            provides=a10constants.VRID_LIST))
-        handle_vrid_for_lb_subflow.add(a10_network_tasks.HandleVRIDFloatingIP(
-            requires=[a10constants.VTHUNDER, a10constants.VRID_LIST, constants.SUBNET],
-            rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
-            provides= a10constants.VRID_LIST))
-        handle_vrid_for_lb_subflow.add(a10_database_tasks.UpdateVRIDForLoadbalancerResource(
-            requires=a10constants.VRID_LIST,
-            rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER}))
+        handle_vrid_for_lb_subflow.add(
+            a10_database_tasks.GetVRIDForLoadbalancerResource(
+                rebind={
+                    a10constants.LB_RESOURCE: constants.LOADBALANCER},
+                provides=a10constants.VRID_LIST))
+        handle_vrid_for_lb_subflow.add(
+            a10_network_tasks.HandleVRIDFloatingIP(
+                requires=[
+                    a10constants.VTHUNDER,
+                    a10constants.VRID_LIST,
+                    constants.SUBNET],
+                rebind={
+                    a10constants.LB_RESOURCE: constants.LOADBALANCER},
+                provides=a10constants.VRID_LIST))
+        handle_vrid_for_lb_subflow.add(
+            a10_database_tasks.UpdateVRIDForLoadbalancerResource(
+                requires=a10constants.VRID_LIST, rebind={
+                    a10constants.LB_RESOURCE: constants.LOADBALANCER}))
         return handle_vrid_for_lb_subflow
 
     def get_delete_lb_vrid_subflow(self):
@@ -368,21 +393,34 @@ class LoadBalancerFlows(object):
         delete_lb_vrid_subflow.add(a10_network_tasks.GetLBResourceSubnet(
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
             provides=constants.SUBNET))
-        delete_lb_vrid_subflow.add(a10_database_tasks.CountLoadbalancersInProjectBySubnet(
-            requires=constants.SUBNET,
-            rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
-            provides=a10constants.LB_COUNT))
-        delete_lb_vrid_subflow.add(a10_database_tasks.CountMembersInProjectBySubnet(
-            requires=constants.SUBNET,
-            rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
-            provides=a10constants.MEMBER_COUNT))
-        delete_lb_vrid_subflow.add(a10_database_tasks.GetVRIDForLoadbalancerResource(
-            rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
-            provides=a10constants.VRID_LIST))
-        delete_lb_vrid_subflow.add(a10_network_tasks.DeleteVRIDPort(
-            requires=[a10constants.VTHUNDER, a10constants.VRID_LIST, constants.SUBNET,
-                      a10constants.LB_COUNT, a10constants.MEMBER_COUNT],
-            provides=(a10constants.VRID, a10constants.DELETE_VRID)))
+        delete_lb_vrid_subflow.add(
+            a10_database_tasks.CountLoadbalancersInProjectBySubnet(
+                requires=constants.SUBNET,
+                rebind={
+                    a10constants.LB_RESOURCE: constants.LOADBALANCER},
+                provides=a10constants.LB_COUNT))
+        delete_lb_vrid_subflow.add(
+            a10_database_tasks.CountMembersInProjectBySubnet(
+                requires=constants.SUBNET,
+                rebind={
+                    a10constants.LB_RESOURCE: constants.LOADBALANCER},
+                provides=a10constants.MEMBER_COUNT))
+        delete_lb_vrid_subflow.add(
+            a10_database_tasks.GetVRIDForLoadbalancerResource(
+                rebind={
+                    a10constants.LB_RESOURCE: constants.LOADBALANCER},
+                provides=a10constants.VRID_LIST))
+        delete_lb_vrid_subflow.add(
+            a10_network_tasks.DeleteVRIDPort(
+                requires=[
+                    a10constants.VTHUNDER,
+                    a10constants.VRID_LIST,
+                    constants.SUBNET,
+                    a10constants.LB_COUNT,
+                    a10constants.MEMBER_COUNT],
+                provides=(
+                    a10constants.VRID,
+                    a10constants.DELETE_VRID)))
         delete_lb_vrid_subflow.add(a10_database_tasks.DeleteVRIDEntry(
             requires=[a10constants.VRID, a10constants.DELETE_VRID]))
 

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -344,15 +344,10 @@ class MemberFlows(object):
                     constants.SUBNET],
                 rebind={
                     a10constants.LB_RESOURCE: constants.MEMBER},
-                provides=(
-                    a10constants.PORT,
-                    a10constants.VRID)))
+                provides=a10constants.VRID_LIST))
         handle_vrid_for_member_subflow.add(
             a10_database_tasks.UpdateVRIDForLoadbalancerResource(
-                requires=[
-                    a10constants.VRID,
-                    a10constants.PORT,
-                    constants.SUBNET],
+                requires=a10constants.VRID_LIST,
                 rebind={
                     a10constants.LB_RESOURCE: constants.MEMBER}))
 

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -730,6 +730,8 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
             else:
                 for vrid in vrid_list:
                     subnet = self.network_driver.get_subnet(vrid.subnet_id)
+                    conf_floating_ip = a10_utils.get_vrid_floating_ip_for_project(
+                               lb_resource.project_id)
                     conf_floating_ip = a10_utils.get_patched_ip_address(
                         conf_floating_ip, subnet.cidr)
                     subnet_ip, subnet_mask = a10_utils.get_net_info_from_cidr(

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 #
-import copy
 import acos_client.errors as acos_errors
+import copy
 from oslo_config import cfg
 from oslo_log import log as logging
 from oslo_utils import uuidutils
@@ -779,8 +779,8 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
                     self.network_driver.delete_port(vrid.vrid_port_id)
                 except Exception as e:
                     LOG.error(
-                        "Failed to delete neutron port for VRID FIP: %s"
-                        , vrid.vrid_floating_ip)
+                        "Failed to delete neutron port for VRID FIP: %s",
+                        vrid.vrid_floating_ip)
                     raise e
                 update_vrid_flag = True
             vrid_list = []
@@ -812,7 +812,10 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
             try:
                 self.network_driver.delete_port(port.id)
             except Exception as e:
-                LOG.error("Failed to delete port %s due to %s", port.id, str(e))
+                LOG.error(
+                    "Failed to delete port %s due to %s",
+                    port.id,
+                    str(e))
 
         # Normalize old vrid entries
         vrid_floating_ip_list = [vrid.vrid_floating_ip for vrid in vrid_list]

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -697,19 +697,22 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
         vrid_value = CONF.a10_global.vrid
         conf_floating_ip = a10_utils.get_vrid_floating_ip_for_project(
             lb_resource.project_id)
-        prev_vrid_value = copy.deepcopy(vrid_list[0].vrid) if vrid_list else None
+        prev_vrid_value = copy.deepcopy(
+            vrid_list[0].vrid) if vrid_list else None
 
         if conf_floating_ip:
             for vr in vrid_list:
                 if vr.subnet_id == subnet.id:
                     break
             else:
-                vrid_list.append(data_models.VRID(id=uuidutils.generate_uuid(),
-                                                  vrid=vrid_value,
-                                                  project_id=lb_resource.project_id,
-                                                  vrid_port_id=None,
-                                                  vrid_floating_ip=None,
-                                                  subnet_id=subnet.id))
+                vrid_list.append(
+                    data_models.VRID(
+                        id=uuidutils.generate_uuid(),
+                        vrid=vrid_value,
+                        project_id=lb_resource.project_id,
+                        vrid_port_id=None,
+                        vrid_floating_ip=None,
+                        subnet_id=subnet.id))
             if conf_floating_ip.lower() == 'dhcp':
                 for vrid in vrid_list:
                     subnet = self.network_driver.get_subnet(vrid.subnet_id)
@@ -719,9 +722,11 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
                     if not a10_utils.check_ip_in_subnet_range(
                             vrid.vrid_floating_ip, subnet_ip, subnet_mask):
                         try:
-                            # delete existing port associated to vrid in question.
+                            # delete existing port associated to vrid in
+                            # question.
                             if vrid.vrid_port_id:
-                                self.network_driver.delete_port(vrid.vrid_port_id)
+                                self.network_driver.delete_port(
+                                    vrid.vrid_port_id)
                             fip_obj = self.network_driver.create_port(
                                 subnet.network_id, subnet.id)
                             self.added_fip_ports.append(fip_obj)
@@ -752,9 +757,11 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
 
                     if conf_floating_ip != vrid.vrid_floating_ip:
                         try:
-                            # delete existing port associated to vrid in question.
+                            # delete existing port associated to vrid in
+                            # question.
                             if vrid.vrid_port_id:
-                                self.network_driver.delete_port(vrid.vrid_port_id)
+                                self.network_driver.delete_port(
+                                    vrid.vrid_port_id)
                             fip_obj = self.network_driver.create_port(
                                 subnet.network_id, subnet.id, fixed_ip=conf_floating_ip)
                             self.added_fip_ports.append(fip_obj)
@@ -774,9 +781,11 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
             vrid_list = []
         if (prev_vrid_value is not None) and (prev_vrid_value != vrid_value):
             self.update_device_vrid_fip(vthunder, [], prev_vrid_value)
-            self.update_device_vrid_fip(vthunder, vrid_floating_ips, vrid_value)
+            self.update_device_vrid_fip(
+                vthunder, vrid_floating_ips, vrid_value)
         elif update_vrid_flag:
-            self.update_device_vrid_fip(vthunder, vrid_floating_ips, vrid_value)
+            self.update_device_vrid_fip(
+                vthunder, vrid_floating_ips, vrid_value)
         return vrid_list
 
     @axapi_client_decorator
@@ -798,15 +807,20 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
             try:
                 self.network_driver.delete_port(port.id)
             except Exception as e:
-                LOG.error("Failed to delete portL %s", port.id)
+                LOG.error("Failed to delete port %s due to %s", port.id, str(e))
 
         # Normalize old vrid entries
         vrid_floating_ip_list = [vrid.vrid_floating_ip for vrid in vrid_list]
         if vrid_floating_ip_list:
             vrid_value = CONF.a10_global.vrid
-            self.update_device_vrid_fip(vthunder, vrid_floating_ip_list, vrid_value)
+            self.update_device_vrid_fip(
+                vthunder, vrid_floating_ip_list, vrid_value)
 
-    def update_device_vrid_fip(self, vthunder, vrid_floating_ip_list, vrid_value):
+    def update_device_vrid_fip(
+            self,
+            vthunder,
+            vrid_floating_ip_list,
+            vrid_value):
         try:
             if not vthunder.partition_name or vthunder.partition_name == 'shared':
                 self.axapi_client.vrrpa.update(
@@ -838,10 +852,13 @@ class DeleteVRIDPort(BaseNetworkTask):
                     self.network_driver.delete_port(vrid.vrid_port_id)
                     self.axapi_client.vrrpa.update(
                         vrid.vrid, floating_ips=vrid_floating_ip_list)
-                    LOG.info("VRID floating IP: %s deleted", vrid.vrid_floating_ip)
+                    LOG.info(
+                        "VRID floating IP: %s deleted",
+                        vrid.vrid_floating_ip)
                     return vrid, True
                 except Exception as e:
-                    LOG.exception("Failed to delete vrid floating ip : %s", str(e))
+                    LOG.exception(
+                        "Failed to delete vrid floating ip : %s", str(e))
                     raise e
         return None, False
 

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -766,7 +766,6 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
             vrid_list = []
         if conf_floating_ip or vrid_history_flag:
             self.update_device_vrid_fip(vthunder, vrid_floating_ips)
-
         return vrid_list
 
     @axapi_client_decorator
@@ -779,10 +778,6 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
             subnet,
             *args,
             **kwargs):
-        if isinstance(result, failure.Failure):
-            LOG.exception(
-                "Unable to allocate & configure VRRP Floating IP Port")
-            return
 
         LOG.warning(
             "Reverting VRRP floating IP delta task for lb_resource %s",

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -326,13 +326,6 @@ class VRIDRepository(BaseRepository):
             vrid_obj_list.append(data.to_data_model())
         return vrid_obj_list
 
-    # def get_vrid_for_subnet(self, session, project_id, subnet_id):
-    #     vrid = session.query(self.model_class).filter(
-    #         and_(self.model_class.project_id == project_id,
-    #              self.model_class.subnet_id == subnet_id)).first()
-    #     if vrid:
-    #         return vrid.to_data_model()
-
 
 class MemberRepository(repo.MemberRepository):
 

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -193,8 +193,6 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
             project_id=a10constants.MOCK_PROJECT_ID
         )
 
-    @mock.patch('a10_octavia.common.utils.get_parent_project',
-                return_value=None)
     def test_update_vrid_for_project_member_with_port_and_with_vrid(self):
         mock_vrid_entry = task.UpdateVRIDForLoadbalancerResource()
         mock_vrid_entry.vrid_repo = mock.Mock()
@@ -204,22 +202,23 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
             mock.ANY,
             VRID.id,
             vrid=VRID.vrid,
-            vrid_floating_ip=PORT.fixed_ips[0].ip_address,
-            vrid_port_id=PORT.id,
-            subnet_id=SUBNET.id)
+            vrid_floating_ip=VRID.vrid_floating_ip,
+            vrid_port_id=VRID.vrid_port_id,
+            subnet_id=VRID.subnet_id)
         mock_vrid_entry.vrid_repo.create.assert_not_called()
 
     def test_update_vrid_for_project_member_with_port_and_no_vrid(self):
         mock_vrid_entry = task.UpdateVRIDForLoadbalancerResource()
         mock_vrid_entry.vrid_repo = mock.Mock()
+        mock_vrid_entry.vrid_repo.exists.return_value = False
         mock_vrid_entry.execute(MEMBER_1, [VRID])
         mock_vrid_entry.vrid_repo.create.assert_called_once_with(
             mock.ANY,
             project_id=MEMBER_1.project_id,
             vrid=VRID.vrid,
-            vrid_floating_ip=PORT.fixed_ips[0].ip_address,
-            vrid_port_id=PORT.id,
-            subnet_id=SUBNET.id)
+            vrid_floating_ip=VRID.vrid_floating_ip,
+            vrid_port_id=VRID.vrid_port_id,
+            subnet_id=VRID.subnet_id)
         mock_vrid_entry.vrid_repo.update.assert_not_called()
 
     def test_delete_vrid_entry_with_vrid(self):

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
@@ -223,8 +223,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         self.network_driver_mock.get_subnet.return_value = subnet
         mock_network_task.execute(VTHUNDER, member, [vrid], subnet)
         self.network_driver_mock.create_port.assert_not_called()
-        self.client_mock.vrrpa.update.assert_called_with(
-            vrid.vrid, floating_ips=[a10constants.MOCK_VRID_FLOATING_IP_1])
+        self.client_mock.vrrpa.update.assert_not_called()
 
     @mock.patch('a10_octavia.common.utils.get_vrid_floating_ip_for_project',
                 return_value=a10constants.MOCK_VRID_FLOATING_IP_2)


### PR DESCRIPTION
## Description
Updated the tasks "HandleVRIDFloatingIP"  and "UpdateVRIDForLoadbalancerResource" in order to handle the multi subnet VRID FIP updates.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1673

## Technical Approach
- Recognized the tasks need to updated in -order to handle the requirement.
- Added changes for adding changes of VRID FIP to VRID fetched from DB
- On the basis of changes from "HandleVRIDFloatingIP" changed "UpdateVRIDForLoadbalancerResource".

## Manual Testing

- Single VRID LB
- Single VRID member (same subnet)
- Muluplr member, same subnet
- SIngle VRID member (differenr subnet)
- Muluplr Member (differenr subnet)
- multiple SLB, same subnet
- multiple SLB, differenr subnet
- Delete LB scenario
- .Delete member scenario
-  
- Muliple LB, change IP static to static, update (octet IP provided)   - redo for member
-  
- Muliple LB, change IP static to DHCP, update    - redo for member
- Muliple LB, chnage IP from DHCP to static     - redo for member
- NO VRID IP configured, create LB
- Remove existing VRID, make an update call
- Change VRID value - 0 to 1
- Change/removal of VRID, create call
-  
- Change VRID value without making any changes in VRID FIP.




