### PR TITLE
[STACK-1893][STACK-1894]: Fixed latest HMT behavior issues

### DIFF
--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -118,7 +118,9 @@ def convert_to_hardware_thunder_conf(hardware_list):
 def get_parent_project_list():
     parent_project_list = []
     for project_id in CONF.hardware_thunder.devices:
-        parent_project_list.append(get_parent_project(project_id))
+        parent_project_id = get_parent_project(project_id)
+        if parent_project_id != 'default':
+            parent_project_list.append(parent_project_id)
     return parent_project_list
 
 
@@ -127,8 +129,7 @@ def get_parent_project(project_id):
     key_client = keystone_client.Client(session=key_session)
     try:
         project = key_client.projects.get(project_id)
-        if project.parent_id != 'default':
-            return project.parent_id
+        return project.parent_id
     except keystone_exception.NotFound:
         return None
 

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -122,7 +122,8 @@ class CheckExistingProjectToThunderMappedEntries(BaseDatabaseTask):
                 parent_project_id = utils.get_parent_project(
                     vthunder_config.project_id)
                 if parent_project_id:
-                    vthunder_config.partition_name = parent_project_id[:14]
+                    if parent_project_id != 'default':
+                        vthunder_config.partition_name = parent_project_id[:14]
                 else:
                     LOG.error(
                         "The parent project for project %s does not exist. ",
@@ -180,7 +181,8 @@ class CheckExistingThunderToProjectMappedEntries(BaseDatabaseTask):
             config_ip_addr_partition = '{}:{}'.format(
                 vthunder_config.ip_address, vthunder_config.partition_name)
             if existing_ip_addr_partition == config_ip_addr_partition:
-                if vthunder.project_id != loadbalancer.project_id:
+                if loadbalancer.project_id not in (vthunder.project_id,
+                    utils.get_parent_project(vthunder.project_id)):
                     raise exceptions.ProjectInUseByExistingThunderError(
                         config_ip_addr_partition, vthunder.project_id, loadbalancer.project_id)
 

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -182,7 +182,7 @@ class CheckExistingThunderToProjectMappedEntries(BaseDatabaseTask):
                 vthunder_config.ip_address, vthunder_config.partition_name)
             if existing_ip_addr_partition == config_ip_addr_partition:
                 if loadbalancer.project_id not in (vthunder.project_id,
-                    utils.get_parent_project(vthunder.project_id)):
+                                                   utils.get_parent_project(vthunder.project_id)):
                     raise exceptions.ProjectInUseByExistingThunderError(
                         config_ip_addr_partition, vthunder.project_id, loadbalancer.project_id)
 

--- a/a10_octavia/tests/unit/common/test_utils.py
+++ b/a10_octavia/tests/unit/common/test_utils.py
@@ -216,7 +216,7 @@ class TestUtils(base.BaseTaskTestCase):
         client_mock = mock.Mock()
         client_mock.projects.get.return_value = FakeProject()
         mock_key_client.return_value = client_mock
-        self.assertIsNone(utils.get_parent_project(a10constants.MOCK_CHILD_PROJECT_ID))
+        self.assertEqual(utils.get_parent_project(a10constants.MOCK_CHILD_PROJECT_ID), 'default')
 
     def test_get_net_info_from_cidr_valid(self):
         self.assertEqual(utils.get_net_info_from_cidr('10.10.10.1/32'),


### PR DESCRIPTION
## Description

- Severity Level : **Highest** 
- If `upp` is `True` and `hmt` is `enabled`, failed to create LB for a project having `default` project as its parent.
- If child project is using parent partition, issue arises if parent starts using its own partition.

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-1893
- https://a10networks.atlassian.net/browse/STACK-1894

## Technical Approach
- All projects in openstack by default has `default` as its parent project. 
- Fixed the issue by considering that when parent is `default`, the partition to use will be the project's itself.
- Also fixed  to **not** throw `ProjectInUseByExistingThunderError` error, if the existing partitions created in vthunders (currently getting used by child project)  will also be accessed by the owner (parent project), regardless of **[upp+hmt]** is enabled or disabled.

## Config Changes
None

## Test Cases

**_STACK-1894_**
1) Given `use_parent_partition` as `True` , 
              `hierarchical_multitenancy` as `enabled`
               and parent project in config, 
    the LB is created  in parent partition.

**_STACK-1893:_** 
2) Given parent partition being used by child projects already, the Parent project can create LB in that partition(parent), 
     regardless of **_hierarchical multitenancy feature_** **_(upp+hmt)_** is enabled or not.

## Manual Testing
- Same as mentioned in [STACK-1893](https://a10networks.atlassian.net/browse/STACK-1893) and [STACK-1894](https://a10networks.atlassian.net/browse/STACK-1894)

- Also created listeners, pool  and members to check the existing functionality is retained for hierarchical multitenancy.
