### PR TITLE
[STACK-1818]: Used HTTP::path instead of HTTP::url for L7 rule creation. 

### DIFF
--- a/a10_octavia/controller/worker/tasks/policy.py
+++ b/a10_octavia/controller/worker/tasks/policy.py
@@ -15,7 +15,7 @@
 
 TYPE_DICT = {
     "HOST_NAME": "HTTP::host",
-    "PATH": "HTTP::uri",
+    "PATH": "HTTP::path",
     "FILE_TYPE": "HTTP::uri endswith",
     "HEADER": "HTTP::header",
     "COOKIE": "HTTP::cookie"
@@ -76,9 +76,9 @@ class PolicyUtil(object):
         # rule string static - required for file type rules only
         if l7rule.type == "FILE_TYPE":
             if l7rule.compare_type == "REGEX":
-                ruleString = "([HTTP::uri] matches_regex"
+                ruleString = "([HTTP::path] matches_regex"
             else:
-                ruleString = "([HTTP::uri] ends_with"
+                ruleString = "([HTTP::path] ends_with"
 
         # value
         value_string = l7rule.value

--- a/a10_octavia/tests/common/a10constants.py
+++ b/a10_octavia/tests/common/a10constants.py
@@ -59,3 +59,6 @@ HEALTH_MONITOR_SECTION = 'health_monitor'
 MOCK_SERVICE_GROUP_PROTOCOL = "HTTP"
 MOCK_POOL_ID_2 = "mock-pool-2"
 MOCK_SUBNET_ID_2 = "mock-subnet-2"
+
+MOCK_L7POLICY_ID = "mock-l7-policy-1"
+MOCK_L7RULE_ID = "mock-l7-rule-1"

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_policy.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_policy.py
@@ -1,0 +1,37 @@
+#    Copyright 2020, A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from octavia.common import data_models as o_data_models
+from octavia.tests.unit import base
+
+from a10_octavia.controller.worker.tasks import policy
+from a10_octavia.tests.common import a10constants
+
+L7POLICY = o_data_models.L7Policy(id=a10constants.MOCK_L7POLICY_ID,
+                                  listener_id=a10constants.MOCK_LISTENER_ID,
+                                  action="REDIRECT_TO_URL",
+                                  redirect_url="www.google.com")
+L7RULE = o_data_models.L7Rule(id=a10constants.MOCK_L7RULE_ID,
+                              l7policy_id=a10constants.MOCK_L7POLICY_ID,
+                              type="PATH", compare_type="EQUAL_TO",
+                              value="www://abc.com")
+
+
+class TestPolicy(base.TestCase):
+    def test_policy_rule_path(self):
+        L7POLICY.l7rules = [L7RULE]
+        policy_util = policy.PolicyUtil()
+        policy_util.createPolicy(L7POLICY)
+        self.assertEqual(policy_util.ruleParser(L7RULE),
+                         '([HTTP::path] equals "www://abc.com")')


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description: there is aflex command about http path on thunder, that is HTTP::path, so when we created l7rule with type PATH, QA suggest to use http::path instead of http::uri.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1818

## Technical Approach
- Checked manual for both HTTP::path and HTTP::uri
- Replaced HTTP::uri to HTTP::path.

## Test Cases
- created L7 rule with type as path and checked the output from ruleparser which generated l7 policy.

## Manual Testing
- Created L7rule with type PATH and checked on thunder for the equivalent aflex script.