### PR TITLE
[STACK-1895]: Added provision for data migration using "a10-octavia-db-manage" utility(DB string provided through CLI).

### DIFF
--- a/a10_octavia/a10_config.py
+++ b/a10_octavia/a10_config.py
@@ -166,7 +166,7 @@ class A10Config(object):
         db_connection_url = self.get_a10_octavia_conf('a10_database', 'neutron_connection_url')
 
         if db_connection_url is None:
-            raise exceptions.NoDatabaseURL()
+            return
 
         LOG.debug("Using %s as db connect string", db_connection_url)
         return db_connection_url

--- a/a10_octavia/a10_config.py
+++ b/a10_octavia/a10_config.py
@@ -166,7 +166,7 @@ class A10Config(object):
         db_connection_url = self.get_a10_octavia_conf('a10_database', 'neutron_connection_url')
 
         if db_connection_url is None:
-            return
+            raise exceptions.NoDatabaseURL()
 
         LOG.debug("Using %s as db connect string", db_connection_url)
         return db_connection_url

--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -205,3 +205,11 @@ class SharedPartitionTemplateNotSupported(acos_errors.FeatureNotSupported):
         msg = ('Shared partition template lookup for [{0}] is not supported'
                ' on template `{1}`').format(resource, template_key)
         super(SharedPartitionTemplateNotSupported, self).__init__(code=505, msg=msg)
+
+
+class NLbaasDBError(exceptions.OctaviaException):
+
+    def __init__(self, error):
+        msg = 'Issue in connecting/performing operation on ' \
+              'neutron lbaas DB due to {}'.format(error)
+        super(NLbaasDBError, self).__init__(msg)

--- a/a10_octavia/db/migration/alembic_migrations/versions/4fa8c3867dcb_a10_device_instance_to_vthunders.py
+++ b/a10_octavia/db/migration/alembic_migrations/versions/4fa8c3867dcb_a10_device_instance_to_vthunders.py
@@ -11,6 +11,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import sessionmaker
 
 from a10_octavia import a10_config
+from a10_octavia.common import exceptions
 from a10_octavia.db.models import VThunder
 
 
@@ -34,35 +35,39 @@ def upgrade():
     if not db_str:
         a10_cfg = a10_config.A10Config()
         db_str = a10_cfg.get('neutron_database_connection')
-    db_engine = sa.create_engine(db_str)
-    with db_engine.connect() as con:
-        results = con.execute('select * from a10_device_instances')
-        vthunders = []
-        for _row in results:
-            nova_instance_id = _row[17]
-            if nova_instance_id is not None:
-                undercloud = False
-            else:
-                undercloud = True
-            vthunders.append(VThunder(vthunder_id=_row[0],
-                                      device_name=_row[4],
-                                      ip_address=_row[18],
-                                      username=_row[5],
-                                      password=_row[6],
-                                      axapi_version=_row[7],
-                                      project_id=_row[3],
-                                      topology="STANDALONE",
-                                      created_at=_row[1],
-                                      updated_at=_row[2],
-                                      partition_name=_row[12],
-                                      write_memory=_row[16],
-                                      protocol=_row[8],
-                                      port=_row[9],
-                                      undercloud=undercloud,
-                                      hierarchical_multitenancy=False))
-        sess.add_all(vthunders)
-        sess.commit()
-    sess.close()
+    try:
+        db_engine = sa.create_engine(db_str)
+
+        with db_engine.connect() as con:
+            results = con.execute('select * from a10_device_instances')
+            vthunders = []
+            for _row in results:
+                nova_instance_id = _row[17]
+                if nova_instance_id is not None:
+                    undercloud = False
+                else:
+                    undercloud = True
+                vthunders.append(VThunder(vthunder_id=_row[0],
+                                          device_name=_row[4],
+                                          ip_address=_row[18],
+                                          username=_row[5],
+                                          password=_row[6],
+                                          axapi_version=_row[7],
+                                          project_id=_row[3],
+                                          topology="STANDALONE",
+                                          created_at=_row[1],
+                                          updated_at=_row[2],
+                                          partition_name=_row[12],
+                                          write_memory=_row[16],
+                                          protocol=_row[8],
+                                          port=_row[9],
+                                          undercloud=undercloud,
+                                          hierarchical_multitenancy=False))
+            sess.add_all(vthunders)
+            sess.commit()
+        sess.close()
+    except Exception as e:
+        raise exceptions.NLbaasDBError(e)
 
 
 def downgrade():

--- a/a10_octavia/db/migration/alembic_migrations/versions/4fa8c3867dcb_a10_device_instance_to_vthunders.py
+++ b/a10_octavia/db/migration/alembic_migrations/versions/4fa8c3867dcb_a10_device_instance_to_vthunders.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import sessionmaker
 
 from a10_octavia import a10_config
 from a10_octavia.db.models import VThunder
+from alembic import context
 
 
 # revision identifiers, used by Alembic.
@@ -30,8 +31,10 @@ else:
 
 
 def upgrade():
-    a10_cfg = a10_config.A10Config()
-    db_str = a10_cfg.get('neutron_database_connection')
+    db_str = context.get_x_argument(as_dictionary=True).get('dbname')
+    if not db_str:
+        a10_cfg = a10_config.A10Config()
+        db_str = a10_cfg.get('neutron_database_connection')
     db_engine = sa.create_engine(db_str)
     with db_engine.connect() as con:
         results = con.execute('select * from a10_device_instances')

--- a/a10_octavia/db/migration/alembic_migrations/versions/4fa8c3867dcb_a10_device_instance_to_vthunders.py
+++ b/a10_octavia/db/migration/alembic_migrations/versions/4fa8c3867dcb_a10_device_instance_to_vthunders.py
@@ -6,13 +6,12 @@ Create Date: 2020-12-03 10:12:07.785078
 
 """
 from alembic import op
+from alembic import context
 import sqlalchemy as sa
-from oslo_utils import uuidutils
 from sqlalchemy.orm import sessionmaker
 
 from a10_octavia import a10_config
 from a10_octavia.db.models import VThunder
-from alembic import context
 
 
 # revision identifiers, used by Alembic.
@@ -31,38 +30,40 @@ else:
 
 
 def upgrade():
-    db_str = context.get_x_argument(as_dictionary=True).get('dbname')
+    db_str = context.config.get_main_option('db')
     if not db_str:
         a10_cfg = a10_config.A10Config()
         db_str = a10_cfg.get('neutron_database_connection')
-    db_engine = sa.create_engine(db_str)
-    with db_engine.connect() as con:
-        results = con.execute('select * from a10_device_instances')
-        vthunders = []
-        for _row in results:
-            nova_instance_id = _row[17]
-            if nova_instance_id is not None:
-                undercloud = False
-            else:
-                undercloud = True
-            vthunders.append(VThunder(vthunder_id=_row[0],
-                                      device_name=_row[4],
-                                      ip_address=_row[18],
-                                      username=_row[5],
-                                      password=_row[6],
-                                      axapi_version=_row[7],
-                                      project_id=_row[3],
-                                      topology="STANDALONE",
-                                      created_at=_row[1],
-                                      updated_at=_row[2],
-                                      partition_name=_row[12],
-                                      write_memory=_row[16],
-                                      protocol=_row[8],
-                                      port=_row[9],
-                                      undercloud=undercloud))
-        sess.add_all(vthunders)
-        sess.commit()
-    sess.close()
+    if db_str:
+        db_engine = sa.create_engine(db_str)
+        with db_engine.connect() as con:
+            results = con.execute('select * from a10_device_instances')
+            vthunders = []
+            for _row in results:
+                nova_instance_id = _row[17]
+                if nova_instance_id is not None:
+                    undercloud = False
+                else:
+                    undercloud = True
+                vthunders.append(VThunder(vthunder_id=_row[0],
+                                          device_name=_row[4],
+                                          ip_address=_row[18],
+                                          username=_row[5],
+                                          password=_row[6],
+                                          axapi_version=_row[7],
+                                          project_id=_row[3],
+                                          topology="STANDALONE",
+                                          created_at=_row[1],
+                                          updated_at=_row[2],
+                                          partition_name=_row[12],
+                                          write_memory=_row[16],
+                                          protocol=_row[8],
+                                          port=_row[9],
+                                          undercloud=undercloud,
+                                          hierarchical_multitenancy=False))
+            sess.add_all(vthunders)
+            sess.commit()
+        sess.close()
 
 
 def downgrade():

--- a/a10_octavia/db/migration/alembic_migrations/versions/4fa8c3867dcb_a10_device_instance_to_vthunders.py
+++ b/a10_octavia/db/migration/alembic_migrations/versions/4fa8c3867dcb_a10_device_instance_to_vthunders.py
@@ -34,36 +34,35 @@ def upgrade():
     if not db_str:
         a10_cfg = a10_config.A10Config()
         db_str = a10_cfg.get('neutron_database_connection')
-    if db_str:
-        db_engine = sa.create_engine(db_str)
-        with db_engine.connect() as con:
-            results = con.execute('select * from a10_device_instances')
-            vthunders = []
-            for _row in results:
-                nova_instance_id = _row[17]
-                if nova_instance_id is not None:
-                    undercloud = False
-                else:
-                    undercloud = True
-                vthunders.append(VThunder(vthunder_id=_row[0],
-                                          device_name=_row[4],
-                                          ip_address=_row[18],
-                                          username=_row[5],
-                                          password=_row[6],
-                                          axapi_version=_row[7],
-                                          project_id=_row[3],
-                                          topology="STANDALONE",
-                                          created_at=_row[1],
-                                          updated_at=_row[2],
-                                          partition_name=_row[12],
-                                          write_memory=_row[16],
-                                          protocol=_row[8],
-                                          port=_row[9],
-                                          undercloud=undercloud,
-                                          hierarchical_multitenancy=False))
-            sess.add_all(vthunders)
-            sess.commit()
-        sess.close()
+    db_engine = sa.create_engine(db_str)
+    with db_engine.connect() as con:
+        results = con.execute('select * from a10_device_instances')
+        vthunders = []
+        for _row in results:
+            nova_instance_id = _row[17]
+            if nova_instance_id is not None:
+                undercloud = False
+            else:
+                undercloud = True
+            vthunders.append(VThunder(vthunder_id=_row[0],
+                                      device_name=_row[4],
+                                      ip_address=_row[18],
+                                      username=_row[5],
+                                      password=_row[6],
+                                      axapi_version=_row[7],
+                                      project_id=_row[3],
+                                      topology="STANDALONE",
+                                      created_at=_row[1],
+                                      updated_at=_row[2],
+                                      partition_name=_row[12],
+                                      write_memory=_row[16],
+                                      protocol=_row[8],
+                                      port=_row[9],
+                                      undercloud=undercloud,
+                                      hierarchical_multitenancy=False))
+        sess.add_all(vthunders)
+        sess.commit()
+    sess.close()
 
 
 def downgrade():

--- a/a10_octavia/db/migration/cli.py
+++ b/a10_octavia/db/migration/cli.py
@@ -24,14 +24,111 @@ from oslo_log import log
 
 from octavia.i18n import _
 
-from octavia.db.migration.cli import do_alembic_command, do_check_migration, do_upgrade, no_downgrade, do_stamp, do_revision, add_command_parsers
-
 
 CONF = cfg.CONF
 options.set_defaults(CONF)
 log.set_defaults()
 log.register_options(CONF)
 log.setup(CONF, 'a10-octavia-db-manage')
+
+
+def do_alembic_command(config, cmd, *args, **kwargs):
+    try:
+        getattr(alembic_cmd, cmd)(config, *args, **kwargs)
+    except alembic_u.CommandError as e:
+        alembic_u.err(str(e))
+
+
+def do_check_migration(config, _cmd):
+    do_alembic_command(config, 'branches')
+
+
+def add_alembic_subparser(sub, cmd):
+    return sub.add_parser(cmd, help=getattr(alembic_cmd, cmd).__doc__)
+
+
+def do_upgrade(config, cmd):
+    if not CONF.command.revision and not CONF.command.delta:
+        raise SystemExit(_('You must provide a revision or relative delta'))
+
+    revision = CONF.command.revision or ''
+    if '-' in revision:
+        raise SystemExit(_('Negative relative revision (downgrade) not '
+                           'supported'))
+
+    delta = CONF.command.delta
+
+    if delta:
+        if '+' in revision:
+            raise SystemExit(_('Use either --delta or relative revision, '
+                               'not both'))
+        if delta < 0:
+            raise SystemExit(_('Negative delta (downgrade) not supported'))
+        revision = '%s+%d' % (revision, delta)
+
+    if CONF.command.db:
+        config.set_main_option('db', CONF.command.db)
+
+    do_alembic_command(config, cmd, revision, sql=CONF.command.sql)
+
+
+def do_downgrade(config, cmd):
+    do_alembic_command(config, cmd, CONF.command.revision)
+
+
+def do_stamp(config, cmd):
+    do_alembic_command(config, cmd,
+                       CONF.command.revision,
+                       sql=CONF.command.sql)
+
+
+def do_revision(config, cmd):
+    do_alembic_command(config, cmd,
+                       message=CONF.command.message,
+                       autogenerate=CONF.command.autogenerate,
+                       sql=CONF.command.sql)
+
+
+def add_command_parsers(subparsers):
+
+    for name in ['current', 'history', 'branches']:
+        parser = add_alembic_subparser(subparsers, name)
+        parser.set_defaults(func=do_alembic_command)
+
+    help_text = (getattr(alembic_cmd, 'branches').__doc__ +
+                 ' and validate head file')
+    parser = subparsers.add_parser('check_migration', help=help_text)
+    parser.set_defaults(func=do_check_migration)
+
+    parser = add_alembic_subparser(subparsers, 'upgrade')
+    parser.add_argument('--delta', type=int)
+    parser.add_argument('--sql', action='store_true')
+    parser.add_argument('--db', type=str)
+    parser.add_argument('revision', nargs='?')
+    parser.set_defaults(func=do_upgrade)
+
+    parser = add_alembic_subparser(subparsers, 'downgrade')
+    parser.add_argument('revision')
+    parser.set_defaults(func=do_downgrade)
+
+    parser = add_alembic_subparser(subparsers, 'stamp')
+    parser.add_argument('--sql', action='store_true')
+    parser.add_argument('revision')
+    parser.set_defaults(func=do_stamp)
+
+    parser = add_alembic_subparser(subparsers, 'revision')
+    parser.add_argument('-m', '--message')
+    parser.add_argument('--autogenerate', action='store_true')
+    parser.add_argument('--sql', action='store_true')
+    parser.set_defaults(func=do_revision)
+
+
+command_opt = cfg.SubCommandOpt('command',
+                                title='Command',
+                                help='Available commands',
+                                handler=add_command_parsers)
+
+CONF.register_cli_opt(command_opt)
 
 
 def main():


### PR DESCRIPTION
## Description
Added the support for using "a10-octavia-db-manage" utility for data migration from a10-neutron-lbaas to Octavia. This utility provides the provision to accept DB string through CLI.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1895

## Technical Approach
- Worked on the investigation of providing DB name through CLI.
- Checked alembic doc to understand the passing of external context to migration script.
- Accessed the DB UL passed to config context.
- Used the DB URL fetched from config context to get the data from a10-neutron-lbaas DB.

## Manual Testing
Test 1: Tested the DB migration by providing DB URL in config.
Test 2: Tested the DB migration by removing DB URL from config(DB from CLI also not provided)
Test 3: Tested DB migration by providing DB URL from CLI through a10-octavia-db-manage utility.
Test 4: Tested DB migration by providing the wrong DB URL through CLI.
Test 5: Tested DB migration when DB URL not provided from config and CLI as well.

