### PR TITLE
STACK-1714: New Data Models to support new a10-octavia database.

### DIFF
--- a/a10_octavia/common/data_models.py
+++ b/a10_octavia/common/data_models.py
@@ -121,7 +121,7 @@ class DeviceNetworkMap(A10OctaviaDataModel):
 
 class ThunderCluster(A10OctaviaDataModel):
 
-    def __init__(self, id=None, created_at=None, updated_at=None, username=None, password=None 
+    def __init__(self, id=None, created_at=None, updated_at=None, username=None, password=None,
                  cluster_name=None, cluster_ip_address=None, undercloud=None, topology=None):
         self.id = id
         self.created_at = created_at

--- a/a10_octavia/common/data_models.py
+++ b/a10_octavia/common/data_models.py
@@ -132,3 +132,19 @@ class AmphoraMeta(A10OctaviaDataModel):
         self.updated_at = updated_at
         self.last_udp_update = last_udp_update
         self.status = status
+
+
+class Partition(A10OctaviaDataModel):
+    def __init__(self, id=None, name=None, hierarchical_multitenancy=None):
+        self.id = id
+        self.name = name
+        self.hierarchical_multitenancy = hierarchical_multitenancy
+
+
+class Thunder(A10OctaviaDataModel):
+    def __init__(self, id=None, vcs_device_id=None,
+                 management_ip_address=None, cluster_id=None):
+        self.id = id
+        self.vcs_device_id = vcs_device_id
+        self.management_ip_address = management_ip_address
+        self.cluster_id = cluster_id

--- a/a10_octavia/common/data_models.py
+++ b/a10_octavia/common/data_models.py
@@ -13,10 +13,6 @@
 #    under the License.
 
 
-from datetime import datetime
-import re
-import six
-from sqlalchemy.orm import collections
 from octavia.common import data_models
 
 
@@ -36,7 +32,7 @@ class A10OctaviaDataModel(data_models.BaseDataModel):
             raise NotImplementedError
 
 
-class ThunderCluster(A10OctaviaDataModel):
+class ThunderV1(A10OctaviaDataModel):
 
     def __init__(self, id=None, vthunder_id=None, amphora_id=None,
                  device_name=None, ip_address=None, username=None,
@@ -70,14 +66,14 @@ class ThunderCluster(A10OctaviaDataModel):
         self.device_network_map = device_network_map or []
 
 
-class HardwareThunder(ThunderCluster):
+class HardwareThunder(ThunderV1):
     def __init__(self, **kwargs):
-        ThunderCluster.__init__(self, **kwargs)
+        ThunderV1.__init__(self, **kwargs)
 
 
-class VThunder(ThunderCluster):
+class VThunder(ThunderV1):
     def __init__(self, **kwargs):
-        ThunderCluster.__init__(self, **kwargs)
+        ThunderV1.__init__(self, **kwargs)
 
 
 class Certificate(A10OctaviaDataModel):
@@ -123,6 +119,21 @@ class DeviceNetworkMap(A10OctaviaDataModel):
         self.state = 'Unknown'
 
 
+class ThunderCluster(A10OctaviaDataModel):
+
+    def __init__(self, id=None, created_at=None, updated_at=None, username=None, password=None 
+                 cluster_name=None, cluster_ip_address=None, undercloud=None, topology=None):
+        self.id = id
+        self.created_at = created_at
+        self.updated_at = updated_at
+        self.username = username
+        self.password = password
+        self.cluster_name = cluster_name
+        self.cluster_ip_address = cluster_ip_address
+        self.undercloud = undercloud
+        self.topology = topology
+
+
 class AmphoraMeta(A10OctaviaDataModel):
 
     def __init__(self, id=None, created_at=None, updated_at=None,
@@ -134,7 +145,7 @@ class AmphoraMeta(A10OctaviaDataModel):
         self.status = status
 
 
-class Partition(A10OctaviaDataModel):
+class Partitions(A10OctaviaDataModel):
     def __init__(self, id=None, name=None, hierarchical_multitenancy=None):
         self.id = id
         self.name = name

--- a/a10_octavia/common/data_models.py
+++ b/a10_octavia/common/data_models.py
@@ -26,7 +26,7 @@ class A10OctaviaDataModel(data_models.BaseDataModel):
         if obj.__class__.__name__ in ['ThunderV1', 'AmphoraMeta', 'Partitions', 'ThunderCluster',
                                       'Thunder', 'DeviceNetworkCluster', 'VRID']:
             return obj.__class__.__name__ + obj.id
-        if obj.__class__.__name__ in ['Interface', 'TrunkInterface', 'EthernetInterface']:
+        if obj.__class__.__name__ in ['Interfaces', 'TrunkInterface', 'EthernetInterface']:
             return obj.__class__.__name__ + obj.interface_num
         else:
             raise NotImplementedError
@@ -100,7 +100,7 @@ class VRID(A10OctaviaDataModel):
         self.subnet_id = subnet_id
 
 
-class InterfaceV1(A10OctaviaDataModel):
+class Interface(A10OctaviaDataModel):
 
     def __init__(self, interface_num=None, tags=None, ve_ips=None):
         self.interface_num = interface_num
@@ -131,7 +131,7 @@ class DeviceNetworkCluster(A10OctaviaDataModel):
         self.updated_at = updated_at
 
 
-class Interface(A10OctaviaDataModel):
+class Interfaces(A10OctaviaDataModel):
 
     def __init__(self, interface_num=None, subnet_id=None, vlan_id=None,
                  ve_ip_address=None, port_id=None, created_at=None, updated_at=None):
@@ -144,16 +144,16 @@ class Interface(A10OctaviaDataModel):
         self.updated_at = updated_at
 
 
-class EthernetInterface(Interface):
+class EthernetInterface(Interfaces):
 
     def __init__(self, **kwargs):
-        Interface.__init__(self, **kwargs)
+        Interfaces.__init__(self, **kwargs)
 
 
-class TrunkInterface(Interface):
+class TrunkInterface(Interfaces):
 
     def __init__(self, **kwargs):
-        Interface.__init__(self, **kwargs)
+        Interfaces.__init__(self, **kwargs)
 
 
 class ThunderCluster(A10OctaviaDataModel):

--- a/a10_octavia/common/data_models.py
+++ b/a10_octavia/common/data_models.py
@@ -23,10 +23,10 @@ class A10OctaviaDataModel(data_models.BaseDataModel):
         obj = obj or self
         # First handle all objects with their own ID, then handle subordinate
         # objects.
-        if obj.__class__.__name__ in ['VThunder', 'AmphoraMeta', 'Partitions', 'ThunderCluster',
-                                      'Thunder', 'DeviceNetworkCluster', 'Project']:
+        if obj.__class__.__name__ in ['ThunderV1', 'AmphoraMeta', 'Partitions', 'ThunderCluster',
+                                      'Thunder', 'DeviceNetworkCluster', 'VRID']:
             return obj.__class__.__name__ + obj.id
-        if obj.__class__.__name__ in ['TrunkInterface', 'EthernetInterface']:
+        if obj.__class__.__name__ in ['Interface', 'TrunkInterface', 'EthernetInterface']:
             return obj.__class__.__name__ + obj.interface_num
         else:
             raise NotImplementedError
@@ -100,7 +100,7 @@ class VRID(A10OctaviaDataModel):
         self.subnet_id = subnet_id
 
 
-class Interface(A10OctaviaDataModel):
+class InterfaceV1(A10OctaviaDataModel):
 
     def __init__(self, interface_num=None, tags=None, ve_ips=None):
         self.interface_num = interface_num
@@ -117,6 +117,43 @@ class DeviceNetworkMap(A10OctaviaDataModel):
         self.ethernet_interfaces = ethernet_interfaces or []
         self.trunk_interfaces = trunk_interfaces or []
         self.state = 'Unknown'
+
+
+class DeviceNetworkCluster(A10OctaviaDataModel):
+
+    def __init__(self, id=None, thunder_id=None, ethernet_interface_num=None,
+                 trunk_interface_num=None, created_at=None, updated_at=None):
+        self.id = id
+        self.thunder_id = thunder_id
+        self.ethernet_interface_num = ethernet_interface_num
+        self.trunk_interface_num = trunk_interface_num
+        self.created_at = created_at
+        self.updated_at = updated_at
+
+
+class Interface(A10OctaviaDataModel):
+
+    def __init__(self, interface_num=None, subnet_id=None, vlan_id=None,
+                 ve_ip_address=None, port_id=None, created_at=None, updated_at=None):
+        self.interface_num = interface_num
+        self.subnet_id = subnet_id
+        self.vlan_id = vlan_id
+        self.ve_ip_address = ve_ip_address
+        self.port_id = port_id
+        self.created_at = created_at
+        self.updated_at = updated_at
+
+
+class EthernetInterface(Interface):
+
+    def __init__(self, **kwargs):
+        Interface.__init__(self, **kwargs)
+
+
+class TrunkInterface(Interface):
+
+    def __init__(self, **kwargs):
+        Interface.__init__(self, **kwargs)
 
 
 class ThunderCluster(A10OctaviaDataModel):
@@ -146,16 +183,21 @@ class AmphoraMeta(A10OctaviaDataModel):
 
 
 class Partitions(A10OctaviaDataModel):
-    def __init__(self, id=None, name=None, hierarchical_multitenancy=None):
+    def __init__(self, id=None, name=None, hierarchical_multitenancy=None,
+                 created_at=None, updated_at=None):
         self.id = id
         self.name = name
         self.hierarchical_multitenancy = hierarchical_multitenancy
+        self.created_at = created_at
+        self.updated_at = updated_at
 
 
 class Thunder(A10OctaviaDataModel):
-    def __init__(self, id=None, vcs_device_id=None,
+    def __init__(self, id=None, vcs_device_id=None, created_at=None, updated_at=None,
                  management_ip_address=None, cluster_id=None):
         self.id = id
         self.vcs_device_id = vcs_device_id
         self.management_ip_address = management_ip_address
         self.cluster_id = cluster_id
+        self.created_at = created_at
+        self.updated_at = updated_at

--- a/a10_octavia/db/models.py
+++ b/a10_octavia/db/models.py
@@ -82,6 +82,7 @@ class Amphora_Meta(base_models.BASE, TimeStampData):
 
 
 class Thunder(base_models.BASE, TimeStampData):
+    __data_model__ = data_models.Thunder
     __tablename__ = 'thunder'
 
     id = sa.Column(sa.String(36), primary_key=True, nullable=False)
@@ -111,6 +112,7 @@ class Thunder_Cluster(base_models.BASE, TimeStampData):
 
 
 class Partitions(base_models.BASE, TimeStampData):
+    __data_model__ = data_models.Partition
     __tablename__ = 'partitions'
 
     id = sa.Column(sa.String(36), primary_key=True, nullable=False)

--- a/a10_octavia/db/models.py
+++ b/a10_octavia/db/models.py
@@ -131,6 +131,7 @@ class Project(base_models.BASE, TimeStampData):
 
 
 class Ethernet_Interface(base_models.BASE, TimeStampData):
+    __data_model__ = data_models.EthernetInterface
     __tablename__ = 'ethernet_interface'
 
     interface_num = sa.Column(sa.Integer, primary_key=True, nullable=False)
@@ -141,6 +142,7 @@ class Ethernet_Interface(base_models.BASE, TimeStampData):
 
 
 class Trunk_Interface(base_models.BASE, TimeStampData):
+    __data_model__ = data_models.TrunkInterface
     __tablename__ = 'trunk_interface'
 
     interface_num = sa.Column(sa.Integer, primary_key=True, nullable=False)
@@ -151,6 +153,7 @@ class Trunk_Interface(base_models.BASE, TimeStampData):
 
 
 class Device_Network_Cluster(base_models.BASE, TimeStampData):
+    __data_model__ = data_models.DeviceNetworkCluster
     __tablename__ = 'device_network_cluster'
 
     id = sa.Column(sa.String(36), primary_key=True, nullable=False)

--- a/a10_octavia/db/models.py
+++ b/a10_octavia/db/models.py
@@ -74,6 +74,7 @@ class VRID(base_models.BASE, TimeStampData):
 
 
 class Amphora_Meta(base_models.BASE, TimeStampData):
+    __data_model__ = data_models.AmphoraMeta
     __tablename__ = 'amphora_meta'
 
     id = sa.Column(sa.String(36), primary_key=True, nullable=False)
@@ -100,6 +101,7 @@ class Role(base_models.BASE, TimeStampData):
 
 
 class Thunder_Cluster(base_models.BASE, TimeStampData):
+    __data_model__ = data_models.ThunderCluster
     __tablename__ = 'thunder_cluster'
 
     id = sa.Column(sa.String(36), primary_key=True, nullable=False)
@@ -112,7 +114,7 @@ class Thunder_Cluster(base_models.BASE, TimeStampData):
 
 
 class Partitions(base_models.BASE, TimeStampData):
-    __data_model__ = data_models.Partition
+    __data_model__ = data_models.Partitions
     __tablename__ = 'partitions'
 
     id = sa.Column(sa.String(36), primary_key=True, nullable=False)

--- a/a10_octavia/tests/unit/common/test_data_models.py
+++ b/a10_octavia/tests/unit/common/test_data_models.py
@@ -14,11 +14,9 @@
 
 import copy
 import datetime
-import random
 
 from oslo_utils import uuidutils
 
-from octavia.common import constants
 from a10_octavia.common import data_models
 from a10_octavia.tests.unit import base
 

--- a/a10_octavia/tests/unit/common/test_data_models.py
+++ b/a10_octavia/tests/unit/common/test_data_models.py
@@ -27,6 +27,7 @@ class TestDataModels(base.BaseTaskTestCase):
 
         super(TestDataModels, self).setUp()
         self.AMP_ID = uuidutils.generate_uuid()
+        self.THUDER_CLUSTER_ID = uuidutils.generate_uuid()
         self.CREATED_AT = datetime.datetime.now()
         self.UPDATED_AT = datetime.datetime.utcnow()
         self.LAST_UDP_UPDATE = datetime.datetime.utcnow()
@@ -39,13 +40,25 @@ class TestDataModels(base.BaseTaskTestCase):
             status="ACTIVE"
         )
 
+        self.THUNDER_CLUSTER_obj = data_models.ThunderCluster(
+            id=self.THUDER_CLUSTER_ID,
+            created_at=self.CREATED_AT,
+            updated_at=self.UPDATED_AT,
+            username="USER1",
+            password="pwd",
+            cluster_name="cluster1",
+            cluster_ip_address="192.0.2.10",
+            undercloud=False,
+            topology="STANDALONE"
+        )
+
     def test_AmphoraMeta_update(self):
 
         new_id = uuidutils.generate_uuid()
         new_created_at = self.CREATED_AT + datetime.timedelta(minutes=5)
         new_updated_at = self.UPDATED_AT + datetime.timedelta(minutes=10)
         new_last_udp_update = self.LAST_UDP_UPDATE + datetime.timedelta(minutes=5)
-        new_status = "ERROR"
+        new_status = "STANDBY"
 
         update_dict = {
             'id': new_id,
@@ -68,3 +81,45 @@ class TestDataModels(base.BaseTaskTestCase):
         test_Amp_obj.update(update_dict)
 
         self.assertEqual(reference_Amp_obj, test_Amp_obj)
+
+    def test_ThunderCluster_update(self):
+
+        new_id = uuidutils.generate_uuid()
+        new_created_at = self.CREATED_AT + datetime.timedelta(minutes=5)
+        new_updated_at = self.UPDATED_AT + datetime.timedelta(minutes=10)
+        new_username = "USER2"
+        new_password = "pwd2"
+        new_cluster_name = "cluster2"
+        new_cluster_ip_address = "10.10.10.10"
+        new_undercloud = False
+        new_topology = "STANDALONE"
+
+        update_dict = {
+            'id': new_id,
+            'created_at': new_created_at,
+            'updated_at': new_updated_at,
+            'username': new_username,
+            'password': new_password,
+            'cluster_name': new_cluster_name,
+            'cluster_ip_address': new_cluster_ip_address,
+            'undercloud': new_undercloud,
+            'topology': new_topology
+        }
+
+        test_Thunder_Cluster_obj = copy.deepcopy(self.THUNDER_CLUSTER_obj)
+
+        reference_Thunder_Cluster_obj = data_models.ThunderCluster(
+            id=new_id,
+            created_at=new_created_at,
+            updated_at=new_updated_at,
+            username=new_username,
+            password=new_password,
+            cluster_name=new_cluster_name,
+            cluster_ip_address=new_cluster_ip_address,
+            undercloud=new_undercloud,
+            topology=new_topology
+        )
+
+        test_Thunder_Cluster_obj.update(update_dict)
+
+        self.assertEqual(reference_Thunder_Cluster_obj, test_Thunder_Cluster_obj)

--- a/a10_octavia/tests/unit/common/test_data_models.py
+++ b/a10_octavia/tests/unit/common/test_data_models.py
@@ -31,6 +31,11 @@ class TestDataModels(base.BaseTaskTestCase):
         self.CREATED_AT = datetime.datetime.now()
         self.UPDATED_AT = datetime.datetime.utcnow()
         self.LAST_UDP_UPDATE = datetime.datetime.utcnow()
+        self.SUBNET_ID = uuidutils.generate_uuid()
+        self.VLAN_ID = uuidutils.generate_uuid()
+        self.PORT_ID = uuidutils.generate_uuid()
+        self.DEVICE_ID = uuidutils.generate_uuid()
+        self.THUNDER_ID = uuidutils.generate_uuid()
 
         self.AMP_obj = data_models.AmphoraMeta(
             id=self.AMP_ID,
@@ -50,6 +55,35 @@ class TestDataModels(base.BaseTaskTestCase):
             cluster_ip_address="192.0.2.10",
             undercloud=False,
             topology="STANDALONE"
+        )
+
+        self.ETH_INT_obj = data_models.EthernetInterface(
+            interface_num=1,
+            created_at=self.CREATED_AT,
+            updated_at=self.UPDATED_AT,
+            subnet_id=self.SUBNET_ID,
+            vlan_id=self.VLAN_ID,
+            ve_ip_address="192.0.2.11",
+            port_id=self.PORT_ID
+        )
+
+        self.TRUNK_INT_obj = data_models.TrunkInterface(
+            interface_num=2,
+            created_at=self.CREATED_AT,
+            updated_at=self.UPDATED_AT,
+            subnet_id=self.SUBNET_ID,
+            vlan_id=self.VLAN_ID,
+            ve_ip_address="192.0.2.12",
+            port_id=self.PORT_ID
+        )
+
+        self.DEVICE_NET_obj = data_models.DeviceNetworkCluster(
+            id=self.DEVICE_ID,
+            created_at=self.CREATED_AT,
+            updated_at=self.UPDATED_AT,
+            thunder_id=self.THUNDER_ID,
+            ethernet_interface_num=1,
+            trunk_interface_num=2
         )
 
     def test_AmphoraMeta_update(self):
@@ -123,3 +157,108 @@ class TestDataModels(base.BaseTaskTestCase):
         test_Thunder_Cluster_obj.update(update_dict)
 
         self.assertEqual(reference_Thunder_Cluster_obj, test_Thunder_Cluster_obj)
+
+    def test_Eth_Interface_update(self):
+
+        new_interface_num = 2
+        new_created_at = self.CREATED_AT + datetime.timedelta(minutes=5)
+        new_updated_at = self.UPDATED_AT + datetime.timedelta(minutes=10)
+        new_subnet_id = uuidutils.generate_uuid()
+        new_vlan_id = uuidutils.generate_uuid()
+        new_ve_ip_address = "192.0.2.10"
+        new_port_id = uuidutils.generate_uuid()
+
+        update_dict = {
+            'interface_num': new_interface_num,
+            'created_at': new_created_at,
+            'updated_at': new_updated_at,
+            'subnet_id': new_subnet_id,
+            'vlan_id': new_vlan_id,
+            've_ip_address': new_ve_ip_address,
+            'port_id': new_port_id
+        }
+
+        test_Eth_Int_obj = copy.deepcopy(self.ETH_INT_obj)
+
+        reference_Eth_Int_obj = data_models.EthernetInterface(
+            interface_num=new_interface_num,
+            created_at=new_created_at,
+            updated_at=new_updated_at,
+            subnet_id=new_subnet_id,
+            vlan_id=new_vlan_id,
+            ve_ip_address=new_ve_ip_address,
+            port_id=new_port_id
+        )
+
+        test_Eth_Int_obj.update(update_dict)
+
+        self.assertEqual(reference_Eth_Int_obj, test_Eth_Int_obj)
+
+    def test_Trunk_Interface_update(self):
+
+        new_interface_num = 3
+        new_created_at = self.CREATED_AT + datetime.timedelta(minutes=5)
+        new_updated_at = self.UPDATED_AT + datetime.timedelta(minutes=10)
+        new_subnet_id = uuidutils.generate_uuid()
+        new_vlan_id = uuidutils.generate_uuid()
+        new_ve_ip_address = "192.0.2.10"
+        new_port_id = uuidutils.generate_uuid()
+
+        update_dict = {
+            'interface_num': new_interface_num,
+            'created_at': new_created_at,
+            'updated_at': new_updated_at,
+            'subnet_id': new_subnet_id,
+            'vlan_id': new_vlan_id,
+            've_ip_address': new_ve_ip_address,
+            'port_id': new_port_id
+        }
+
+        test_Trunk_Int_obj = copy.deepcopy(self.TRUNK_INT_obj)
+
+        reference_Trunk_Int_obj = data_models.TrunkInterface(
+            interface_num=new_interface_num,
+            created_at=new_created_at,
+            updated_at=new_updated_at,
+            subnet_id=new_subnet_id,
+            vlan_id=new_vlan_id,
+            ve_ip_address=new_ve_ip_address,
+            port_id=new_port_id
+        )
+
+        test_Trunk_Int_obj.update(update_dict)
+
+        self.assertEqual(reference_Trunk_Int_obj, test_Trunk_Int_obj)
+
+    def test_DeviceNetworkCluster_update(self):
+
+        new_id = uuidutils.generate_uuid()
+        new_created_at = self.CREATED_AT + datetime.timedelta(minutes=5)
+        new_updated_at = self.UPDATED_AT + datetime.timedelta(minutes=10)
+        new_thunder_id = uuidutils.generate_uuid()
+        new_ethernet_interface_num = 3
+        new_trunk_interface_num = 4
+
+        update_dict = {
+            'id': new_id,
+            'created_at': new_created_at,
+            'updated_at': new_updated_at,
+            'thunder_id': new_thunder_id,
+            'ethernet_interface_num': new_ethernet_interface_num,
+            'trunk_interface_num': new_trunk_interface_num
+        }
+
+        test_Device_Net_obj = copy.deepcopy(self.DEVICE_NET_obj)
+
+        reference_Device_Net_obj = data_models.DeviceNetworkCluster(
+            id=new_id,
+            created_at=new_created_at,
+            updated_at=new_updated_at,
+            thunder_id=new_thunder_id,
+            ethernet_interface_num=new_ethernet_interface_num,
+            trunk_interface_num=new_trunk_interface_num
+        )
+
+        test_Device_Net_obj.update(update_dict)
+
+        self.assertEqual(reference_Device_Net_obj, test_Device_Net_obj)

--- a/a10_octavia/tests/unit/common/test_data_models.py
+++ b/a10_octavia/tests/unit/common/test_data_models.py
@@ -12,7 +12,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import copy
 import datetime
 
 from oslo_utils import uuidutils
@@ -26,97 +25,35 @@ class TestDataModels(base.BaseTaskTestCase):
     def setUp(self):
 
         super(TestDataModels, self).setUp()
-        self.AMP_ID = uuidutils.generate_uuid()
-        self.THUDER_CLUSTER_ID = uuidutils.generate_uuid()
         self.CREATED_AT = datetime.datetime.now()
         self.UPDATED_AT = datetime.datetime.utcnow()
         self.LAST_UDP_UPDATE = datetime.datetime.utcnow()
-        self.SUBNET_ID = uuidutils.generate_uuid()
-        self.VLAN_ID = uuidutils.generate_uuid()
-        self.PORT_ID = uuidutils.generate_uuid()
-        self.DEVICE_ID = uuidutils.generate_uuid()
-        self.THUNDER_ID = uuidutils.generate_uuid()
 
-        self.AMP_obj = data_models.AmphoraMeta(
-            id=self.AMP_ID,
-            created_at=self.CREATED_AT,
-            updated_at=self.UPDATED_AT,
-            last_udp_update=self.LAST_UDP_UPDATE,
-            status="ACTIVE"
-        )
-
-        self.THUNDER_CLUSTER_obj = data_models.ThunderCluster(
-            id=self.THUDER_CLUSTER_ID,
-            created_at=self.CREATED_AT,
-            updated_at=self.UPDATED_AT,
-            username="USER1",
-            password="pwd",
-            cluster_name="cluster1",
-            cluster_ip_address="192.0.2.10",
-            undercloud=False,
-            topology="STANDALONE"
-        )
-
-        self.ETH_INT_obj = data_models.EthernetInterface(
-            interface_num=1,
-            created_at=self.CREATED_AT,
-            updated_at=self.UPDATED_AT,
-            subnet_id=self.SUBNET_ID,
-            vlan_id=self.VLAN_ID,
-            ve_ip_address="192.0.2.11",
-            port_id=self.PORT_ID
-        )
-
-        self.TRUNK_INT_obj = data_models.TrunkInterface(
-            interface_num=2,
-            created_at=self.CREATED_AT,
-            updated_at=self.UPDATED_AT,
-            subnet_id=self.SUBNET_ID,
-            vlan_id=self.VLAN_ID,
-            ve_ip_address="192.0.2.12",
-            port_id=self.PORT_ID
-        )
-
-        self.DEVICE_NET_obj = data_models.DeviceNetworkCluster(
-            id=self.DEVICE_ID,
-            created_at=self.CREATED_AT,
-            updated_at=self.UPDATED_AT,
-            thunder_id=self.THUNDER_ID,
-            ethernet_interface_num=1,
-            trunk_interface_num=2
-        )
-
-    def test_AmphoraMeta_update(self):
+    def test_AmphoraMeta(self):
 
         new_id = uuidutils.generate_uuid()
         new_created_at = self.CREATED_AT + datetime.timedelta(minutes=5)
         new_updated_at = self.UPDATED_AT + datetime.timedelta(minutes=10)
         new_last_udp_update = self.LAST_UDP_UPDATE + datetime.timedelta(minutes=5)
-        new_status = "STANDBY"
 
-        update_dict = {
+        amphora_meta_data = {
             'id': new_id,
             'created_at': new_created_at,
             'updated_at': new_updated_at,
             'last_udp_update': new_last_udp_update,
-            'status': new_status
+            'status': None
         }
-
-        test_Amp_obj = copy.deepcopy(self.AMP_obj)
 
         reference_Amp_obj = data_models.AmphoraMeta(
             id=new_id,
             created_at=new_created_at,
             updated_at=new_updated_at,
             last_udp_update=new_last_udp_update,
-            status=new_status
         )
 
-        test_Amp_obj.update(update_dict)
+        self.assertEqual(reference_Amp_obj.__dict__, amphora_meta_data)
 
-        self.assertEqual(reference_Amp_obj, test_Amp_obj)
-
-    def test_ThunderCluster_update(self):
+    def test_ThunderCluster(self):
 
         new_id = uuidutils.generate_uuid()
         new_created_at = self.CREATED_AT + datetime.timedelta(minutes=5)
@@ -128,7 +65,7 @@ class TestDataModels(base.BaseTaskTestCase):
         new_undercloud = False
         new_topology = "STANDALONE"
 
-        update_dict = {
+        thunder_cluster_data = {
             'id': new_id,
             'created_at': new_created_at,
             'updated_at': new_updated_at,
@@ -139,8 +76,6 @@ class TestDataModels(base.BaseTaskTestCase):
             'undercloud': new_undercloud,
             'topology': new_topology
         }
-
-        test_Thunder_Cluster_obj = copy.deepcopy(self.THUNDER_CLUSTER_obj)
 
         reference_Thunder_Cluster_obj = data_models.ThunderCluster(
             id=new_id,
@@ -154,11 +89,9 @@ class TestDataModels(base.BaseTaskTestCase):
             topology=new_topology
         )
 
-        test_Thunder_Cluster_obj.update(update_dict)
+        self.assertEqual(reference_Thunder_Cluster_obj.__dict__, thunder_cluster_data)
 
-        self.assertEqual(reference_Thunder_Cluster_obj, test_Thunder_Cluster_obj)
-
-    def test_Eth_Interface_update(self):
+    def test_Eth_Interface(self):
 
         new_interface_num = 2
         new_created_at = self.CREATED_AT + datetime.timedelta(minutes=5)
@@ -168,7 +101,7 @@ class TestDataModels(base.BaseTaskTestCase):
         new_ve_ip_address = "192.0.2.10"
         new_port_id = uuidutils.generate_uuid()
 
-        update_dict = {
+        ethernet_interface_data = {
             'interface_num': new_interface_num,
             'created_at': new_created_at,
             'updated_at': new_updated_at,
@@ -177,8 +110,6 @@ class TestDataModels(base.BaseTaskTestCase):
             've_ip_address': new_ve_ip_address,
             'port_id': new_port_id
         }
-
-        test_Eth_Int_obj = copy.deepcopy(self.ETH_INT_obj)
 
         reference_Eth_Int_obj = data_models.EthernetInterface(
             interface_num=new_interface_num,
@@ -190,11 +121,9 @@ class TestDataModels(base.BaseTaskTestCase):
             port_id=new_port_id
         )
 
-        test_Eth_Int_obj.update(update_dict)
+        self.assertEqual(reference_Eth_Int_obj.__dict__, ethernet_interface_data)
 
-        self.assertEqual(reference_Eth_Int_obj, test_Eth_Int_obj)
-
-    def test_Trunk_Interface_update(self):
+    def test_Trunk_Interface(self):
 
         new_interface_num = 3
         new_created_at = self.CREATED_AT + datetime.timedelta(minutes=5)
@@ -204,7 +133,7 @@ class TestDataModels(base.BaseTaskTestCase):
         new_ve_ip_address = "192.0.2.10"
         new_port_id = uuidutils.generate_uuid()
 
-        update_dict = {
+        trunk_interface_data = {
             'interface_num': new_interface_num,
             'created_at': new_created_at,
             'updated_at': new_updated_at,
@@ -213,8 +142,6 @@ class TestDataModels(base.BaseTaskTestCase):
             've_ip_address': new_ve_ip_address,
             'port_id': new_port_id
         }
-
-        test_Trunk_Int_obj = copy.deepcopy(self.TRUNK_INT_obj)
 
         reference_Trunk_Int_obj = data_models.TrunkInterface(
             interface_num=new_interface_num,
@@ -226,11 +153,9 @@ class TestDataModels(base.BaseTaskTestCase):
             port_id=new_port_id
         )
 
-        test_Trunk_Int_obj.update(update_dict)
+        self.assertEqual(reference_Trunk_Int_obj.__dict__, trunk_interface_data)
 
-        self.assertEqual(reference_Trunk_Int_obj, test_Trunk_Int_obj)
-
-    def test_DeviceNetworkCluster_update(self):
+    def test_DeviceNetworkCluster(self):
 
         new_id = uuidutils.generate_uuid()
         new_created_at = self.CREATED_AT + datetime.timedelta(minutes=5)
@@ -239,7 +164,7 @@ class TestDataModels(base.BaseTaskTestCase):
         new_ethernet_interface_num = 3
         new_trunk_interface_num = 4
 
-        update_dict = {
+        device_network_cluster_data = {
             'id': new_id,
             'created_at': new_created_at,
             'updated_at': new_updated_at,
@@ -247,8 +172,6 @@ class TestDataModels(base.BaseTaskTestCase):
             'ethernet_interface_num': new_ethernet_interface_num,
             'trunk_interface_num': new_trunk_interface_num
         }
-
-        test_Device_Net_obj = copy.deepcopy(self.DEVICE_NET_obj)
 
         reference_Device_Net_obj = data_models.DeviceNetworkCluster(
             id=new_id,
@@ -259,6 +182,59 @@ class TestDataModels(base.BaseTaskTestCase):
             trunk_interface_num=new_trunk_interface_num
         )
 
-        test_Device_Net_obj.update(update_dict)
+        self.assertEqual(reference_Device_Net_obj.__dict__, device_network_cluster_data)
 
-        self.assertEqual(reference_Device_Net_obj, test_Device_Net_obj)
+    def test_Partitions(self):
+
+        new_id = uuidutils.generate_uuid()
+        new_created_at = self.CREATED_AT + datetime.timedelta(minutes=5)
+        new_updated_at = self.UPDATED_AT + datetime.timedelta(minutes=10)
+        new_name = "partition-alpha"
+        new_hierarchical_multitenancy = "enable"
+
+        partition_data = {
+            'id': new_id,
+            'created_at': new_created_at,
+            'updated_at': new_updated_at,
+            'name': new_name,
+            'hierarchical_multitenancy': new_hierarchical_multitenancy
+        }
+
+        partition_data_obj = data_models.Partitions(
+            id=new_id,
+            name=new_name,
+            hierarchical_multitenancy=new_hierarchical_multitenancy,
+            created_at=new_created_at,
+            updated_at=new_updated_at
+        )
+
+        self.assertEqual(partition_data_obj.__dict__, partition_data)
+
+    def test_Thunder(self):
+
+        new_id = uuidutils.generate_uuid()
+        new_created_at = self.CREATED_AT + datetime.timedelta(minutes=5)
+        new_updated_at = self.UPDATED_AT + datetime.timedelta(minutes=10)
+        new_vcs_device_id = 1
+        new_management_ip_address = "10.0.0.74"
+        new_cluster_id = uuidutils.generate_uuid()
+
+        thunder_data = {
+            'id': new_id,
+            'vcs_device_id': new_vcs_device_id,
+            'management_ip_address': new_management_ip_address,
+            'cluster_id': new_cluster_id,
+            'created_at': new_created_at,
+            'updated_at': new_updated_at,
+        }
+
+        thunder_data_obj = data_models.Thunder(
+            id=new_id,
+            vcs_device_id=new_vcs_device_id,
+            management_ip_address=new_management_ip_address,
+            cluster_id=new_cluster_id,
+            created_at=new_created_at,
+            updated_at=new_updated_at
+        )
+
+        self.assertEqual(thunder_data_obj.__dict__, thunder_data)


### PR DESCRIPTION
## Description
Added data models for supporting new a10-octavia database.

## Jira Ticket
Main Story : https://a10networks.atlassian.net/browse/STACK-1177
https://a10networks.atlassian.net/browse/STACK-1777
https://a10networks.atlassian.net/browse/STACK-1779
https://a10networks.atlassian.net/browse/STACK-1780
https://a10networks.atlassian.net/browse/STACK-1781
https://a10networks.atlassian.net/browse/STACK-1783

## Technical Approach
- Modified data_models.py by refactoring BaseDataModel class in it.
- Set all parameters to None by default in all data models.
- Added a data model for AmphoraMeta, Partitions, Interfaces (EthernetInterface and TrunkInterface), Thunder, ThunderCluster.
- Converted old `Thunder` to `ThunderV1`.
- Added UTs for all data models.

Note: We are not touching old models , to avoid more UT failures, however as we move forward, we will be removing the usage of old data_models further.
