### PR TITLE
[Write-Memory-Enhancement]: Added new tasks for locking LBs to PENDING_UPDATE

### DIFF
--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -107,6 +107,7 @@ HANDLE_VRID_MEMBER_SUBFLOW = 'handle-vrid-member-subflow'
 SPARE_VTHUNDER_CREATE = 'spare-vthunder-create'
 WRITE_MEMORY_THUNDER_FLOW = 'write-memory-thunder-flow'
 LB_TO_VTHUNDER_SUBFLOW = 'lb-to-vthunder-subflow'
+LOADBALANCERS_LIST = 'loadbalancers_list'
 VRID_LIST = 'vrid_list'
 RESOURCE_COUNT = 'resource_count'
 

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -380,6 +380,15 @@ class VThunderFlows(object):
         vthunder_store = {}
         for vthunder in thunders:
             vthunder_store[vthunder.vthunder_id] = vthunder
+            write_memory_flow.add(a10_database_tasks.GetActiveLoadBalancersByThunder(
+                requires=a10constants.VTHUNDER,
+                rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
+                name='{flow}-{id}'.format(
+                    id=vthunder.vthunder_id,
+                    flow='GetActiveLoadBalancersByThunder'),
+                provides=a10constants.LOADBALANCERS_LIST))
+            write_memory_flow.add(a10_database_tasks.MarkLoadBalancersPendingUpdateInDB(
+                requires=a10constants.LOADBALANCERS_LIST))
             write_memory_flow.add(vthunder_tasks.WriteMemoryHouseKeeper(
                 requires=a10constants.VTHUNDER,
                 rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
@@ -394,5 +403,7 @@ class VThunderFlows(object):
                     id=vthunder.vthunder_id,
                     flow='WriteMemory-' + a10constants.WRITE_MEMORY_THUNDER_FLOW,
                     partition=a10constants.WRITE_MEM_FOR_SHARED_PARTITION)))
+            write_memory_flow.add(a10_database_tasks.MarkLoadBalancersActiveInDB(
+                requires=a10constants.LOADBALANCERS_LIST))
         store.update(vthunder_store)
         return write_memory_flow

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -750,3 +750,45 @@ class SetThunderUpdatedAt(BaseDatabaseTask):
         except Exception as e:
             LOG.exception('Failed to set updated_at field for thunder due to: {}'
                           ', skipping.'.format(str(e)))
+
+
+class GetActiveLoadBalancersByThunder(BaseDatabaseTask):
+
+    def execute(self, vthunder):
+        try:
+            if vthunder:
+                loadbalancers_list = self.loadbalancer_repo.get_active_lbs_by_thunder(
+                    db_apis.get_session(),
+                    vthunder)
+                return loadbalancers_list
+        except Exception as e:
+            LOG.exception('Failed to get active Loadbalancers related to thunder '
+                          'due to: {}'.format(str(e)))
+
+
+class MarkLoadBalancersPendingUpdateInDB(BaseDatabaseTask):
+
+    def execute(self, loadbalancers_list):
+        try:
+            for lb in loadbalancers_list:
+                self.loadbalancer_repo.update(
+                    db_apis.get_session(),
+                    lb.id,
+                    provisioning_status='PENDING_UPDATE')
+        except Exception as e:
+            LOG.exception('Failed to set Loadbalancers to PENDING_UPDATE due to '
+                          ': {}'.format(str(e)))
+
+
+class MarkLoadBalancersActiveInDB(BaseDatabaseTask):
+
+    def execute(self, loadbalancers_list):
+        try:
+            for lb in loadbalancers_list:
+                self.loadbalancer_repo.update(
+                    db_apis.get_session(),
+                    lb.id,
+                    provisioning_status='ACTIVE')
+        except Exception as e:
+            LOG.exception('Failed to set Loadbalancers to ACTIVE due to '
+                          ': {}'.format(str(e)))

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -319,6 +319,17 @@ class VThunderRepository(BaseRepository):
 
 
 class LoadBalancerRepository(repo.LoadBalancerRepository):
+    thunder_model_class = models.VThunder
+
+    def get_active_lbs_by_thunder(self, session, vthunder):
+        lb_list = []
+        query = session.query(self.model_class).filter(
+            and_(vthunder.loadbalancer_id == self.model_class.id,
+                 self.model_class.provisioning_status == consts.ACTIVE))
+        model_list = query.all()
+        for data in model_list:
+            lb_list.append(data.to_data_model())
+        return lb_list
 
     def get_lb_count_by_subnet(self, session, project_ids, subnet_id):
         return session.query(self.model_class).join(base_models.Vip).filter(

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -497,3 +497,55 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         db_task.vthunder_repo.update.assert_called_once_with(mock.ANY,
                                                              vthunder.id,
                                                              updated_at=mock.ANY)
+
+    def test_GetActiveLoadBalancersByThunder_return_empty(self):
+        lb_task = task.GetActiveLoadBalancersByThunder()
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.loadbalancer_id = a10constants.MOCK_LOAD_BALANCER_ID
+        lb_task.loadbalancer_repo.get_active_lbs_by_thunder = mock.Mock()
+        lb_task.loadbalancer_repo.get_active_lbs_by_thunder.return_value = []
+        lb_list = lb_task.execute(vthunder)
+        self.assertEqual(lb_list, [])
+
+    def test_GetActiveLoadBalancersByThunder_return_list(self):
+        lb_task = task.GetActiveLoadBalancersByThunder()
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.loadbalancer_id = a10constants.MOCK_LOAD_BALANCER_ID
+        lb_task.loadbalancer_repo.get_active_lbs_by_thunder = mock.Mock()
+        lb_task.loadbalancer_repo.get_active_lbs_by_thunder.return_value = [LB]
+        lb_list = lb_task.execute(vthunder)
+        self.assertEqual(len(lb_list), 1)
+
+    def test_MarkLoadBalancersPendingUpdateInDB_execute(self):
+        lb_task = task.MarkLoadBalancersPendingUpdateInDB()
+        lb_list = []
+        lb_list.append(LB)
+        lb_task.loadbalancer_repo.update = mock.Mock()
+        lb_task.execute(lb_list)
+        lb_task.loadbalancer_repo.update.assert_called_once_with(mock.ANY,
+                                                                 LB.id,
+                                                                 provisioning_status=mock.ANY)
+
+    def test_MarkLoadBalancersPendingUpdateInDB_execute_for_empty_list(self):
+        lb_task = task.MarkLoadBalancersPendingUpdateInDB()
+        lb_list = []
+        lb_task.loadbalancer_repo.update = mock.Mock()
+        lb_task.execute(lb_list)
+        lb_task.loadbalancer_repo.update.assert_not_called()
+
+    def test_MarkLoadBalancersActiveInDB_execute(self):
+        lb_task = task.MarkLoadBalancersActiveInDB()
+        lb_list = []
+        lb_list.append(LB)
+        lb_task.loadbalancer_repo.update = mock.Mock()
+        lb_task.execute(lb_list)
+        lb_task.loadbalancer_repo.update.assert_called_once_with(mock.ANY,
+                                                                 LB.id,
+                                                                 provisioning_status=mock.ANY)
+
+    def test_MarkLoadBalancersActiveInDB_execute_for_empty_list(self):
+        lb_task = task.MarkLoadBalancersActiveInDB()
+        lb_list = []
+        lb_task.loadbalancer_repo.update = mock.Mock()
+        lb_task.execute(lb_list)
+        lb_task.loadbalancer_repo.update.assert_not_called()


### PR DESCRIPTION
## Description
- As per review comment on https://github.com/a10networks/a10-octavia/pull/268/files#r549871738
Needed to lock associated ACTIVE LB's to PENDING_UPDATE before doing write_memory operation. This ensures, no other threads are performing any configuration over those LBs.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1991
https://a10networks.atlassian.net/browse/STACK-1992

## Technical Approach
```
1. Fetch All Active LBs associated to Thunder from db
2. Set `PENDING_UPDATE` status in db for all lbs.
3. After `WriteMemoryHouseKeeper` task, set status back to `ACTIVE` for all lbs.
4. Added corresponding UTs.
```

## Config Changes
None

## Test Cases
- UTs.

## Manual Testing
None