### PR TITLE
[STACK-1677] Fixed VRID partial IP behavior

### DIFF
--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -40,7 +40,11 @@ class AllocateTrunkException(base.NetworkException):
 
 
 class VRIDIPNotInSubentRangeError(base.NetworkException):
-    pass
+    def __init__(self, vrid_ip, subnet, subnet_id):
+        msg = ('Invalid VRID floating IP specified. ' +
+               'VRID IP {0} out of range for subnet {1}.'
+        ).format(vrid_ip, subnet, subnet_id)
+        super(VRIDIPNotInSubentRangeError, self).__init__(msg=msg)
 
 
 class MissingVlanIDConfigError(cfg.ConfigFileValueError):

--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -40,10 +40,10 @@ class AllocateTrunkException(base.NetworkException):
 
 
 class VRIDIPNotInSubentRangeError(base.NetworkException):
-    def __init__(self, vrid_ip, subnet, subnet_id):
+    def __init__(self, vrid_ip, subnet):
         msg = ('Invalid VRID floating IP specified. ' +
-               'VRID IP {0} out of range for subnet {1}.'
-        ).format(vrid_ip, subnet, subnet_id)
+               'VRID IP {0} out of range ' +
+               'for subnet {1}.').format(vrid_ip, subnet)
         super(VRIDIPNotInSubentRangeError, self).__init__(msg=msg)
 
 

--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -178,15 +178,43 @@ def get_network_driver():
 
 
 def get_patched_ip_address(ip, cidr):
-    host_ip = ip.lstrip('.')
-    octets = host_ip.split('.')
+    net_ip, netmask = get_net_info_from_cidr(cidr)
+    octets = ip.lstrip('.').split('.')
+
     if len(octets) == 4:
         validate_ipv4(ip)
-        return ip
+        if check_ip_in_subnet_range(ip, net_ip, netmask):
+            return ip
+        else:
+            msg = "Invalid VRID floating IP. IP out of subnet range: "
+            msg += str(host_ip)
+            raise exceptions.VRIDIPNotInSubentRangeError(msg)
+
     for idx in range(4 - len(octets)):
         octets.insert(0, '0')
     host_ip = '.'.join(octets)
-    return merge_host_and_network_ip(cidr, host_ip)
+
+    int_host_ip = struct.unpack('>L', socket.inet_aton(host_ip))[0]
+    int_net_ip = struct.unpack('>L', socket.inet_aton(net_ip))[0]
+    int_netmask = struct.unpack('>L', socket.inet_aton(netmask))[0]
+
+    # Create a set of test bits to find partial netmask octet
+    # ie 1.1.1.1 & 255.255.254.0 -> 1.1.0.0
+    test_bits = (1 << 24 | 1 << 16 | 1 << 8 | 1)
+    test_bits = (int_netmask & test_bits)
+
+    # Then shift 8 bits (1 -> 256) and subtract by 1 in each octet to get 255
+    test_bits = (test_bits << 8) - test_bits
+
+    # Use truncated mask to fill in any missing octets of partial IP
+    canidate_ip = (test_bits & int_net_ip) | int_host_ip
+
+    if (canidate_ip & int_netmask) != int_net_ip:
+        msg = "Invalid VRID floating IP. IP out of subnet range: "
+        msg += str(host_ip)
+        raise exceptions.VRIDIPNotInSubentRangeError(msg)
+
+    return socket.inet_ntoa(struct.pack('>L', canidate_ip))
 
 
 def get_vrid_floating_ip_for_project(project_id):

--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -186,11 +186,9 @@ def get_patched_ip_address(ip, cidr):
         if check_ip_in_subnet_range(ip, net_ip, netmask):
             return ip
         else:
-            msg = "Invalid VRID floating IP. IP out of subnet range: "
-            msg += str(host_ip)
-            raise exceptions.VRIDIPNotInSubentRangeError(msg)
+            raise exceptions.VRIDIPNotInSubentRangeError(ip, cidr)
 
-    for idx in range(4 - len(octets)):
+    for i in range(4 - len(octets)):
         octets.insert(0, '0')
     host_ip = '.'.join(octets)
 
@@ -210,9 +208,7 @@ def get_patched_ip_address(ip, cidr):
     canidate_ip = (test_bits & int_net_ip) | int_host_ip
 
     if (canidate_ip & int_netmask) != int_net_ip:
-        msg = "Invalid VRID floating IP. IP out of subnet range: "
-        msg += str(host_ip)
-        raise exceptions.VRIDIPNotInSubentRangeError(msg)
+        raise exceptions.VRIDIPNotInSubentRangeError(host_ip, cidr)
 
     return socket.inet_ntoa(struct.pack('>L', canidate_ip))
 

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -745,15 +745,7 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
                         lb_resource.project_id)
                     conf_floating_ip = a10_utils.get_patched_ip_address(
                         conf_floating_ip, subnet.cidr)
-                    subnet_ip, subnet_mask = a10_utils.get_net_info_from_cidr(
-                        subnet.cidr)
                     vrid.vrid = vrid_value
-                    if not a10_utils.check_ip_in_subnet_range(
-                            conf_floating_ip, subnet_ip, subnet_mask):
-                        msg = "Invalid VRID floating IP. IP out of subnet range: "
-                        msg += str(conf_floating_ip)
-                        raise exceptions.VRIDIPNotInSubentRangeError(msg)
-
                     if conf_floating_ip != vrid.vrid_floating_ip:
                         try:
                             # delete existing port associated to vrid in

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -29,7 +29,6 @@ from octavia.network import data_models as n_data_models
 
 from a10_octavia.common import a10constants
 from a10_octavia.common import data_models
-from a10_octavia.common import exceptions
 from a10_octavia.common import utils as a10_utils
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
 

--- a/a10_octavia/tests/unit/common/test_utils.py
+++ b/a10_octavia/tests/unit/common/test_utils.py
@@ -262,14 +262,19 @@ class TestUtils(base.BaseTaskTestCase):
         self.assertEqual(utils.get_patched_ip_address('45', '10.10.0.0/24'), '10.10.0.45')
         self.assertEqual(utils.get_patched_ip_address('0.45', '10.10.0.0/24'), '10.10.0.45')
         self.assertEqual(utils.get_patched_ip_address('0.0.45', '10.10.0.0/24'), '10.10.0.45')
-        self.assertEqual(utils.get_patched_ip_address('1.0.0.23', '10.10.0.0/24'), '1.0.0.23')
         self.assertEqual(utils.get_patched_ip_address('.45', '10.10.0.0/24'), '10.10.0.45')
+        self.assertEqual(utils.get_patched_ip_address('11.45', '11.11.11.0/24'), '11.11.11.45')
+        self.assertEqual(utils.get_patched_ip_address('3.45', '11.11.2.0/23'), '11.11.3.45')
+        self.assertEqual(utils.get_patched_ip_address('3.45', '11.11.2.0/22'), '11.11.3.45')
 
     def test_get_patched_ip_address_invalid(self):
-        self.assertRaises(Exception, utils.get_patched_ip_address, 'abc.cef', '10.10.0.0/24')
-        self.assertRaises(Exception, utils.get_patched_ip_address, '11.10.0.11.10', '10.10.0.0/24')
-        self.assertRaises(Exception, utils.get_patched_ip_address, '10.333.11.10', '10.10.0.0/24')
-        self.assertRaises(Exception, utils.get_patched_ip_address, '1e.3d.4f.1o', '10.10.0.0/24')
+        vrid_exc = exceptions.VRIDIPNotInSubentRangeError
+        cfg_err = cfg.ConfigFileValueError
+        self.assertRaises(vrid_exc, utils.get_patched_ip_address, 'abc.cef', '10.10.0.0/24')
+        self.assertRaises(vrid_exc, utils.get_patched_ip_address, '.0.11.10', '10.10.0.0/24')
+        self.assertRaises(vrid_exc, utils.get_patched_ip_address, '1.0.0.23', '10.10.0.0/24')
+        self.assertRaises(cfg_err, utils.get_patched_ip_address, '10.333.11.10', '10.10.0.0/24')
+        self.assertRaises(cfg_err, utils.get_patched_ip_address, '1e.3d.4f.1o', '10.10.0.0/24')
 
     def test_get_vrid_floating_ip_for_project_with_only_local_config(self):
         vthunder = copy.deepcopy(VTHUNDER_1)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
@@ -27,7 +27,6 @@ from octavia.network import data_models as o_net_data_models
 
 from a10_octavia.common import config_options
 from a10_octavia.common import data_models
-from a10_octavia.common import exceptions
 from a10_octavia.controller.worker.tasks import a10_network_tasks
 from a10_octavia.tests.common import a10constants
 from a10_octavia.tests.unit import base

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
@@ -382,34 +382,6 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         self.network_driver_mock.delete_port.assert_called_with(
             a10constants.MOCK_VRRP_PORT_ID)
 
-    @mock.patch(
-        'a10_octavia.common.utils.check_ip_in_subnet_range',
-        return_value=False)
-    @mock.patch('a10_octavia.common.utils.get_vrid_floating_ip_for_project',
-                return_value=a10constants.MOCK_VRID_FLOATING_IP_1)
-    @mock.patch('a10_octavia.common.utils.get_patched_ip_address',
-                return_value=a10constants.MOCK_VRID_FLOATING_IP_1)
-    def test_HandleVRIDFloatingIP_raise_VRIDIPNotInSubentRangeError_conf_fip_out_of_range(
-            self, mock_patched_ip, mock_get_floating_ip, check_subnet):
-        vrid = copy.deepcopy(VRID_1)
-        vrid.vrid_floating_ip = a10constants.MOCK_VRID_FLOATING_IP_1
-        vrid.vrid = VRID_VALUE
-        vrid.vrid_port_id = a10constants.MOCK_VRRP_PORT_ID
-        member = copy.deepcopy(MEMBER)
-        member.subnet_id = a10constants.MOCK_SUBNET_ID
-        subnet = copy.deepcopy(SUBNET_1)
-        subnet.cidr = a10constants.MOCK_SUBNET_CIDR
-        mock_network_task = a10_network_tasks.HandleVRIDFloatingIP()
-        mock_network_task.axapi_client = self.client_mock
-        self.network_driver_mock.get_subnet.return_value = subnet
-        self.assertRaises(
-            exceptions.VRIDIPNotInSubentRangeError,
-            mock_network_task.execute,
-            VTHUNDER,
-            member,
-            [vrid],
-            subnet)
-
     @mock.patch('a10_octavia.common.utils.get_vrid_floating_ip_for_project',
                 return_value=a10constants.MOCK_VRID_PARTIAL_FLOATING_IP)
     def test_HandleVRIDFloatingIP_creating_floating_ip_conf_fip_is_partial(


### PR DESCRIPTION
## Description
Severity Level: High

1. When a VRID was specified with a partial IP of 0.0.25.105 and added to a subnet of 10.11.12.0/24 no error was thrown.
2. Only the /24 CIDR form was working as the last octet would always be fully replaced.
     - ie specifying `3.45` for subnet `10.0.2.0/23` would result in `10.0.2.45` instead of `10.0.3.45`

This PR only fixed the issue for VRID. The issue is also present in VE IP; however, it was not pursued in this PR due to heavy refactor occurring in VE IP branch.

## Jira Ticket
[STACK-1677](https://a10networks.atlassian.net/browse/STACK-1677)

## Technical Approach
- If a full static IP is specified for the VRID then we simply check that it is a valid IPv4 address and then check that it is in subnet range.

- If a partial IP address is provided then the following occurs:

1. The partial IP has it's missing octets filled in with 0's

2. A set of 4 test bits are created within a 32 bit integer in the 24, 16, 8, and 0 positions (equivalent to the IP 1.1.1.1)

3. This test set is AND'd with the netmask to discover which part of the netmask has a partial mask
         - Ex: `1.1.1.1 & 255.255.254.0`  equals `1.1.0.0`

4. The resulting set of bits are shifted over by 8
        - Ex: `1.1.0.0 << 8 ` equals `1.0.0.0` 

5. Now that we've overflowed everything by 1 bit we simply subtract 1 from each subnet
       - Ex: `1.0.0.0 - 1.1.1.1` equals `255.255.0.0`

6. Next we use this partial mask to extract only the full blocks of the subnet
      - Ex:  `10.11.2.0 & 255.255.0.0` equals `10.11.0.0`

7. Then we use this and the partial IP to produce the full desired IP
      - Ex: `0.0.3.25 | 10.11.0.0` equals `10.11.3.25`


8. Finally, check this desired IP against the netmask
      - Ex: `10.11.3.25 & 255.255.254.0` equals `10.11.2.0` so it's valid
 
## Config Changes
N/A

## Test Cases
- Added the assertion that `3.45` is valid for `11.11.2.0/23`
- Added the assertion that `3.45` is valid for `11.11.2.0/22`
- Moved the assertion of `1.0.0.23` under subnet `10.10.0.0/24` to the invalid section
- Added the assertion that `.0.11.10` is invalid under subnet `10.10.0.0/24`
- Modify test cases to handle exact exceptions instead of just generic `Exception`

## Manual Testing
Config used for testing:

```
[a10_controller_worker]
network_driver = a10_octavia_neutron_driver

[hardware_thunder]
devices = [
                    {
                     "project_id": "2fac86b7d3144f92861ffc2d23e65ccc",
                     "device_name": "device1",
                     "ip_address": "10.0.0.189",
                     "username": "admin",
                     "password": "a10",
                     "interface_vlan_map": {
                         "device_1": {
                             "vcs_device_id": 2,
                             "mgmt_ip_address": "10.0.0.88",
                             "ethernet_interfaces": [{
                                 "interface_num": 1,
                                 "vlan_map": [
                                     {"vlan_id": 11, "ve_ip": ".6"}
                                 ]},
                                 {
                                 "interface_num": 2,
                                 "vlan_map": [
                                     {"vlan_id": 12, "ve_ip": ".5"}
                                 ]
                             }]
                          },
                          "device_2": {
                             "vcs_device_id": 1,
                             "mgmt_ip_address": "10.0.0.83",
                             "ethernet_interfaces": [{
                                 "interface_num": 1,
                                 "vlan_map": [
                                     {"vlan_id": 11, "ve_ip": ".6"}
                                 ]},
                                 {
                                 "interface_num": 2,
                                 "vlan_map": [
                                     {"vlan_id": 12, "ve_ip": ".5"}
                                 ]
                             }]
                          }
                        }
                     }
             ]
```

### Pre-Reqs
- 2 vThunders or Thunders in an HA pair with VRRPA and VCS running
- 2 openstack networks (Example uses 10.0.11.0/24 and 10.0.12.0/24)

### Out of Range Failure Case

#### Add the following to config and restart service
```
[a10_global]
vrid_floating_ip = 11.25
```

**This assumes a network of 10.0.12.0/24 is being used**

#### Create a load balancer on a subnet out of range of the IP

```
openstack loadbalancer create --vip-subnet-id provider-vlan-12-subnet --name test_vip --project project_a
```

#### Expected Outcome

The following error should be raised: `a10_octavia.common.exceptions.VRIDIPNotInSubentRangeError`

### IP Completion Success Case

#### Add the following to config and restart service
```
[a10_global]
vrid_floating_ip = 12.25
```

**This assumes a network of 10.0.12.0/24 is being used**

#### Create a load balancer on a subnet out of range of the IP

```
openstack loadbalancer create --vip-subnet-id provider-vlan-12-subnet --name test_vip --project project_a
```

#### Expected Outcome
```
vrrp-a vrid 0
  floating-ip 10.0.12.25
```

Should be present in the show run of both devices