### PR TITLE
[STACK-1730] Removed sqlalchemy_utils to support MariaDB

### DIFF
--- a/a10_octavia/db/migration/alembic_migrations/versions/ea8bfcbd654c_modified_hmt_column_to_accept_only_.py
+++ b/a10_octavia/db/migration/alembic_migrations/versions/ea8bfcbd654c_modified_hmt_column_to_accept_only_.py
@@ -7,7 +7,6 @@ Create Date: 2020-08-10 19:11:58.780617
 """
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy_utils.types.choice import ChoiceType
 
 from a10_octavia.db.models import VThunder
 
@@ -23,7 +22,8 @@ def upgrade():
         table_name='vthunders',
         column_name='hierarchical_multitenancy',
         nullable=False,
-        type_=ChoiceType(VThunder.HIERARCHICAL_MT_TYPES)
+        type_=sa.String(7),
+        server_default="disable"
     )
 
 

--- a/a10_octavia/db/models.py
+++ b/a10_octavia/db/models.py
@@ -18,7 +18,6 @@ from sqlalchemy.ext import orderinglist
 from sqlalchemy import orm
 from sqlalchemy.orm import validates
 from sqlalchemy.sql import func
-from sqlalchemy_utils.types.choice import ChoiceType
 
 from a10_octavia.common import data_models
 from a10_octavia.db import base_models
@@ -28,11 +27,6 @@ from octavia.i18n import _
 class VThunder(base_models.BASE):
     __data_model__ = data_models.VThunder
     __tablename__ = 'vthunders'
-
-    HIERARCHICAL_MT_TYPES = [
-        (u'enable', 1),
-        (u'disable', 0)
-    ]
 
     id = sa.Column(sa.Integer, primary_key=True)
     vthunder_id = sa.Column(sa.String(36), nullable=False)
@@ -53,7 +47,7 @@ class VThunder(base_models.BASE):
     created_at = sa.Column(u'created_at', sa.DateTime(), nullable=True)
     updated_at = sa.Column(u'updated_at', sa.DateTime(), nullable=True)
     partition_name = sa.Column(sa.String(14), nullable=True)
-    hierarchical_multitenancy = sa.Column(ChoiceType(HIERARCHICAL_MT_TYPES))
+    hierarchical_multitenancy = sa.Column(sa.String(7), nullable=False)
 
     @classmethod
     def find_by_loadbalancer_id(cls, loadbalancer_id, db_session=None):

--- a/tox.ini
+++ b/tox.ini
@@ -26,14 +26,12 @@ usedevelop = True
 install_command = pip install -U {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-       sqlalchemy_utils>0.33.0,<=0.34.0
        pyrsistent>0.15.4,<=0.16.0
 
 [testenv:pep8]
 commands = flake8
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-       sqlalchemy_utils>0.33.0,<=0.34.0
        pyrsistent>0.15.4,<=0.16.0
 
 [flake8]


### PR DESCRIPTION
## Description

Severity Level: Critical

The sqlalchemy_utils library's custom datatypes are incompatible with 

## Jira Ticket
[STACK-1730](https://a10networks.atlassian.net/browse/STACK-1730)

## Technical Approach
- Modified revision to change from Boolean to String instead of Boolean to ChoiceType

## Config Changes
N/A

## Test Cases
N/A

## Manual Testing

Requirements: RDO on CentOS with MariaDB as the database type

#### Test Case 1: Downgrade current running setup

```
cd a10-octavia/a10_octavia/db/migration

alembic downgrade 4028e5f7a198
```

Expected result: Downgrade successful


#### Test Case 2: Upgrade 

```
cd a10-octavia/a10_octavia/db/migration

alembic upgrade head
````

Expected result:
```
MariaDB [octavia]> show columns from vthunders;
+---------------------------+---------------+------+-----+---------+----------------+
| Field                     | Type          | Null | Key | Default | Extra          |
+---------------------------+---------------+------+-----+---------+----------------+
| id                        | int(11)       | NO   | PRI | NULL    | auto_increment |
| vthunder_id               | varchar(36)   | NO   |     | NULL    |                |
| amphora_id                | varchar(36)   | YES  |     | NULL    |                |
| device_name               | varchar(1024) | NO   |     | NULL    |                |
| ip_address                | varchar(64)   | NO   |     | NULL    |                |
| username                  | varchar(1024) | NO   |     | NULL    |                |
| password                  | varchar(50)   | NO   |     | NULL    |                |
| axapi_version             | int(11)       | NO   |     | NULL    |                |
| undercloud                | tinyint(1)    | NO   |     | NULL    |                |
| loadbalancer_id           | varchar(36)   | YES  |     | NULL    |                |
| project_id                | varchar(36)   | YES  |     | NULL    |                |
| compute_id                | varchar(36)   | YES  |     | NULL    |                |
| topology                  | varchar(50)   | YES  |     | NULL    |                |
| role                      | varchar(50)   | YES  |     | NULL    |                |
| last_udp_update           | datetime      | YES  |     | NULL    |                |
| status                    | varchar(36)   | NO   |     | NULL    |                |
| created_at                | datetime      | YES  |     | NULL    |                |
| updated_at                | datetime      | YES  |     | NULL    |                |
| partition_name            | varchar(14)   | YES  |     | NULL    |                |
| hierarchical_multitenancy | varchar(7)    | NO   |     | disable |                |
+---------------------------+---------------+------+-----+---------+----------------+
```

#### Test Case 3: Enable HMT

1. Set `hierarchical_multitenancy` to `enable` 
2. Restart service
3. Create loadbalancer 

Expected Result: virtual server is created into partition with name equal to first 14 char of partition name