### PR TITLE
[BUG][STACK-1669]: Fixed an issue for creating another LB on a different project under same parent partition

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -308,17 +308,16 @@ class LoadBalancerFlows(object):
                     a10constants.VTHUNDER_CONFIG: vthunder_conf},
                 requires=(
                     constants.LOADBALANCER,
-                    a10constants.VTHUNDER_CONFIG)))
+                    a10constants.VTHUNDER_CONFIG),
+                provides=a10constants.VTHUNDER_CONFIG))
         lb_create_flow.add(
             a10_database_tasks.CheckExistingThunderToProjectMappedEntries(
-                inject={
-                    a10constants.VTHUNDER_CONFIG: vthunder_conf},
                 requires=(
                     constants.LOADBALANCER,
                     a10constants.VTHUNDER_CONFIG)))
         lb_create_flow.add(
             self.vthunder_flows.get_rack_vthunder_for_lb_subflow(
-                vthunder_conf=vthunder_conf,
+                vthunder_conf=a10constants.VTHUNDER_CONFIG,
                 prefix=constants.ROLE_STANDALONE,
                 role=constants.ROLE_STANDALONE))
         post_amp_prefix = constants.POST_LB_AMP_ASSOCIATION_SUBFLOW

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -357,7 +357,6 @@ class VThunderFlows(object):
 
         amp_for_lb_flow.add(a10_database_tasks.CreateRackVthunderEntry(
             name=sf_name + '-' + 'create_rack_vThunder_entry_in_database',
-            inject={a10constants.VTHUNDER_CONFIG: vthunder_conf},
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG)))
         amp_for_lb_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -160,7 +160,7 @@ class CheckExistingThunderToProjectMappedEntries(BaseDatabaseTask):
 
     def execute(self, loadbalancer, vthunder_config):
         hierarchical_mt = vthunder_config.hierarchical_multitenancy
-        if ((hierarchical_mt == 'enable') and (CONF.a10_global.use_parent_partition)):
+        if hierarchical_mt == 'enable' and CONF.a10_global.use_parent_partition:
             return
         vthunder_ids = self.vthunder_repo.get_vthunders_by_ip_address(
             db_apis.get_session(),

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -114,6 +114,23 @@ class CheckExistingProjectToThunderMappedEntries(BaseDatabaseTask):
     """
 
     def execute(self, loadbalancer, vthunder_config):
+        hierarchical_mt = vthunder_config.hierarchical_multitenancy
+        if hierarchical_mt == 'enable':
+            vthunder_config.partition_name = loadbalancer.project_id[:14]
+            if CONF.a10_global.use_parent_partition:
+                parent_project_id = utils.get_parent_project(
+                    vthunder_config.project_id)
+                if parent_project_id:
+                    vthunder_config.partition_name = parent_project_id[:14]
+                else:
+                    LOG.error("The parent project for project %s does not exist. ",
+                              vthunder_config.project_id)
+                    raise exceptions.ParentProjectNotFound(
+                        vthunder_config.project_id)
+            else:
+                LOG.warning("Hierarchical multitenancy is disabled, use_parent_partition "
+                            "configuration will not be applied for loadbalancer: %s",
+                            loadbalancer.id)
         vthunder_ids = self.vthunder_repo.get_vthunders_by_project_id(
             db_apis.get_session(),
             project_id=loadbalancer.project_id)
@@ -132,6 +149,7 @@ class CheckExistingProjectToThunderMappedEntries(BaseDatabaseTask):
                 raise exceptions.ThunderInUseByExistingProjectError(config_ip_addr_partition,
                                                                     existing_ip_addr_partition,
                                                                     loadbalancer.project_id)
+        return vthunder_config
 
 
 class CheckExistingThunderToProjectMappedEntries(BaseDatabaseTask):
@@ -141,6 +159,9 @@ class CheckExistingThunderToProjectMappedEntries(BaseDatabaseTask):
     """
 
     def execute(self, loadbalancer, vthunder_config):
+        hierarchical_mt = vthunder_config.hierarchical_multitenancy
+        if ((hierarchical_mt == 'enable') and (CONF.a10_global.use_parent_partition)):
+            return
         vthunder_ids = self.vthunder_repo.get_vthunders_by_ip_address(
             db_apis.get_session(),
             ip_address=vthunder_config.ip_address)
@@ -260,22 +281,6 @@ class CreateRackVthunderEntry(BaseDatabaseTask):
 
     def execute(self, loadbalancer, vthunder_config):
         hierarchical_mt = vthunder_config.hierarchical_multitenancy
-        if hierarchical_mt == 'enable':
-            vthunder_config.partition_name = loadbalancer.project_id[:14]
-            if CONF.a10_global.use_parent_partition:
-                parent_project_id = utils.get_parent_project(
-                    vthunder_config.project_id)
-                if parent_project_id:
-                    vthunder_config.partition_name = parent_project_id[:14]
-                else:
-                    LOG.error("The parent project for project %s does not exist. ",
-                              vthunder_config.project_id)
-                    raise exceptions.ParentProjectNotFound(
-                        vthunder_config.project_id)
-            else:
-                LOG.warning("Hierarchical multitenancy is disabled, use_parent_partition "
-                            "configuration will not be applied for loadbalancer: %s",
-                            loadbalancer.id)
         try:
             vthunder = self.vthunder_repo.create(db_apis.get_session(),
                                                  vthunder_id=uuidutils.generate_uuid(),

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -129,7 +129,7 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         mock_lb.project_id = a10constants.MOCK_CHILD_PROJECT_ID
         mock_vthunder_config = copy.deepcopy(HW_THUNDER)
         mock_vthunder_config.hierarchical_multitenancy = "enable"
-        mock_create_vthunder = task.CreateRackVthunderEntry()
+        mock_create_vthunder = task.CheckExistingProjectToThunderMappedEntries()
         mock_create_vthunder.vthunder_repo = mock.MagicMock()
         mock_vthunder = copy.deepcopy(VTHUNDER)
         mock_vthunder.partition_name = a10constants.MOCK_CHILD_PART
@@ -167,6 +167,21 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         mock_create_vthunder.vthunder_repo.create.return_value = mock_vthunder
         vthunder = mock_create_vthunder.execute(mock_lb, mock_vthunder_config)
         self.assertEqual(vthunder.partition_name, a10constants.MOCK_CHILD_PART)
+
+    def test_create_rack_vthunder_entry_child_partition_exists(self):
+        self.conf.config(
+            group=a10constants.A10_GLOBAL_CONF_SECTION, use_parent_partition=False)
+        mock_lb = copy.deepcopy(LB)
+        mock_lb.project_id = a10constants.MOCK_CHILD_PROJECT_ID
+        mock_vthunder_config = copy.deepcopy(HW_THUNDER)
+        mock_vthunder_config.hierarchical_multitenancy = "enable"
+        mock_create_vthunder = task.CreateRackVthunderEntry()
+        mock_create_vthunder.vthunder_repo = mock.MagicMock()
+        mock_vthunder = copy.deepcopy(VTHUNDER)
+        mock_vthunder.partition_name = a10constants.MOCK_CHILD_PROJECT_ID[:14]
+        mock_create_vthunder.vthunder_repo.create.return_value = mock_vthunder
+        vthunder = mock_create_vthunder.execute(mock_lb, mock_vthunder_config)
+        self.assertEqual(vthunder.partition_name, a10constants.MOCK_CHILD_PROJECT_ID[:14])
 
     def test_get_vrid_for_project_member(self):
         mock_vrid_entry = task.GetVRIDForLoadbalancerResource()


### PR DESCRIPTION
## Description
- Severity Level: Medium
- Allowing to create another(second) load balancer of a different project(child2_project) under same partition(parent partition) when there is already a load balancer with different project(child1_project) under same partition(parent partition) exists.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1669

## Technical Approach
- Shifted hmt logic from task `CreateRackVthunderEntry` to task  `CheckExistingProjectToThunderMappedEntries` ensuring correct partition_name is stored for vthunder_config.
- Returning the correct `vthunder_config` from `CheckExistingProjectToThunderMappedEntries` and using it in further tasks(`CheckExistingThunderToProjectMappedEntries` and `CreateRackVthunderEntry`) by modifying the flows `get_create_rack_vthunder_load_balancer_flow` and `get_rack_vthunder_for_lb_subflow`

## Test Cases
Test cases resolved by the above changes:
lb1 --->  project_id: child1,  partition: parent
lb2 --->  project_id: child2,  partition: parent -----> OK
lb3 --->  project_id: child2,  partition: parent -----> OK

lb1 --->  project_id: child1,   partition: parent
lb2 --->  project_id: child1,  partition: parent  ---> OK

## Manual Testing
By performing the steps mentioned in the bug https://a10networks.atlassian.net/browse/STACK-1669, getting following results:
loadbalancer lc1 is getting created under parent partition
**loadbalancer lcc1 is getting created under parent partition
loadbalancer lcc2 is getting created under parent partition**
