### PR TITLE
[STACK 1647][STACK-1651] Add replace methods to address template overwrite needs

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -147,7 +147,7 @@ class PoolFlows(object):
             requires=[constants.POOL, a10constants.VTHUNDER, constants.UPDATE_DICT],
             provides=constants.POOL)
         update_pool_flow.add(*self._get_sess_pers_subflow(update_pool))
-        update_pool_flow.add(virtual_port_tasks.ListenerUpdate(
+        update_pool_flow.add(virtual_port_tasks.ListenerUpdateForPool(
             requires=[constants.LOADBALANCER, constants.LISTENER, a10constants.VTHUNDER]))
         update_pool_flow.add(database_tasks.UpdatePoolInDB(
             requires=[constants.POOL, constants.UPDATE_DICT]))

--- a/a10_octavia/controller/worker/tasks/server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/server_tasks.py
@@ -145,9 +145,9 @@ class MemberUpdate(task.Task):
             status = True
 
         try:
-            self.axapi_client.slb.server.update(server_name, member.ip_address, status=status,
-                                                server_templates=server_temp,
-                                                axapi_args=server_args)
+            self.axapi_client.slb.server.replace(server_name, member.ip_address, status=status,
+                                                 server_templates=server_temp,
+                                                 axapi_args=server_args)
             LOG.debug("Successfully updated member: %s", member.id)
         except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception("Failed to update member: %s", member.id)

--- a/a10_octavia/controller/worker/tasks/service_group_tasks.py
+++ b/a10_octavia/controller/worker/tasks/service_group_tasks.py
@@ -125,7 +125,7 @@ class PoolUpdate(PoolParent, task.Task):
     def execute(self, pool, vthunder, update_dict):
         pool.update(update_dict)
         try:
-            self.set(self.axapi_client.slb.service_group.update, pool, vthunder)
+            self.set(self.axapi_client.slb.service_group.replace, pool, vthunder)
             LOG.debug("Successfully updated pool: %s", pool.id)
         except (acos_errors.ACOSException, ConnectionError) as e:
             LOG.exception("Failed to update pool: %s", pool.id)

--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -118,7 +118,8 @@ class ListenersParent(object):
                                                                   device_templates)
             vport_templates[template_key] = template_policy
 
-        set_method(loadbalancer.id, listener.id,
+        set_method(loadbalancer.id,
+                   listener.id,
                    listener.protocol,
                    listener.protocol_port,
                    listener.default_pool_id,
@@ -167,7 +168,7 @@ class ListenerUpdate(ListenersParent, task.Task):
     def execute(self, loadbalancer, listener, vthunder):
         try:
             if listener:
-                self.set(self.axapi_client.slb.virtual_server.vport.update,
+                self.set(self.axapi_client.slb.virtual_server.vport.replace,
                          loadbalancer, listener, vthunder)
                 LOG.debug("Successfully updated listener: %s", listener.id)
         except (acos_errors.ACOSException, ConnectionError) as e:

--- a/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
@@ -93,7 +93,7 @@ class UpdateVirtualServerTask(LoadBalancerParent, task.Task):
     @axapi_client_decorator
     def execute(self, loadbalancer, vthunder):
         try:
-            self.set(self.axapi_client.slb.virtual_server.update, loadbalancer)
+            self.set(self.axapi_client.slb.virtual_server.replace, loadbalancer)
             LOG.debug("Successfully updated load balancer: %s", loadbalancer.id)
         except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception("Failed to update load balancer: %s", loadbalancer.id)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
@@ -197,6 +197,6 @@ class TestHandlerVirtualPortTasks(base.BaseTaskTestCase):
                         return_value=listener.protocol):
             listener_task.execute(LB, listener, VTHUNDER)
 
-        args, kwargs = self.client_mock.slb.virtual_server.vport.update.call_args
+        args, kwargs = self.client_mock.slb.virtual_server.vport.replace.call_args
         self.assertIn('use_rcv_hop', kwargs)
         self.assertFalse(kwargs.get('use_rcv_hop'))

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,10 @@ deps = -r{toxinidir}/requirements.txt
 
 [testenv:pep8]
 commands = flake8
+deps = -r{toxinidir}/requirements.txt
+       -r{toxinidir}/test-requirements.txt
+       sqlalchemy_utils>0.33.0,<=0.34.0
+       pyrsistent>0.15.4,<=0.16.0
 
 [flake8]
 #ignore = E122,E125,E126,E128,E129,E251,E265,E713,F402,F811,F812,H104,H237,H302,H304,H305,H307,H401,H402,H404,H405,H904


### PR DESCRIPTION
## Description
Severity: High

Templates could not be removed during object updates. To address this problem, a replace method has been implemented on the acos-client side for objects affected by the bug.

Not all update tasks require a replace. For example, the UpdateListenerForPool shouldn't strip the templates of the listener just ensure that the pool is associated to the listener.

## Jira Ticket
[STACK-1647](https://a10networks.atlassian.net/browse/STACK-1647)
[STACK-1651](https://a10networks.atlassian.net/browse/STACK-1651)

## Links
[PR 305 in acos-client](https://github.com/a10networks/acos-client/pull/305)


## Technical Approach
- Converted update calls into replace calls for Update taskss
- Added ListenerUpdateForPool to PoolUpdate flow so that listener templates are overwritten during pool update

## Test Cases
N/A

## Manual Testing

### For listener and member

1. Set a template for object in config
2. Create object and confirm template has been associated
3. Comment the template out of the config
4. Update object using set command

Expected result: Template is disassociated from the object

### For pool

#### Test pool doesn't effect listener
1. Set a template for pool in config
2. Set a template for listener in config
2. Create listener and confirm template has been associated
3. Create pool with listener and confirm template has been associated
4. Comment pool template out of the config
5. Comment listener template out of the config
6. Update pool using set command

Expected result: Template is disassociated from the pool, but listener template should remain
