### PR TITLE
[Write-Memory-Enhancement] Added write memory related configs in house_keeping service

### DIFF
--- a/a10_octavia/cmd/a10_house_keeper.py
+++ b/a10_octavia/cmd/a10_house_keeper.py
@@ -34,6 +34,7 @@ spare_amp_thread_event = threading.Event()
 db_cleanup_thread_event = threading.Event()
 write_memory_thread_event = threading.Event()
 
+
 def spare_amphora_check():
     """Initiates spare amp check with respect to configured interval."""
 
@@ -72,6 +73,7 @@ def db_cleanup():
                      'is restarting: {}'.format(e))
         db_cleanup_thread_event.wait(interval)
 
+
 def write_memory():
     """Performs write memory for all thunders"""
     if not CONF.a10_house_keeping.disable_write_memory:
@@ -84,10 +86,11 @@ def write_memory():
                 write_memory_perform.perform_memory_writes()
             except Exception as e:
                 LOG.exception('write memory caught the following exception and '
-                         ' is restarting: {}'.format(e))
+                              ' is restarting: {}'.format(e))
             write_memory_thread_event.wait(interval)
     else:
         LOG.warning("Write memory flag is disabled...")
+
 
 def _mutate_config(*args, **kwargs):
     LOG.info("Housekeeping recieved HUP signal, mutating config.")
@@ -112,7 +115,7 @@ def main():
     db_cleanup_thread.daemon = True
     db_cleanup_thread.start()
 
-    #Thread to perform write memory
+    # Thread to perform write memory
     write_memory_thread = threading.Thread(target=write_memory)
     write_memory_thread.daemon = True
     write_memory_thread.start()

--- a/a10_octavia/cmd/a10_house_keeper.py
+++ b/a10_octavia/cmd/a10_house_keeper.py
@@ -32,7 +32,7 @@ CONF = cfg.CONF
 
 spare_amp_thread_event = threading.Event()
 db_cleanup_thread_event = threading.Event()
-
+write_memory_thread_event = threading.Event()
 
 def spare_amphora_check():
     """Initiates spare amp check with respect to configured interval."""
@@ -72,6 +72,22 @@ def db_cleanup():
                      'is restarting: {}'.format(e))
         db_cleanup_thread_event.wait(interval)
 
+def write_memory():
+    """Performs write memory for all thunders"""
+    if not CONF.a10_house_keeping.disable_write_memory:
+        interval = CONF.a10_house_keeping.write_mem_interval
+        write_memory_perform = house_keeping.WriteMemory()
+        LOG.info("Write Memory interval set to %s seconds", interval)
+        while not write_memory_thread_event.is_set():
+            LOG.info("Initiating the write memory operation for all thunders......")
+            try:
+                write_memory_perform.perform_memory_writes()
+            except Exception as e:
+                LOG.exception('write memory caught the following exception and '
+                         ' is restarting: {}'.format(e))
+            write_memory_thread_event.wait(interval)
+    else:
+        LOG.warning("Write memory flag is disabled...")
 
 def _mutate_config(*args, **kwargs):
     LOG.info("Housekeeping recieved HUP signal, mutating config.")
@@ -96,6 +112,11 @@ def main():
     db_cleanup_thread.daemon = True
     db_cleanup_thread.start()
 
+    #Thread to perform write memory
+    write_memory_thread = threading.Thread(target=write_memory)
+    write_memory_thread.daemon = True
+    write_memory_thread.start()
+
     signal.signal(signal.SIGHUP, _mutate_config)
 
     # Try-Exception block should be at the end to gracefully exit threads
@@ -106,6 +127,8 @@ def main():
         LOG.info("Attempting to gracefully terminate House-Keeping")
         spare_amp_thread_event.set()
         db_cleanup_thread_event.set()
+        write_memory_thread_event.set()
         spare_amp_thread.join()
         db_cleanup_thread.join()
+        write_memory_thread.join()
         LOG.info("House-Keeping process terminated")

--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -285,7 +285,17 @@ A10_HOUSE_KEEPING_OPTS = [
     cfg.IntOpt('cert_rotate_threads',
                default=10,
                help=_('Number of threads performing vthunder certificate'
-                      ' rotation'))
+                      ' rotation')),
+    cfg.IntOpt('write_mem_interval',
+               default=3600,
+               help=_('Write Memory interval in seconds')),
+    cfg.BoolOpt('disable_write_memory',
+                default=False,
+                help=_('Set this flag to disable write memory on all thunders')),
+    cfg.IntOpt('write_mem_expiry_time',
+               default=3600,
+               help=_('Interval(seconds) window after which thunders needs'
+                      ' Write Memory operation'))
 ]
 
 A10_NOVA_OPTS = [


### PR DESCRIPTION
## Description
- Added config support for Write memory thread in houseKeeper service

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-1945
- https://a10networks.atlassian.net/browse/STACK-1942
- https://a10networks.atlassian.net/browse/STACK-1941
- https://a10networks.atlassian.net/browse/STACK-1940
- https://a10networks.atlassian.net/browse/STACK-1957


## Technical Approach
- Added configs like `disable_write_memory`, `write_mem_interval`, `write_mem_expiry_time` 
```
disable_write_memory (boolean, default=False): User can set this to True, If they don’t want housekeeper to perform write memory feature. 

write_mem_interval (seconds, default and min =3600 ie 1 hour) : interval to wait before performing write memory operation on thunders. 

write_mem_expiry_time(seconds, default and min=3600 ie 1 hour) : helps in maintaining a window and filtering thunder that are eligible for performing write memory.
```
- Added thread of write memory in main() class of housekeeper module and based on configuration call perform_write_memory()

## Config Changes

<pre>
[a10_house_keeping]
<b>write_mem_interval = 3600</b>
<b>write_mem_expiry_time = 3660</b>
</pre>

## Test Cases
- None

## Manual Testing
- None
