### PR TITLE
[New-DB] Added support for getting engine for a10_octavia db

### DIFF
--- a/a10_octavia/db/api.py
+++ b/a10_octavia/db/api.py
@@ -45,27 +45,25 @@ def get_session(url=None, **kwargs):
     return DBSession(**kwargs)
 
 
+def get_a10_engine(url=None):
+    global A10_CFG
+
+    if url is None:
+        if A10_CFG is None:
+            A10_CFG = a10_config.A10Config()
+
+        url = A10_CFG.get('a10_database_connection')
+
+    return sqlalchemy.create_engine(url)
+
+
+def get_a10_session(url=None, **kwargs):
+    DBSession = sqlalchemy.orm.sessionmaker(bind=get_a10_engine(url=url))
+    return DBSession(**kwargs)
+
+
 def close_session(session):
     try:
         session.commit()
     finally:
         session.close()
-
-
-@contextmanager
-def magic_session(db_session=None, url=None):
-    """Either does nothing with the session you already have or
-    makes one that commits and closes no matter what happens
-    """
-
-    if db_session is not None:
-        yield db_session
-    else:
-        session = get_session(url, expire_on_commit=False)
-        try:
-            try:
-                yield session
-            finally:
-                session.commit()
-        finally:
-            session.close()


### PR DESCRIPTION
## Description
Now we can get sessions from both `a10_octavia` and `octavia` db for connecting to different repositories.
This is part of a large db migration story.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1816

## Technical Approach
- Added seperate method `get_a10_session()` to get session from `a10_octavia` db similar to `octavia`.

## Config Changes
None

## Test Cases
- Whenever `get_a10_session()` is called via db apis, we will get a10_octavia db session and further CRUDS operation is possible to repositories existing inside this database.
- Removed unused method.

## Manual Testing
a) Be connected to `a10_octavia` database using `[a10-database]` section config on `a10-octavia.conf`, restart the service.
b) For manual testing, I modified a file `a10_octavia/controller/worker/tasks/a10_vthunder_db.py` to use `get_a10_session()`


![image](https://user-images.githubusercontent.com/52992745/99957952-8098f780-2dae-11eb-8143-c534bd9e07fd.png)
![image](https://user-images.githubusercontent.com/52992745/99958007-960e2180-2dae-11eb-98ea-87a312fdb632.png)

c) Created Class object and called create and delete methods, passing vthunder params to vthunder_repositories.

![image](https://user-images.githubusercontent.com/52992745/99958071-ae7e3c00-2dae-11eb-8dc0-1ca853f50c4b.png)

d) Ran it as python file

![image](https://user-images.githubusercontent.com/52992745/99958144-d7063600-2dae-11eb-831f-2e3faab716c0.png)

![image](https://user-images.githubusercontent.com/52992745/99958196-f3a26e00-2dae-11eb-99e1-385a15430e4d.png)

e) After firing delete

![image](https://user-images.githubusercontent.com/52992745/99958257-0fa60f80-2daf-11eb-85df-e5ceafd5c6c1.png)

![image](https://user-images.githubusercontent.com/52992745/99958402-585dc880-2daf-11eb-8fc5-8e1894e14334.png)

