### PR TITLE
STACK-1896 Feature Source NAT flavor support

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -204,7 +204,7 @@ class MemberFlows(object):
         delete_member_flow.add(a10_database_tasks.GetNatPoolEntry(
             requires=[constants.MEMBER, a10constants.NAT_FLAVOR],
             provides=a10constants.NAT_POOL))
-        delete_member_flow.add(server_tasks.MemberReleaseSubnetAddr(
+        delete_member_flow.add(a10_network_tasks.ReleaseSubnetAddressForMember(
             requires=[constants.MEMBER, a10constants.NAT_FLAVOR, a10constants.NAT_POOL]))
         delete_member_flow.add(a10_database_tasks.DeleteNatPoolEntry(
             requires=a10constants.NAT_POOL))
@@ -498,7 +498,7 @@ class MemberFlows(object):
         create_member_flow.add(a10_database_tasks.GetNatPoolEntry(
             requires=[constants.MEMBER, a10constants.NAT_FLAVOR],
             provides=a10constants.NAT_POOL))
-        create_member_flow.add(server_tasks.MemberReserveSubnetAddr(
+        create_member_flow.add(a10_network_tasks.ReserveSubnetAddressForMember(
             requires=[constants.MEMBER, a10constants.NAT_FLAVOR, a10constants.NAT_POOL],
             provides=a10constants.SUBNET_PORT))
         create_member_flow.add(a10_database_tasks.UpdateNatPoolDB(

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -18,6 +18,8 @@ from oslo_config import cfg
 from oslo_log import log as logging
 from requests import exceptions as req_exceptions
 import six
+import socket
+import struct
 from taskflow import task
 from taskflow.types import failure
 
@@ -934,3 +936,43 @@ class GetLBResourceSubnet(BaseNetworkTask):
         else:
             subnet = self.network_driver.get_subnet(lb_resource.subnet_id)
         return subnet
+
+
+class ReserveSubnetAddressForMember(BaseNetworkTask):
+
+    def execute(self, member, nat_flavor=None, nat_pool=None):
+        if nat_flavor is None:
+            return
+
+        if nat_pool is None:
+            try:
+                addr_list = []
+                start = (struct.unpack(">L", socket.inet_aton(nat_flavor['start_address'])))[0]
+                end = (struct.unpack(">L", socket.inet_aton(nat_flavor['end_address'])))[0]
+                while start <= end:
+                    addr_list.append(socket.inet_ntoa(struct.pack(">L", start)))
+                    start += 1
+                port = self.network_driver.reserve_subnet_addresses(member.subnet_id, addr_list)
+                LOG.debug("Successfully allocated addresses for nat pool %s on port %s",
+                          nat_flavor['pool_name'], port.id)
+                return port
+            except Exception as e:
+                LOG.exception("Failed to reserve addresses in NAT pool %s from subnet %s",
+                              nat_flavor['pool_name'], member.subnet_id)
+                raise e
+        return
+
+
+class ReleaseSubnetAddressForMember(BaseNetworkTask):
+
+    def execute(self, member, nat_flavor=None, nat_pool=None):
+        if nat_flavor is None or nat_pool is None:
+            return
+
+        if nat_pool.member_ref_count == 1:
+            try:
+                self.network_driver.delete_port(nat_pool.port_id)
+            except Exception as e:
+                LOG.exception("Failed to release addresses in NAT pool %s from subnet %s",
+                              nat_flavor['pool_name'], member.subnet_id)
+                raise e

--- a/a10_octavia/controller/worker/tasks/server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/server_tasks.py
@@ -22,7 +22,7 @@ import socket
 import struct
 
 from a10_octavia.common import openstack_mappings
-from a10_octavia.common import utils as a10_utils
+from a10_octavia.controller.worker.tasks.a10_network_tasks import BaseNetworkTask
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
 from a10_octavia.controller.worker.tasks import utils
 
@@ -31,20 +31,7 @@ CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
 
 
-class MemberBaseTask(task.Task):
-
-    def __init__(self, **kwargs):
-        super(MemberBaseTask, self).__init__(**kwargs)
-        self._network_driver = None
-
-    @property
-    def network_driver(self):
-        if self._network_driver is None:
-            self._network_driver = a10_utils.get_network_driver()
-        return self._network_driver
-
-
-class MemberCreate(MemberBaseTask):
+class MemberCreate(task.Task):
     """Task to create a member and associate to pool"""
 
     @axapi_client_decorator
@@ -127,7 +114,7 @@ class MemberCreate(MemberBaseTask):
                           member.id, pool.id, str(e))
 
 
-class MemberDelete(MemberBaseTask):
+class MemberDelete(task.Task):
     """Task to delete member"""
 
     @axapi_client_decorator
@@ -158,7 +145,7 @@ class MemberDelete(MemberBaseTask):
             raise e
 
 
-class MemberUpdate(MemberBaseTask):
+class MemberUpdate(task.Task):
     """Task to update member"""
 
     @axapi_client_decorator
@@ -216,7 +203,7 @@ class MemberUpdate(MemberBaseTask):
             # no raise, it will still work even no port. but options for port will missing
 
 
-class MemberDeletePool(MemberBaseTask):
+class MemberDeletePool(task.Task):
     """Task to delete member"""
 
     @axapi_client_decorator
@@ -240,7 +227,7 @@ class MemberDeletePool(MemberBaseTask):
             raise e
 
 
-class MemberFindNatPool(MemberBaseTask):
+class MemberFindNatPool(task.Task):
 
     @axapi_client_decorator
     def execute(self, member, vthunder, pool, flavor=None):
@@ -263,7 +250,7 @@ class MemberFindNatPool(MemberBaseTask):
                             return flavor
 
 
-class MemberReserveSubnetAddr(MemberBaseTask):
+class MemberReserveSubnetAddr(BaseNetworkTask):
 
     def execute(self, member, nat_flavor=None, nat_pool=None):
         if nat_flavor is None:
@@ -288,7 +275,7 @@ class MemberReserveSubnetAddr(MemberBaseTask):
         return
 
 
-class MemberReleaseSubnetAddr(MemberBaseTask):
+class MemberReleaseSubnetAddr(BaseNetworkTask):
 
     def execute(self, member, nat_flavor=None, nat_pool=None):
         if nat_flavor is None or nat_pool is None:

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
@@ -31,7 +31,7 @@ from a10_octavia.controller.worker.tasks import a10_network_tasks
 from a10_octavia.tests.common import a10constants
 from a10_octavia.tests.unit import base
 
-MEMBER = o_data_models.Member()
+MEMBER = o_data_models.Member(subnet_id=a10constants.MOCK_SUBNET_ID)
 VTHUNDER = data_models.VThunder()
 SUBNET = o_net_data_models.Subnet()
 PORT = o_net_data_models.Port()
@@ -39,6 +39,7 @@ VRID = data_models.VRID()
 VRID_VALUE = 0
 SUBNET_1 = o_net_data_models.Subnet(id=a10constants.MOCK_SUBNET_ID)
 VRID_1 = data_models.VRID(id=1, subnet_id=a10constants.MOCK_SUBNET_ID)
+NAT_POOL = data_models.NATPool(port_id=a10constants.MOCK_PORT_ID)
 
 
 class MockIP(object):
@@ -449,3 +450,26 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         self.network_driver_mock.delete_port.assert_not_called()
         self.client_mock.vrrpa.update.assert_not_called()
         self.assertEqual(result, None)
+
+    def test_reserver_subnet_addr_for_member(self):
+        mock_network_task = a10_network_tasks.ReserveSubnetAddressForMember()
+        mock_network_task.network_driver = self.client_mock
+        flavor = {"pool_name": "p1", "start_address": "1.1.1.1", "end_address": "1.1.1.2"}
+        mock_network_task.execute(MEMBER, flavor)
+        self.client_mock.reserve_subnet_addresses.assert_called_with(
+            MEMBER.subnet_id, ["1.1.1.1", "1.1.1.2"])
+
+    def test_release_subnet_addr_referenced(self):
+        mock_network_task = a10_network_tasks.ReleaseSubnetAddressForMember()
+        flavor = {"pool_name": "p1", "start_address": "1.1.1.1", "end_address": "1.1.1.2"}
+        NAT_POOL.member_ref_count = 2
+        ret_val = mock_network_task.execute(MEMBER, flavor, NAT_POOL)
+        self.assertEqual(ret_val, None)
+
+    def test_release_subnet_addr(self):
+        mock_network_task = a10_network_tasks.ReleaseSubnetAddressForMember()
+        mock_network_task.network_driver = self.client_mock
+        flavor = {"pool_name": "p1", "start_address": "1.1.1.1", "end_address": "1.1.1.2"}
+        NAT_POOL.member_ref_count = 1
+        mock_network_task.execute(MEMBER, flavor, NAT_POOL)
+        self.client_mock.delete_port.assert_called_with(NAT_POOL.port_id)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
@@ -40,6 +40,7 @@ VRID_VALUE = 0
 SUBNET_1 = o_net_data_models.Subnet(id=a10constants.MOCK_SUBNET_ID)
 VRID_1 = data_models.VRID(id=1, subnet_id=a10constants.MOCK_SUBNET_ID)
 NAT_POOL = data_models.NATPool(port_id=a10constants.MOCK_PORT_ID)
+NAT_FLAVOR = {"pool_name": "p1", "start_address": "1.1.1.1", "end_address": "1.1.1.2"}
 
 
 class MockIP(object):
@@ -451,25 +452,22 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         self.client_mock.vrrpa.update.assert_not_called()
         self.assertEqual(result, None)
 
-    def test_reserver_subnet_addr_for_member(self):
+    def test_reserve_subnet_addr_for_member(self):
         mock_network_task = a10_network_tasks.ReserveSubnetAddressForMember()
         mock_network_task.network_driver = self.client_mock
-        flavor = {"pool_name": "p1", "start_address": "1.1.1.1", "end_address": "1.1.1.2"}
-        mock_network_task.execute(MEMBER, flavor)
+        mock_network_task.execute(MEMBER, NAT_FLAVOR)
         self.client_mock.reserve_subnet_addresses.assert_called_with(
             MEMBER.subnet_id, ["1.1.1.1", "1.1.1.2"])
 
     def test_release_subnet_addr_referenced(self):
         mock_network_task = a10_network_tasks.ReleaseSubnetAddressForMember()
-        flavor = {"pool_name": "p1", "start_address": "1.1.1.1", "end_address": "1.1.1.2"}
         NAT_POOL.member_ref_count = 2
-        ret_val = mock_network_task.execute(MEMBER, flavor, NAT_POOL)
+        ret_val = mock_network_task.execute(MEMBER, NAT_FLAVOR, NAT_POOL)
         self.assertEqual(ret_val, None)
 
     def test_release_subnet_addr(self):
         mock_network_task = a10_network_tasks.ReleaseSubnetAddressForMember()
         mock_network_task.network_driver = self.client_mock
-        flavor = {"pool_name": "p1", "start_address": "1.1.1.1", "end_address": "1.1.1.2"}
         NAT_POOL.member_ref_count = 1
-        mock_network_task.execute(MEMBER, flavor, NAT_POOL)
+        mock_network_task.execute(MEMBER, NAT_FLAVOR, NAT_POOL)
         self.client_mock.delete_port.assert_called_with(NAT_POOL.port_id)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_server_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_server_tasks.py
@@ -14,6 +14,7 @@
 
 
 import imp
+import sys
 
 try:
     from unittest import mock
@@ -210,10 +211,13 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
             SERVER_NAME, MEMBER.protocol_port, pool_protocol_tcp)
 
     def test_reserver_subnet_addr(self):
-        mock = task.MemberReserveSubnetAddr()
-        mock._network_driver = self.client_mock
+        mock1 = task.MemberReserveSubnetAddr()
+        if sys.version_info[0] < 3:
+            mock1._network_driver = self.client_mock
+        else:
+            mock1.network_driver = self.client_mock
         flavor = {"pool_name": "p1", "start_address": "1.1.1.1", "end_address": "1.1.1.2"}
-        mock.execute(MEMBER, flavor)
+        mock1.execute(MEMBER, flavor)
         self.client_mock.reserve_subnet_addresses.assert_called_with(
             MEMBER.subnet_id, ["1.1.1.1", "1.1.1.2"])
 
@@ -226,7 +230,10 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
 
     def test_release_subnet_addr(self):
         mock = task.MemberReleaseSubnetAddr()
-        mock._network_driver = self.client_mock
+        if sys.version_info[0] < 3:
+            mock._network_driver = self.client_mock
+        else:
+            mock.network_driver = self.client_mock
         flavor = {"pool_name": "p1", "start_address": "1.1.1.1", "end_address": "1.1.1.2"}
         NAT_POOL.member_ref_count = 1
         mock.execute(MEMBER, flavor, NAT_POOL)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_server_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_server_tasks.py
@@ -14,7 +14,6 @@
 
 
 import imp
-import sys
 
 try:
     from unittest import mock
@@ -45,7 +44,6 @@ MEMBER = o_data_models.Member(
 KEY_ARGS = {'server': utils.meta(MEMBER, 'server', {'conn_resume': None, 'conn_limit': 64000000})}
 SERVER_NAME = '{}_{}'.format(MEMBER.project_id[:5],
                              MEMBER.ip_address.replace('.', '_'))
-NAT_POOL = data_models.NATPool(port_id=a10constants.MOCK_PORT_ID)
 
 
 class TestHandlerServerTasks(base.BaseTaskTestCase):
@@ -209,32 +207,3 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
             POOL.id, SERVER_NAME, MEMBER.protocol_port)
         self.client_mock.slb.server.port.delete.assert_called_with(
             SERVER_NAME, MEMBER.protocol_port, pool_protocol_tcp)
-
-    def test_reserver_subnet_addr(self):
-        mock1 = task.MemberReserveSubnetAddr()
-        if sys.version_info[0] < 3:
-            mock1._network_driver = self.client_mock
-        else:
-            mock1.network_driver = self.client_mock
-        flavor = {"pool_name": "p1", "start_address": "1.1.1.1", "end_address": "1.1.1.2"}
-        mock1.execute(MEMBER, flavor)
-        self.client_mock.reserve_subnet_addresses.assert_called_with(
-            MEMBER.subnet_id, ["1.1.1.1", "1.1.1.2"])
-
-    def test_release_subnet_addr_referenced(self):
-        mock = task.MemberReleaseSubnetAddr()
-        flavor = {"pool_name": "p1", "start_address": "1.1.1.1", "end_address": "1.1.1.2"}
-        NAT_POOL.member_ref_count = 2
-        ret_val = mock.execute(MEMBER, flavor, NAT_POOL)
-        self.assertEqual(ret_val, None)
-
-    def test_release_subnet_addr(self):
-        mock = task.MemberReleaseSubnetAddr()
-        if sys.version_info[0] < 3:
-            mock._network_driver = self.client_mock
-        else:
-            mock.network_driver = self.client_mock
-        flavor = {"pool_name": "p1", "start_address": "1.1.1.1", "end_address": "1.1.1.2"}
-        NAT_POOL.member_ref_count = 1
-        mock.execute(MEMBER, flavor, NAT_POOL)
-        self.client_mock.delete_port.assert_called_with(NAT_POOL.port_id)


### PR DESCRIPTION
## Description
fix PR review comments for https://github.com/a10networks/a10-octavia/pull/281

Feature Requirements 

- Requires SNAT Pools to be allocated from Neutron 
- Frequent changes to these pools will occur 
- Restarting configuration file is tedious and can interrupt DevOps tooling workflow 
- Shouldn’t require SNAT Pool to be pre-defined on the ACOS device 
- Adds snat pool option to flavor schema for loadbalancers and can be shared between loadbalancers 

Design Document: https://teams.microsoft.com/l/file/27F4222F-7CDD-421B-8F0C-97A5C60B2B5D?tenantId=91d27ab9-8c5e-41d4-82e8-3d1bf81fcb2f&fileType=docx&objectUrl=https%3A%2F%2Fa10networks.sharepoint.com%2Fsites%2FOpenstack%2FShared%20Documents%2FDevelopment%2FResearch%20%26%20Design%2FSNAT%20Pools%2FSNAT%20Pools%20Design%20Document.docx&baseUrl=https%3A%2F%2Fa10networks.sharepoint.com%2Fsites%2FOpenstack&serviceName=teams&threadId=19:0f1acbb173d74758b05ee8bacb000d68@thread.tacv2&groupId=37bbf3ad-c05a-4e67-b0cc-12bcd1479beb
Story: https://a10networks.atlassian.net/browse/STACK-1896

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1896

## Technical Approach
Check design document for detail.

```

1. Add flavor schema for nat-pool and nat-pool-list in api/drivers/flavor_schema.py 
2. show flavor support and validate flavor data in api/drivers/driver.py 
3. In a10-octavia, add new task class for nat pool creation 
  - create pool according to the flavor 
  -  if exist but range is different -> failed 
  -  if exist but range is same -> pass 
4. The NAT pool creation task should also create nat pools in nat-pool-list 
5. Add the nat pool creation task to loadbalancer create flow 
6. For listener create/set, it should select nat pool with the priority nat-pool flavor < virtual-port flavor < virtual-port flavor regex 
7. Handle update cases: 
   - Set command for loadbalancer.  After update loadbalancer, nat pool should still configure properly on Thunder. 
   - Set command for listener. For listener update, after update Thunder should still use the proper source-nat value  
8. Delete the NAT pools in nat-pool and nat-pool-list flavor when loadbalancer is deleted. 
    -  If nat pool is reference by others, the loadbalancer delete flow should still success. (leave the nat pool for other loadbalancer to delete) And we raise a warning in this case. 
9. Rrefactor nat.py in acos-client (like other slb objects in acos-client) 

```

## Config Changes
**This is only required if the config has been updated in this PR**
- Required: Provide example config snippet within pre block

<pre>
<b>Add changes in bold</b>
</pre>

(Example Snippet - Remove This Before Submission)

<pre>
[rack_vthunder]

devices=[
 {
 "project_id": "fake_uuid",
 "username" : "username",
 "password" : "password",
 "ip_address" : "10.43.12.137",
 "device_name" : "rack_1"
 <b>"example": "change",</b>
 },
 }]
</pre>

## Test Cases

1. Reject flavor data with invalid format or manditory key missing 
2. NAT pool should be created on Thunder when loadbalancer is created. 
3. If NAT pool name already used in Thunder 
  -  Return error when pool content is different. 
  - Pass the creation when pool content is the same. 
4. All listener will use the NAT pool created by flavor in this loadbalancer 
5. For NAT pool selection 
  - virtual-port flavor has higher priority than nat-pool flavor 
  - Virtual-pool flavor regex has higher priority than virtual-port flavor 
6. Listener can use NAT pool that already on Thunder 
7. Thunder will create NAT pools that specified in nat-pool-list. 
8.  listener can use pools in nat-pool-list by specify the pool in virtual-port flavor or virtual-port flavor regex. 

## Manual Testing
Please check detail test steps and logs in RD unit-test document:
https://teams.microsoft.com/l/file/DA35D246-0822-42C7-BFF6-1562535E3802?tenantId=91d27ab9-8c5e-41d4-82e8-3d1bf81fcb2f&fileType=docx&objectUrl=https%3A%2F%2Fa10networks.sharepoint.com%2Fsites%2FOpenstack%2FShared%20Documents%2FDevelopment%2FResearch%20%26%20Design%2FSNAT%20Pools%2FSNAT%20Flavor%20Support%20Unit%20Test%20Notes.docx&baseUrl=https%3A%2F%2Fa10networks.sharepoint.com%2Fsites%2FOpenstack&serviceName=teams&threadId=19:0f1acbb173d74758b05ee8bacb000d68@thread.tacv2&groupId=37bbf3ad-c05a-4e67-b0cc-12bcd1479beb


```
openstack loadbalancer flavorprofile create --name fp_snat_list --provider a10 --flavor-data '{"nat-pool":{"pool-name":"pool1", "start-address":"172.16.1.101", "end-address":"172.16.1.102", "netmask":"/24", "gateway":"172.16.1.1"}, "nat-pool-list":[{"pool-name":"pool2", "start-address":"172.16.2.101", "end-address":"172.16.2.102", "netmask":"/24", "gateway":"172.16.2.1"}, {"pool-name":"pool3", "start-address":"172.16.3.101", "end-address":"172.16.3.102", "netmask":"/24", "gateway":"172.16.3.1"}]}'
openstack loadbalancer flavor create --name f_snat_list --flavorprofile fp_snat_list --description "flaovr all test1" --enable
openstack loadbalancer flavorprofile create --name fp_snat_list --provider a10 --flavor-data '{"nat-pool":{"pool-name":"pool4", "start-address":"172.17.1.101", "end-address":"172.17.1.102", "netmask":"/24", "gateway":"172.17.1.1"}}'
openstack loadbalancer flavor create --name f_snat --flavorprofile fp_snat --description "flaovr all test2" --enable
openstack loadbalancer flavorprofile create --name fp_snat_vport --provider a10 --flavor-data '{"nat-pool":{"pool-name":"pool4", "start-address":"172.17.1.101", "end-address":"172.17.1.102", "netmask":"/24", "gateway":"172.17.1.1"}, "virtual-port": {"name-expressions": [{"regex": "vport2", "json": {"pool": "pool2"}}]}}'
openstack loadbalancer flavor create --name f_snat_vport --flavorprofile fp_snat_vport --description "flaovr all test3" --enable
Case1:
Create lb1 with flavor f_snat_list
openstack loadbalancer create --flavor f_snat_list --vip-subnet-id 11dcb328-f947-4b5f-a789-5ae46118bb81 --name lb1
Result --> lb1 and pool1, pool2, pool3 created
Create lb2 with flavor f_snat
openstack loadbalancer create --flavor f_snat --vip-subnet-id 11dcb328-f947-4b5f-a789-5ae46118bb81 --name lb2
Result --> lb2 and pool4 created

Delete lb1
openstack loadbalancer delete lb1
Result --> lb1 and nat-pools pool1, pool2 and pool3 got deleted
Delete lb2
openstack loadbalancer delete lb2
Result --> lb2 and nat-pool pool4 got deleted

Case2:
Create lb1 with flavor f_snat_list
openstack loadbalancer create --flavor f_snat_list --vip-subnet-id 11dcb328-f947-4b5f-a789-5ae46118bb81 --name lb1
Result --> lb1 and pool1, pool2, pool3 created
Create lb2 with flavor f_snat_list
openstack loadbalancer create --flavor f_snat_list --vip-subnet-id 11dcb328-f947-4b5f-a789-5ae46118bb81 --name lb2
Result --> lb2 created
Delete lb1
openstack loadbalancer delete lb1
Result --> lb1 got deleted with following warning:
WARNING a10_octavia.controller.worker.tasks.nat_pool_tasks [-] Cannot delete Nat-pool(s) in flavor 1d874007-1045-499f-8821-6b396ec79b0c as they are in use by another loadbalancer(s)
Delete lb2
openstack loadbalancer delete lb2
Result --> lb2 and nat-pools pool1, pool2 and pool3 got deleted

Case3:
Create lb1 with flavor f_snat_list
openstack loadbalancer create --flavor f_snat_list --vip-subnet-id 11dcb328-f947-4b5f-a789-5ae46118bb81 --name lb1
Result --> lb1 and pool1, pool2, pool3 created
Create lb2 with flavor f_snat_vport
openstack loadbalancer create --flavor f_snat_vport --vip-subnet-id 11dcb328-f947-4b5f-a789-5ae46118bb81 --name lb2
Result --> lb2 and pool4 created
Create a listener "vport2" for lb2
openstack loadbalancer listener create --protocol tcp --protocol-port 80 --name vport2 lb2
Result --> listener vport2 created with having source-nat pool pool2 configured to it.
Delete lb1
openstack loadbalancer delete lb1
Result --> lb1 and pool1 and pool3 got deleted with following error message:
ERROR a10_octavia.controller.worker.tasks.nat_pool_tasks [-] Failed to delete Nat-pool with name pool2 due to 654376991 This NAT pool is referenced by a Virtual Port. Please remove the binding first.: ACOSException: 654376991 This NAT pool is referenced by a Virtual Port. Please remove the binding first.
Delete vport2
Delete lb2
Result --> vport2, lb2 and pool4 and pool2 got deleted
```