### PR TITLE
[DO NOT MERGE][STACK-1702] Added null checking for tasks in delete flow of lb and members

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -399,6 +399,7 @@ class GetVRIDForLoadbalancerResource(BaseDatabaseTask):
         try:
             project_id = lb_resource.project_id
             vthunder_conf = CONF.hardware_thunder.devices.get(project_id)
+            project_ids = []
             if vthunder_conf:
                 if (vthunder_conf.hierarchical_multitenancy == 'enable' and
                         CONF.a10_global.use_parent_partition):
@@ -407,15 +408,16 @@ class GetVRIDForLoadbalancerResource(BaseDatabaseTask):
                     project_ids = self.vthunder_repo.get_project_list_using_partition(
                         db_apis.get_session(), partition_name=partition_name)
 
-                else:
-                    project_ids = [project_id]
-                vrid_list = self.vrid_repo.get_vrid_from_project_ids(
-                    db_apis.get_session(), project_ids=project_ids)
-                return vrid_list
+            else:
+                project_ids = [project_id]
+
+            vrid_list = self.vrid_repo.get_vrid_from_project_ids(
+                db_apis.get_session(), project_ids=project_ids)
+            return vrid_list
         except Exception as e:
             LOG.exception("Failed to get VRID list for given project  %s due to %s",
-                lb_resource.project_id,
-                str(e))
+                          lb_resource.project_id,
+                          str(e))
             raise e
 
 
@@ -482,12 +484,11 @@ class CountLoadbalancersInProjectBySubnet(BaseDatabaseTask):
             project_ids = []
             if vthunder_conf:
                 if (vthunder_conf.hierarchical_multitenancy == 'enable' and
-                    CONF.a10_global.use_parent_partition):
+                        CONF.a10_global.use_parent_partition):
                     partition_name = self.vthunder_repo.get_partition_for_project(
                         db_apis.get_session(), project_id=project_id)
-                    if partition_name:
-                        project_ids = self.vthunder_repo.get_project_list_using_partition(
-                            db_apis.get_session(), partition_name=partition_name)
+                    project_ids = self.vthunder_repo.get_project_list_using_partition(
+                        db_apis.get_session(), partition_name=partition_name)
             else:
                 project_ids = [project_id]
 
@@ -496,7 +497,7 @@ class CountLoadbalancersInProjectBySubnet(BaseDatabaseTask):
                 project_ids=project_ids, subnet_id=subnet.id)
         except Exception as e:
             LOG.exception("Failed to get LB count for subnet %s due to %s ",
-                subnet.id, str(e))
+                          subnet.id, str(e))
             raise e
 
 
@@ -511,17 +512,16 @@ class CountMembersInProjectBySubnet(BaseDatabaseTask):
                         CONF.a10_global.use_parent_partition):
                     partition_name = self.vthunder_repo.get_partition_for_project(
                         db_apis.get_session(), project_id=project_id)
-                    if partition_name:
-                        project_ids = self.vthunder_repo.get_project_list_using_partition(
-                            db_apis.get_session(), partition_name=partition_name)
+                    project_ids = self.vthunder_repo.get_project_list_using_partition(
+                        db_apis.get_session(), partition_name=partition_name)
             else:
                 project_ids = [project_id]
             return self.member_repo.get_member_count_by_subnet(
-                    db_apis.get_session(),
-                    project_ids=project_ids, subnet_id=subnet.id)
+                db_apis.get_session(),
+                project_ids=project_ids, subnet_id=subnet.id)
         except Exception as e:
             LOG.exception("Failed to get LB member count for subnet %s due to %s",
-                subnet.id, str(e))
+                          subnet.id, str(e))
             raise e
 
 

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -401,7 +401,7 @@ class GetVRIDForLoadbalancerResource(BaseDatabaseTask):
             vthunder_conf = CONF.hardware_thunder.devices.get(project_id)
             project_ids = []
             if (vthunder_conf and vthunder_conf.hierarchical_multitenancy == 'enable' and
-                CONF.a10_global.use_parent_partition):
+                    CONF.a10_global.use_parent_partition):
                 partition_name = self.vthunder_repo.get_partition_for_project(
                     db_apis.get_session(), project_id=project_id)
                 project_ids = self.vthunder_repo.get_project_list_using_partition(
@@ -482,7 +482,7 @@ class CountLoadbalancersInProjectBySubnet(BaseDatabaseTask):
             vthunder_conf = CONF.hardware_thunder.devices.get(project_id)
             project_ids = []
             if (vthunder_conf and vthunder_conf.hierarchical_multitenancy == 'enable' and
-                CONF.a10_global.use_parent_partition):
+                    CONF.a10_global.use_parent_partition):
                 partition_name = self.vthunder_repo.get_partition_for_project(
                     db_apis.get_session(), project_id=project_id)
                 project_ids = self.vthunder_repo.get_project_list_using_partition(
@@ -506,7 +506,7 @@ class CountMembersInProjectBySubnet(BaseDatabaseTask):
             vthunder_conf = CONF.hardware_thunder.devices.get(project_id)
             project_ids = []
             if (vthunder_conf and vthunder_conf.hierarchical_multitenancy == 'enable' and
-                CONF.a10_global.use_parent_partition):
+                    CONF.a10_global.use_parent_partition):
                 partition_name = self.vthunder_repo.get_partition_for_project(
                     db_apis.get_session(), project_id=project_id)
                 project_ids = self.vthunder_repo.get_project_list_using_partition(

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -400,13 +400,12 @@ class GetVRIDForLoadbalancerResource(BaseDatabaseTask):
             project_id = lb_resource.project_id
             vthunder_conf = CONF.hardware_thunder.devices.get(project_id)
             project_ids = []
-            if vthunder_conf:
-                if (vthunder_conf.hierarchical_multitenancy == 'enable' and
-                        CONF.a10_global.use_parent_partition):
-                    partition_name = self.vthunder_repo.get_partition_for_project(
-                        db_apis.get_session(), project_id=project_id)
-                    project_ids = self.vthunder_repo.get_project_list_using_partition(
-                        db_apis.get_session(), partition_name=partition_name)
+            if (vthunder_conf and vthunder_conf.hierarchical_multitenancy == 'enable' and
+                CONF.a10_global.use_parent_partition):
+                partition_name = self.vthunder_repo.get_partition_for_project(
+                    db_apis.get_session(), project_id=project_id)
+                project_ids = self.vthunder_repo.get_project_list_using_partition(
+                    db_apis.get_session(), partition_name=partition_name)
 
             else:
                 project_ids = [project_id]
@@ -482,13 +481,12 @@ class CountLoadbalancersInProjectBySubnet(BaseDatabaseTask):
             project_id = lb_resource.project_id
             vthunder_conf = CONF.hardware_thunder.devices.get(project_id)
             project_ids = []
-            if vthunder_conf:
-                if (vthunder_conf.hierarchical_multitenancy == 'enable' and
-                        CONF.a10_global.use_parent_partition):
-                    partition_name = self.vthunder_repo.get_partition_for_project(
-                        db_apis.get_session(), project_id=project_id)
-                    project_ids = self.vthunder_repo.get_project_list_using_partition(
-                        db_apis.get_session(), partition_name=partition_name)
+            if (vthunder_conf and vthunder_conf.hierarchical_multitenancy == 'enable' and
+                CONF.a10_global.use_parent_partition):
+                partition_name = self.vthunder_repo.get_partition_for_project(
+                    db_apis.get_session(), project_id=project_id)
+                project_ids = self.vthunder_repo.get_project_list_using_partition(
+                    db_apis.get_session(), partition_name=partition_name)
             else:
                 project_ids = [project_id]
 
@@ -507,13 +505,12 @@ class CountMembersInProjectBySubnet(BaseDatabaseTask):
             project_id = lb_resource.project_id
             vthunder_conf = CONF.hardware_thunder.devices.get(project_id)
             project_ids = []
-            if vthunder_conf:
-                if (vthunder_conf.hierarchical_multitenancy == 'enable' and
-                        CONF.a10_global.use_parent_partition):
-                    partition_name = self.vthunder_repo.get_partition_for_project(
-                        db_apis.get_session(), project_id=project_id)
-                    project_ids = self.vthunder_repo.get_project_list_using_partition(
-                        db_apis.get_session(), partition_name=partition_name)
+            if (vthunder_conf and vthunder_conf.hierarchical_multitenancy == 'enable' and
+                CONF.a10_global.use_parent_partition):
+                partition_name = self.vthunder_repo.get_partition_for_project(
+                    db_apis.get_session(), project_id=project_id)
+                project_ids = self.vthunder_repo.get_project_list_using_partition(
+                    db_apis.get_session(), partition_name=partition_name)
             else:
                 project_ids = [project_id]
             return self.member_repo.get_member_count_by_subnet(

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -843,18 +843,13 @@ class DeleteVRIDPort(BaseNetworkTask):
     def execute(self, vthunder, vrid_list, subnet, lb_count, member_count):
         vrid = None
         vrid_floating_ip_list = []
-        if not lb_count:
-            lb_count = 0
-        if not member_count:
-            member_count = 0
         resource_count = lb_count + member_count
         if resource_count <= 1:
-            if vrid_list:
-                for vr in vrid_list:
-                    if vr.subnet_id == subnet.id:
-                        vrid = vr
-                    else:
-                        vrid_floating_ip_list.append(vr.vrid_floating_ip)
+            for vr in vrid_list:
+                if vr.subnet_id == subnet.id:
+                    vrid = vr
+                else:
+                    vrid_floating_ip_list.append(vr.vrid_floating_ip)
             if vrid:
                 try:
                     self.network_driver.delete_port(vrid.vrid_port_id)

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -843,13 +843,18 @@ class DeleteVRIDPort(BaseNetworkTask):
     def execute(self, vthunder, vrid_list, subnet, lb_count, member_count):
         vrid = None
         vrid_floating_ip_list = []
+        if not lb_count:
+            lb_count = 0
+        if not member_count:
+            member_count = 0
         resource_count = lb_count + member_count
         if resource_count <= 1:
-            for vr in vrid_list:
-                if vr.subnet_id == subnet.id:
-                    vrid = vr
-                else:
-                    vrid_floating_ip_list.append(vr.vrid_floating_ip)
+            if vrid_list:
+                for vr in vrid_list:
+                    if vr.subnet_id == subnet.id:
+                        vrid = vr
+                    else:
+                        vrid_floating_ip_list.append(vr.vrid_floating_ip)
             if vrid:
                 try:
                     self.network_driver.delete_port(vrid.vrid_port_id)

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -376,7 +376,7 @@ class MemberRepository(repo.MemberRepository):
             self.model_class.project_id == project_id).filter(
             and_(self.model_class.ip_address == ip_address,
                  or_(self.model_class.provisioning_status == consts.PENDING_DELETE,
-                     self.model_class.provisioning_status == consts.ACTIVE))).count() 
+                     self.model_class.provisioning_status == consts.ACTIVE))).count()
 
     def get_pool_count_subnet(self, session, project_id, subnet_id):
         return session.query(self.model_class.pool_id.distinct()).filter(

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -303,8 +303,9 @@ class VThunderRepository(BaseRepository):
         return id_list
 
     def get_partition_for_project(self, session, project_id):
-        return session.query(self.model_class).filter(
-            self.model_class.project_id == project_id).first().partition_name
+        query = session.query(self.model_class).filter(
+            self.model_class.project_id == project_id).first()
+        return query.partition_name if query else None
 
     def get_project_list_using_partition(self, session, partition_name):
         return [col_project[0] for col_project in session.query(self.model_class).filter(


### PR DESCRIPTION
## Description

- Severity Level :**Critical**
- Required: Deleting Error'ed LB was introduced because of recent changes in flows. Handled null checks in all tasks in delete flow of LB and Member.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1702

## Technical Approach
- Added None checks for `vthunder_conf` in db tasks - `GetVRIDForLoadbalancerResource`, `CountLoadbalancersInProjectBySubnet`, `CountMembersInProjectBySubnet` 
- Added None check for `get_partition_for_project` to fetch `partition_name` only when query is not `None`

## Config Changes
None

## Test Cases
During `hmt` and `upp` enabled : 
a) Deleting Error'ed LB
b) Deleting Error'ed Member

Expected : Both above should get deleted properly.

## Manual Testing
- Detailed LB test scenario is mentioned in [STACK-1702](https://a10networks.atlassian.net/browse/STACK-1702) description. 
