### PR TITLE
[BUG][STACK-1692] : Added activate_partition logic for Blade vThunder.

### DIFF
--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -34,6 +34,7 @@ from a10_octavia.common import a10constants
 from a10_octavia.common import exceptions
 from a10_octavia.common import openstack_mappings
 from a10_octavia.common import utils as a10_utils
+from a10_octavia.controller.worker.tasks.decorators import activate_partition
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
 from a10_octavia.controller.worker.tasks.decorators import device_context_switch_decorator
 
@@ -466,6 +467,8 @@ class TagInterfaceBaseTask(VThunderBaseTask):
             device_obj = vthunder.device_network_map[1]
             client = acos_client.Client(device_obj.mgmt_ip_address, api_ver,
                                         vthunder.username, vthunder.password, timeout=30)
+            if vthunder.partition_name != "shared":
+                activate_partition(client, vthunder.partition_name)
             close_axapi_client = True
         else:
             client = self.axapi_client


### PR DESCRIPTION
## Description

- Severity Level : High
- Only one ve ip is assigned from openstack dashboard port list during hmt logic or any partition specific.

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-1692
seems to be resolving [STACK-1668](https://a10networks.atlassian.net/browse/STACK-1668)

## Technical Approach
- Debugged and found that network create port logic not getting executed because interface information was not getting fetched properly from the concerned partition.

## Config Changes
None

## Test Cases
a) network_type = `vlan`
-  Keep `hierarchical_multitenancy` as `enabled` and `use_parent_partition` as `True` and child project id in config.
- Add vlan_map for device_1 and device_2.
- Create loadbalancer using child project id.
- Check on openstack dashboard > Network (subnet where vlan is created)> Port and observe ve_ips are all there.
 
## Manual Testing

Follow the steps on [STACK-1692](https://a10networks.atlassian.net/browse/STACK-1692)
Here for `vlan 12` taking--> `device_1` has `ve_ip` : `.31` and `device_2` has `ve_ip` : `.32`

![image](https://user-images.githubusercontent.com/52992745/96554913-c7d62900-12d4-11eb-9283-97ae7f2b041d.png)

