### PR TITLE
[DB-Migrations][First-Revision]: Added the required new db tables using an alembic script.

### DIFF
--- a/a10_octavia/db/migration/alembic_migrations/versions/f7017d3417ce_create_required_tables.py
+++ b/a10_octavia/db/migration/alembic_migrations/versions/f7017d3417ce_create_required_tables.py
@@ -1,4 +1,4 @@
-"""create amphora_meta table
+"""create required tables
 
 Revision ID: f7017d3417ce
 Revises: 05b1446c7f20

--- a/a10_octavia/db/migration/alembic_migrations/versions/f7017d3417ce_create_required_tables.py
+++ b/a10_octavia/db/migration/alembic_migrations/versions/f7017d3417ce_create_required_tables.py
@@ -1,0 +1,97 @@
+"""create amphora_meta table
+
+Revision ID: f7017d3417ce
+Revises: 05b1446c7f20
+Create Date: 2020-11-04 05:22:12.860858
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'f7017d3417ce'
+down_revision = '05b1446c7f20'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'amphora_meta',
+        sa.Column('id', sa.String(36), primary_key=True, nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.Column('last_udp_update', sa.DateTime(), nullable=True),
+        sa.Column('status', sa.String(36), default='ACTIVE', nullable=False)
+    )
+    op.create_table(
+        'thunder',
+        sa.Column('id', sa.String(36), primary_key=True, nullable=False),
+        sa.Column('vcs_device_id', sa.String(1), nullable=False),
+        sa.Column('management_ip_address', sa.String(64), nullable=False)
+    )
+    op.create_table(
+        'role',
+        sa.Column('id', sa.String(36), primary_key=True, nullable=False),
+        sa.Column('role', sa.String(36), nullable=False),
+        sa.Column('thunder_id', sa.String(36), sa.ForeignKey('thunder.id'))
+    )
+    op.create_table(
+        'thunder_cluster',
+        sa.Column('id', sa.String(36), primary_key=True, nullable=False),
+        sa.Column('username', sa.String(1024), nullable=False),
+        sa.Column('password', sa.String(50), nullable=False),
+        sa.Column('cluster_name', sa.String(1024), nullable=False),
+        sa.Column('cluster_ip_address', sa.String(64), nullable=False),
+        sa.Column('topology', sa.String(50)),
+        sa.Column('undercloud', sa.Boolean(), default=False, nullable=False)
+    )
+    op.create_table(
+        'partitions',
+        sa.Column('id', sa.String(36), primary_key=True, nullable=False),
+        sa.Column('partition_name', sa.String(14), nullable=True),
+        sa.Column('hierarchical_multitenancy', sa.String(7), nullable=False),
+    )
+    op.create_table(
+        'project',
+        sa.Column('id', sa.String(36), primary_key=True, nullable=False),
+        sa.Column('partition_id', sa.String(36), sa.ForeignKey('partitions.id')),
+        sa.Column('thunder_cluster_id', sa.String(36), sa.ForeignKey('thunder_cluster.id')),
+    )
+    op.create_table(
+        'ethernet_interface',
+        sa.Column('interface_num', sa.Integer, primary_key=True, nullable=False),
+        sa.Column('vlan_id', sa.String(36), nullable=False),
+        sa.Column('subnet_id', sa.String(36), nullable=False),
+        sa.Column('ve_ip_address', sa.String(64), nullable=False),
+        sa.Column('port_id', sa.String(36), nullable=False),
+        sa.Column('state', sa.String(36), nullable=False)
+    )
+    op.create_table(
+        'trunk_interface',
+        sa.Column('interface_num', sa.Integer, primary_key=True, nullable=False),
+        sa.Column('vlan_id', sa.String(36), nullable=False),
+        sa.Column('subnet_id', sa.String(36), nullable=False),
+        sa.Column('ve_ip_address', sa.String(64), nullable=False),
+        sa.Column('port_id', sa.String(36), nullable=False),
+        sa.Column('state', sa.String(36), nullable=False)
+    )
+    op.create_table(
+        've_interface_cluster',
+        sa.Column('thunder_id', sa.String(36), sa.ForeignKey('thunder.id')),
+        sa.Column('ethernet_interface_num', sa.Integer,
+                  sa.ForeignKey('ethernet_interface.interface_num')),
+        sa.Column('trunk_interface_num', sa.Integer, sa.ForeignKey('trunk_interface.interface_num'))
+    )
+
+
+def downgrade():
+    op.drop_table('ve_interface_cluster')
+    op.drop_table('trunk_interface')
+    op.drop_table('ethernet_interface')
+    op.drop_table('project')
+    op.drop_table('partitions')
+    op.drop_table('thunder_cluster')
+    op.drop_table('role')
+    op.drop_table('thunder')
+    op.drop_table('amphora_meta')


### PR DESCRIPTION
## Description
Added new database tables required for a10-octavia in a custom database named `a10_octavia` for now, by following the schema diagram(update_db) attached in https://a10networks.atlassian.net/browse/STACK-1177, by using an alembic script.
Creating the following tables by this:
- amphora_meta
- thunder
- role
- thunder_cluster
- partitions
- project
- ethernet_interface
- trunk_interface
- ve_interface_cluster

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1723
https://a10networks.atlassian.net/browse/STACK-1725
https://a10networks.atlassian.net/browse/STACK-1740
https://a10networks.atlassian.net/browse/STACK-1741
https://a10networks.atlassian.net/browse/STACK-1742

## Technical Approach
Written an alembic script to create the required tables for a10-octavia.

## Manual Testing
For now, Tested the table creation on a custom database named `a10_octavia`.
Step1: Create database a10_octavia:
mysql> **CREATE DATABASE a10_octavia;**

Step2: For connecting to the custom db, add following to [database] section in `/etc/octavia/octavia.conf` file and then restart the octavia-api service:
`connection = mysql+pymysql://root:password@127.0.0.1:3306/a10_octavia`

Step2: From the `/path/to/a10-octavia/a10_octavia/db/migration` folder run:
$ **alembic upgrade head**

Step3: Check the newly created tables with their added columns in mysql `a10_octavia` database
mysql> use a10_octavia;

mysql> show tables;
+-----------------------+
| Tables_in_a10_octavia |
+-----------------------+
| alembic_version       |
| amphora_meta         |
| ethernet_interface    |
| partitions            |
| project               |
| role                  |
| thunder               |
| thunder_cluster       |
| trunk_interface       |
| ve_interface_cluster  |
| vrid                  |
| vthunders             |
+-----------------------+


