### PR TITLE
[Bug][STACK-1686]:Added http template for terminated https listener

### DIFF
--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -84,10 +84,11 @@ class ListenersParent(object):
             vport_templates[template_key] = template_vport
 
         template_args = {}
-        if listener.protocol == 'https' and listener.tls_certificate_id:
-            # Adding TERMINATED_HTTPS SSL cert, created in previous task
-            template_args["template_client_ssl"] = listener.id
-        elif listener.protocol.upper() in a10constants.HTTP_TYPE:
+        if listener.protocol.upper() in a10constants.HTTP_TYPE:
+            if listener.protocol == 'https' and listener.tls_certificate_id:
+                # Adding TERMINATED_HTTPS SSL cert, created in previous task
+                template_args["template_client_ssl"] = listener.id
+
             template_http = CONF.listener.template_http
             if template_http and template_http.lower() != 'none':
                 template_key = 'template-http'

--- a/a10_octavia/tests/common/a10constants.py
+++ b/a10_octavia/tests/common/a10constants.py
@@ -62,3 +62,5 @@ MOCK_SUBNET_ID_2 = "mock-subnet-2"
 
 MOCK_L7POLICY_ID = "mock-l7-policy-1"
 MOCK_L7RULE_ID = "mock-l7-rule-1"
+
+MOCK_TLS_CERTIFICATE_ID="mock_tls_certificate_id"

--- a/a10_octavia/tests/common/a10constants.py
+++ b/a10_octavia/tests/common/a10constants.py
@@ -63,4 +63,4 @@ MOCK_SUBNET_ID_2 = "mock-subnet-2"
 MOCK_L7POLICY_ID = "mock-l7-policy-1"
 MOCK_L7RULE_ID = "mock-l7-rule-1"
 
-MOCK_TLS_CERTIFICATE_ID="mock_tls_certificate_id"
+MOCK_TLS_CERTIFICATE_ID = "mock_tls_certificate_id"

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
@@ -59,7 +59,7 @@ class TestHandlerVirtualPortTasks(base.BaseTaskTestCase):
     def _create_shared_template(self, template_type, template_config,
                                 mock_protocol, mock_templates):
         template_type = template_type.lower()
-        if template_type=="https":
+        if template_type == "https":
             mock_templates.return_value = 'template-http-shared'
         else:
             mock_templates.return_value = 'template-{}-shared'.format(template_type)
@@ -100,7 +100,7 @@ class TestHandlerVirtualPortTasks(base.BaseTaskTestCase):
         vthunder.partition_name = "my_partition"
         listener_task, listener = self._create_shared_template(
             'https', {'template_http': 'temp1'}, mock_protocol, mock_templates)
-        listener.tls_certificate_id=a10constants.MOCK_TLS_CERTIFICATE_ID
+        listener.tls_certificate_id = a10constants.MOCK_TLS_CERTIFICATE_ID
         listener_task.execute(LB, listener, vthunder)
         args, kwargs = self.client_mock.slb.virtual_server.vport.create.call_args
         self.assertIn('template-http-shared', kwargs['virtual_port_templates'])
@@ -156,11 +156,10 @@ class TestHandlerVirtualPortTasks(base.BaseTaskTestCase):
         vthunder.partition_name = "shared"
         listener_task, listener = self._create_shared_template(
             'https', {'template_http': 'temp1'}, mock_protocol, mock_templates)
-        listener.tls_certificate_id=a10constants.MOCK_TLS_CERTIFICATE_ID
+        listener.tls_certificate_id = a10constants.MOCK_TLS_CERTIFICATE_ID
         listener_task.execute(LB, listener, vthunder)
         args, kwargs = self.client_mock.slb.virtual_server.vport.create.call_args
         self.assertIn('template-http', kwargs['virtual_port_templates'])
-
 
     @mock.patch('a10_octavia.controller.worker.tasks.utils.shared_template_modifier')
     @mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol')

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+PyMySQL<=0.10.1
 mock
 nose
 hacking


### PR DESCRIPTION
## Description
Added some template under [listener] in config file, found there is no http template bound to listener of terminated_https, but if creating http listener, the http template will be configured under vport http.

Severity Level High

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1686

## Technical Approach
- Change the sequence of condition checks 

## Test Cases
- Given https listener in shared partition then template_http is attached.
- Given https listener in l3v partition  then template_http_shared is attached


## Manual Testing
Step 1: Manually created some templates on thunder
Step 2: Added template under [listener] in config file.
[listener]
ipinip=False
no_dest_nat=False
#ha_conn_mirror=False
template_virtual_port=tp_vport
template_tcp=tp_tcp
template_policy=tp_policy
autosnat=False
conn_limit=10980
template_http=tp_http <<<----------
use_rcv_hop_for_resp=False

Step 3: Created loadbalancer
openstack loadbalancer create --vip-subnet-id 6cf85683-6f16-4bf6-8570-18e114e44f90  --name lb1 --project demo

Step 4: Created listener of terminated_https
openstack loadbalancer listener create --protocol TERMINATED_HTTPS --default-tls-container-ref  http://172.17.20.175/key-manager/v1/containers/8e502924-d1f6-4398-86a0-526e6c4a485b  --protocol-port 443 lb1 --name list_term

Step 5:check on virtual-server
show run slb virtual-server
!Section configuration: 492 bytes
!
slb virtual-server 0905604f-239f-4b64-ac42-2f2cb9014797 192.168.8.137
  port 443 https
    name a875213f-4b5f-43ca-bcf1-061a718579cd
    conn-limit 10980
    extended-stats
    template policy partition shared tp_policy_1
    template http partition shared tp_http
    template client-ssl a875213f-4b5f-43ca-bcf1-061a718579cd
    template virtual-port partition shared vport
