### PR TITLE
[STACK-1703][STACK-1699] Replace methods cause overwrite of connected objects

### DIFF
--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -59,7 +59,7 @@ class CreateAndAssociateHealthMonitor(task.Task):
 
         try:
             self.axapi_client.slb.service_group.update(health_mon.pool_id,
-                                                       health_monitor=health_mon.id,
+                                                       hm_name=health_mon.id,
                                                        health_check_disable=0)
             LOG.debug("Successfully associated health monitor %s to pool %s",
                       health_mon.id, health_mon.pool_id)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_service_group_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_service_group_tasks.py
@@ -174,6 +174,8 @@ class TestHandlerServiceGroupTasks(BaseTaskTestCase):
             protocol=mock.ANY,
             lb_method=mock_pool.axapi_client.slb.service_group.SOURCE_IP_HASH_ONLY,
             service_group_templates=mock.ANY,
+            hm_name=None,
+            mem_list=None,
             axapi_args=AXAPI_ARGS)
 
     def test_create_pool_with_protocol_proxy(self):


### PR DESCRIPTION
## Description

Severity: Critical

When using the `set` command to update an object, a replace method is called which uses the PUT operation to send a payload. The object on the device is fully overwritten by the contents of this payload, so if the reference objects aren't included then they are removed.

Ex: Virtual server vs1 has a listener l1. When a replace is called without l1 in the port list, then l1 is disassociated from vs1.

## Jira Ticket
[STACK-1699](https://a10networks.atlassian.net/browse/STACK-1699)
[STACK-1703](https://a10networks.atlassian.net/browse/STACK-1703)

## Links
[PR#206 of acos-client](https://github.com/a10networks/acos-client/pull/306)

## Technical Approach
To fix the issue, a GET call is used to access the contents of the object from which the reference objects are extracted. These objects are then added to the payload as-is so that they aren't removed from the object being updated.

## Config Changes
N/A

## Test Cases
N/A: There isn't any testable logic here everything surrounding this is on the device side.

## Manual Testing

Requirements:
- 1 vThunder or Thunder device
- 2 openstack networks

#### Test virtual server doesn't replace its listener


Setup:
```
openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name test_vip --project project_a

openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name test_listener test_vip
```

Test:
```
openstack loadbalancer set test_vip
```

Expected Behavior: virtual port stays attached to the virtual server on the device

#### Test listener doesn't replace its pool

Setup:
```
openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name test_vip --project project_a

openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name test_listener test_vip

openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener test_listener --name test_pool
```

Test:
```
openstack loadbalancer pool set test_listener
```

Expected Behavior: service group stays attached to the virtual port on the device

#### Test pool doesn't replace its members

Setup:
```
openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name test_vip --project project_a

openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name test_listener test_vip

openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener test_listener --name test_pool

openstack loadbalancer member create --address 10.0.112.5 --subnet-id provider-vlan-12-subnet --protocol 80 --name test_mem_1 test_pool

openstack loadbalancer member create --address 10.0.112.6 --subnet-id provider-vlan-12-subnet --protocol 80 --name test_mem_2 test_pool
```

Test:
```
openstack loadbalancer pool set test_pool
```

Expected Behavior: members stay attached to the service group on the device

#### Test pool doesn't replace its health monitor

Setup:
```
openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name test_vip --project project_a

openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name test_listener test_vip

openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener test_listener --name test_pool

openstack loadbalancer healthmonitor create --delay 10 --max-retries 4 --timeout 5 --type HTTP --url-path / --name test_hm test_pooll
```

Test:
```
openstack loadbalancer pool set test_pool
```

Expected Behavior: Health monitor stays attached to the service group on the device