### PR TITLE
[BUG][STACK-1687][STACK-1691]: Fixed LB component creation and deletion when HMT settings enabled.

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -104,7 +104,8 @@ class CreateVThunderEntry(BaseDatabaseTask):
                 db_apis.get_session(), loadbalancer_id=loadbalancer.id)
         except NoResultFound:
             LOG.error(
-                "Failed to delete vThunder entry for load balancer: %s", loadbalancer.id)
+                "Failed to delete vThunder entry for load balancer: %s",
+                loadbalancer.id)
 
 
 class CheckExistingProjectToThunderMappedEntries(BaseDatabaseTask):
@@ -123,14 +124,16 @@ class CheckExistingProjectToThunderMappedEntries(BaseDatabaseTask):
                 if parent_project_id:
                     vthunder_config.partition_name = parent_project_id[:14]
                 else:
-                    LOG.error("The parent project for project %s does not exist. ",
-                              vthunder_config.project_id)
+                    LOG.error(
+                        "The parent project for project %s does not exist. ",
+                        vthunder_config.project_id)
                     raise exceptions.ParentProjectNotFound(
                         vthunder_config.project_id)
             else:
-                LOG.warning("Hierarchical multitenancy is disabled, use_parent_partition "
-                            "configuration will not be applied for loadbalancer: %s",
-                            loadbalancer.id)
+                LOG.warning(
+                    "Hierarchical multitenancy is disabled, use_parent_partition "
+                    "configuration will not be applied for loadbalancer: %s",
+                    loadbalancer.id)
         vthunder_ids = self.vthunder_repo.get_vthunders_by_project_id(
             db_apis.get_session(),
             project_id=loadbalancer.project_id)
@@ -141,14 +144,13 @@ class CheckExistingProjectToThunderMappedEntries(BaseDatabaseTask):
                 id=vthunder_id)
             if vthunder is None:
                 return
-            existing_ip_addr_partition = '{}:{}'.format(vthunder.ip_address,
-                                                        vthunder.partition_name)
-            config_ip_addr_partition = '{}:{}'.format(vthunder_config.ip_address,
-                                                      vthunder_config.partition_name)
+            existing_ip_addr_partition = '{}:{}'.format(
+                vthunder.ip_address, vthunder.partition_name)
+            config_ip_addr_partition = '{}:{}'.format(
+                vthunder_config.ip_address, vthunder_config.partition_name)
             if existing_ip_addr_partition != config_ip_addr_partition:
-                raise exceptions.ThunderInUseByExistingProjectError(config_ip_addr_partition,
-                                                                    existing_ip_addr_partition,
-                                                                    loadbalancer.project_id)
+                raise exceptions.ThunderInUseByExistingProjectError(
+                    config_ip_addr_partition, existing_ip_addr_partition, loadbalancer.project_id)
         return vthunder_config
 
 
@@ -173,15 +175,14 @@ class CheckExistingThunderToProjectMappedEntries(BaseDatabaseTask):
             if vthunder is None:
                 return
 
-            existing_ip_addr_partition = '{}:{}'.format(vthunder.ip_address,
-                                                        vthunder.partition_name)
-            config_ip_addr_partition = '{}:{}'.format(vthunder_config.ip_address,
-                                                      vthunder_config.partition_name)
+            existing_ip_addr_partition = '{}:{}'.format(
+                vthunder.ip_address, vthunder.partition_name)
+            config_ip_addr_partition = '{}:{}'.format(
+                vthunder_config.ip_address, vthunder_config.partition_name)
             if existing_ip_addr_partition == config_ip_addr_partition:
                 if vthunder.project_id != loadbalancer.project_id:
-                    raise exceptions.ProjectInUseByExistingThunderError(config_ip_addr_partition,
-                                                                        vthunder.project_id,
-                                                                        loadbalancer.project_id)
+                    raise exceptions.ProjectInUseByExistingThunderError(
+                        config_ip_addr_partition, vthunder.project_id, loadbalancer.project_id)
 
 
 class DeleteVThunderEntry(BaseDatabaseTask):
@@ -236,8 +237,11 @@ class GetComputeForProject(BaseDatabaseTask):
         if vthunder is None:
             vthunder = self.vthunder_repo.get_spare_vthunder(
                 db_apis.get_session())
-            self.vthunder_repo.update(db_apis.get_session(), vthunder.id,
-                                      status="USED_SPARE", updated_at=datetime.utcnow())
+            self.vthunder_repo.update(
+                db_apis.get_session(),
+                vthunder.id,
+                status="USED_SPARE",
+                updated_at=datetime.utcnow())
         amphora_id = vthunder.amphora_id
         self.amphora_repo.get(db_apis.get_session(), id=amphora_id)
         compute_id = vthunder.compute_id
@@ -282,29 +286,31 @@ class CreateRackVthunderEntry(BaseDatabaseTask):
     def execute(self, loadbalancer, vthunder_config):
         hierarchical_mt = vthunder_config.hierarchical_multitenancy
         try:
-            vthunder = self.vthunder_repo.create(db_apis.get_session(),
-                                                 vthunder_id=uuidutils.generate_uuid(),
-                                                 device_name=vthunder_config.device_name,
-                                                 username=vthunder_config.username,
-                                                 password=vthunder_config.password,
-                                                 ip_address=vthunder_config.ip_address,
-                                                 undercloud=vthunder_config.undercloud,
-                                                 loadbalancer_id=loadbalancer.id,
-                                                 project_id=vthunder_config.project_id,
-                                                 axapi_version=vthunder_config.axapi_version,
-                                                 topology="STANDALONE",
-                                                 role="MASTER",
-                                                 status="ACTIVE",
-                                                 last_udp_update=datetime.utcnow(),
-                                                 created_at=datetime.utcnow(),
-                                                 updated_at=datetime.utcnow(),
-                                                 partition_name=vthunder_config.partition_name,
-                                                 hierarchical_multitenancy=hierarchical_mt)
+            vthunder = self.vthunder_repo.create(
+                db_apis.get_session(),
+                vthunder_id=uuidutils.generate_uuid(),
+                device_name=vthunder_config.device_name,
+                username=vthunder_config.username,
+                password=vthunder_config.password,
+                ip_address=vthunder_config.ip_address,
+                undercloud=vthunder_config.undercloud,
+                loadbalancer_id=loadbalancer.id,
+                project_id=vthunder_config.project_id,
+                axapi_version=vthunder_config.axapi_version,
+                topology="STANDALONE",
+                role="MASTER",
+                status="ACTIVE",
+                last_udp_update=datetime.utcnow(),
+                created_at=datetime.utcnow(),
+                updated_at=datetime.utcnow(),
+                partition_name=vthunder_config.partition_name,
+                hierarchical_multitenancy=hierarchical_mt)
             LOG.info("Successfully created vthunder entry in database.")
             return vthunder
         except Exception as e:
-            LOG.error('Failed to create vThunder entry in db for load balancer: %s.',
-                      loadbalancer.id)
+            LOG.error(
+                'Failed to create vThunder entry in db for load balancer: %s.',
+                loadbalancer.id)
             raise e
 
     def revert(self, result, loadbalancer, vthunder_config, *args, **kwargs):
@@ -313,12 +319,16 @@ class CreateRackVthunderEntry(BaseDatabaseTask):
             # revert
             return
 
-        LOG.warning('Reverting create Rack VThunder in DB for load balancer: %s', loadbalancer.id)
+        LOG.warning(
+            'Reverting create Rack VThunder in DB for load balancer: %s',
+            loadbalancer.id)
         try:
             self.vthunder_repo.delete(
                 db_apis.get_session(), loadbalancer_id=loadbalancer.id)
         except Exception:
-            LOG.error("Failed to delete vThunder entry for load balancer: %s", loadbalancer.id)
+            LOG.error(
+                "Failed to delete vThunder entry for load balancer: %s",
+                loadbalancer.id)
 
 
 class CreateVThunderHealthEntry(BaseDatabaseTask):
@@ -345,9 +355,11 @@ class MarkVThunderStatusInDB(BaseDatabaseTask):
     def execute(self, vthunder, status):
         try:
             if vthunder:
-                self.vthunder_repo.update(db_apis.get_session(),
-                                          vthunder.id,
-                                          status=status, updated_at=datetime.utcnow())
+                self.vthunder_repo.update(
+                    db_apis.get_session(),
+                    vthunder.id,
+                    status=status,
+                    updated_at=datetime.utcnow())
         except (sqlalchemy.orm.exc.NoResultFound,
                 sqlalchemy.orm.exc.UnmappedInstanceError):
             LOG.debug('No existing amphora health record to mark busy '
@@ -387,7 +399,8 @@ class GetVRIDForLoadbalancerResource(BaseDatabaseTask):
         try:
             project_id = lb_resource.project_id
             vthunder_conf = CONF.hardware_thunder.devices[project_id]
-            if vthunder_conf.hierarchical_multitenancy == 'enable' and CONF.a10_global.use_parent_partition:
+            if (vthunder_conf.hierarchical_multitenancy == 'enable' and
+                    CONF.a10_global.use_parent_partition):
                 partition_name = self.vthunder_repo.get_partition_for_project(
                     db_apis.get_session(), project_id=project_id)
                 project_ids = self.vthunder_repo.get_project_list_using_partition(
@@ -399,8 +412,10 @@ class GetVRIDForLoadbalancerResource(BaseDatabaseTask):
                 db_apis.get_session(), project_ids=project_ids)
             return vrid_list
         except Exception as e:
-            LOG.exception("Failed to get VRID list for given project  %s due to %s",
-                          lb_resource.project_id, str(e))
+            LOG.exception(
+                "Failed to get VRID list for given project  %s due to %s",
+                lb_resource.project_id,
+                str(e))
             raise e
 
 
@@ -415,8 +430,10 @@ class UpdateVRIDForLoadbalancerResource(BaseDatabaseTask):
                 LOG.debug("Successfully deleted DB vrid from project %s",
                           lb_resource.project_id)
             except Exception as e:
-                LOG.error("Failed to delete VRID data for project %s due to %s",
-                          lb_resource.project_id, str(e))
+                LOG.error(
+                    "Failed to delete VRID data for project %s due to %s",
+                    lb_resource.project_id,
+                    str(e))
                 raise e
             return
         for vrid in vrid_list:
@@ -429,24 +446,31 @@ class UpdateVRIDForLoadbalancerResource(BaseDatabaseTask):
                         vrid_port_id=vrid.vrid_port_id,
                         vrid=vrid.vrid,
                         subnet_id=vrid.subnet_id)
-                    LOG.debug("Successfully updated DB vrid %s entry for loadbalancer resource %s",
-                              vrid.id, lb_resource.id)
+                    LOG.debug(
+                        "Successfully updated DB vrid %s entry for loadbalancer resource %s",
+                        vrid.id,
+                        lb_resource.id)
                 except Exception as e:
-                    LOG.error("Failed to update VRID data for VRID FIP %s due to %s",
-                              vrid.vrid_floating_ip, str(e))
+                    LOG.error(
+                        "Failed to update VRID data for VRID FIP %s due to %s",
+                        vrid.vrid_floating_ip,
+                        str(e))
                     raise e
 
             else:
                 try:
-                    self.vrid_repo.create(db_apis.get_session(),
-                                          project_id=vrid.project_id,
-                                          vrid_floating_ip=vrid.vrid_floating_ip,
-                                          vrid_port_id=vrid.vrid_port_id,
-                                          vrid=vrid.vrid,
-                                          subnet_id=vrid.subnet_id)
+                    self.vrid_repo.create(
+                        db_apis.get_session(),
+                        project_id=vrid.project_id,
+                        vrid_floating_ip=vrid.vrid_floating_ip,
+                        vrid_port_id=vrid.vrid_port_id,
+                        vrid=vrid.vrid,
+                        subnet_id=vrid.subnet_id)
                 except Exception as e:
-                    LOG.error("Failed to create VRID data for VRID FIP %s due to %s",
-                              vrid.vrid_floating_ip, str(e))
+                    LOG.error(
+                        "Failed to create VRID data for VRID FIP %s due to %s",
+                        vrid.vrid_floating_ip,
+                        str(e))
                     raise e
 
 
@@ -455,7 +479,8 @@ class CountLoadbalancersInProjectBySubnet(BaseDatabaseTask):
         try:
             project_id = lb_resource.project_id
             vthunder_conf = CONF.hardware_thunder.devices[project_id]
-            if vthunder_conf.hierarchical_multitenancy == 'enable' and CONF.a10_global.use_parent_partition:
+            if (vthunder_conf.hierarchical_multitenancy == 'enable' and
+                    CONF.a10_global.use_parent_partition):
                 partition_name = self.vthunder_repo.get_partition_for_project(
                     db_apis.get_session(), project_id=project_id)
                 project_ids = self.vthunder_repo.get_project_list_using_partition(
@@ -477,7 +502,8 @@ class CountMembersInProjectBySubnet(BaseDatabaseTask):
         try:
             project_id = lb_resource.project_id
             vthunder_conf = CONF.hardware_thunder.devices[project_id]
-            if vthunder_conf.hierarchical_multitenancy == 'enable' and CONF.a10_global.use_parent_partition:
+            if (vthunder_conf.hierarchical_multitenancy == 'enable' and
+                    CONF.a10_global.use_parent_partition):
                 partition_name = self.vthunder_repo.get_partition_for_project(
                     db_apis.get_session(), project_id=project_id)
                 project_ids = self.vthunder_repo.get_project_list_using_partition(
@@ -509,8 +535,9 @@ class DeleteMultiVRIDEntry(BaseDatabaseTask):
     def execute(self, vrid_list):
         if vrid_list:
             try:
-                self.vrid_repo.delete_batch(db_apis.get_session(),
-                                            ids=[vrid.id for vrid in vrid_list])
+                self.vrid_repo.delete_batch(
+                    db_apis.get_session(), ids=[
+                        vrid.id for vrid in vrid_list])
             except Exception as e:
                 LOG.exception(
                     "Failed to delete VRID entry from vrid table: %s", str(e))
@@ -529,13 +556,15 @@ class CheckVLANCanBeDeletedParent(object):
         lbs = db_apis.get_session().query(self.loadbalancer_repo.model_class).filter(
             self.loadbalancer_repo.model_class.project_id == project_id).all()
         for lb in lbs:
-            vips = db_apis.get_session().query(self.vip_repo.model_class).filter(
+            vips = db_apis.get_session().query(
+                self.vip_repo.model_class).filter(
                 self.vip_repo.model_class.load_balancer_id == lb.id).all()
             for vip in vips:
                 if vip.subnet_id == subnet_id:
                     subnet_usage_count += 1
 
-        members = db_apis.get_session().query(self.member_repo.model_class).filter(
+        members = db_apis.get_session().query(
+            self.member_repo.model_class).filter(
             self.member_repo.model_class.project_id == project_id).all()
         for member in members:
             if member.subnet_id == subnet_id:
@@ -558,11 +587,14 @@ class CheckVipVLANCanBeDeleted(CheckVLANCanBeDeletedParent, BaseDatabaseTask):
                                       True)
 
 
-class CheckMemberVLANCanBeDeleted(CheckVLANCanBeDeletedParent, BaseDatabaseTask):
+class CheckMemberVLANCanBeDeleted(
+        CheckVLANCanBeDeletedParent,
+        BaseDatabaseTask):
     default_provides = a10constants.DELETE_VLAN
 
     def execute(self, member):
-        return self.is_vlan_deletable(member.project_id, member.subnet_id, False)
+        return self.is_vlan_deletable(
+            member.project_id, member.subnet_id, False)
 
 
 class MarkLBAndListenerActiveInDB(BaseDatabaseTask):
@@ -611,7 +643,9 @@ class CountMembersWithIP(BaseDatabaseTask):
             return self.member_repo.get_member_count_by_ip_address(
                 db_apis.get_session(), member.ip_address, member.project_id)
         except Exception as e:
-            LOG.exception("Failed to get count of members with given IP for a pool: %s", str(e))
+            LOG.exception(
+                "Failed to get count of members with given IP for a pool: %s",
+                str(e))
             raise e
 
 
@@ -634,7 +668,9 @@ class PoolCountforIP(BaseDatabaseTask):
             return self.member_repo.get_pool_count_by_ip(
                 db_apis.get_session(), member.ip_address, member.project_id)
         except Exception as e:
-            LOG.exception("Failed to get pool count with same IP address: %s", str(e))
+            LOG.exception(
+                "Failed to get pool count with same IP address: %s",
+                str(e))
             raise e
 
 

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -385,8 +385,17 @@ class GetVRIDForLoadbalancerResource(BaseDatabaseTask):
 
     def execute(self, lb_resource):
         project_id = lb_resource.project_id
-        vrid_list = self.vrid_repo.get_vrid_from_project_id(
-            db_apis.get_session(), project_id=project_id)
+        vthunder_conf = CONF.hardware_thunder.devices[project_id]
+        if vthunder_conf.hierarchical_multitenancy and CONF.a10_global.use_parent_partition:
+            partition_name = self.vthunder_repo.get_partition_for_project(
+                db_apis.get_session(), project_id=project_id)
+            project_ids = self.vthunder_repo.get_project_list_using_partition(
+                db_apis.get_session(), partition_name=partition_name)
+
+        else:
+            project_ids = [project_id]
+        vrid_list = self.vrid_repo.get_vrid_from_project_ids(
+            db_apis.get_session(), project_ids=project_ids)
         return vrid_list
 
 

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -313,9 +313,9 @@ class VThunderRepository(BaseRepository):
 
 class LoadBalancerRepository(repo.LoadBalancerRepository):
 
-    def get_lb_count_by_subnet(self, session, project_id, subnet_id):
+    def get_lb_count_by_subnet(self, session, project_ids, subnet_id):
         return session.query(self.model_class).join(base_models.Vip).filter(
-            and_(self.model_class.project_id == project_id,
+            and_(self.model_class.project_id.in_(project_ids),
                  base_models.Vip.subnet_id == subnet_id,
                  or_(self.model_class.provisioning_status == consts.PENDING_DELETE,
                      self.model_class.provisioning_status == consts.ACTIVE))).count()
@@ -346,9 +346,9 @@ class MemberRepository(repo.MemberRepository):
                      self.model_class.provisioning_status == consts.ACTIVE))).count()
         return count
 
-    def get_member_count_by_subnet(self, session, project_id, subnet_id):
+    def get_member_count_by_subnet(self, session, project_ids, subnet_id):
         return session.query(self.model_class).filter(
-            and_(self.model_class.project_id == project_id,
+            and_(self.model_class.project_id.in_(project_ids),
                  self.model_class.subnet_id == subnet_id,
                  or_(self.model_class.provisioning_status == consts.PENDING_DELETE,
                      self.model_class.provisioning_status == consts.ACTIVE))).count()

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -302,6 +302,14 @@ class VThunderRepository(BaseRepository):
         id_list = [model.id for model in model_list]
         return id_list
 
+    def get_partition_for_project(self, session, project_id):
+        return session.query(self.model_class).filter(
+            self.model_class.project_id == project_id).first().partition_name
+
+    def get_project_list_using_partition(self, session, partition_name):
+        return [col_project[0] for col_project in session.query(self.model_class).filter(
+            self.model_class.partition_name == partition_name).values('project_id')]
+
 
 class LoadBalancerRepository(repo.LoadBalancerRepository):
 
@@ -318,12 +326,14 @@ class VRIDRepository(BaseRepository):
 
     # A project can have multiple VRIDs, so need to convert each vrid object through
     # "to_data_model"
-    def get_vrid_from_project_id(self, session, project_id):
+    def get_vrid_from_project_ids(self, session, project_ids):
         vrid_obj_list = []
+
         model = session.query(self.model_class).filter(
-            self.model_class.project_id == project_id)
+            self.model_class.project_id.in_(project_ids))
         for data in model:
             vrid_obj_list.append(data.to_data_model())
+
         return vrid_obj_list
 
 

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -186,7 +186,7 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
     def test_get_vrid_for_project_member(self):
         mock_vrid_entry = task.GetVRIDForLoadbalancerResource()
         mock_vrid_entry.vrid_repo = mock.Mock()
-        mock_vrid_entry.vrid_repo.get_vrid_from_project_id.return_value = VRID
+        mock_vrid_entry.vrid_repo.get_vrid_from_project_ids.return_value = VRID
         vrid = mock_vrid_entry.execute(MEMBER_1)
         self.assertEqual(VRID, vrid)
 

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -94,7 +94,8 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
 
     def test_get_vthunder_by_loadbalancer(self):
         self.conf.config(
-            group=a10constants.A10_GLOBAL_CONF_SECTION, use_parent_partition=True)
+            group=a10constants.A10_GLOBAL_CONF_SECTION,
+            use_parent_partition=True)
         mock_get_vthunder = task.GetVThunderByLoadBalancer()
         mock_get_vthunder.vthunder_repo = mock.MagicMock()
         mock_get_vthunder.vthunder_repo.get_vthunder_from_lb.return_value = None
@@ -103,10 +104,11 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
 
     @mock.patch('a10_octavia.common.utils.get_parent_project',
                 return_value=a10constants.MOCK_PARENT_PROJECT_ID)
-    def test_create_rack_vthunder_entry_parent_partition_exists(self,
-                                                                mock_parent_project_id):
+    def test_create_rack_vthunder_entry_parent_partition_exists(
+            self, mock_parent_project_id):
         self.conf.config(
-            group=a10constants.A10_GLOBAL_CONF_SECTION, use_parent_partition=True)
+            group=a10constants.A10_GLOBAL_CONF_SECTION,
+            use_parent_partition=True)
         mock_lb = copy.deepcopy(LB)
         mock_lb.project_id = a10constants.MOCK_CHILD_PROJECT_ID
         mock_vthunder_config = copy.deepcopy(HW_THUNDER)
@@ -117,14 +119,16 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         mock_vthunder.partition_name = a10constants.MOCK_PARENT_PROJECT_ID[:14]
         mock_create_vthunder.vthunder_repo.create.return_value = mock_vthunder
         vthunder = mock_create_vthunder.execute(mock_lb, mock_vthunder_config)
-        self.assertEqual(vthunder.partition_name, a10constants.MOCK_PARENT_PROJECT_ID[:14])
+        self.assertEqual(vthunder.partition_name,
+                         a10constants.MOCK_PARENT_PROJECT_ID[:14])
 
     @mock.patch('a10_octavia.common.utils.get_parent_project',
                 return_value=None)
-    def test_create_rack_vthunder_entry_parent_partition_not_exists(self,
-                                                                    mock_parent_project_id):
+    def test_create_rack_vthunder_entry_parent_partition_not_exists(
+            self, mock_parent_project_id):
         self.conf.config(
-            group=a10constants.A10_GLOBAL_CONF_SECTION, use_parent_partition=True)
+            group=a10constants.A10_GLOBAL_CONF_SECTION,
+            use_parent_partition=True)
         mock_lb = copy.deepcopy(LB)
         mock_lb.project_id = a10constants.MOCK_CHILD_PROJECT_ID
         mock_vthunder_config = copy.deepcopy(HW_THUNDER)
@@ -153,9 +157,11 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         vthunder = mock_create_vthunder.execute(mock_lb, mock_vthunder_config)
         self.assertEqual(vthunder.partition_name, a10constants.MOCK_CHILD_PART)
 
-    def test_create_rack_vthunder_entry_parent_partition_hmt_no_use_parent_partition(self):
+    def test_create_rack_vthunder_entry_parent_partition_hmt_no_use_parent_partition(
+            self):
         self.conf.config(
-            group=a10constants.A10_GLOBAL_CONF_SECTION, use_parent_partition=False)
+            group=a10constants.A10_GLOBAL_CONF_SECTION,
+            use_parent_partition=False)
         mock_lb = copy.deepcopy(LB)
         mock_lb.project_id = a10constants.MOCK_CHILD_PROJECT_ID
         mock_vthunder_config = copy.deepcopy(HW_THUNDER)
@@ -170,7 +176,8 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
 
     def test_create_rack_vthunder_entry_child_partition_exists(self):
         self.conf.config(
-            group=a10constants.A10_GLOBAL_CONF_SECTION, use_parent_partition=False)
+            group=a10constants.A10_GLOBAL_CONF_SECTION,
+            use_parent_partition=False)
         mock_lb = copy.deepcopy(LB)
         mock_lb.project_id = a10constants.MOCK_CHILD_PROJECT_ID
         mock_vthunder_config = copy.deepcopy(HW_THUNDER)
@@ -181,13 +188,54 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         mock_vthunder.partition_name = a10constants.MOCK_CHILD_PROJECT_ID[:14]
         mock_create_vthunder.vthunder_repo.create.return_value = mock_vthunder
         vthunder = mock_create_vthunder.execute(mock_lb, mock_vthunder_config)
-        self.assertEqual(vthunder.partition_name, a10constants.MOCK_CHILD_PROJECT_ID[:14])
+        self.assertEqual(vthunder.partition_name,
+                         a10constants.MOCK_CHILD_PROJECT_ID[:14])
 
-    def test_get_vrid_for_project_member(self):
+    def test_get_vrid_for_project_member_hmt_use_partition(self):
+        thunder = copy.deepcopy(HW_THUNDER)
+        thunder.hierarchical_multitenancy = 'enable'
+        thunder.vrid_floating_ip = VRID.vrid_floating_ip
+        hardware_device_conf = self._generate_hardware_device_conf(thunder)
+        self.conf.config(group=a10constants.HARDWARE_THUNDER_CONF_SECTION,
+                         devices=[hardware_device_conf])
+        self.conf.config(
+            group=a10constants.A10_GLOBAL_CONF_SECTION,
+            use_parent_partition=True)
+        self.conf.conf.hardware_thunder.devices = {
+            a10constants.MOCK_PROJECT_ID: thunder}
+
         mock_vrid_entry = task.GetVRIDForLoadbalancerResource()
+        mock_vrid_entry.CONF = self.conf
+
         mock_vrid_entry.vrid_repo = mock.Mock()
+        mock_vrid_entry.vthunder_repo = mock.Mock()
         mock_vrid_entry.vrid_repo.get_vrid_from_project_ids.return_value = VRID
         vrid = mock_vrid_entry.execute(MEMBER_1)
+        mock_vrid_entry.vthunder_repo.get_partition_for_project.assert_called_once_with(
+            mock.ANY, project_id=a10constants.MOCK_PROJECT_ID)
+        self.assertEqual(VRID, vrid)
+
+    def test_get_vrid_for_project(self):
+        thunder = copy.deepcopy(HW_THUNDER)
+        thunder.hierarchical_multitenancy = 'disable'
+        thunder.vrid_floating_ip = VRID.vrid_floating_ip
+        hardware_device_conf = self._generate_hardware_device_conf(thunder)
+        self.conf.config(group=a10constants.HARDWARE_THUNDER_CONF_SECTION,
+                         devices=[hardware_device_conf])
+        self.conf.config(
+            group=a10constants.A10_GLOBAL_CONF_SECTION,
+            use_parent_partition=False)
+        self.conf.conf.hardware_thunder.devices = {
+            a10constants.MOCK_PROJECT_ID: thunder}
+
+        mock_vrid_entry = task.GetVRIDForLoadbalancerResource()
+        mock_vrid_entry.CONF = self.conf
+
+        mock_vrid_entry.vrid_repo = mock.Mock()
+        mock_vrid_entry.vthunder_repo = mock.Mock()
+        mock_vrid_entry.vrid_repo.get_vrid_from_project_ids.return_value = VRID
+        vrid = mock_vrid_entry.execute(MEMBER_1)
+        mock_vrid_entry.vthunder_repo.get_partition_for_project.assert_not_called()
         self.assertEqual(VRID, vrid)
 
     def test_update_vrid_for_project_member_delete_vrid(self):


### PR DESCRIPTION
## Description
- Severity Level: Medium
- Required:
STACK-1687: 
1. Admin has 2 child projects cadmin and ccadmin,  Set project as ccadmin, with HMT enabled and use parent partition 
2. Create lb “lcc1”, it will be created in admin project partition with VRID FIP as expected. 
3. Change project to cadmin, created LB "lc1" an equivalent virtual server is created but VRID FIP is not created

STACK-1691:
From STACK-1687 bug, when created LB i.e, "lc1" is deleted it removes the VRID FIP associated to subnet used to create LB "lcc1"

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1687
https://a10networks.atlassian.net/browse/STACK-1691

## Technical Approach
- Analysed the a10-octavia config file to understand the HMT and use the parent partition settings.
- Updated "GetVRIDForLoadbalancerResource" as below, 
     IF HMT is "enabled" and use parent is activated
          GET VRID list by partition
     ELSE:
          GET VRID list by provided LB component project 
- Updated "CountLoadbalancersInProjectBySubnet" and "CountMembersInProjectBySubnet" as "GetVRIDForLoadbalancerResource"

## Test Cases
- GetVRIDForLoadbalancerResource - HMT enabled and use parent partition setting ON.
- GetVRIDForLoadbalancerResource-  HMT disabled and use parent partition setting OFF.

## Manual Testing
Pre-testing settings:

1. Admin project "admin" with 2 children project as "ccadmin" and "cadmin"
2. HMT settings enabled, use parent partition ON

Testing Creation of LB:
1. Created LB "lcc1" in project "ccadmin", equivalent virtual server is created in parent partition on vThunder. VRID FIP also created for specified subnet.
2. Created LB "lc1" in project "cadmin", equivalent virtual server is created in parent partition on vThunder. VRID FIP also getting created for another subnet.
3. Created LB "lc2" in project 'cadmin', all equivalent components getting created on vThunder.

Testing Deletion of LB:
1. Deleted LB "lcc1", virtual server and VRID FIP also removed from vThunder.
2. Deleted LB "lc1",  virtual server deleted,  VRID FIP remained in vThunder.
3. Deleted LB "lc2", virtual server and VRID FIP removed from Thunder.


**[NOTE]: Some changes shown are related to formatting, changes are in DB tasks "CountLoadbalancersInProjectBySubnet", "CountMembersInProjectBySubnet",  "GetVRIDForLoadbalancerResource".**