### PR TITLE
[Data-Migration with Config support][STACK-1866]: Data migration from a10-neutron-lbaas to octavia with config support

### DIFF
--- a/a10_octavia/a10_config.py
+++ b/a10_octavia/a10_config.py
@@ -76,6 +76,7 @@ class A10Config(object):
             self._config = blank_config
 
         self._config.octavia_conf_dir = '/etc/octavia/'
+        self._config.a10_octavia_conf_dir = '/etc/a10'
         self._load_config()
 
     def get_conf(self):
@@ -113,6 +114,9 @@ class A10Config(object):
         if self._config.database_connection is None:
             self._config.database_connection = self._get_octavia_db_string()
 
+        if self._config.neutron_database_connection is None:
+            self._config.neutron_database_connection = self._get_neutron_db_string()
+
         if self._config.keystone_auth_url is None:
             self._config.keystone_auth_url = self.get_octavia_conf('keystone_authtoken', 'auth_uri')
 
@@ -132,8 +136,34 @@ class A10Config(object):
             raise Exception('FatalError: Octavia config directoty could not be found.')
             LOG.error("A10Config could not find %s", self._config_path)
 
+    def get_a10_octavia_conf(self, section, option):
+        a10_octavia_conf_dir = os.environ.get(
+            'A10_OCTAVIA_CONF_DIR', self._config.a10_octavia_conf_dir)
+        a10_octavia_conf = '%s/a10-octavia.conf' % a10_octavia_conf_dir
+
+        if os.path.exists(a10_octavia_conf):
+            LOG.debug("found a10-octavia.conf file in /etc")
+            n = ini.ConfigParser()
+            n.read(a10_octavia_conf)
+            try:
+                return n.get(section, option)
+            except (ini.NoSectionError, ini.NoOptionError):
+                pass
+        else:
+            raise Exception('FatalError: a10 Octavia config directory could not be found.')
+            LOG.error("A10Config could not find %s", self._config_path)
+
     def _get_octavia_db_string(self):
         db_connection_url = self.get_octavia_conf('database', 'connection')
+
+        if db_connection_url is None:
+            raise exceptions.NoDatabaseURL()
+
+        LOG.debug("Using %s as db connect string", db_connection_url)
+        return db_connection_url
+
+    def _get_neutron_db_string(self):
+        db_connection_url = self.get_a10_octavia_conf('a10_database', 'neutron_connection_url')
 
         if db_connection_url is None:
             raise exceptions.NoDatabaseURL()

--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -149,6 +149,14 @@ A10_HARDWARE_THUNDER_OPTS = [
                                help=_('List of all device configuration'))
 ]
 
+A10_DATABASE_OPTS = [
+    cfg.StrOpt('neutron_connection_url',
+               default='',
+               help=_('Specify the neutron Database connection url along with'
+                      'username and password to connect. Eg - '
+                      'mysql+pymysql://<username>:<password>@<host>:<port>/neutron'))
+]
+
 A10_HEALTH_MANAGER_OPTS = [
     cfg.IPOpt('udp_server_ip_address',
               help=_('Server IP address that sends udp packets for '
@@ -332,6 +340,7 @@ cfg.CONF.register_opts(A10_LISTENER_OPTS, group='listener')
 cfg.CONF.register_opts(A10_SERVICE_GROUP_OPTS, group='service_group')
 cfg.CONF.register_opts(A10_SERVER_OPTS, group='server')
 cfg.CONF.register_opts(A10_HARDWARE_THUNDER_OPTS, group='hardware_thunder')
+cfg.CONF.register_opts(A10_DATABASE_OPTS, group='a10_database')
 
 
 # Ensure that the control exchange is set correctly

--- a/a10_octavia/db/migration/alembic_migrations/env.py
+++ b/a10_octavia/db/migration/alembic_migrations/env.py
@@ -23,7 +23,7 @@ target_metadata = None
 
 if getattr(config, 'connection', None) is None:
     a10_cfg = a10_config.A10Config()
-    config.set_main_option("sqlalchemy.url", a10_cfg.get('neutron_database_connection'))
+    config.set_main_option("sqlalchemy.url", a10_cfg.get('database_connection'))
 
 
 # other values from the config, defined by the needs of env.py,

--- a/a10_octavia/db/migration/alembic_migrations/env.py
+++ b/a10_octavia/db/migration/alembic_migrations/env.py
@@ -23,7 +23,7 @@ target_metadata = None
 
 if getattr(config, 'connection', None) is None:
     a10_cfg = a10_config.A10Config()
-    config.set_main_option("sqlalchemy.url", a10_cfg.get('database_connection'))
+    config.set_main_option("sqlalchemy.url", a10_cfg.get('neutron_database_connection'))
 
 
 # other values from the config, defined by the needs of env.py,

--- a/a10_octavia/db/migration/alembic_migrations/versions/4fa8c3867dcb_a10_device_instance_to_vthunders.py
+++ b/a10_octavia/db/migration/alembic_migrations/versions/4fa8c3867dcb_a10_device_instance_to_vthunders.py
@@ -42,6 +42,8 @@ def upgrade():
             nova_instance_id = _row[17]
             if nova_instance_id is not None:
                 undercloud = False
+            else:
+                undercloud = True
             vthunders.append(VThunder(vthunder_id=_row[0],
                                       device_name=_row[4],
                                       ip_address=_row[18],
@@ -49,6 +51,7 @@ def upgrade():
                                       password=_row[6],
                                       axapi_version=_row[7],
                                       project_id=_row[3],
+                                      topology="STANDALONE",
                                       created_at=_row[1],
                                       updated_at=_row[2],
                                       partition_name=_row[12],

--- a/a10_octavia/db/migration/alembic_migrations/versions/4fa8c3867dcb_a10_device_instance_to_vthunders.py
+++ b/a10_octavia/db/migration/alembic_migrations/versions/4fa8c3867dcb_a10_device_instance_to_vthunders.py
@@ -1,0 +1,63 @@
+"""a10-device-instance to vthunders
+
+Revision ID: 4fa8c3867dcb
+Revises: 05b1446c7f20
+Create Date: 2020-12-03 10:12:07.785078
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from oslo_utils import uuidutils
+from sqlalchemy.orm import sessionmaker
+
+from a10_octavia import a10_config
+from a10_octavia.db.models import VThunder
+
+# revision identifiers, used by Alembic.
+revision = '4fa8c3867dcb'
+down_revision = 'a6e9b9b69494'
+branch_labels = None
+depends_on = None
+
+try:
+    bind = op.get_bind()
+except NameError:
+    pass
+else:
+    session = sessionmaker(bind=bind)
+    sess = session()
+
+
+def upgrade():
+    # a10_cfg = a10_config.A10Config()
+    # db_str = a10_cfg.get('a10_database_connection')
+    db_engine = sa.create_engine(db_str)
+    with db_engine.connect() as con:
+        results = con.execute('select * from a10_device_instances')
+        vthunders = []
+        for _row in results:
+            nova_instance_id = _row[17]
+            if nova_instance_id not None:
+                undercloud = False
+            vthunders.append(VThunder(device_name=_row[4],
+                                      ip_address=_row[18],
+                                      username=_row[5],
+                                      password=_row[6],
+                                      axapi_version=_row[7],
+                                      project_id=_row[3],
+                                      created_at=_row[1],
+                                      updated_at=_row[2],
+                                      partition_name=_row[12],
+                                      write_memory=_row[16],
+                                      protocol=_row[8],
+                                      port=_row[9],
+                                      undercloud=undercloud))
+        sess.add_all(vthunders)
+        sess.commit()
+    sess.close()
+
+
+def downgrade():
+    sess.query(VThunder).filter().delete()
+    sess.commit()
+    sess.close()

--- a/a10_octavia/db/migration/alembic_migrations/versions/4fa8c3867dcb_a10_device_instance_to_vthunders.py
+++ b/a10_octavia/db/migration/alembic_migrations/versions/4fa8c3867dcb_a10_device_instance_to_vthunders.py
@@ -9,12 +9,10 @@ from alembic import op
 import sqlalchemy as sa
 from oslo_utils import uuidutils
 from sqlalchemy.orm import sessionmaker
-from oslo_config import cfg
 
 from a10_octavia import a10_config
 from a10_octavia.db.models import VThunder
 
-CONF = cfg.CONF
 
 # revision identifiers, used by Alembic.
 revision = '4fa8c3867dcb'
@@ -59,8 +57,8 @@ def upgrade():
                                       protocol=_row[8],
                                       port=_row[9],
                                       undercloud=undercloud))
-    sess.add_all(vthunders)
-    sess.commit()
+        sess.add_all(vthunders)
+        sess.commit()
     sess.close()
 
 

--- a/a10_octavia/etc/defaults.py
+++ b/a10_octavia/etc/defaults.py
@@ -1,5 +1,6 @@
 GLOBAL_DEFAULTS = {
     "database_connection": None,
+    "neutron_database_connection": None,
     "octavia_conf_dir": '/etc/octavia',
     "member_name_use_uuid": False,
     "keystone_auth_url": None,


### PR DESCRIPTION
## Description
Migrating data from a10-neutron-lbaas's a10_device_instances table to octavia's vthunders table by getting database connection of a10-neutron-lbaas through config file

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1866
https://a10networks.atlassian.net/browse/STACK-1864
https://a10networks.atlassian.net/browse/STACK-1865
https://a10networks.atlassian.net/browse/STACK-1891

## Technical Approach
- Added support for **neutron_connection_url** by adding it to `defaults.py` and `config_options.py`
- Getting **neutron_database_connection** from config to data-migration script by adding respective code for it in `a10_config.py`
- For this, added methods `get_a10_octavia_conf()` to get the `a10-octavia.conf` path and added another method `_get_neutron_db_string` to get `neutron_connection_url` from it
- Written data migration script to map and migrate a10-device-instances fields to vthunder's fields.
- In the migration script, added logic to set **undercloud == False** in vthunders if **nova_instance_id is true** in a10_device_instances.
- Set **topology = STANDALONE** by default in vthunders table

## Config Changes
For data migration from a10_device_instances to vthunders, add the following section to config:

```
[a10_database]
neutron_connection_url = mysql+pymysql://root:password@127.0.0.1:3306/lbaas
```
Value of neutron_connection_url will be connection_url of a10-neutron-lbaas's database


## Manual Testing
Testing is done with 1 custom database(lbaas) and octavia database as a10-neutron-lbaas setup is not yet done
Data Migration is done from `a10_device_instances table of lbaas db` to `vthunders table of octavia db.`

![image](https://user-images.githubusercontent.com/58077446/101615966-c8698100-3a34-11eb-9a22-7b7d982dde6d.png)

![image](https://user-images.githubusercontent.com/58077446/101616074-e59e4f80-3a34-11eb-97b3-146598c6b4a2.png)


