### PR TITLE
[BUG][STACK-1691]: [vrid_floating_ip] different subnet vrid_floating_ip is deleted wrongly

### DIFF
--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -119,3 +119,5 @@ WRITE_MEM_FOR_LOCAL_PARTITION = 'write_memory_for_local_partition'
 
 MEMBER_LIST = 'member_list'
 SUBNET_LIST = 'subnet_list'
+
+PARTITION_PROJECT_LIST = 'partition_project_list'

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -367,9 +367,13 @@ class LoadBalancerFlows(object):
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
             provides=constants.SUBNET))
         handle_vrid_for_lb_subflow.add(
+            a10_database_tasks.GetProjectsForPartition(
+                rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
+                provides=a10constants.PARTITION_PROJECT_LIST
+            ))
+        handle_vrid_for_lb_subflow.add(
             a10_database_tasks.GetVRIDForLoadbalancerResource(
-                rebind={
-                    a10constants.LB_RESOURCE: constants.LOADBALANCER},
+                requires=a10constants.PARTITION_PROJECT_LIST,
                 provides=a10constants.VRID_LIST))
         handle_vrid_for_lb_subflow.add(
             a10_network_tasks.HandleVRIDFloatingIP(
@@ -393,21 +397,21 @@ class LoadBalancerFlows(object):
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
             provides=constants.SUBNET))
         delete_lb_vrid_subflow.add(
+            a10_database_tasks.GetProjectsForPartition(
+                rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
+                provides=a10constants.PARTITION_PROJECT_LIST
+            ))
+        delete_lb_vrid_subflow.add(
             a10_database_tasks.CountLoadbalancersInProjectBySubnet(
-                requires=constants.SUBNET,
-                rebind={
-                    a10constants.LB_RESOURCE: constants.LOADBALANCER},
+                requires=[constants.SUBNET, a10constants.PARTITION_PROJECT_LIST],
                 provides=a10constants.LB_COUNT))
         delete_lb_vrid_subflow.add(
             a10_database_tasks.CountMembersInProjectBySubnet(
-                requires=constants.SUBNET,
-                rebind={
-                    a10constants.LB_RESOURCE: constants.LOADBALANCER},
+                requires=[constants.SUBNET, a10constants.PARTITION_PROJECT_LIST],
                 provides=a10constants.MEMBER_COUNT))
         delete_lb_vrid_subflow.add(
             a10_database_tasks.GetVRIDForLoadbalancerResource(
-                rebind={
-                    a10constants.LB_RESOURCE: constants.LOADBALANCER},
+                requires=a10constants.PARTITION_PROJECT_LIST,
                 provides=a10constants.VRID_LIST))
         delete_lb_vrid_subflow.add(
             a10_network_tasks.DeleteVRIDPort(

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -367,7 +367,7 @@ class LoadBalancerFlows(object):
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
             provides=constants.SUBNET))
         handle_vrid_for_lb_subflow.add(
-            a10_database_tasks.GetProjectsForPartition(
+            a10_database_tasks.GetChildProjectsOfParentPartition(
                 rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
                 provides=a10constants.PARTITION_PROJECT_LIST
             ))
@@ -397,7 +397,7 @@ class LoadBalancerFlows(object):
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
             provides=constants.SUBNET))
         delete_lb_vrid_subflow.add(
-            a10_database_tasks.GetProjectsForPartition(
+            a10_database_tasks.GetChildProjectsOfParentPartition(
                 rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
                 provides=a10constants.PARTITION_PROJECT_LIST
             ))

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -269,21 +269,21 @@ class MemberFlows(object):
             rebind={a10constants.LB_RESOURCE: constants.MEMBER},
             provides=constants.SUBNET))
         delete_member_vrid_subflow.add(
+            a10_database_tasks.GetProjectsForPartition(
+                rebind={a10constants.LB_RESOURCE: constants.MEMBER},
+                provides=a10constants.PARTITION_PROJECT_LIST
+            ))
+        delete_member_vrid_subflow.add(
             a10_database_tasks.CountLoadbalancersInProjectBySubnet(
-                requires=constants.SUBNET,
-                rebind={
-                    a10constants.LB_RESOURCE: constants.MEMBER},
+                requires=[constants.SUBNET, a10constants.PARTITION_PROJECT_LIST],
                 provides=a10constants.LB_COUNT))
         delete_member_vrid_subflow.add(
             a10_database_tasks.CountMembersInProjectBySubnet(
-                requires=constants.SUBNET,
-                rebind={
-                    a10constants.LB_RESOURCE: constants.MEMBER},
+                requires=[constants.SUBNET, a10constants.PARTITION_PROJECT_LIST],
                 provides=a10constants.MEMBER_COUNT))
         delete_member_vrid_subflow.add(
             a10_database_tasks.GetVRIDForLoadbalancerResource(
-                rebind={
-                    a10constants.LB_RESOURCE: constants.MEMBER},
+                requires=a10constants.PARTITION_PROJECT_LIST,
                 provides=a10constants.VRID_LIST))
         delete_member_vrid_subflow.add(
             a10_network_tasks.DeleteVRIDPort(
@@ -304,13 +304,17 @@ class MemberFlows(object):
         delete_member_vrid_subflow = linear_flow.Flow(
             a10constants.DELETE_MEMBER_VRID_INTERNAL_SUBFLOW)
         delete_member_vrid_subflow.add(
+            a10_database_tasks.GetProjectsForPartition(
+                rebind={a10constants.LB_RESOURCE: constants.POOL},
+                provides=a10constants.PARTITION_PROJECT_LIST
+            ))
+        delete_member_vrid_subflow.add(
             a10_database_tasks.GetSubnetForDeletionInPool(
-                requires=a10constants.MEMBER_LIST,
+                requires=[a10constants.MEMBER_LIST, a10constants.PARTITION_PROJECT_LIST],
                 provides=a10constants.SUBNET_LIST))
         delete_member_vrid_subflow.add(
             a10_database_tasks.GetVRIDForLoadbalancerResource(
-                rebind={
-                    a10constants.LB_RESOURCE: constants.POOL},
+                requires=a10constants.PARTITION_PROJECT_LIST,
                 provides=a10constants.VRID_LIST))
         delete_member_vrid_subflow.add(
             a10_network_tasks.DeleteMultipleVRIDPort(
@@ -332,9 +336,13 @@ class MemberFlows(object):
                     a10constants.LB_RESOURCE: constants.MEMBER},
                 provides=constants.SUBNET))
         handle_vrid_for_member_subflow.add(
+            a10_database_tasks.GetProjectsForPartition(
+                rebind={a10constants.LB_RESOURCE: constants.MEMBER},
+                provides=a10constants.PARTITION_PROJECT_LIST
+            ))
+        handle_vrid_for_member_subflow.add(
             a10_database_tasks.GetVRIDForLoadbalancerResource(
-                rebind={
-                    a10constants.LB_RESOURCE: constants.MEMBER},
+                requires=a10constants.PARTITION_PROJECT_LIST,
                 provides=a10constants.VRID_LIST))
         handle_vrid_for_member_subflow.add(
             a10_network_tasks.HandleVRIDFloatingIP(

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -269,7 +269,7 @@ class MemberFlows(object):
             rebind={a10constants.LB_RESOURCE: constants.MEMBER},
             provides=constants.SUBNET))
         delete_member_vrid_subflow.add(
-            a10_database_tasks.GetProjectsForPartition(
+            a10_database_tasks.GetChildProjectsOfParentPartition(
                 rebind={a10constants.LB_RESOURCE: constants.MEMBER},
                 provides=a10constants.PARTITION_PROJECT_LIST
             ))
@@ -304,7 +304,7 @@ class MemberFlows(object):
         delete_member_vrid_subflow = linear_flow.Flow(
             a10constants.DELETE_MEMBER_VRID_INTERNAL_SUBFLOW)
         delete_member_vrid_subflow.add(
-            a10_database_tasks.GetProjectsForPartition(
+            a10_database_tasks.GetChildProjectsOfParentPartition(
                 rebind={a10constants.LB_RESOURCE: constants.POOL},
                 provides=a10constants.PARTITION_PROJECT_LIST
             ))
@@ -336,7 +336,7 @@ class MemberFlows(object):
                     a10constants.LB_RESOURCE: constants.MEMBER},
                 provides=constants.SUBNET))
         handle_vrid_for_member_subflow.add(
-            a10_database_tasks.GetProjectsForPartition(
+            a10_database_tasks.GetChildProjectsOfParentPartition(
                 rebind={a10constants.LB_RESOURCE: constants.MEMBER},
                 provides=a10constants.PARTITION_PROJECT_LIST
             ))

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -651,27 +651,14 @@ class GetSubnetForDeletionInPool(BaseDatabaseTask):
             raise e
 
 
-class GetProjectsForPartition(BaseDatabaseTask):
-    """
-    On the basis of whether multi-tenancy settings are enabled with use parent partition,
-    the list of projects using partition will be returned.
-    """
+class GetChildProjectsOfParentPartition(BaseDatabaseTask):
     def execute(self, lb_resource):
         try:
-            l2_project = []
             project_id = lb_resource.project_id
             partition_name = self.vthunder_repo.get_partition_for_project(
                 db_apis.get_session(), project_id=project_id)
-            if not partition_name:
-                # There is a case when error occured while creating LB causes vthunder
-                # entry to be removed, hence need to fetch partition name using parent project id
-                parent_project_id = utils.get_parent_project(project_id)
-                if parent_project_id:
-                    partition_name = parent_project_id[:14]
-                l2_project.append(project_id)
             partition_project_list = self.vthunder_repo.get_project_list_using_partition(
                 db_apis.get_session(), partition_name=partition_name)
-            partition_project_list.extend(l2_project)
             return partition_project_list
         except Exception as e:
             LOG.exception(

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -21,7 +21,6 @@ from oslo_config import cfg
 from oslo_log import log as logging
 from oslo_utils import uuidutils
 from taskflow import task
-from taskflow.types import failure
 
 from octavia.common import constants
 from octavia.db import api as db_apis
@@ -312,23 +311,6 @@ class CreateRackVthunderEntry(BaseDatabaseTask):
                 'Failed to create vThunder entry in db for load balancer: %s.',
                 loadbalancer.id)
             raise e
-
-    def revert(self, result, loadbalancer, vthunder_config, *args, **kwargs):
-        if isinstance(result, failure.Failure):
-            # This task's execute failed, so nothing needed to be done to
-            # revert
-            return
-
-        LOG.warning(
-            'Reverting create Rack VThunder in DB for load balancer: %s',
-            loadbalancer.id)
-        try:
-            self.vthunder_repo.delete(
-                db_apis.get_session(), loadbalancer_id=loadbalancer.id)
-        except Exception:
-            LOG.error(
-                "Failed to delete vThunder entry for load balancer: %s",
-                loadbalancer.id)
 
 
 class CreateVThunderHealthEntry(BaseDatabaseTask):

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -303,12 +303,17 @@ class VThunderRepository(BaseRepository):
         return id_list
 
     def get_partition_for_project(self, session, project_id):
-        return session.query(self.model_class).filter(
-            self.model_class.project_id == project_id).first().partition_name
+        vthunder_project = self.get_vthunder_by_project_id(session, project_id)
+        if vthunder_project:
+            return vthunder_project.partition_name
 
     def get_project_list_using_partition(self, session, partition_name):
-        return [col_project[0] for col_project in session.query(self.model_class).filter(
-            self.model_class.partition_name == partition_name).values('project_id')]
+        list_projects = []
+        queryset_vthunders = session.query(self.model_class.project_id.distinct()).filter(
+            self.model_class.partition_name == partition_name)
+        if queryset_vthunders:
+            list_projects = [col_project[0] for col_project in queryset_vthunders.values('project_id')]
+        return list_projects
 
 
 class LoadBalancerRepository(repo.LoadBalancerRepository):
@@ -377,9 +382,9 @@ class MemberRepository(repo.MemberRepository):
                  or_(self.model_class.provisioning_status == consts.PENDING_DELETE,
                      self.model_class.provisioning_status == consts.ACTIVE))).count() 
 
-    def get_pool_count_subnet(self, session, project_id, subnet_id):
+    def get_pool_count_subnet(self, session, project_ids, subnet_id):
         return session.query(self.model_class.pool_id.distinct()).filter(
-            self.model_class.project_id == project_id).filter(
+            self.model_class.project_id.in_(project_ids)).filter(
             and_(self.model_class.subnet_id == subnet_id,
                  or_(self.model_class.provisioning_status == consts.PENDING_DELETE,
                      self.model_class.provisioning_status == consts.ACTIVE))).count()

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -303,18 +303,15 @@ class VThunderRepository(BaseRepository):
         return id_list
 
     def get_partition_for_project(self, session, project_id):
-        vthunder_project = self.get_vthunder_by_project_id(session, project_id)
-        if vthunder_project:
-            return vthunder_project.partition_name
+        return self.get_vthunder_by_project_id(session, project_id).\
+             partition_name
 
     def get_project_list_using_partition(self, session, partition_name):
-        list_projects = []
         queryset_vthunders = session.query(self.model_class.project_id.distinct()).filter(
             and_(self.model_class.partition_name == partition_name,
                  or_(self.model_class.role == "STANDALONE",
                      self.model_class.role == "MASTER")))
-        if queryset_vthunders:
-            list_projects = [col_project[0] for col_project in queryset_vthunders.values('project_id')]
+        list_projects = [project[0] for project in queryset_vthunders]
         return list_projects
 
 

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -310,7 +310,9 @@ class VThunderRepository(BaseRepository):
     def get_project_list_using_partition(self, session, partition_name):
         list_projects = []
         queryset_vthunders = session.query(self.model_class.project_id.distinct()).filter(
-            self.model_class.partition_name == partition_name)
+            and_(self.model_class.partition_name == partition_name,
+                 or_(self.model_class.role == "STANDALONE",
+                     self.model_class.role == "MASTER")))
         if queryset_vthunders:
             list_projects = [col_project[0] for col_project in queryset_vthunders.values('project_id')]
         return list_projects

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -210,9 +210,7 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         mock_vrid_entry.vrid_repo = mock.Mock()
         mock_vrid_entry.vthunder_repo = mock.Mock()
         mock_vrid_entry.vrid_repo.get_vrid_from_project_ids.return_value = VRID
-        vrid = mock_vrid_entry.execute(MEMBER_1)
-        mock_vrid_entry.vthunder_repo.get_partition_for_project.assert_called_once_with(
-            mock.ANY, project_id=a10constants.MOCK_PROJECT_ID)
+        vrid = mock_vrid_entry.execute([a10constants.MOCK_PROJECT_ID])
         self.assertEqual(VRID, vrid)
 
     def test_get_vrid_for_project(self):
@@ -347,7 +345,8 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         mock_subnets.member_repo.get_pool_count_subnet.return_value = 1
         mock_subnets.loadbalancer_repo.get_lb_count_by_subnet = mock.Mock()
         mock_subnets.loadbalancer_repo.get_lb_count_by_subnet.return_value = 0
-        subnet_list = mock_subnets.execute([MEMBER_1, MEMBER_2])
+        subnet_list = mock_subnets.execute(
+            [MEMBER_1, MEMBER_2], [a10constants.MOCK_PROJECT_ID])
         self.assertEqual(['mock-subnet-1', 'mock-subnet-2'], subnet_list)
 
     def test_get_subnet_for_deletion_with_multiple_pool_lb(self):
@@ -356,5 +355,15 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         mock_subnets.member_repo.get_pool_count_subnet.return_value = 2
         mock_subnets.loadbalancer_repo.get_lb_count_by_subnet = mock.Mock()
         mock_subnets.loadbalancer_repo.get_lb_count_by_subnet.return_value = 2
-        subnet_list = mock_subnets.execute([MEMBER_1, MEMBER_2])
+        subnet_list = mock_subnets.execute(
+            [MEMBER_1, MEMBER_2], [a10constants.MOCK_PROJECT_ID])
         self.assertEqual([], subnet_list)
+
+    def test_get_projects_for_partition(self):
+        mock_get_projects = task.GetProjectsForPartition()
+        mock_get_projects.vthunder_repo = mock.Mock()
+        mock_get_projects.vthunder_repo.get_partition_for_project.\
+            return_value = "mock-partition-name"
+        mock_get_projects.execute(MEMBER_1)
+        mock_get_projects.vthunder_repo.get_project_list_using_partition.\
+            assert_called_once_with(mock.ANY, partition_name='mock-partition-name')

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -359,8 +359,8 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
             [MEMBER_1, MEMBER_2], [a10constants.MOCK_PROJECT_ID])
         self.assertEqual([], subnet_list)
 
-    def test_get_projects_for_partition(self):
-        mock_get_projects = task.GetProjectsForPartition()
+    def test_get_child_projects_for_partition(self):
+        mock_get_projects = task.GetChildProjectsOfParentPartition()
         mock_get_projects.vthunder_repo = mock.Mock()
         mock_get_projects.vthunder_repo.get_partition_for_project.\
             return_value = "mock-partition-name"


### PR DESCRIPTION
## Description
- Severity Level: High
- Required: Issue: The VRID feature is not built by keeping HMT and use parent partition in mind. Previously the consideration was user mapped with project and project is mapped to partition so the VRID list from DB, LB count for the subnet and, member count subnet are fetched based on a project which caused issues when the partition is shared among projects. 
 Now with this PR, we use to partition and the projects using that partition for fetching VRID list, LB count, and member count. 

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1691

## Technical Approach
- Recognized the other cases of failure like member delete, LB delete and pool delete.
- With previous PR we fixed the issue fo LB and member creation. 
- Through bug STACK-1691, we recognized the fetch VRID list, LB count, member count needed to be integrated with delete flow.
- Added new DB task  "GetProjectsForPartition" for fetching projects using a partition in question.
- Updated existing tasks for fetching the VRID list, LB count, and member count to accept the project list and accordingly update query to DB.

## Test Cases
- Added test for testing "GetProjectsForPartition", fetching project list for a specific partition.

## Manual Testing
- Created LB in 2 different child projects with below config:
     hierarchical_multitenancy="enable"
     use_parent_partition=True
 Load balancers created:
   "lc1" -> "cadmin"(project) 
   "lcc1"-> "ccadmin"(project)

Testing deletion of LB:
- Deleted lc1, deleted the equivalent virtual server from vThunder and VRID FIP also getting removed, neutron port is getting removed
- Deleted lcc1, deleted equivalent virtual server,  VRID FIP removed, and neutron port is also getting removed. 
