### PR TITLE
[STACK-1690]: Wrapping up loadbalancer description into quotes.

### DIFF
--- a/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
@@ -37,7 +37,12 @@ class LoadBalancerParent(object):
         arp_disable = CONF.slb.arp_disable
         vrid = CONF.slb.default_virtual_server_vrid
         desc = loadbalancer.description
-        desc = "" if str(desc).isspace() else desc
+        if not desc:
+            desc = None
+        elif str(desc).isspace() or (not str(desc)):
+            desc = ""
+        else:
+            desc = '"{}"'.format(desc)
 
         set_method(
             loadbalancer.id,

--- a/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
@@ -39,7 +39,7 @@ class LoadBalancerParent(object):
         desc = loadbalancer.description
         if not desc:
             desc = None
-        elif str(desc).isspace() or (not str(desc)):
+        elif str(desc).isspace() or not str(desc):
             desc = ""
         else:
             desc = '"{}"'.format(desc)


### PR DESCRIPTION
## Description
- Adding quotes around the loadbalancer description sothat there will be sync between OpenStack side and vThunder side for any description with having leading or trailing spaces to it.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1690

## Technical Approach
- If there is no description parameter provided while creating a loadbalancer, then None will be set as the description and there will not be any description associated with the loadbalancer on both sides.
- If description provided while creating a loadbalancer is "      " or "", then there will not be any description associated with the loadbalancer on both sides.
- Otherwise any other description will get associated exactly same as that of provided while loadbalancer creation, wrapped in quotes(""), on both sides. 

## Manual Testing
Testcases required for this story:

![image](https://user-images.githubusercontent.com/58077446/96104462-815c8500-0ef6-11eb-8dde-3c8e5e05a882.png)

![image](https://user-images.githubusercontent.com/58077446/96104534-96391880-0ef6-11eb-936d-e3e3303a262f.png)
