### PR TITLE
flavor and name-expr logic to health monitor

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
@@ -43,8 +43,12 @@ class HealthMonitorFlows(object):
         create_hm_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
+        create_hm_flow.add(a10_database_tasks.GetFlavorObject(
+            rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
+            provides=constants.FLAVOR))
         create_hm_flow.add(health_monitor_tasks.CreateAndAssociateHealthMonitor(
-            requires=[constants.LISTENERS, constants.HEALTH_MON, a10constants.VTHUNDER]))
+            requires=[constants.LISTENERS, constants.HEALTH_MON, a10constants.VTHUNDER,
+                      constants.FLAVOR]))
         create_hm_flow.add(database_tasks.MarkHealthMonitorActiveInDB(
             requires=constants.HEALTH_MON))
         create_hm_flow.add(database_tasks.MarkPoolActiveInDB(

--- a/a10_octavia/controller/worker/tasks/utils.py
+++ b/a10_octavia/controller/worker/tasks/utils.py
@@ -80,6 +80,7 @@ def parse_name_expressions(name, name_expressions):
     flavor_data = {}
     if name_expressions:
         for expression in name_expressions:
-            if re.search(expression['regex'], name):
-                flavor_data.update(expression['json'])
+            if 'regex' in expression:
+                if re.search(expression['regex'], name):
+                    flavor_data.update(expression['json'])
     return flavor_data


### PR DESCRIPTION
## Description
flavor and name-expr logic to health monitor


## Jira Ticket
STACK-1799 Add name-expr and flavor logic to healthmonitor tasks

## Config Changes
flavor shows below:
<pre>
<b>{
  "health-monitor":{
    "monitor":{
      "retry":5,
      "method":{
        "http":{
          "http-response-code":"201"
        }
      }
    },
    "name-expressions":[
    {
      "regex":"hm1",
      "json":{
        "monitor":{
          "timeout":8,
          "method":{
            "http":{
              "http-host":"my.test.com"
            }
          }
        }
      }
    }
    ]
  }
}</b>
</pre>

## Test Cases
 - health monitor global flavor
 - health monitor flavor with regex

## Manual Testing
 - health monitor global flavor
 - health monitor flavor with regex
