### PR TITLE
Added handling for removal of object in error state

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -398,6 +398,7 @@ class LoadBalancerFlows(object):
             provides=constants.SUBNET))
         delete_lb_vrid_subflow.add(
             a10_database_tasks.GetChildProjectsOfParentPartition(
+                requires=[a10constants.VTHUNDER],
                 rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
                 provides=a10constants.PARTITION_PROJECT_LIST
             ))

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -396,16 +396,17 @@ class CreateSpareVThunderEntry(BaseDatabaseTask):
 class GetVRIDForLoadbalancerResource(BaseDatabaseTask):
 
     def execute(self, partition_project_list):
-        try:
-            vrid_list = self.vrid_repo.get_vrid_from_project_ids(
-                db_apis.get_session(), project_ids=partition_project_list)
-            return vrid_list
-        except Exception as e:
-            LOG.exception(
-                "Failed to get VRID list for given project list  %s due to %s",
-                partition_project_list,
-                str(e))
-            raise e
+        if partition_project_list:
+            try:
+                vrid_list = self.vrid_repo.get_vrid_from_project_ids(
+                    db_apis.get_session(), project_ids=partition_project_list)
+                return vrid_list
+            except Exception as e:
+                LOG.exception(
+                    "Failed to get VRID list for given project list  %s due to %s",
+                    partition_project_list,
+                    str(e))
+                raise e
 
 
 class UpdateVRIDForLoadbalancerResource(BaseDatabaseTask):
@@ -464,28 +465,34 @@ class UpdateVRIDForLoadbalancerResource(BaseDatabaseTask):
 
 
 class CountLoadbalancersInProjectBySubnet(BaseDatabaseTask):
+
     def execute(self, subnet, partition_project_list):
-        try:
-            return self.loadbalancer_repo.get_lb_count_by_subnet(
-                db_apis.get_session(),
-                project_ids=partition_project_list, subnet_id=subnet.id)
-        except Exception as e:
-            LOG.exception("Failed to get LB count for subnet %s due to %s ",
-                          subnet.id, str(e))
-            raise e
+        if partition_project_list:
+            try:
+                return self.loadbalancer_repo.get_lb_count_by_subnet(
+                    db_apis.get_session(),
+                    project_ids=partition_project_list, subnet_id=subnet.id)
+            except Exception as e:
+                LOG.exception("Failed to get LB count for subnet %s due to %s ",
+                              subnet.id, str(e))
+                raise e
+        return 0
 
 
 class CountMembersInProjectBySubnet(BaseDatabaseTask):
+
     def execute(self, subnet, partition_project_list):
-        try:
-            return self.member_repo.get_member_count_by_subnet(
-                db_apis.get_session(),
-                project_ids=partition_project_list, subnet_id=subnet.id)
-        except Exception as e:
-            LOG.exception(
-                "Failed to get LB member count for subnet %s due to %s",
-                subnet.id, str(e))
-            raise e
+        if partition_project_list:
+            try:
+                return self.member_repo.get_member_count_by_subnet(
+                    db_apis.get_session(),
+                    project_ids=partition_project_list, subnet_id=subnet.id)
+            except Exception as e:
+                LOG.exception(
+                    "Failed to get LB member count for subnet %s due to %s",
+                    subnet.id, str(e))
+                raise e
+        return 0
 
 
 class DeleteVRIDEntry(BaseDatabaseTask):
@@ -672,16 +679,16 @@ class GetSubnetForDeletionInPool(BaseDatabaseTask):
 
 
 class GetChildProjectsOfParentPartition(BaseDatabaseTask):
-    def execute(self, lb_resource):
-        try:
-            project_id = lb_resource.project_id
-            partition_name = self.vthunder_repo.get_partition_for_project(
-                db_apis.get_session(), project_id=project_id)
-            partition_project_list = self.vthunder_repo.get_project_list_using_partition(
-                db_apis.get_session(), partition_name=partition_name)
-            return partition_project_list
-        except Exception as e:
-            LOG.exception(
-                "Failed to fetch list of projects, if multi-tenancy and use parent partition "
-                "is enabled due to %s", str(e))
-            raise e
+
+    def execute(self, lb_resource, vthunder):
+        if vthunder:
+            try:
+                partition_project_list = self.vthunder_repo.get_project_list_using_partition(
+                    db_apis.get_session(),
+                    partition_name=vthunder.partition_name)
+                return partition_project_list
+            except Exception as e:
+                LOG.exception(
+                    "Failed to fetch list of projects, if multi-tenancy and use parent partition "
+                    "is enabled due to %s", str(e))
+                raise e

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -838,7 +838,9 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
 
 
 class DeleteVRIDPort(BaseNetworkTask):
+
     """Delete VRID Port if the last resource associated with it is deleted"""
+
     @axapi_client_decorator
     def execute(self, vthunder, vrid_list, subnet, lb_count, member_count):
         vrid = None

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -302,10 +302,6 @@ class VThunderRepository(BaseRepository):
         id_list = [model.id for model in model_list]
         return id_list
 
-    def get_partition_for_project(self, session, project_id):
-        return self.get_vthunder_by_project_id(session, project_id).\
-             partition_name
-
     def get_project_list_using_partition(self, session, partition_name):
         queryset_vthunders = session.query(self.model_class.project_id.distinct()).filter(
             and_(self.model_class.partition_name == partition_name,

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -360,10 +360,10 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         self.assertEqual([], subnet_list)
 
     def test_get_child_projects_for_partition(self):
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.partition_name = "mock-partition-name"
         mock_get_projects = task.GetChildProjectsOfParentPartition()
-        mock_get_projects.vthunder_repo = mock.Mock()
-        mock_get_projects.vthunder_repo.get_partition_for_project.\
-            return_value = "mock-partition-name"
-        mock_get_projects.execute(MEMBER_1)
+        mock_get_projects.vthunder_repo.get_project_list_using_partition = mock.Mock()
+        mock_get_projects.execute(MEMBER_1, vthunder)
         mock_get_projects.vthunder_repo.get_project_list_using_partition.\
             assert_called_once_with(mock.ANY, partition_name='mock-partition-name')


### PR DESCRIPTION
## Description
Severity Level: Critical

When using hierarchical multitenancy, objects in error state cannot be removed as a db query was returning None.

## Jira Ticket
[STACK-1716](https://a10networks.atlassian.net/browse/STACK-1716)

## Technical Approach
- Removed query causing the issue. Replaced query with already present vthunder argument
- Added handling for None / empty returns expected for an object in error state

## Config Changes
N/A

## Test Cases
N/A

## Manual Testing

### Config file used for testing
```
[a10_global]
use_parent_partition = True
use_shared_for_template_lookup = True
vrid_floating_ip = 25

[a10_controller_worker]
network_driver = a10_octavia_neutron_driver

[service_group]
#template_port = test_port
#template_policy = test_policy

[listener]
#template_virtual_port = none
#template_http = test_http
#autosnat = True

[hardware_thunder]
devices = [
                    {
                     "project_id": "0e567ea4ea824228b06fce04805c8c16",
                     "device_name": "device1",
                     "ip_address": "10.0.0.189",
                     "username": "admin",
                     "password": "a10",
                     "hierarchical_multitenancy": "enable",
                     "interface_vlan_map": {
                         "device_1": {
                             "vcs_device_id": 2,
                             "mgmt_ip_address": "10.0.0.88",
                             "ethernet_interfaces": [{
                                 "interface_num": 1,
                                 "vlan_map": [
                                     {"vlan_id": 11, "ve_ip": ".6"}
                                 ]},
                                 {
                                 "interface_num": 2,
                                 "vlan_map": [
                                     {"vlan_id": 12, "ve_ip": ".5"}
                                 ]
                             }]
                          },
                          "device_2": {
                             "vcs_device_id": 1,
                             "mgmt_ip_address": "10.0.0.83",
                             "ethernet_interfaces": [{
                                 "interface_num": 1,
                                 "vlan_map": [
                                     {"vlan_id": 11, "ve_ip": ".6"}
                                 ]},
                                 {
                                 "interface_num": 2,
                                 "vlan_map": [
                                     {"vlan_id": 12, "ve_ip": ".5"}
                                 ]
                             }]
                          }
                        }
                     }
             ]
```

### Setup
1.  A parent project called ProjectA
2.  A child project called ChildA

### Test Case 1: Standard delete

1. Create a loadbalancer with the following

```
openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name test_vip --project ChildA
```

2. Delete with the following

```
openstack loadbalancer delete test_vip
```

Expected result is a successful deletion of the VRID port, loadbalancer, and VRID

### Test Case 1: Deletion of object in error state

#### Setup
Set the VRID floating IP to be out of range like `285`

1. Create a loadbalancer with the following

```
openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name test_vip --project ChildA
```

** We expect this to error out with a VRID error. Now we are in error state **

2. Delete with the following

```
openstack loadbalancer delete test_vip
```

Expected result is a successful deletion of the VRID port, loadbalancer, and VRID