### PR TITLE
[BUG][STACK-1755] Setting member removed the ports

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -378,7 +378,7 @@ class MemberFlows(object):
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
         update_member_flow.add(server_tasks.MemberUpdate(
-            requires=(constants.MEMBER, a10constants.VTHUNDER)))
+            requires=(constants.MEMBER, a10constants.VTHUNDER, constants.POOL)))
         update_member_flow.add(database_tasks.UpdateMemberInDB(
             requires=[constants.MEMBER, constants.UPDATE_DICT]))
         update_member_flow.add(database_tasks.MarkMemberActiveInDB(
@@ -415,7 +415,7 @@ class MemberFlows(object):
         # Handle VRID settings
         update_member_flow.add(self.handle_vrid_for_member_subflow())
         update_member_flow.add(server_tasks.MemberUpdate(
-            requires=(constants.MEMBER, a10constants.VTHUNDER)))
+            requires=(constants.MEMBER, a10constants.VTHUNDER, constants.POOL)))
         update_member_flow.add(database_tasks.UpdateMemberInDB(
             requires=[constants.MEMBER, constants.UPDATE_DICT]))
         if CONF.a10_global.network_type == 'vlan':


### PR DESCRIPTION
## Description
-  Severity Level  **Critical**
- Any set command to `member` was removing the port configuration.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1755

## Technical Approach
- While debugging found that port setting is taken care by `service_group.member.create()` api of acos-client.
- Added api call for creating port and associating with service_group after replace call on server


## Config Changes
None

## Test Cases
- Required: List edge cases tested against in unit tests 

## Manual Testing
1. Create LB, Listener and pool
2. Create member with following configuration of `[server]` of `a10-octavia.conf`
```
conn_limit=11000000
conn_resume=899999
template_server=tp_server
```
`openstack loadbalancer member create --address 10.0.12.195 --subnet-id bb62cec6-6135-4066-aec5-ec59ec58c2ce --protocol-port 80 --name member1 pool1`

Output on vthunder: 

```

vThunder-Active-vMaster[1/1](NOLICENSE)#sh run slb
!Section configuration: 475 bytes
!
slb template server tp_server
!
slb server b8a9e_10_0_12_195 10.0.12.195   <<<------------------------
  template server tp_server
  conn-limit 10000000
  conn-resume 899998
  port 8080 tcp
!
slb service-group 4d9a4b9a-8b37-4fc6-816d-ab2250b8bd1e tcp
  member b8a9e_10_0_12_195 8080
!
slb virtual-server edf7d722-3762-4ca3-89b2-76c7af29e983 10.0.11.170
  port 8080 http
    name 142c43cb-2020-49d9-a0e0-c6973e643917
    extended-stats
    service-group 4d9a4b9a-8b37-4fc6-816d-ab2250b8bd1e
!

```

4. Modified `a10-octavia.conf` and commented template_server config
```
conn_limit=11000000
conn_resume=899999
#template_server=tp_server
```

5. Restarted service and Updated member
`openstack loadbalancer member set pool1 member1`

Following configuration 
```

vThunder-Active-vMaster[1/1](NOLICENSE)#sh run slb
!Section configuration: 475 bytes
!
slb template server tp_server
!
slb server b8a9e_10_0_12_195 10.0.12.195   <<<------------------------
  conn-limit 10000000
  conn-resume 899998
  port 8080 tcp
!
slb service-group 4d9a4b9a-8b37-4fc6-816d-ab2250b8bd1e tcp
  member b8a9e_10_0_12_195 8080
!
slb virtual-server edf7d722-3762-4ca3-89b2-76c7af29e983 10.0.11.170
  port 8080 http
    name 142c43cb-2020-49d9-a0e0-c6973e643917
    extended-stats
    service-group 4d9a4b9a-8b37-4fc6-816d-ab2250b8bd1e
!

```

Observe that `template_server` configuration is removed without port getting removed.