### PR TITLE
[BUG][centos_member][STACK-1751]: creating member will see some database error in log.

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -16,7 +16,6 @@ import acos_client.errors as acos_errors
 import copy
 from oslo_config import cfg
 from oslo_log import log as logging
-from oslo_utils import uuidutils
 from requests import exceptions as req_exceptions
 import six
 from taskflow import task
@@ -705,7 +704,6 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
             else:
                 vrid_list.append(
                     data_models.VRID(
-                        id=uuidutils.generate_uuid(),
                         vrid=vrid_value,
                         project_id=lb_resource.project_id,
                         vrid_port_id=None,

--- a/a10_octavia/tests/common/a10constants.py
+++ b/a10_octavia/tests/common/a10constants.py
@@ -55,4 +55,3 @@ SERVER_CONF_SECTION = 'server'
 MOCK_SERVICE_GROUP_PROTOCOL = "HTTP"
 MOCK_POOL_ID_2 = "mock-pool-2"
 MOCK_SUBNET_ID_2 = "mock-subnet-2"
-MOCK_VRID_ID = 'mock-vrid-1'

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -48,7 +48,7 @@ HW_THUNDER = data_models.HardwareThunder(
 LB = o_data_models.LoadBalancer(id=a10constants.MOCK_LOAD_BALANCER_ID)
 FIXED_IP = n_data_models.FixedIP(ip_address='10.10.10.10')
 PORT = n_data_models.Port(id=uuidutils.generate_uuid(), fixed_ips=[FIXED_IP])
-VRID = data_models.VRID(id=uuidutils.generate_uuid(), vrid=0,
+VRID = data_models.VRID(id=1, vrid=0,
                         project_id=a10constants.MOCK_PROJECT_ID,
                         vrid_port_id=uuidutils.generate_uuid(),
                         vrid_floating_ip='10.0.12.32')
@@ -302,7 +302,7 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         mock_vrid_entry.vrid_repo.delete.assert_not_called()
 
     def test_delete_vrid_entry_with_multi_vrids(self):
-        VRID_1 = data_models.VRID(id=uuidutils.generate_uuid())
+        VRID_1 = data_models.VRID(id=2)
         mock_vrid_entry = task.DeleteMultiVRIDEntry()
         mock_vrid_entry.vrid_repo = mock.Mock()
         mock_vrid_entry.execute([VRID, VRID_1])

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
@@ -38,8 +38,7 @@ PORT = o_net_data_models.Port()
 VRID = data_models.VRID()
 VRID_VALUE = 0
 SUBNET_1 = o_net_data_models.Subnet(id=a10constants.MOCK_SUBNET_ID)
-VRID_1 = data_models.VRID(id=a10constants.MOCK_VRID_ID,
-                          subnet_id=a10constants.MOCK_SUBNET_ID)
+VRID_1 = data_models.VRID(id=1, subnet_id=a10constants.MOCK_SUBNET_ID)
 
 
 class MockIP(object):


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description: member creation failing, since for adding vrid data into table there was an issue related to id.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1751

## Technical Approach
- Checked the code for member creation. 
- Discovered an issue while adding new VRID if vrid not present for a given subnet. we were specifically generating UUID for id of VRID object.  

## Test Cases
- No required

## Manual Testing
- Created load balancer with subnet-1.
- Created member in subnet-2
- Created member in subnet-3
- Created member in subnet-3

[NOTE]: Was able to create members when changes checked out on centos and on development machines as well. But anyway the UUID changes were not required there. 