### PR TITLE
Handled vthunder as None case in VRID Story

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -844,7 +844,7 @@ class DeleteVRIDPort(BaseNetworkTask):
         vrid = None
         vrid_floating_ip_list = []
         resource_count = lb_count + member_count
-        if resource_count <= 1:
+        if resource_count <= 1 and vthunder:
             for vr in vrid_list:
                 if vr.subnet_id == subnet.id:
                     vrid = vr
@@ -874,7 +874,7 @@ class DeleteMultipleVRIDPort(BaseNetworkTask):
     @axapi_client_decorator
     def execute(self, vthunder, vrid_list, subnet_list):
         try:
-            if subnet_list:
+            if subnet_list and vthunder and vrid_list:
                 vrids = []
                 vrid_floating_ip_list = []
                 for vrid in vrid_list:


### PR DESCRIPTION
## Issue Description
1. If vThunder object is available as None in database, the VRID task fails to delete LB and POOL in error state.
2. If VRID is not configured, pool delete fails if multiple members are being deleted, as VRID_LIST is coming empty

## Severity Level : Critical

## Jira Ticket
This does not contain any bug for now, as its high priority

## Technical Approach
- Added check for vthunder object
- Added check if vrid list is empty then avoiding further flow


## Manual Testing
PART A: When deleting LB in ERROR state
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| bb3fdbaa-ca31-481b-b33c-d8870fffbdd8 | lb2  | fe67b8fe8c664580831df20569393c32 | 10.0.11.181 | ERROR               | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+

# openstack loadbalancer delete lb2

PART B: Create LB graph with multiple members in a pool with NO vrid setting
#openstack loadbalancer create --vip-subnet-id e9608efd-529d-43a8-b06e-b8ee8cb84f34 --name SLB1
#openstack loadbalancer listener create --protocol TCP --protocol-port 8080 SLB1 --name listener1
#openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener listener1 --name pool1
#openstack loadbalancer member create --address 192.168.9.232 --subnet-id 54c84ef3-dd72-46be-958d-c545604055ce --protocol-port 80 --name member1 d0814e8a-c46a-4800-85be-06850bb8be6e
#openstack loadbalancer member create --address 192.168.9.34 --subnet-id 54c84ef3-dd72-46be-958d-c545604055ce --protocol-port 80 --name member2 d0814e8a-c46a-4800-85be-06850bb8be6e

Then delete the pool directly, forcing members to be deleted in the process.
# openstack loadbalancer pool delete pool1 


