### PR TITLE
[STACK-1712][PART1]: Added new columns required for a10-neutron-lbaas data migration.

### DIFF
--- a/a10_octavia/common/data_models.py
+++ b/a10_octavia/common/data_models.py
@@ -139,6 +139,7 @@ class Thunder(BaseDataModel):
                  topology="STANDALONE", role="MASTER", last_udp_update=None, status="ACTIVE",
                  created_at=datetime.utcnow(), updated_at=datetime.utcnow(),
                  partition_name="shared", hierarchical_multitenancy="disable",
+                 write_memory=None, protocol=None, port=None,
                  vrid_floating_ip=None, device_network_map=None):
         self.id = id
         self.vthunder_id = vthunder_id
@@ -160,6 +161,9 @@ class Thunder(BaseDataModel):
         self.updated_at = updated_at
         self.partition_name = partition_name
         self.hierarchical_multitenancy = hierarchical_multitenancy
+        self.write_memory = write_memory
+        self.protocol = protocol
+        self.port = port
         self.vrid_floating_ip = vrid_floating_ip
         self.device_network_map = device_network_map or []
 

--- a/a10_octavia/db/migration/alembic_migrations/versions/a6e9b9b69494_add_write_memory_protocol_port_columns.py
+++ b/a10_octavia/db/migration/alembic_migrations/versions/a6e9b9b69494_add_write_memory_protocol_port_columns.py
@@ -1,0 +1,28 @@
+"""add write_memory protocol port columns
+
+Revision ID: a6e9b9b69494
+Revises: 05b1446c7f20
+Create Date: 2020-12-02 10:31:36.286722
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a6e9b9b69494'
+down_revision = '05b1446c7f20'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('vthunders', sa.Column('write_memory', sa.Boolean, nullable=False))
+    op.add_column('vthunders', sa.Column('protocol', sa.String(32), nullable=False))
+    op.add_column('vthunders', sa.Column('port', sa.Integer, nullable=False))
+
+
+def downgrade():
+    op.drop_column('vthunders', 'port')
+    op.drop_column('vthunders', 'protocol')
+    op.drop_column('vthunders', 'write_memory')

--- a/a10_octavia/db/models.py
+++ b/a10_octavia/db/models.py
@@ -48,6 +48,9 @@ class VThunder(base_models.BASE):
     updated_at = sa.Column(u'updated_at', sa.DateTime(), nullable=True)
     partition_name = sa.Column(sa.String(14), nullable=True)
     hierarchical_multitenancy = sa.Column(sa.String(7), nullable=False)
+    write_memory = sa.Column(sa.Boolean(), nullable=False)
+    protocol = sa.Column(sa.String(32), nullable=False)
+    port = sa.Column(sa.Integer, nullable=False)
 
     @classmethod
     def find_by_loadbalancer_id(cls, loadbalancer_id, db_session=None):


### PR DESCRIPTION
## Description
Added **write_memory**, **protocol** and **port** columns in vthunders table which is required for data migration from a10-neutron-lbaas to octavia.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1860
https://a10networks.atlassian.net/browse/STACK-1862
https://a10networks.atlassian.net/browse/STACK-1863

## Technical Approach
- Added write_memory, protocol and port fields in db/models.py.
- Created an alembic script `a6e9b9b69494_add_write_memory_protocol_port_columns.py` for adding the columns to `vthunders` table.
- Updated the Thunder data model to have the newly added columns in it.

## Manual Testing
After running `alembic upgrade head`, getting the newly added columns into vthunders table.

![image](https://user-images.githubusercontent.com/58077446/100976457-8be5e300-3565-11eb-9d84-3711c3330728.png)

