### PR TITLE
[STACK-1755][STACK-1737] Obtained server ports before preforming replace to preserve them

### DIFF
--- a/a10_octavia/controller/worker/tasks/server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/server_tasks.py
@@ -145,21 +145,14 @@ class MemberUpdate(task.Task):
             status = True
 
         try:
+            port_list = self.axapi_client.slb.server.get(server_name)['server'].get('port-list')
             self.axapi_client.slb.server.replace(server_name, member.ip_address, status=status,
                                                  server_templates=server_temp,
-                                                 axapi_args=server_args)
+                                                 axapi_args=server_args,
+                                                 port_list=port_list)
             LOG.debug("Successfully updated member: %s", member.id)
         except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception("Failed to update member: %s", member.id)
-            raise e
-        try:
-            self.axapi_client.slb.service_group.member.create(
-                pool.id, server_name, member.protocol_port)
-            LOG.debug("Successfully associated member %s to pool %s",
-                      member.id, pool.id)
-        except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
-            LOG.exception("Failed to associate member %s to pool %s",
-                          member.id, pool.id)
             raise e
 
 


### PR DESCRIPTION
## Description

Severity Level: Critical

Whenever members are updated, the real server ports are removed from associated server objects. This has the extra effect of removing the member object from the service group.

## Jira Ticket
[STACK-1755](https://a10networks.atlassian.net/browse/STACK-1755)
[STACK-1737](https://a10networks.atlassian.net/browse/STACK-1737)

## Technical Approach
- Added get call for port-list so that real server ports are obtained
- Reverted previous code change which attempted to resolve STACK-1755

## Linked

[acos-client PR#308](https://github.com/a10networks/acos-client/pull/308)

## Config Changes
N/A

## Test Cases
N/A - No testable logic. Just a single get call more or less.

## Manual Testing

### Prep

```
    openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name lb1 --project project_a
    openstack loadbalancer listener create --protocol HTTP --protocol-port 8080 --name l1 lb1
    openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener l1 --name pool1
    openstack loadbalancer member create --address 10.0.12.112 --subnet-id provider-vlan-12-subnet  --protocol-port 80 --name mem1 pool1
    openstack loadbalancer member create --address 10.0.12.112 --subnet-id provider-vlan-12-subnet  --protocol-port 81 --name mem2 pool1
    openstack loadbalancer member create --address 10.0.13.113 --subnet-id provider-vlan-13-subnet  --protocol-port 80 --name mem3 pool1
```

3 member objects will be created. The first two share the same IP address, but have different ports. The last has a different IP and different port.

Therefore, the first two members share a server and the last has it's own server. All of these will be added to the same pool.

mem1 - 10.0.12.112:80
mem2 - 10.0.12.112:81

mem3 - 10.0.13.113:80

#### Test Case 1: Check ports and members of server 10.0.12.112 aren't effected by server 10.0.13.113

```
openstack loadbalancer member set pool1 mem1
openstack loadbalancer member set pool1 mem2
```

Expected Outcome: Nothing should change. No ports should be removed from server 10.0.13.113 or  10.0.12.112 and no members should be removed from the service group.

#### Test Case 2: Check port and member for server 10.0.13.113 isn't effected by server 10.0.12.112


```
openstack loadbalancer member set pool1 mem3
```

Expected Outcome: Nothing should change. No ports should be removed from server 10.0.12.112 or 10.0.13.113 and no members should be removed from the service group.