### PR TITLE
[STACK-1693]: [vrid] non-existed vrid will cause lb in pending_create status

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -821,8 +821,12 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
         vrid_floating_ip_list = [vrid.vrid_floating_ip for vrid in vrid_list]
         if vrid_floating_ip_list:
             vrid_value = CONF.a10_global.vrid
-            self.update_device_vrid_fip(
-                vthunder, vrid_floating_ip_list, vrid_value)
+            try:
+                self.update_device_vrid_fip(
+                    vthunder, vrid_floating_ip_list, vrid_value)
+            except Exception as e:
+                LOG.error("Failed to update VRID floating IPs %s due to %s",
+                          vrid_floating_ip_list, str(e))
 
     def update_device_vrid_fip(
             self,


### PR DESCRIPTION
## Description
If VRID not present at vthunder and tried to create LB, LB state going into pending_create state.  

- Severity Level: Medium

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1693

## Technical Approach
- Looked into the error log, checked the stack trace, and recognized the issue.
- Added the changes in revert of HandleVRIDFloatingIP


## Manual Testing
Steps: 
1.  Changed the VRID value to which the channel is not created in vThunder.
2. Created LB, checked the status, and log for error message getting displayed.
