### PR TITLE
[STACK-1717] Added [a10_database] section support to a10-octavia.conf

### DIFF
--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -144,6 +144,14 @@ A10_HARDWARE_THUNDER_OPTS = [
                                help=_('List of all device configuration'))
 ]
 
+A10_DATABASE_OPTS = [
+    cfg.StrOpt('connection_url',
+               default='',
+               help=_('Specify the A10 Database connection url along with'
+                      'username and password to connect. Eg - '
+                      'mysql+pymysql://<username>:<password>@<host>:<port>/a10-octavia'))
+]
+
 A10_HEALTH_MANAGER_OPTS = [
     cfg.IPOpt('udp_server_ip_address',
               help=_('Server IP address that sends udp packets for '
@@ -327,6 +335,7 @@ cfg.CONF.register_opts(A10_LISTENER_OPTS, group='listener')
 cfg.CONF.register_opts(A10_SERVICE_GROUP_OPTS, group='service_group')
 cfg.CONF.register_opts(A10_SERVER_OPTS, group='server')
 cfg.CONF.register_opts(A10_HARDWARE_THUNDER_OPTS, group='hardware_thunder')
+cfg.CONF.register_opts(A10_DATABASE_OPTS, group='a10_database')
 
 
 # Ensure that the control exchange is set correctly


### PR DESCRIPTION
## Description
- Added Database connection config support to `a10-octavia.conf`.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1717

## Technical Approach
- Registered `a10_database` section to config options.
- Added `connection_url` config support inside this section.

## Config Changes
<pre>
[a10_database]
connection_url = mysql+pymysql://root:password@127.0.0.1:3306/a10-octavia
</pre>

## Test Cases
- None

## Manual Testing
- None
(Note: Not able to test it since all the code is not in place.)