### PR TITLE
[Write-Memory-Enhancement]: Added controller worker flow for write memory operation

### DIFF
--- a/a10_octavia/cmd/a10_house_keeper.py
+++ b/a10_octavia/cmd/a10_house_keeper.py
@@ -76,7 +76,7 @@ def db_cleanup():
 
 def write_memory():
     """Performs write memory for all thunders"""
-    if not CONF.a10_house_keeping.disable_write_memory:
+    if CONF.a10_house_keeping.use_periodic_write_memory == 'enable':
         interval = CONF.a10_house_keeping.write_mem_interval
         write_memory_perform = house_keeping.WriteMemory()
         LOG.info("Write Memory interval set to %s seconds", interval)

--- a/a10_octavia/cmd/a10_house_keeper.py
+++ b/a10_octavia/cmd/a10_house_keeper.py
@@ -82,6 +82,8 @@ def write_memory():
         LOG.info("Write Memory interval set to %s seconds", interval)
         while not write_memory_thread_event.is_set():
             LOG.info("Initiating the write memory operation for all thunders...")
+            timestamp = datetime.datetime.utcnow()
+            LOG.debug("Starting write memory thread ar %s", str(timestamp))
             try:
                 write_memory_perform.perform_memory_writes()
             except Exception as e:
@@ -102,8 +104,8 @@ def main():
 
     gmr.TextGuruMeditation.setup_autorun(version)
 
-    timestamp = str(datetime.datetime.utcnow())
-    LOG.info("Starting house keeping at %s", timestamp)
+    timestamp = datetime.datetime.utcnow()
+    LOG.info("Starting house keeping at %s", str(timestamp))
 
     # Thread to perform spare amphora check
     spare_amp_thread = threading.Thread(target=spare_amphora_check)

--- a/a10_octavia/cmd/a10_house_keeper.py
+++ b/a10_octavia/cmd/a10_house_keeper.py
@@ -81,7 +81,7 @@ def write_memory():
         write_memory_perform = house_keeping.WriteMemory()
         LOG.info("Write Memory interval set to %s seconds", interval)
         while not write_memory_thread_event.is_set():
-            LOG.info("Initiating the write memory operation for all thunders......")
+            LOG.info("Initiating the write memory operation for all thunders...")
             try:
                 write_memory_perform.perform_memory_writes()
             except Exception as e:

--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -105,6 +105,7 @@ DELETE_HEALTH_MONITOR_SUBFLOW_WITH_POOL_DELETE_FLOW = 'delete-health-monitor-sub
 DELETE_MEMBERS_SUBFLOW_WITH_POOL_DELETE_FLOW = 'delete-members-subflow-with-pool-delete-flow'
 HANDLE_VRID_MEMBER_SUBFLOW = 'handle-vrid-member-subflow'
 SPARE_VTHUNDER_CREATE = 'spare-vthunder-create'
+WRITE_MEMORY_THUNDER_FLOW = 'write-memory-thunder-flow'
 LB_TO_VTHUNDER_SUBFLOW = 'lb-to-vthunder-subflow'
 VRID_LIST = 'vrid_list'
 RESOURCE_COUNT = 'resource_count'

--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -291,11 +291,7 @@ A10_HOUSE_KEEPING_OPTS = [
                help=_('Write Memory interval in seconds')),
     cfg.BoolOpt('disable_write_memory',
                 default=False,
-                help=_('Set this flag to disable write memory on all thunders')),
-    cfg.IntOpt('write_mem_expiry_time',
-               default=3600,
-               help=_('Interval(seconds) window after which thunders needs'
-                      ' Write Memory operation'))
+                help=_('Set this flag to disable write memory on all thunders'))
 ]
 
 A10_NOVA_OPTS = [

--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -289,9 +289,10 @@ A10_HOUSE_KEEPING_OPTS = [
     cfg.IntOpt('write_mem_interval',
                default=3600,
                help=_('Write Memory interval in seconds')),
-    cfg.BoolOpt('disable_write_memory',
-                default=False,
-                help=_('Set this flag to disable write memory on all thunders'))
+    cfg.StrOpt('use_periodic_write_memory',
+               choices=['enable', 'disable'],
+               default='disable',
+               help=_('Enable to use periodic write memory on all thunders'))
 ]
 
 A10_NOVA_OPTS = [

--- a/a10_octavia/controller/housekeeping/house_keeping.py
+++ b/a10_octavia/controller/housekeeping/house_keeping.py
@@ -102,13 +102,14 @@ class WriteMemory(object):
         self.cw = cw.A10ControllerWorker()
 
     def perform_memory_writes(self):
-        exp_age = datetime.timedelta(seconds=CONF.a10_house_keeping.write_mem_expiry_time)
+        write_interval = datetime.timedelta(seconds=CONF.a10_house_keeping.write_mem_interval)
         session = db_api.get_session()
-        thunders = self.thunder_repo.get_write_memory_eligible_thunders(session, exp_age=exp_age)
-        thunder_ids = [thunder.vthunder_id for thunder in thunders]
+        thunders = self.thunder_repo.get_write_memory_eligible_thunders(session,
+                                                                        exp_age=write_interval)
+        thunder_ids = [str(thunder.vthunder_id) for thunder in thunders]
         if thunders:
             LOG.info("Write Memory for Thunder ids: %s", thunder_ids)
             self.cw.perform_write_memory(thunders)
             LOG.info("Finished write memory for {} vthunders...".format(len(thunders)))
         else:
-            LOG.warning("All thunders are in cool down period......")
+            LOG.warning("All thunders are in cool down period...")

--- a/a10_octavia/controller/housekeeping/house_keeping.py
+++ b/a10_octavia/controller/housekeeping/house_keeping.py
@@ -103,13 +103,12 @@ class WriteMemory(object):
 
     def perform_memory_writes(self):
         write_interval = datetime.timedelta(seconds=CONF.a10_house_keeping.write_mem_interval)
-        session = db_api.get_session()
-        thunders = self.thunder_repo.get_write_memory_eligible_thunders(session,
+        thunders = self.thunder_repo.get_recently_updated_thunders(db_api.get_session(),
                                                                         exp_age=write_interval)
         thunder_ids = [str(thunder.vthunder_id) for thunder in thunders]
         if thunders:
             LOG.info("Write Memory for Thunder ids: %s", thunder_ids)
             self.cw.perform_write_memory(thunders)
-            LOG.info("Finished write memory for {} vthunders...".format(len(thunders)))
+            LOG.info("Finished write memory for {} thunders...".format(len(thunders)))
         else:
             LOG.warning("All thunders are in cool down period...")

--- a/a10_octavia/controller/housekeeping/house_keeping.py
+++ b/a10_octavia/controller/housekeeping/house_keeping.py
@@ -109,9 +109,10 @@ class WriteMemory(object):
         global prev_run_time
 
         write_interval = datetime.timedelta(seconds=CONF.a10_house_keeping.write_mem_interval)
-        expiry_time = datetime.datetime.utcnow() - write_interval
-        if prev_run_time and prev_run_time < expiry_time:
-            LOG.debug("Previous write memory thread ran at %s: ", str(prev_run_time))
+        curr_time_stamp = datetime.datetime.utcnow()
+        expiry_time = curr_time_stamp - write_interval
+        if (prev_run_time and int(prev_run_time.strftime("%s")) < int(expiry_time.strftime("%s"))):
+            LOG.debug("Previous write memory thread ran at %s: ", str(prev_run_time)) 
             expiry_time = prev_run_time
         thunders = self.thunder_repo.get_recently_updated_thunders(db_api.get_session(),
                                                                    expiry_time=expiry_time)
@@ -123,7 +124,7 @@ class WriteMemory(object):
                 ip_partition_list.add(ip_partition)
                 thunder_list.append(thunder)
 
-        prev_run_time = datetime.datetime.utcnow()
+        prev_run_time = curr_time_stamp
 
         if thunder_list:
             LOG.info("Write Memory for Thunders : %s", list(ip_partition_list))

--- a/a10_octavia/controller/housekeeping/house_keeping.py
+++ b/a10_octavia/controller/housekeeping/house_keeping.py
@@ -104,7 +104,7 @@ class WriteMemory(object):
     def perform_memory_writes(self):
         write_interval = datetime.timedelta(seconds=CONF.a10_house_keeping.write_mem_interval)
         thunders = self.thunder_repo.get_recently_updated_thunders(db_api.get_session(),
-                                                                        exp_age=write_interval)
+                                                                   exp_age=write_interval)
         thunder_ids = [str(thunder.vthunder_id) for thunder in thunders]
         if thunders:
             LOG.info("Write Memory for Thunder ids: %s", thunder_ids)

--- a/a10_octavia/controller/housekeeping/house_keeping.py
+++ b/a10_octavia/controller/housekeeping/house_keeping.py
@@ -110,8 +110,8 @@ class WriteMemory(object):
 
         write_interval = datetime.timedelta(seconds=CONF.a10_house_keeping.write_mem_interval)
         expiry_time = datetime.datetime.utcnow() - write_interval
-
         if prev_run_time and prev_run_time < expiry_time:
+            LOG.debug("Previous write memory thread ran at %s: ", str(prev_run_time))
             expiry_time = prev_run_time
         thunders = self.thunder_repo.get_recently_updated_thunders(db_api.get_session(),
                                                                    expiry_time=expiry_time)
@@ -128,7 +128,7 @@ class WriteMemory(object):
         if thunder_list:
             LOG.info("Write Memory for Thunders : %s", list(ip_partition_list))
             self.cw.perform_write_memory(thunder_list)
-            LOG.info("Finished write memory for {} thunders...".format(len(thunder_list)))
+            LOG.info("Finished running write memory for {} thunders...".format(len(thunder_list)))
         else:
             LOG.warning("No thunders found that are recently updated."
                         " Not performing write memory...")

--- a/a10_octavia/controller/housekeeping/house_keeping.py
+++ b/a10_octavia/controller/housekeeping/house_keeping.py
@@ -98,22 +98,19 @@ class DatabaseCleanup(object):
 
 class WriteMemory(object):
 
-    global prev_run_time
-    prev_run_time = None
-
     def __init__(self):
+        self.prev_run_time = None
         self.thunder_repo = a10repo.VThunderRepository()
         self.cw = cw.A10ControllerWorker()
 
     def perform_memory_writes(self):
-        global prev_run_time
-
         write_interval = datetime.timedelta(seconds=CONF.a10_house_keeping.write_mem_interval)
         curr_time_stamp = datetime.datetime.utcnow()
         expiry_time = curr_time_stamp - write_interval
-        if (prev_run_time and int(prev_run_time.strftime("%s")) < int(expiry_time.strftime("%s"))):
-            LOG.debug("Previous write memory thread ran at %s: ", str(prev_run_time)) 
-            expiry_time = prev_run_time
+        if (self.prev_run_time and int(self.prev_run_time.strftime("%s")) <
+                int(expiry_time.strftime("%s"))):
+            LOG.debug("Previous write memory thread ran at %s: ", str(self.prev_run_time))
+            expiry_time = self.prev_run_time
         thunders = self.thunder_repo.get_recently_updated_thunders(db_api.get_session(),
                                                                    expiry_time=expiry_time)
         ip_partition_list = set()
@@ -124,7 +121,7 @@ class WriteMemory(object):
                 ip_partition_list.add(ip_partition)
                 thunder_list.append(thunder)
 
-        prev_run_time = curr_time_stamp
+        self.prev_run_time = curr_time_stamp
 
         if thunder_list:
             LOG.info("Write Memory for Thunders : %s", list(ip_partition_list))

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -892,3 +892,19 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
     def _get_db_obj_until_pending_update(self, repo, id):
         return repo.get(db_apis.get_session(), id=id)
+
+    def perform_write_memory(self, thunders):
+        """Perform write memory operations for a thunders
+
+        :param thunders: group of thunder objects
+        :returns: None
+        """
+        store = {a10constants.WRITE_MEM_SHARED_PART: True}
+
+        write_mem_tf = self._taskflow_load(self._vthunder_flows.get_write_memory_flow(thunders,
+                                                                                      store),
+                                           store=store)
+
+        with tf_logging.DynamicLoggingListener(write_mem_tf,
+                                               log=LOG):
+            write_mem_tf.run()

--- a/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
@@ -59,13 +59,12 @@ class HealthMonitorFlows(object):
             requires=constants.POOL))
         create_hm_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        if CONF.a10_house_keeping.disable_write_memory:
-            create_hm_flow.add(vthunder_tasks.WriteMemory(
-                name=a10constants.WRITE_MEM_FOR_LOCAL_PARTITION,
-                requires=(a10constants.VTHUNDER)))
-            create_hm_flow.add(vthunder_tasks.WriteMemory(
-                name=a10constants.WRITE_MEM_FOR_SHARED_PARTITION,
-                requires=(a10constants.VTHUNDER, a10constants.WRITE_MEM_SHARED_PART)))
+        create_hm_flow.add(vthunder_tasks.WriteMemory(
+            name=a10constants.WRITE_MEM_FOR_LOCAL_PARTITION,
+            requires=(a10constants.VTHUNDER)))
+        create_hm_flow.add(vthunder_tasks.WriteMemory(
+            name=a10constants.WRITE_MEM_FOR_SHARED_PARTITION,
+            requires=(a10constants.VTHUNDER, a10constants.WRITE_MEM_SHARED_PART)))
         create_hm_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=(a10constants.VTHUNDER)))
         return create_hm_flow
@@ -101,13 +100,12 @@ class HealthMonitorFlows(object):
             requires=constants.POOL))
         delete_hm_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        if CONF.a10_house_keeping.disable_write_memory:
-            delete_hm_flow.add(vthunder_tasks.WriteMemory(
-                name=a10constants.WRITE_MEM_FOR_LOCAL_PARTITION,
-                requires=(a10constants.VTHUNDER)))
-            delete_hm_flow.add(vthunder_tasks.WriteMemory(
-                name=a10constants.WRITE_MEM_FOR_SHARED_PARTITION,
-                requires=(a10constants.VTHUNDER, a10constants.WRITE_MEM_SHARED_PART)))
+        delete_hm_flow.add(vthunder_tasks.WriteMemory(
+            name=a10constants.WRITE_MEM_FOR_LOCAL_PARTITION,
+            requires=(a10constants.VTHUNDER)))
+        delete_hm_flow.add(vthunder_tasks.WriteMemory(
+            name=a10constants.WRITE_MEM_FOR_SHARED_PARTITION,
+            requires=(a10constants.VTHUNDER, a10constants.WRITE_MEM_SHARED_PART)))
         delete_hm_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=(a10constants.VTHUNDER)))
         return delete_hm_flow
@@ -149,13 +147,12 @@ class HealthMonitorFlows(object):
             requires=constants.POOL))
         update_hm_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        if CONF.a10_house_keeping.disable_write_memory:
-            update_hm_flow.add(vthunder_tasks.WriteMemory(
-                name=a10constants.WRITE_MEM_FOR_LOCAL_PARTITION,
-                requires=(a10constants.VTHUNDER)))
-            update_hm_flow.add(vthunder_tasks.WriteMemory(
-                name=a10constants.WRITE_MEM_FOR_SHARED_PARTITION,
-                requires=(a10constants.VTHUNDER, a10constants.WRITE_MEM_SHARED_PART)))
+        update_hm_flow.add(vthunder_tasks.WriteMemory(
+            name=a10constants.WRITE_MEM_FOR_LOCAL_PARTITION,
+            requires=(a10constants.VTHUNDER)))
+        update_hm_flow.add(vthunder_tasks.WriteMemory(
+            name=a10constants.WRITE_MEM_FOR_SHARED_PARTITION,
+            requires=(a10constants.VTHUNDER, a10constants.WRITE_MEM_SHARED_PART)))
         update_hm_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=(a10constants.VTHUNDER)))
         return update_hm_flow

--- a/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
@@ -54,6 +54,13 @@ class HealthMonitorFlows(object):
             requires=constants.POOL))
         create_hm_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
+        if CONF.a10_house_keeping.disable_write_memory:
+            create_hm_flow.add(vthunder_tasks.WriteMemory(
+                name=a10constants.WRITE_MEM_FOR_LOCAL_PARTITION,
+                requires=(a10constants.VTHUNDER)))
+            create_hm_flow.add(vthunder_tasks.WriteMemory(
+                name=a10constants.WRITE_MEM_FOR_SHARED_PARTITION,
+                requires=(a10constants.VTHUNDER, a10constants.WRITE_MEM_SHARED_PART)))
         create_hm_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=(a10constants.VTHUNDER)))
         return create_hm_flow
@@ -89,6 +96,13 @@ class HealthMonitorFlows(object):
             requires=constants.POOL))
         delete_hm_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
+        if CONF.a10_house_keeping.disable_write_memory:
+            delete_hm_flow.add(vthunder_tasks.WriteMemory(
+                name=a10constants.WRITE_MEM_FOR_LOCAL_PARTITION,
+                requires=(a10constants.VTHUNDER)))
+            delete_hm_flow.add(vthunder_tasks.WriteMemory(
+                name=a10constants.WRITE_MEM_FOR_SHARED_PARTITION,
+                requires=(a10constants.VTHUNDER, a10constants.WRITE_MEM_SHARED_PART)))
         delete_hm_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=(a10constants.VTHUNDER)))
         return delete_hm_flow
@@ -130,6 +144,13 @@ class HealthMonitorFlows(object):
             requires=constants.POOL))
         update_hm_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
+        if CONF.a10_house_keeping.disable_write_memory:
+            update_hm_flow.add(vthunder_tasks.WriteMemory(
+                name=a10constants.WRITE_MEM_FOR_LOCAL_PARTITION,
+                requires=(a10constants.VTHUNDER)))
+            update_hm_flow.add(vthunder_tasks.WriteMemory(
+                name=a10constants.WRITE_MEM_FOR_SHARED_PARTITION,
+                requires=(a10constants.VTHUNDER, a10constants.WRITE_MEM_SHARED_PART)))
         update_hm_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=(a10constants.VTHUNDER)))
         return update_hm_flow

--- a/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
@@ -13,8 +13,6 @@
 #    under the License.
 
 
-from oslo_config import cfg
-
 from taskflow.patterns import linear_flow
 
 from octavia.common import constants
@@ -26,8 +24,6 @@ from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks
 from a10_octavia.controller.worker.tasks import health_monitor_tasks
 from a10_octavia.controller.worker.tasks import vthunder_tasks
-
-CONF = cfg.CONF
 
 
 class HealthMonitorFlows(object):

--- a/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
@@ -23,7 +23,6 @@ from octavia.controller.worker.tasks import model_tasks
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks
 from a10_octavia.controller.worker.tasks import health_monitor_tasks
-from a10_octavia.controller.worker.tasks import vthunder_tasks
 
 
 class HealthMonitorFlows(object):
@@ -55,12 +54,8 @@ class HealthMonitorFlows(object):
             requires=constants.POOL))
         create_hm_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        create_hm_flow.add(vthunder_tasks.WriteMemory(
-            name=a10constants.WRITE_MEM_FOR_LOCAL_PARTITION,
+        create_hm_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=(a10constants.VTHUNDER)))
-        create_hm_flow.add(vthunder_tasks.WriteMemory(
-            name=a10constants.WRITE_MEM_FOR_SHARED_PARTITION,
-            requires=(a10constants.VTHUNDER, a10constants.WRITE_MEM_SHARED_PART)))
         return create_hm_flow
 
     def get_delete_health_monitor_flow(self):
@@ -94,12 +89,8 @@ class HealthMonitorFlows(object):
             requires=constants.POOL))
         delete_hm_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        delete_hm_flow.add(vthunder_tasks.WriteMemory(
-            name=a10constants.WRITE_MEM_FOR_LOCAL_PARTITION,
+        delete_hm_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=(a10constants.VTHUNDER)))
-        delete_hm_flow.add(vthunder_tasks.WriteMemory(
-            name=a10constants.WRITE_MEM_FOR_SHARED_PARTITION,
-            requires=(a10constants.VTHUNDER, a10constants.WRITE_MEM_SHARED_PART)))
         return delete_hm_flow
 
     def get_delete_health_monitor_vthunder_subflow(self):
@@ -139,10 +130,6 @@ class HealthMonitorFlows(object):
             requires=constants.POOL))
         update_hm_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        update_hm_flow.add(vthunder_tasks.WriteMemory(
-            name=a10constants.WRITE_MEM_FOR_LOCAL_PARTITION,
+        update_hm_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=(a10constants.VTHUNDER)))
-        update_hm_flow.add(vthunder_tasks.WriteMemory(
-            name=a10constants.WRITE_MEM_FOR_SHARED_PARTITION,
-            requires=(a10constants.VTHUNDER, a10constants.WRITE_MEM_SHARED_PART)))
         return update_hm_flow

--- a/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
@@ -61,7 +61,7 @@ class HealthMonitorFlows(object):
         create_hm_flow.add(vthunder_tasks.WriteMemory(
             name=a10constants.WRITE_MEM_FOR_SHARED_PARTITION,
             requires=(a10constants.VTHUNDER, a10constants.WRITE_MEM_SHARED_PART)))
-        create_hm_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        create_hm_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=(a10constants.VTHUNDER)))
         return create_hm_flow
 
@@ -102,7 +102,7 @@ class HealthMonitorFlows(object):
         delete_hm_flow.add(vthunder_tasks.WriteMemory(
             name=a10constants.WRITE_MEM_FOR_SHARED_PARTITION,
             requires=(a10constants.VTHUNDER, a10constants.WRITE_MEM_SHARED_PART)))
-        delete_hm_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        delete_hm_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=(a10constants.VTHUNDER)))
         return delete_hm_flow
 
@@ -149,6 +149,6 @@ class HealthMonitorFlows(object):
         update_hm_flow.add(vthunder_tasks.WriteMemory(
             name=a10constants.WRITE_MEM_FOR_SHARED_PARTITION,
             requires=(a10constants.VTHUNDER, a10constants.WRITE_MEM_SHARED_PART)))
-        update_hm_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        update_hm_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=(a10constants.VTHUNDER)))
         return update_hm_flow

--- a/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
@@ -13,6 +13,8 @@
 #    under the License.
 
 
+from oslo_config import cfg
+
 from taskflow.patterns import linear_flow
 
 from octavia.common import constants
@@ -23,6 +25,9 @@ from octavia.controller.worker.tasks import model_tasks
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks
 from a10_octavia.controller.worker.tasks import health_monitor_tasks
+from a10_octavia.controller.worker.tasks import vthunder_tasks
+
+CONF = cfg.CONF
 
 
 class HealthMonitorFlows(object):

--- a/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
@@ -22,7 +22,6 @@ from octavia.controller.worker.tasks import model_tasks
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks
 from a10_octavia.controller.worker.tasks import l7policy_tasks
-from a10_octavia.controller.worker.tasks import vthunder_tasks
 
 
 class L7PolicyFlows(object):
@@ -48,7 +47,7 @@ class L7PolicyFlows(object):
             requires=constants.L7POLICY))
         create_l7policy_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        create_l7policy_flow.add(vthunder_tasks.WriteMemory(
+        create_l7policy_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_l7policy_flow
 
@@ -75,7 +74,7 @@ class L7PolicyFlows(object):
             requires=constants.L7POLICY))
         delete_l7policy_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        delete_l7policy_flow.add(vthunder_tasks.WriteMemory(
+        delete_l7policy_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_l7policy_flow
 
@@ -107,6 +106,6 @@ class L7PolicyFlows(object):
             requires=constants.L7POLICY))
         update_l7policy_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        update_l7policy_flow.add(vthunder_tasks.WriteMemory(
+        update_l7policy_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_l7policy_flow

--- a/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
@@ -12,7 +12,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from oslo_config import cfg
 from taskflow.patterns import linear_flow
 
 from octavia.common import constants
@@ -24,8 +23,6 @@ from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks
 from a10_octavia.controller.worker.tasks import l7policy_tasks
 from a10_octavia.controller.worker.tasks import vthunder_tasks
-
-CONF = cfg.CONF
 
 
 class L7PolicyFlows(object):

--- a/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
@@ -51,9 +51,8 @@ class L7PolicyFlows(object):
             requires=constants.L7POLICY))
         create_l7policy_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        if CONF.a10_house_keeping.disable_write_memory:
-            create_l7policy_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        create_l7policy_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         create_l7policy_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_l7policy_flow
@@ -81,9 +80,8 @@ class L7PolicyFlows(object):
             requires=constants.L7POLICY))
         delete_l7policy_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        if CONF.a10_house_keeping.disable_write_memory:
-            delete_l7policy_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        delete_l7policy_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         delete_l7policy_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_l7policy_flow
@@ -116,9 +114,8 @@ class L7PolicyFlows(object):
             requires=constants.L7POLICY))
         update_l7policy_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        if CONF.a10_house_keeping.disable_write_memory:
-            update_l7policy_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        update_l7policy_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         update_l7policy_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_l7policy_flow

--- a/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
@@ -47,6 +47,9 @@ class L7PolicyFlows(object):
             requires=constants.L7POLICY))
         create_l7policy_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
+        if CONF.a10_house_keeping.disable_write_memory:
+            create_l7policy_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         create_l7policy_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_l7policy_flow
@@ -74,6 +77,9 @@ class L7PolicyFlows(object):
             requires=constants.L7POLICY))
         delete_l7policy_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
+        if CONF.a10_house_keeping.disable_write_memory:
+            delete_l7policy_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         delete_l7policy_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_l7policy_flow
@@ -106,6 +112,9 @@ class L7PolicyFlows(object):
             requires=constants.L7POLICY))
         update_l7policy_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
+        if CONF.a10_house_keeping.disable_write_memory:
+            update_l7policy_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         update_l7policy_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_l7policy_flow

--- a/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
@@ -12,6 +12,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from oslo_config import cfg
 from taskflow.patterns import linear_flow
 
 from octavia.common import constants
@@ -22,6 +23,9 @@ from octavia.controller.worker.tasks import model_tasks
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks
 from a10_octavia.controller.worker.tasks import l7policy_tasks
+from a10_octavia.controller.worker.tasks import vthunder_tasks
+
+CONF = cfg.CONF
 
 
 class L7PolicyFlows(object):

--- a/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
@@ -50,7 +50,7 @@ class L7PolicyFlows(object):
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
         create_l7policy_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        create_l7policy_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        create_l7policy_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_l7policy_flow
 
@@ -79,7 +79,7 @@ class L7PolicyFlows(object):
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
         delete_l7policy_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        delete_l7policy_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        delete_l7policy_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_l7policy_flow
 
@@ -113,6 +113,6 @@ class L7PolicyFlows(object):
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
         update_l7policy_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        update_l7policy_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        update_l7policy_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_l7policy_flow

--- a/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
@@ -12,7 +12,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from oslo_config import cfg
 
 from taskflow.patterns import linear_flow
 
@@ -25,8 +24,6 @@ from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks
 from a10_octavia.controller.worker.tasks import l7rule_tasks
 from a10_octavia.controller.worker.tasks import vthunder_tasks
-
-CONF = cfg.CONF
 
 
 class L7RuleFlows(object):

--- a/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
@@ -22,7 +22,6 @@ from octavia.controller.worker.tasks import model_tasks
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks
 from a10_octavia.controller.worker.tasks import l7rule_tasks
-from a10_octavia.controller.worker.tasks import vthunder_tasks
 
 
 class L7RuleFlows(object):
@@ -49,7 +48,7 @@ class L7RuleFlows(object):
             requires=constants.L7POLICY))
         create_l7rule_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        create_l7rule_flow.add(vthunder_tasks.WriteMemory(
+        create_l7rule_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_l7rule_flow
 
@@ -76,7 +75,7 @@ class L7RuleFlows(object):
             requires=constants.L7POLICY))
         delete_l7rule_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        delete_l7rule_flow.add(vthunder_tasks.WriteMemory(
+        delete_l7rule_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_l7rule_flow
 
@@ -109,6 +108,6 @@ class L7RuleFlows(object):
             requires=constants.L7POLICY))
         update_l7rule_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        update_l7rule_flow.add(vthunder_tasks.WriteMemory(
+        update_l7rule_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_l7rule_flow

--- a/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
@@ -52,7 +52,7 @@ class L7RuleFlows(object):
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
         create_l7rule_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        create_l7rule_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        create_l7rule_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_l7rule_flow
 
@@ -81,7 +81,7 @@ class L7RuleFlows(object):
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
         delete_l7rule_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        delete_l7rule_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        delete_l7rule_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_l7rule_flow
 
@@ -116,6 +116,6 @@ class L7RuleFlows(object):
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
         update_l7rule_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        update_l7rule_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        update_l7rule_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_l7rule_flow

--- a/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
@@ -53,9 +53,8 @@ class L7RuleFlows(object):
             requires=constants.L7POLICY))
         create_l7rule_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        if CONF.a10_house_keeping.disable_write_memory:
-            create_l7rule_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        create_l7rule_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         create_l7rule_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_l7rule_flow
@@ -83,9 +82,8 @@ class L7RuleFlows(object):
             requires=constants.L7POLICY))
         delete_l7rule_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        if CONF.a10_house_keeping.disable_write_memory:
-            delete_l7rule_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        delete_l7rule_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         delete_l7rule_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_l7rule_flow
@@ -119,9 +117,8 @@ class L7RuleFlows(object):
             requires=constants.L7POLICY))
         update_l7rule_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        if CONF.a10_house_keeping.disable_write_memory:
-            update_l7rule_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        update_l7rule_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         update_l7rule_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_l7rule_flow

--- a/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
@@ -12,6 +12,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from oslo_config import cfg
+
 from taskflow.patterns import linear_flow
 
 from octavia.common import constants
@@ -22,6 +24,9 @@ from octavia.controller.worker.tasks import model_tasks
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks
 from a10_octavia.controller.worker.tasks import l7rule_tasks
+from a10_octavia.controller.worker.tasks import vthunder_tasks
+
+CONF = cfg.CONF
 
 
 class L7RuleFlows(object):

--- a/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
@@ -48,6 +48,9 @@ class L7RuleFlows(object):
             requires=constants.L7POLICY))
         create_l7rule_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
+        if CONF.a10_house_keeping.disable_write_memory:
+            create_l7rule_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         create_l7rule_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_l7rule_flow
@@ -75,6 +78,9 @@ class L7RuleFlows(object):
             requires=constants.L7POLICY))
         delete_l7rule_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
+        if CONF.a10_house_keeping.disable_write_memory:
+            delete_l7rule_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         delete_l7rule_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_l7rule_flow
@@ -108,6 +114,9 @@ class L7RuleFlows(object):
             requires=constants.L7POLICY))
         update_l7rule_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
+        if CONF.a10_house_keeping.disable_write_memory:
+            update_l7rule_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         update_l7rule_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_l7rule_flow

--- a/a10_octavia/controller/worker/flows/a10_listener_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_listener_flows.py
@@ -25,7 +25,6 @@ from a10_octavia.controller.worker.tasks import a10_database_tasks
 from a10_octavia.controller.worker.tasks import a10_network_tasks
 from a10_octavia.controller.worker.tasks import cert_tasks
 from a10_octavia.controller.worker.tasks import virtual_port_tasks
-from a10_octavia.controller.worker.tasks import vthunder_tasks
 
 
 class ListenerFlows(object):
@@ -48,7 +47,7 @@ class ListenerFlows(object):
                                  MarkLBAndListenerActiveInDB(
                                      requires=[constants.LOADBALANCER,
                                                constants.LISTENER]))
-        create_listener_flow.add(vthunder_tasks.WriteMemory(
+        create_listener_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_listener_flow
 
@@ -91,7 +90,7 @@ class ListenerFlows(object):
             requires=constants.LISTENER))
         delete_listener_flow.add(database_tasks.MarkLBActiveInDB(
             requires=constants.LOADBALANCER))
-        delete_listener_flow.add(vthunder_tasks.WriteMemory(
+        delete_listener_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_listener_flow
 
@@ -113,7 +112,7 @@ class ListenerFlows(object):
             requires=constants.LISTENER))
         delete_listener_flow.add(database_tasks.MarkLBActiveInDB(
             requires=constants.LOADBALANCER))
-        delete_listener_flow.add(vthunder_tasks.WriteMemory(
+        delete_listener_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_listener_flow
 
@@ -139,7 +138,7 @@ class ListenerFlows(object):
                                  MarkLBAndListenerActiveInDB(
                                      requires=[constants.LOADBALANCER,
                                                constants.LISTENER]))
-        update_listener_flow.add(vthunder_tasks.WriteMemory(
+        update_listener_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_listener_flow
 
@@ -163,7 +162,7 @@ class ListenerFlows(object):
                                  MarkLBAndListenerActiveInDB(
                                      requires=[constants.LOADBALANCER,
                                                constants.LISTENER]))
-        create_listener_flow.add(vthunder_tasks.WriteMemory(
+        create_listener_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_listener_flow
 

--- a/a10_octavia/controller/worker/flows/a10_listener_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_listener_flows.py
@@ -12,6 +12,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from oslo_config import cfg
+
 from taskflow.patterns import graph_flow
 from taskflow.patterns import linear_flow
 
@@ -25,6 +27,9 @@ from a10_octavia.controller.worker.tasks import a10_database_tasks
 from a10_octavia.controller.worker.tasks import a10_network_tasks
 from a10_octavia.controller.worker.tasks import cert_tasks
 from a10_octavia.controller.worker.tasks import virtual_port_tasks
+from a10_octavia.controller.worker.tasks import vthunder_tasks
+
+CONF = cfg.CONF
 
 
 class ListenerFlows(object):

--- a/a10_octavia/controller/worker/flows/a10_listener_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_listener_flows.py
@@ -12,7 +12,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from oslo_config import cfg
 
 from taskflow.patterns import graph_flow
 from taskflow.patterns import linear_flow
@@ -28,8 +27,6 @@ from a10_octavia.controller.worker.tasks import a10_network_tasks
 from a10_octavia.controller.worker.tasks import cert_tasks
 from a10_octavia.controller.worker.tasks import virtual_port_tasks
 from a10_octavia.controller.worker.tasks import vthunder_tasks
-
-CONF = cfg.CONF
 
 
 class ListenerFlows(object):

--- a/a10_octavia/controller/worker/flows/a10_listener_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_listener_flows.py
@@ -47,6 +47,9 @@ class ListenerFlows(object):
                                  MarkLBAndListenerActiveInDB(
                                      requires=[constants.LOADBALANCER,
                                                constants.LISTENER]))
+        if CONF.a10_house_keeping.disable_write_memory:
+            create_listener_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         create_listener_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_listener_flow
@@ -90,6 +93,9 @@ class ListenerFlows(object):
             requires=constants.LISTENER))
         delete_listener_flow.add(database_tasks.MarkLBActiveInDB(
             requires=constants.LOADBALANCER))
+        if CONF.a10_house_keeping.disable_write_memory:
+            delete_listener_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         delete_listener_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_listener_flow
@@ -112,6 +118,9 @@ class ListenerFlows(object):
             requires=constants.LISTENER))
         delete_listener_flow.add(database_tasks.MarkLBActiveInDB(
             requires=constants.LOADBALANCER))
+        if CONF.a10_house_keeping.disable_write_memory:
+            delete_listener_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         delete_listener_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_listener_flow
@@ -138,6 +147,9 @@ class ListenerFlows(object):
                                  MarkLBAndListenerActiveInDB(
                                      requires=[constants.LOADBALANCER,
                                                constants.LISTENER]))
+        if CONF.a10_house_keeping.disable_write_memory:
+            update_listener_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         update_listener_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_listener_flow
@@ -162,6 +174,9 @@ class ListenerFlows(object):
                                  MarkLBAndListenerActiveInDB(
                                      requires=[constants.LOADBALANCER,
                                                constants.LISTENER]))
+        if CONF.a10_house_keeping.disable_write_memory:
+            create_listener_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         create_listener_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_listener_flow

--- a/a10_octavia/controller/worker/flows/a10_listener_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_listener_flows.py
@@ -52,9 +52,8 @@ class ListenerFlows(object):
                                  MarkLBAndListenerActiveInDB(
                                      requires=[constants.LOADBALANCER,
                                                constants.LISTENER]))
-        if CONF.a10_house_keeping.disable_write_memory:
-            create_listener_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        create_listener_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         create_listener_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_listener_flow
@@ -98,9 +97,8 @@ class ListenerFlows(object):
             requires=constants.LISTENER))
         delete_listener_flow.add(database_tasks.MarkLBActiveInDB(
             requires=constants.LOADBALANCER))
-        if CONF.a10_house_keeping.disable_write_memory:
-            delete_listener_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        delete_listener_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         delete_listener_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_listener_flow
@@ -123,9 +121,8 @@ class ListenerFlows(object):
             requires=constants.LISTENER))
         delete_listener_flow.add(database_tasks.MarkLBActiveInDB(
             requires=constants.LOADBALANCER))
-        if CONF.a10_house_keeping.disable_write_memory:
-            delete_listener_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        delete_listener_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         delete_listener_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_listener_flow
@@ -152,9 +149,8 @@ class ListenerFlows(object):
                                  MarkLBAndListenerActiveInDB(
                                      requires=[constants.LOADBALANCER,
                                                constants.LISTENER]))
-        if CONF.a10_house_keeping.disable_write_memory:
-            update_listener_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        update_listener_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         update_listener_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_listener_flow
@@ -179,9 +175,8 @@ class ListenerFlows(object):
                                  MarkLBAndListenerActiveInDB(
                                      requires=[constants.LOADBALANCER,
                                                constants.LISTENER]))
-        if CONF.a10_house_keeping.disable_write_memory:
-            create_listener_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        create_listener_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         create_listener_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_listener_flow

--- a/a10_octavia/controller/worker/flows/a10_listener_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_listener_flows.py
@@ -51,7 +51,7 @@ class ListenerFlows(object):
                                                constants.LISTENER]))
         create_listener_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        create_listener_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        create_listener_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_listener_flow
 
@@ -96,7 +96,7 @@ class ListenerFlows(object):
             requires=constants.LOADBALANCER))
         delete_listener_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        delete_listener_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        delete_listener_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_listener_flow
 
@@ -120,7 +120,7 @@ class ListenerFlows(object):
             requires=constants.LOADBALANCER))
         delete_listener_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        delete_listener_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        delete_listener_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_listener_flow
 
@@ -148,7 +148,7 @@ class ListenerFlows(object):
                                                constants.LISTENER]))
         update_listener_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        update_listener_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        update_listener_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_listener_flow
 
@@ -174,7 +174,7 @@ class ListenerFlows(object):
                                                constants.LISTENER]))
         create_listener_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        create_listener_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        create_listener_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_listener_flow
 

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -77,6 +77,9 @@ class LoadBalancerFlows(object):
         lb_create_flow.add(virtual_server_tasks.CreateVirtualServerTask(
             requires=(constants.LOADBALANCER,
                            a10constants.VTHUNDER)))
+        if CONF.a10_house_keeping.disable_write_memory:
+            lb_create_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         lb_create_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return lb_create_flow
@@ -193,6 +196,9 @@ class LoadBalancerFlows(object):
             requires=constants.LOADBALANCER))
         delete_LB_flow.add(database_tasks.DecrementLoadBalancerQuota(
             requires=constants.LOADBALANCER))
+        if CONF.a10_house_keeping.disable_write_memory:
+            delete_LB_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         delete_LB_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return (delete_LB_flow, store)
@@ -290,6 +296,9 @@ class LoadBalancerFlows(object):
                           a10constants.VTHUNDER]))
         update_LB_flow.add(database_tasks.MarkLBActiveInDB(
             requires=constants.LOADBALANCER))
+        if CONF.a10_house_keeping.disable_write_memory:
+            update_LB_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         update_LB_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_LB_flow
@@ -335,7 +344,9 @@ class LoadBalancerFlows(object):
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
                       constants.FLAVOR_DATA),
             provides=a10constants.STATUS))
-
+        if CONF.a10_house_keeping.disable_write_memory:
+            lb_create_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         lb_create_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return lb_create_flow

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -77,9 +77,8 @@ class LoadBalancerFlows(object):
         lb_create_flow.add(virtual_server_tasks.CreateVirtualServerTask(
             requires=(constants.LOADBALANCER,
                            a10constants.VTHUNDER)))
-        if CONF.a10_house_keeping.disable_write_memory:
-            lb_create_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        lb_create_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         lb_create_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return lb_create_flow
@@ -196,9 +195,8 @@ class LoadBalancerFlows(object):
             requires=constants.LOADBALANCER))
         delete_LB_flow.add(database_tasks.DecrementLoadBalancerQuota(
             requires=constants.LOADBALANCER))
-        if CONF.a10_house_keeping.disable_write_memory:
-            delete_LB_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        delete_LB_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         delete_LB_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return (delete_LB_flow, store)
@@ -296,9 +294,8 @@ class LoadBalancerFlows(object):
                           a10constants.VTHUNDER]))
         update_LB_flow.add(database_tasks.MarkLBActiveInDB(
             requires=constants.LOADBALANCER))
-        if CONF.a10_house_keeping.disable_write_memory:
-            update_LB_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        update_LB_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         update_LB_flow.add(a10_database_tasks.MarkVThunderStatusInDB(
             name="pending_update_to_active",
             requires=a10constants.VTHUNDER,
@@ -348,9 +345,8 @@ class LoadBalancerFlows(object):
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
                       constants.FLAVOR_DATA),
             provides=a10constants.STATUS))
-        if CONF.a10_house_keeping.disable_write_memory:
-            lb_create_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        lb_create_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         lb_create_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return lb_create_flow

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -299,6 +299,10 @@ class LoadBalancerFlows(object):
         if CONF.a10_house_keeping.disable_write_memory:
             update_LB_flow.add(vthunder_tasks.WriteMemory(
                 requires=a10constants.VTHUNDER))
+        update_LB_flow.add(a10_database_tasks.MarkVThunderStatusInDB(
+            name="pending_update_to_active",
+            requires=a10constants.VTHUNDER,
+            inject={"status": constants.ACTIVE}))
         update_LB_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_LB_flow

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -77,7 +77,7 @@ class LoadBalancerFlows(object):
         lb_create_flow.add(virtual_server_tasks.CreateVirtualServerTask(
             requires=(constants.LOADBALANCER,
                            a10constants.VTHUNDER)))
-        lb_create_flow.add(vthunder_tasks.WriteMemory(
+        lb_create_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return lb_create_flow
 
@@ -193,7 +193,7 @@ class LoadBalancerFlows(object):
             requires=constants.LOADBALANCER))
         delete_LB_flow.add(database_tasks.DecrementLoadBalancerQuota(
             requires=constants.LOADBALANCER))
-        delete_LB_flow.add(vthunder_tasks.WriteMemory(
+        delete_LB_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return (delete_LB_flow, store)
 
@@ -290,7 +290,7 @@ class LoadBalancerFlows(object):
                           a10constants.VTHUNDER]))
         update_LB_flow.add(database_tasks.MarkLBActiveInDB(
             requires=constants.LOADBALANCER))
-        update_LB_flow.add(vthunder_tasks.WriteMemory(
+        update_LB_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_LB_flow
 
@@ -336,7 +336,7 @@ class LoadBalancerFlows(object):
                       constants.FLAVOR_DATA),
             provides=a10constants.STATUS))
 
-        lb_create_flow.add(vthunder_tasks.WriteMemory(
+        lb_create_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return lb_create_flow
 

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -79,7 +79,7 @@ class LoadBalancerFlows(object):
                            a10constants.VTHUNDER)))
         lb_create_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        lb_create_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        lb_create_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return lb_create_flow
 
@@ -197,7 +197,7 @@ class LoadBalancerFlows(object):
             requires=constants.LOADBALANCER))
         delete_LB_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        delete_LB_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        delete_LB_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return (delete_LB_flow, store)
 
@@ -300,7 +300,7 @@ class LoadBalancerFlows(object):
             name="pending_update_to_active",
             requires=a10constants.VTHUNDER,
             inject={"status": constants.ACTIVE}))
-        update_LB_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        update_LB_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_LB_flow
 
@@ -347,7 +347,7 @@ class LoadBalancerFlows(object):
             provides=a10constants.STATUS))
         lb_create_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        lb_create_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        lb_create_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return lb_create_flow
 

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -157,7 +157,7 @@ class MemberFlows(object):
         delete_member_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
         delete_member_flow.add(vthunder_tasks.WriteMemory(
-        requires=a10constants.VTHUNDER))
+            requires=a10constants.VTHUNDER))
         delete_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_member_flow

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -109,7 +109,7 @@ class MemberFlows(object):
                                              constants.LISTENERS)))
         create_member_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        create_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        create_member_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_member_flow
 
@@ -158,7 +158,7 @@ class MemberFlows(object):
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
         delete_member_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        delete_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        delete_member_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_member_flow
 
@@ -219,7 +219,7 @@ class MemberFlows(object):
                       constants.LISTENERS]))
         delete_member_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        delete_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        delete_member_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_member_flow
 
@@ -397,7 +397,7 @@ class MemberFlows(object):
                                              constants.LISTENERS]))
         update_member_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        update_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        update_member_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_member_flow
 
@@ -443,7 +443,7 @@ class MemberFlows(object):
                                              constants.LISTENERS]))
         update_member_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        update_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        update_member_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_member_flow
 
@@ -489,6 +489,6 @@ class MemberFlows(object):
                                              constants.LISTENERS)))
         create_member_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        create_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        create_member_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_member_flow

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -107,9 +107,8 @@ class MemberFlows(object):
                                MarkLBAndListenersActiveInDB(
                                    requires=(constants.LOADBALANCER,
                                              constants.LISTENERS)))
-        if CONF.a10_house_keeping.disable_write_memory:
-            create_member_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        create_member_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         create_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_member_flow
@@ -157,9 +156,8 @@ class MemberFlows(object):
             requires=constants.POOL))
         delete_member_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        if CONF.a10_house_keeping.disable_write_memory:
-            delete_member_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        delete_member_flow.add(vthunder_tasks.WriteMemory(
+        requires=a10constants.VTHUNDER))
         delete_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_member_flow
@@ -219,9 +217,8 @@ class MemberFlows(object):
         delete_member_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER,
                       constants.LISTENERS]))
-        if CONF.a10_house_keeping.disable_write_memory:
-            delete_member_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        delete_member_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         delete_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_member_flow
@@ -398,9 +395,8 @@ class MemberFlows(object):
                                MarkLBAndListenersActiveInDB(
                                    requires=[constants.LOADBALANCER,
                                              constants.LISTENERS]))
-        if CONF.a10_house_keeping.disable_write_memory:
-            update_member_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        update_member_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         update_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_member_flow
@@ -445,9 +441,8 @@ class MemberFlows(object):
                                MarkLBAndListenersActiveInDB(
                                    requires=[constants.LOADBALANCER,
                                              constants.LISTENERS]))
-        if CONF.a10_house_keeping.disable_write_memory:
-            update_member_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        update_member_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         update_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_member_flow
@@ -492,9 +487,8 @@ class MemberFlows(object):
                                MarkLBAndListenersActiveInDB(
                                    requires=(constants.LOADBALANCER,
                                              constants.LISTENERS)))
-        if CONF.a10_house_keeping.disable_write_memory:
-            create_member_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        create_member_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         create_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_member_flow

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -107,6 +107,9 @@ class MemberFlows(object):
                                MarkLBAndListenersActiveInDB(
                                    requires=(constants.LOADBALANCER,
                                              constants.LISTENERS)))
+        if CONF.a10_house_keeping.disable_write_memory:
+            create_member_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         create_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_member_flow
@@ -154,6 +157,9 @@ class MemberFlows(object):
             requires=constants.POOL))
         delete_member_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
+        if CONF.a10_house_keeping.disable_write_memory:
+            delete_member_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         delete_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_member_flow
@@ -213,6 +219,9 @@ class MemberFlows(object):
         delete_member_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER,
                       constants.LISTENERS]))
+        if CONF.a10_house_keeping.disable_write_memory:
+            delete_member_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         delete_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_member_flow
@@ -389,6 +398,9 @@ class MemberFlows(object):
                                MarkLBAndListenersActiveInDB(
                                    requires=[constants.LOADBALANCER,
                                              constants.LISTENERS]))
+        if CONF.a10_house_keeping.disable_write_memory:
+            update_member_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         update_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_member_flow
@@ -433,6 +445,9 @@ class MemberFlows(object):
                                MarkLBAndListenersActiveInDB(
                                    requires=[constants.LOADBALANCER,
                                              constants.LISTENERS]))
+        if CONF.a10_house_keeping.disable_write_memory:
+            update_member_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         update_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_member_flow
@@ -477,6 +492,9 @@ class MemberFlows(object):
                                MarkLBAndListenersActiveInDB(
                                    requires=(constants.LOADBALANCER,
                                              constants.LISTENERS)))
+        if CONF.a10_house_keeping.disable_write_memory:
+            create_member_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         create_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_member_flow

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -107,7 +107,7 @@ class MemberFlows(object):
                                MarkLBAndListenersActiveInDB(
                                    requires=(constants.LOADBALANCER,
                                              constants.LISTENERS)))
-        create_member_flow.add(vthunder_tasks.WriteMemory(
+        create_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_member_flow
 
@@ -154,7 +154,7 @@ class MemberFlows(object):
             requires=constants.POOL))
         delete_member_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        delete_member_flow.add(vthunder_tasks.WriteMemory(
+        delete_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_member_flow
 
@@ -213,7 +213,7 @@ class MemberFlows(object):
         delete_member_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER,
                       constants.LISTENERS]))
-        delete_member_flow.add(vthunder_tasks.WriteMemory(
+        delete_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return delete_member_flow
 
@@ -389,7 +389,7 @@ class MemberFlows(object):
                                MarkLBAndListenersActiveInDB(
                                    requires=[constants.LOADBALANCER,
                                              constants.LISTENERS]))
-        update_member_flow.add(vthunder_tasks.WriteMemory(
+        update_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_member_flow
 
@@ -433,7 +433,7 @@ class MemberFlows(object):
                                MarkLBAndListenersActiveInDB(
                                    requires=[constants.LOADBALANCER,
                                              constants.LISTENERS]))
-        update_member_flow.add(vthunder_tasks.WriteMemory(
+        update_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return update_member_flow
 
@@ -477,6 +477,6 @@ class MemberFlows(object):
                                MarkLBAndListenersActiveInDB(
                                    requires=(constants.LOADBALANCER,
                                              constants.LISTENERS)))
-        create_member_flow.add(vthunder_tasks.WriteMemory(
+        create_member_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return create_member_flow

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -12,7 +12,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from oslo_config import cfg
 
 from taskflow.patterns import graph_flow
 from taskflow.patterns import linear_flow
@@ -30,8 +29,6 @@ from a10_octavia.controller.worker.tasks import persist_tasks
 from a10_octavia.controller.worker.tasks import service_group_tasks
 from a10_octavia.controller.worker.tasks import virtual_port_tasks
 from a10_octavia.controller.worker.tasks import vthunder_tasks
-
-CONF = cfg.CONF
 
 
 class PoolFlows(object):

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -27,7 +27,6 @@ from a10_octavia.controller.worker.tasks import a10_database_tasks
 from a10_octavia.controller.worker.tasks import persist_tasks
 from a10_octavia.controller.worker.tasks import service_group_tasks
 from a10_octavia.controller.worker.tasks import virtual_port_tasks
-from a10_octavia.controller.worker.tasks import vthunder_tasks
 
 
 class PoolFlows(object):
@@ -64,7 +63,7 @@ class PoolFlows(object):
             requires=constants.POOL))
         create_pool_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        create_pool_flow.add(vthunder_tasks.WriteMemory(
+        create_pool_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
 
         return create_pool_flow
@@ -104,7 +103,7 @@ class PoolFlows(object):
             requires=[constants.POOL, constants.POOL_CHILD_COUNT]))
         delete_pool_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        delete_pool_flow.add(vthunder_tasks.WriteMemory(
+        delete_pool_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
 
         return delete_pool_flow
@@ -163,7 +162,7 @@ class PoolFlows(object):
             requires=constants.POOL))
         update_pool_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        update_pool_flow.add(vthunder_tasks.WriteMemory(
+        update_pool_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
 
         return update_pool_flow

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -63,6 +63,9 @@ class PoolFlows(object):
             requires=constants.POOL))
         create_pool_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
+        if CONF.a10_house_keeping.disable_write_memory:
+            create_pool_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         create_pool_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
 
@@ -103,6 +106,9 @@ class PoolFlows(object):
             requires=[constants.POOL, constants.POOL_CHILD_COUNT]))
         delete_pool_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
+        if CONF.a10_house_keeping.disable_write_memory:
+            delete_pool_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         delete_pool_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
 
@@ -162,6 +168,9 @@ class PoolFlows(object):
             requires=constants.POOL))
         update_pool_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
+        if CONF.a10_house_keeping.disable_write_memory:
+            update_pool_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         update_pool_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
 

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -12,6 +12,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from oslo_config import cfg
+
 from taskflow.patterns import graph_flow
 from taskflow.patterns import linear_flow
 
@@ -27,6 +29,9 @@ from a10_octavia.controller.worker.tasks import a10_database_tasks
 from a10_octavia.controller.worker.tasks import persist_tasks
 from a10_octavia.controller.worker.tasks import service_group_tasks
 from a10_octavia.controller.worker.tasks import virtual_port_tasks
+from a10_octavia.controller.worker.tasks import vthunder_tasks
+
+CONF = cfg.CONF
 
 
 class PoolFlows(object):

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -67,7 +67,7 @@ class PoolFlows(object):
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
         create_pool_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        create_pool_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        create_pool_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
 
         return create_pool_flow
@@ -109,7 +109,7 @@ class PoolFlows(object):
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
         delete_pool_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        delete_pool_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        delete_pool_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
 
         return delete_pool_flow
@@ -170,7 +170,7 @@ class PoolFlows(object):
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
         update_pool_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
-        update_pool_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
+        update_pool_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
 
         return update_pool_flow

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -68,9 +68,8 @@ class PoolFlows(object):
             requires=constants.POOL))
         create_pool_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        if CONF.a10_house_keeping.disable_write_memory:
-            create_pool_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        create_pool_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         create_pool_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
 
@@ -111,9 +110,8 @@ class PoolFlows(object):
             requires=[constants.POOL, constants.POOL_CHILD_COUNT]))
         delete_pool_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        if CONF.a10_house_keeping.disable_write_memory:
-            delete_pool_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        delete_pool_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         delete_pool_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
 
@@ -173,9 +171,8 @@ class PoolFlows(object):
             requires=constants.POOL))
         update_pool_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
             requires=[constants.LOADBALANCER, constants.LISTENERS]))
-        if CONF.a10_house_keeping.disable_write_memory:
-            update_pool_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        update_pool_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         update_pool_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
 

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -380,14 +380,14 @@ class VThunderFlows(object):
         vthunder_store = {}
         for vthunder in thunders:
             vthunder_store[vthunder.vthunder_id] = vthunder
-            write_memory_flow.add(vthunder_tasks.WriteMemory(
+            write_memory_flow.add(vthunder_tasks.WriteMemoryHouseKeeper(
                 requires=a10constants.VTHUNDER,
                 rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
                 name='{flow}-{partition}-{id}'.format(
                     id=vthunder.vthunder_id,
                     flow='WriteMemory-' + a10constants.WRITE_MEMORY_THUNDER_FLOW,
                     partition=a10constants.WRITE_MEM_FOR_LOCAL_PARTITION)))
-            write_memory_flow.add(vthunder_tasks.WriteMemory(
+            write_memory_flow.add(vthunder_tasks.WriteMemoryHouseKeeper(
                 requires=(a10constants.VTHUNDER, a10constants.WRITE_MEM_SHARED_PART),
                 rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
                 name='{flow}-{partition}-{id}'.format(

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -394,11 +394,5 @@ class VThunderFlows(object):
                     id=vthunder.vthunder_id,
                     flow='WriteMemory-' + a10constants.WRITE_MEMORY_THUNDER_FLOW,
                     partition=a10constants.WRITE_MEM_FOR_SHARED_PARTITION)))
-            write_memory_flow.add(a10_database_tasks.UpdateVThunderUpdatedAt(
-                requires=a10constants.VTHUNDER,
-                rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
-                name='{flow}-{id}'.format(
-                    id=vthunder.vthunder_id,
-                    flow='UpdateVThunderUpdatedAt-' + a10constants.WRITE_MEMORY_THUNDER_FLOW)))
         store.update(vthunder_store)
         return write_memory_flow

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -734,3 +734,19 @@ class GetFlavorData(BaseDatabaseTask):
                     id=flavor.flavor_profile_id)
                 flavor_data = json.loads(flavor_profile.flavor_data)
                 return self._format_keys(flavor_data)
+
+
+class UpdateVThunderUpdatedAt(BaseDatabaseTask):
+
+    def execute(self, vthunder):
+        try:
+            if vthunder:
+                LOG.debug("Updated the updated_at field for thunder : {}:{}"
+                          .format(vthunder.ip_address, vthunder.partition_name))
+                self.vthunder_repo.update(
+                    db_apis.get_session(),
+                    vthunder.id,
+                    updated_at=datetime.utcnow())
+        except Exception as e:
+            LOG.exception('Failed to set updated_at field for thunder due to: {}'
+                          ', skipping.'.format(str(e)))

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -736,7 +736,7 @@ class GetFlavorData(BaseDatabaseTask):
                 return self._format_keys(flavor_data)
 
 
-class UpdateVThunderUpdatedAt(BaseDatabaseTask):
+class SetThunderUpdatedAt(BaseDatabaseTask):
 
     def execute(self, vthunder):
         try:

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -768,18 +768,19 @@ class WriteMemory(VThunderBaseTask):
 
     @axapi_client_decorator
     def execute(self, vthunder, write_mem_shared_part=False):
-        try:
-            if vthunder:
-                if vthunder.partition_name != "shared" and not write_mem_shared_part:
-                    LOG.info("Performing write memory for thunder - {}:{}"
-                             .format(vthunder.ip_address, vthunder.partition_name))
-                    self.axapi_client.system.action.write_memory(
-                        partition="specified",
-                        specified_partition=vthunder.partition_name)
-                else:
-                    LOG.info("Performing write memory for thunder - {}:{}"
-                             .format(vthunder.ip_address, "shared"))
-                    self.axapi_client.system.action.write_memory(partition="shared")
-        except (acos_errors.ACOSException, req_exceptions.ConnectionError):
-            LOG.warning("Failed to write memory on thunder device: %s.... skipping",
-                        vthunder.ip_address)
+        if CONF.a10_house_keeping.disable_write_memory:
+            try:
+                if vthunder:
+                    if vthunder.partition_name != "shared" and not write_mem_shared_part:
+                        LOG.info("Performing write memory for thunder - {}:{}"
+                                 .format(vthunder.ip_address, vthunder.partition_name))
+                        self.axapi_client.system.action.write_memory(
+                            partition="specified",
+                            specified_partition=vthunder.partition_name)
+                    else:
+                        LOG.info("Performing write memory for thunder - {}:{}"
+                                 .format(vthunder.ip_address, "shared"))
+                        self.axapi_client.system.action.write_memory(partition="shared")
+            except (acos_errors.ACOSException, req_exceptions.ConnectionError):
+                LOG.warning("Failed to write memory on thunder device: %s.... skipping",
+                            vthunder.ip_address)

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -12,6 +12,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+
+from datetime import datetime
+
 import acos_client
 from acos_client import errors as acos_errors
 try:
@@ -784,3 +787,7 @@ class WriteMemory(VThunderBaseTask):
             except (acos_errors.ACOSException, req_exceptions.ConnectionError):
                 LOG.warning("Failed to write memory on thunder device: %s.... skipping",
                             vthunder.ip_address)
+                if not CONF.a10_house_keeping.disable_write_memory:
+                    self.vthunder_repo.update(db_apis.get_session(),
+                                              vthunder.id,
+                                              updated_at=datetime.utcnow())

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -787,6 +787,8 @@ class WriteMemory(VThunderBaseTask):
             except (acos_errors.ACOSException, req_exceptions.ConnectionError):
                 LOG.warning("Failed to write memory on thunder device: %s.... skipping",
                             vthunder.ip_address)
+                # Set updated_at of thunder to retry write memory
+                # for failed thunder via housekeeper
                 if not CONF.a10_house_keeping.disable_write_memory:
                     self.vthunder_repo.update(db_apis.get_session(),
                                               vthunder.id,

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -773,7 +773,7 @@ class WriteMemory(VThunderBaseTask):
 
     @axapi_client_decorator
     def execute(self, vthunder, write_mem_shared_part=False):
-        if CONF.a10_house_keeping.disable_write_memory:
+        if CONF.a10_house_keeping.use_periodic_write_memory == 'disable':
             try:
                 if vthunder:
                     if vthunder.partition_name != "shared" and not write_mem_shared_part:

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -771,10 +771,15 @@ class WriteMemory(VThunderBaseTask):
         try:
             if vthunder:
                 if vthunder.partition_name != "shared" and not write_mem_shared_part:
+                    LOG.info("Performing write memory for thunder - {}:{}"
+                             .format(vthunder.ip_address, vthunder.partition_name))
                     self.axapi_client.system.action.write_memory(
                         partition="specified",
                         specified_partition=vthunder.partition_name)
                 else:
+                    LOG.info("Performing write memory for thunder - {}:{}"
+                             .format(vthunder.ip_address, "shared"))
                     self.axapi_client.system.action.write_memory(partition="shared")
         except (acos_errors.ACOSException, req_exceptions.ConnectionError):
-            LOG.warning("Failed to write memory on thunder device: %s", vthunder.ip_address)
+            LOG.warning("Failed to write memory on thunder device: %s.... skipping",
+                        vthunder.ip_address)

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -186,7 +186,7 @@ class VThunderRepository(BaseRepository):
     def get_write_memory_eligible_thunders(self, session, exp_age):
         expiry_time = datetime.datetime.utcnow() - exp_age
         query = session.query(self.model_class).filter(
-            self.model_class.updated_at < expiry_time).filter(
+            self.model_class.updated_at > expiry_time).filter(
             self.model_class.status == 'ACTIVE')
         query = query.options(noload('*'))
         return query.all()

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -183,6 +183,14 @@ class BaseRepository(object):
 class VThunderRepository(BaseRepository):
     model_class = models.VThunder
 
+    def get_write_memory_eligible_thunders(self, session, exp_age):
+        expiry_time = datetime.datetime.utcnow() - exp_age
+        query = session.query(self.model_class).filter(
+            self.model_class.updated_at < expiry_time).filter(
+            self.model_class.status == 'ACTIVE')
+        query = query.options(noload('*'))
+        return query.all()
+
     def get_stale_vthunders(self, session, initial_setup_wait_time, failover_wait_time):
         model = session.query(self.model_class).filter(
             self.model_class.created_at < initial_setup_wait_time).filter(
@@ -375,7 +383,7 @@ class MemberRepository(repo.MemberRepository):
             self.model_class.project_id == project_id).filter(
             and_(self.model_class.ip_address == ip_address,
                  or_(self.model_class.provisioning_status == consts.PENDING_DELETE,
-                     self.model_class.provisioning_status == consts.ACTIVE))).count() 
+                     self.model_class.provisioning_status == consts.ACTIVE))).count()
 
     def get_pool_count_subnet(self, session, project_ids, subnet_id):
         return session.query(self.model_class.pool_id.distinct()).filter(

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -183,8 +183,7 @@ class BaseRepository(object):
 class VThunderRepository(BaseRepository):
     model_class = models.VThunder
 
-    def get_recently_updated_thunders(self, session, exp_age):
-        expiry_time = datetime.datetime.utcnow() - exp_age
+    def get_recently_updated_thunders(self, session, expiry_time):
         query = session.query(self.model_class).filter(
             self.model_class.updated_at >= expiry_time).filter(
             self.model_class.status == 'ACTIVE')

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -183,10 +183,10 @@ class BaseRepository(object):
 class VThunderRepository(BaseRepository):
     model_class = models.VThunder
 
-    def get_write_memory_eligible_thunders(self, session, exp_age):
+    def get_recently_updated_thunders(self, session, exp_age):
         expiry_time = datetime.datetime.utcnow() - exp_age
         query = session.query(self.model_class).filter(
-            self.model_class.updated_at > expiry_time).filter(
+            self.model_class.updated_at >= expiry_time).filter(
             self.model_class.status == 'ACTIVE')
         query = query.options(noload('*'))
         return query.all()

--- a/a10_octavia/tests/common/a10constants.py
+++ b/a10_octavia/tests/common/a10constants.py
@@ -56,6 +56,8 @@ SERVER_CONF_SECTION = 'server'
 VIRTUAL_SERVER_CONFIG_SECTION = 'slb'
 HEALTH_MONITOR_SECTION = 'health_monitor'
 
+A10_HOUSE_KEEPING = 'a10_house_keeping'
+
 MOCK_SERVICE_GROUP_PROTOCOL = "HTTP"
 MOCK_POOL_ID_2 = "mock-pool-2"
 MOCK_SUBNET_ID_2 = "mock-subnet-2"

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -489,8 +489,8 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         ret_val = flavor_task.execute(LB)
         self.assertEqual(ret_val, {})
 
-    def test_UpdateVThunderUpdatedAt_execute_update(self):
-        db_task = task.UpdateVThunderUpdatedAt()
+    def test_SetThunderUpdatedAt_execute_update(self):
+        db_task = task.SetThunderUpdatedAt()
         vthunder = copy.deepcopy(VTHUNDER)
         db_task.vthunder_repo.update = mock.Mock()
         db_task.execute(vthunder)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -488,3 +488,12 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         flavor_task.flavor_profile_repo.get.return_value = flavor_prof
         ret_val = flavor_task.execute(LB)
         self.assertEqual(ret_val, {})
+
+    def test_UpdateVThunderUpdatedAt_execute_update(self):
+        db_task = task.UpdateVThunderUpdatedAt()
+        vthunder = copy.deepcopy(VTHUNDER)
+        db_task.vthunder_repo.update = mock.Mock()
+        db_task.execute(vthunder)
+        db_task.vthunder_repo.update.assert_called_once_with(mock.ANY,
+                                                             vthunder.id,
+                                                             updated_at=mock.ANY)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -514,6 +514,23 @@ class TestVThunderTasks(base.BaseTaskTestCase):
             partition='specified',
             specified_partition='testPartition')
 
+    def test_WriteMemoryHouseKeeper_execute_save_shared_mem(self):
+        mock_thunder = copy.deepcopy(VTHUNDER)
+        mock_task = task.WriteMemoryHouseKeeper()
+        mock_task.axapi_client = self.client_mock
+        mock_task.execute(mock_thunder)
+        self.client_mock.system.action.write_memory.assert_called_with(partition='shared')
+
+    def test_WriteMemoryHouseKeeper_execute_save_specific_partition_mem(self):
+        thunder = copy.deepcopy(VTHUNDER)
+        thunder.partition_name = "testPartition"
+        mock_task = task.WriteMemoryHouseKeeper()
+        mock_task.axapi_client = self.client_mock
+        mock_task.execute(thunder)
+        self.client_mock.system.action.write_memory.assert_called_with(
+            partition='specified',
+            specified_partition='testPartition')
+
     def test_WriteMemory_execute_not_called(self):
         self.conf.register_opts(config_options.A10_HOUSE_KEEPING_OPTS,
                                 group=a10constants.A10_HOUSE_KEEPING)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -490,6 +490,10 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         self.assertIsNone(ret_val)
 
     def test_WriteMemory_execute_save_shared_mem(self):
+        self.conf.register_opts(config_options.A10_HOUSE_KEEPING_OPTS,
+                                group=a10constants.A10_HOUSE_KEEPING)
+        self.conf.config(group=a10constants.A10_HOUSE_KEEPING,
+                         disable_write_memory=True)
         mock_thunder = copy.deepcopy(VTHUNDER)
         mock_task = task.WriteMemory()
         mock_task.axapi_client = self.client_mock
@@ -497,6 +501,10 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         self.client_mock.system.action.write_memory.assert_called_with(partition='shared')
 
     def test_WriteMemory_execute_save_specific_partition_mem(self):
+        self.conf.register_opts(config_options.A10_HOUSE_KEEPING_OPTS,
+                                group=a10constants.A10_HOUSE_KEEPING)
+        self.conf.config(group=a10constants.A10_HOUSE_KEEPING,
+                         disable_write_memory=True)
         thunder = copy.deepcopy(VTHUNDER)
         thunder.partition_name = "testPartition"
         mock_task = task.WriteMemory()
@@ -507,6 +515,10 @@ class TestVThunderTasks(base.BaseTaskTestCase):
             specified_partition='testPartition')
 
     def test_WriteMemory_execute_delete_flow_after_error_no_fail(self):
+        self.conf.register_opts(config_options.A10_HOUSE_KEEPING_OPTS,
+                                group=a10constants.A10_HOUSE_KEEPING)
+        self.conf.config(group=a10constants.A10_HOUSE_KEEPING,
+                         disable_write_memory=True)
         ret_val = task.WriteMemory().execute(vthunder=None)
         self.assertIsNone(ret_val)
 

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -493,7 +493,7 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         self.conf.register_opts(config_options.A10_HOUSE_KEEPING_OPTS,
                                 group=a10constants.A10_HOUSE_KEEPING)
         self.conf.config(group=a10constants.A10_HOUSE_KEEPING,
-                         disable_write_memory=True)
+                         use_periodic_write_memory='disable')
         mock_thunder = copy.deepcopy(VTHUNDER)
         mock_task = task.WriteMemory()
         mock_task.axapi_client = self.client_mock
@@ -504,7 +504,7 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         self.conf.register_opts(config_options.A10_HOUSE_KEEPING_OPTS,
                                 group=a10constants.A10_HOUSE_KEEPING)
         self.conf.config(group=a10constants.A10_HOUSE_KEEPING,
-                         disable_write_memory=True)
+                         use_periodic_write_memory='disable')
         thunder = copy.deepcopy(VTHUNDER)
         thunder.partition_name = "testPartition"
         mock_task = task.WriteMemory()
@@ -535,7 +535,7 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         self.conf.register_opts(config_options.A10_HOUSE_KEEPING_OPTS,
                                 group=a10constants.A10_HOUSE_KEEPING)
         self.conf.config(group=a10constants.A10_HOUSE_KEEPING,
-                         disable_write_memory=False)
+                         use_periodic_write_memory='enable')
         mock_thunder = copy.deepcopy(VTHUNDER)
         mock_task = task.WriteMemory()
         mock_task.axapi_client = self.client_mock
@@ -546,7 +546,7 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         self.conf.register_opts(config_options.A10_HOUSE_KEEPING_OPTS,
                                 group=a10constants.A10_HOUSE_KEEPING)
         self.conf.config(group=a10constants.A10_HOUSE_KEEPING,
-                         disable_write_memory=True)
+                         use_periodic_write_memory='enable')
         ret_val = task.WriteMemory().execute(vthunder=None)
         self.assertIsNone(ret_val)
 

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -514,6 +514,17 @@ class TestVThunderTasks(base.BaseTaskTestCase):
             partition='specified',
             specified_partition='testPartition')
 
+    def test_WriteMemory_execute_not_called(self):
+        self.conf.register_opts(config_options.A10_HOUSE_KEEPING_OPTS,
+                                group=a10constants.A10_HOUSE_KEEPING)
+        self.conf.config(group=a10constants.A10_HOUSE_KEEPING,
+                         disable_write_memory=False)
+        mock_thunder = copy.deepcopy(VTHUNDER)
+        mock_task = task.WriteMemory()
+        mock_task.axapi_client = self.client_mock
+        mock_task.execute(mock_thunder)
+        self.client_mock.system.action.write_memory.assert_not_called()
+
     def test_WriteMemory_execute_delete_flow_after_error_no_fail(self):
         self.conf.register_opts(config_options.A10_HOUSE_KEEPING_OPTS,
                                 group=a10constants.A10_HOUSE_KEEPING)


### PR DESCRIPTION
## Description
- Added controller worker linear flow to perform write memory when enabled.

## Jira Ticket

https://a10networks.atlassian.net/browse/STACK-1947
https://a10networks.atlassian.net/browse/STACK-1948
https://a10networks.atlassian.net/browse/STACK-1958
https://a10networks.atlassian.net/browse/STACK-1959

https://a10networks.atlassian.net/browse/STACK-1946
https://a10networks.atlassian.net/browse/STACK-1950
https://a10networks.atlassian.net/browse/STACK-1951
https://a10networks.atlassian.net/browse/STACK-1952
https://a10networks.atlassian.net/browse/STACK-1953
https://a10networks.atlassian.net/browse/STACK-1954
https://a10networks.atlassian.net/browse/STACK-1955

## Technical Approach
- housekeeper will fetch "eligible" thunders after every configured write_mem_interval of time from vthunder db 
- thunders are filtered again based on unique `ip_address` and `partition_name`
- Loop through thunder list and perform 3 tasks: 
    -> Write memory api call in shared partition
    -> Write memory api call in specified partition (based on vthunder.partition_name)
    
- Called `WriteMemory` tasks only if `disable_write_memory` is `True` 
- Added new `UpdateVThunderUpdatedAt` task at end of each flow in 
     - lb,
     - listener
     - hm 
     - member
     - pool, 
     - l7policy 
     - l7rule 
     flows.(create,update and delete)
- Placed more logs in tasks

## Config Changes
None

## Test Cases
- Working on testcase doc. Need input from QA team.

## Manual Testing
- Working on testcase doc. Need input from QA team.