### PR TITLE
STACK-1900: Creation of nat-pools in nat-pool-list flavor

### DIFF
--- a/a10_octavia/controller/worker/tasks/nat_pool_tasks.py
+++ b/a10_octavia/controller/worker/tasks/nat_pool_tasks.py
@@ -50,8 +50,9 @@ class NatPoolCreate(task.Task):
                             self.axapi_client.nat.pool.create(
                                 pool_name, start_address, end_address, netmask, gateway=gateway)
                         except(acos_errors.Exists) as e:
-                            LOG.exception(
-                                "The specified nat-pool already exists on thunder")
+                            LOG.exception("Nat-pool with name %s already exists on partition %s of "
+                                          "thunder device %s",
+                                          pool_name, vthunder.partition_name, vthunder.ip_address)
                             raise e
                     else:
                         continue
@@ -73,5 +74,7 @@ class NatPoolCreate(task.Task):
                     self.axapi_client.nat.pool.create(
                         pool_name, start_address, end_address, netmask, gateway=gateway)
                 except(acos_errors.Exists) as e:
-                    LOG.exception("The specified nat-pool already exists on thunder")
+                    LOG.exception("Nat-pool with name %s already exists on partition %s of "
+                                  "thunder device %s",
+                                  pool_name, vthunder.partition_name, vthunder.ip_address)
                     raise e

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_nat_pool_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_nat_pool_tasks.py
@@ -42,7 +42,7 @@ class TestHandlerNatPoolTasks(base.BaseTaskTestCase):
     def tearDown(self):
         super(TestHandlerNatPoolTasks, self).tearDown()
 
-    def test_create_nat_pool_with_nat_pool_not_exists(self):
+    def test_create_nat_pool_with_nat_pool_not_exists_with_nat_pool_flavor(self):
         flavor = {u'nat_pool': {u'start_address': u'172.16.1.101', u'end_address': u'172.16.1.108',
                                 u'netmask': u'/24', u'gateway': u'172.16.1.1',
                                 u'pool_name': u'pool1'}}
@@ -56,15 +56,55 @@ class TestHandlerNatPoolTasks(base.BaseTaskTestCase):
         self.assertIn('172.16.1.101', args)
         self.assertEqual(kwargs['gateway'], '172.16.1.1')
 
-    def test_create_nat_pool_with_nat_pool_exists(self):
+    def test_create_nat_pool_with_nat_pool_exists_with_nat_pool_flavor(self):
         flavor = {u'nat_pool': {u'start_address': u'172.16.1.101', u'end_address': u'172.16.1.108',
                                 u'netmask': u'/24', u'gateway': u'172.16.1.1',
                                 u'pool_name': u'pool1'}}
+
         device_pool = {u'pool': {u'uuid': u'947c228e-443a-11eb-9273-525400bf462d',
                                  u'start-address': u'172.16.1.101', u'port-overload': 0,
                                  u'a10-url': u'/axapi/v3/ip/nat/pool/pool1', u'netmask': u'/24',
                                  u'end-address': u'172.16.1.108', u'ip-rr': 0,
                                  u'gateway': u'172.16.1.1', u'pool-name': u'pool1'}}
+
+        vthunder = copy.deepcopy(VTHUNDER)
+        mock_nat_pool_task = task.NatPoolCreate()
+        mock_nat_pool_task.axapi_client = self.client_mock
+        self.client_mock.nat.pool.exists.return_value = True
+        self.client_mock.nat.pool.get.return_value = device_pool
+        mock_nat_pool_task.execute(LB, vthunder, flavor_data=flavor)
+        self.client_mock.nat.pool.create.not_called()
+
+    def test_create_nat_pool_with_nat_pool_not_exists_with_nat_pool_list_flavor(self):
+        flavor = {u'nat_pool_list': [{u'start_address': u'172.16.2.101',
+                                      u'end_address': u'172.16.2.102', u'netmask': u'/24',
+                                      u'gateway': u'172.16.2.1', u'pool_name': u'pooln1'},
+                                     {u'start_address': u'172.16.3.101',
+                                      u'end_address': u'172.16.3.102', u'netmask': u'/24',
+                                      u'gateway': u'172.16.3.1', u'pool_name': u'pooln2'}]}
+
+        vthunder = copy.deepcopy(VTHUNDER)
+        mock_nat_pool_task = task.NatPoolCreate()
+        mock_nat_pool_task.axapi_client = self.client_mock
+        self.client_mock.nat.pool.exists.return_value = False
+        mock_nat_pool_task.execute(LB, vthunder, flavor_data=flavor)
+        args, kwargs = self.client_mock.nat.pool.create.call_args
+        self.assertIn('pooln2', args)
+        self.assertEqual(kwargs['gateway'], '172.16.3.1')
+
+    def test_create_nat_pool_with_nat_pool_exists_with_nat_pool_list_flavor(self):
+        flavor = {u'nat_pool_list': [{u'start_address': u'172.16.2.101',
+                                      u'end_address': u'172.16.2.102', u'netmask': u'/24',
+                                      u'gateway': u'172.16.2.1', u'pool_name': u'pooln1'},
+                                     {u'start_address': u'172.16.3.101',
+                                      u'end_address': u'172.16.3.102', u'netmask': u'/24',
+                                      u'gateway': u'172.16.3.1', u'pool_name': u'pooln2'}]}
+
+        device_pool = {u'pool': {u'uuid': u'eef8b1ea-48dc-11eb-b050-5254000780f9',
+                                 u'start-address': u'172.16.2.101', u'port-overload': 0,
+                                 u'a10-url': u'/axapi/v3/ip/nat/pool/pooln1', u'netmask': u'/24',
+                                 u'end-address': u'172.16.2.102', u'ip-rr': 0,
+                                 u'gateway': u'172.16.2.1', u'pool-name': u'pooln1'}}
 
         vthunder = copy.deepcopy(VTHUNDER)
         mock_nat_pool_task = task.NatPoolCreate()


### PR DESCRIPTION
## Description
For given nat-pool-list flavor, NAT pool will be created on Thunder when loadbalancer is created.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1900

## Technical Approach
- When nat-pool-list flavor or both nat-pool and nat-pool-list is passed while creating a loadbalancer:
        - if the specified nat-pool with the same range does not exists on thunder, the nat-pool given in the flavor gets created.
        - if the specified nat-pool with the same range exists on thunder, the nat-pool will not get created on thunder as it already
          exists.
        - if the specified nat-pool with the different range exists on thunder, an error will be raised with a message as "The nat-pool
          already exists on thunder".

## Test Cases
- Given a nat-pool-list flavor, when a loadbalancer is created, the nat-pool will get created on thunder if the same nat-pool does not exist on it.
- Given a nat-pool-list flavor, when a loadbalancer is created, the nat-pool will not get created on thunder if the same nat-pool with same range exists on thunder.
- Given a nat-pool-list flavor, when a loadbalancer is created, an error will be raised if the same nat-pool with different range exists on thunder.

## Manual Testing
Flavor used for testing:
1.

```
{ 
    "nat-pool":{ 
        "pool-name":"pool1", 
        "start-address":"172.16.1.101", 
        "end-address":"172.16.1.104", 
        "netmask":"/24", 
        "gateway":"172.16.1.1" 
    }, 
    "nat-pool-list":[ 
        { 
            "pool-name":"pool2", 
            "start-address":"172.16.2.101", 
            "end-address":"172.16.2.104", 
            "netmask":"/24", 
            "gateway":"172.16.2.1" 
        }, 
        { 
            "pool-name":"pool3", 
            "start-address":"172.16.3.101", 
            "end-address":"172.16.3.104", 
            "netmask":"/24", 
            "gateway":"172.16.3.1" 
        } 
    ],
}
```
```
openstack loadbalancer flavorprofile create --name fp_snat_list --provider a10 --flavor-data '{"nat-pool":{"pool-name":"pool1", "start-address":"172.16.1.101", "end-address":"172.16.1.102", "netmask":"/24", "gateway":"172.16.1.1"}, "nat-pool-list":[{"pool-name":"pool2", "start-address":"172.16.2.101", "end-address":"172.16.2.102", "netmask":"/24", "gateway":"172.16.2.1"}, {"pool-name":"pool3", "start-address":"172.16.3.101", "end-address":"172.16.3.102", "netmask":"/24", "gateway":"172.16.3.1"}]}'

openstack loadbalancer flavor create --name f_snat_list --flavorprofile fp_snat_list --description "flaovr all test1" --enable

openstack loadbalancer create --flavor f_snat_list --vip-subnet-id 11dcb328-f947-4b5f-a789-5ae46118bb81 --name lb1

```
Result:
![image](https://user-images.githubusercontent.com/58077446/103208674-47145880-4927-11eb-8e01-9fb3f84550df.png)

2.
```
{
    "nat-pool-list":[ 
        { 
            "pool-name":"pool1", 
            "start-address":"172.16.2.101", 
            "end-address":"172.16.2.104", 
            "netmask":"/24", 
            "gateway":"172.16.2.1" 
        }, 
        { 
            "pool-name":"pool2", 
            "start-address":"172.16.3.101", 
            "end-address":"172.16.3.104", 
            "netmask":"/24", 
            "gateway":"172.16.3.1" 
        } 
    ],
}
```

```
openstack loadbalancer flavorprofile create --name fp_snat_list2 --provider a10 --flavor-data '{"nat-pool-list":[{"pool-name":"pooln1", "start-address":"172.16.2.101", "end-address":"172.16.2.102", "netmask":"/24", "gateway":"172.16.2.1"}, {"pool-name":"pooln2", "start-address":"172.16.3.101", "end-address":"172.16.3.102", "netmask":"/24", "gateway":"172.16.3.1"}]}'

openstack loadbalancer flavor create --name f_snat_list2 --flavorprofile fp_snat_list2 --description "flaovr all test2" --enable

openstack loadbalancer create --flavor f_snat_list2 --vip-subnet-id 11dcb328-f947-4b5f-a789-5ae46118bb81 --name lb2

```
Result:
![image](https://user-images.githubusercontent.com/58077446/103209065-24367400-4928-11eb-8c83-50c592123d51.png)

