### PR TITLE
STACK-2009 Bug hm flavor issues

### DIFF
--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -14,7 +14,6 @@
 
 
 from acos_client import errors as acos_errors
-from acos_client.v21 import axapi_http as axapi_v21
 from oslo_config import cfg
 from oslo_log import log as logging
 from requests.exceptions import ConnectionError
@@ -52,8 +51,8 @@ class CreateAndAssociateHealthMonitor(task.Task):
                 name_exprs = flavors.get('name_expressions')
                 parsed_exprs = utils.parse_name_expressions(health_mon.name, name_exprs)
                 flavors.pop('name_expressions', None)
-                args = axapi_v21.merge_dicts(args, flavors)
-                args = axapi_v21.merge_dicts(args, parsed_exprs)
+                flavors.update(parsed_exprs)
+                args.update({'monitor': flavors})
 
         try:
             post_data = CONF.health_monitor.post_data
@@ -144,8 +143,8 @@ class UpdateHealthMonitor(task.Task):
                 name_exprs = flavors.get('name_expressions')
                 parsed_exprs = utils.parse_name_expressions(health_mon.name, name_exprs)
                 flavors.pop('name_expressions', None)
-                args = axapi_v21.merge_dicts(args, flavors)
-                args = axapi_v21.merge_dicts(args, parsed_exprs)
+                flavors.update(parsed_exprs)
+                args.update({'monitor': flavors})
 
         try:
             post_data = CONF.health_monitor.post_data

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_health_monitor_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_health_monitor_tasks.py
@@ -53,7 +53,7 @@ FLAVOR_WITH_REGEX_ARGS = {
     'monitor': {
         'retry': 5,
         'method': {
-            'http': {'http_response_code': '201', 'http_host': 'my.test.com'}
+            'http': {'http_host': 'my.test.com'}
         },
         'timeout': 8
     }
@@ -98,12 +98,10 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
     def test_health_monitor_create_with_flavor_task(self):
         flavor = {
             "health_monitor": {
-                "monitor": {
-                    "retry": 5,
-                    "method": {
-                        "http": {
-                            "http_response_code": "201"
-                        }
+                "retry": 5,
+                "method": {
+                    "http": {
+                        "http_response_code": "201"
                     }
                 }
             }
@@ -123,12 +121,10 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
     def test_health_monitor_create_with_flavor_and_config(self):
         flavor = {
             "health_monitor": {
-                "monitor": {
-                    "retry": 5,
-                    "method": {
-                        "http": {
-                            "http_response_code": "201"
-                        }
+                "retry": 5,
+                "method": {
+                    "http": {
+                        "http_response_code": "201"
                     }
                 }
             }
@@ -150,24 +146,20 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
     def test_health_monitor_create_with_flavor_regex_task(self):
         flavor = {
             "health_monitor": {
-                "monitor": {
-                    "retry": 5,
-                    "method": {
-                        "http": {
-                            "http_response_code": "201"
-                        }
+                "retry": 5,
+                "method": {
+                    "http": {
+                        "http_response_code": "201"
                     }
                 },
                 "name_expressions": [
                     {
                         "regex": "hm1",
                         "json": {
-                            "monitor": {
-                                "timeout": 8,
-                                "method": {
-                                    "http": {
-                                        "http_host": "my.test.com"
-                                    }
+                            "timeout": 8,
+                            "method": {
+                                "http": {
+                                    "http_host": "my.test.com"
                                 }
                             }
                         }
@@ -191,25 +183,21 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
     def test_health_monitor_create_with_regex_overwrite_flavor_task(self):
         flavor = {
             "health_monitor": {
-                "monitor": {
-                    "retry": 5,
-                    "timeout": 90,
-                    "method": {
-                        "http": {
-                            "http_response_code": "201"
-                        }
+                "retry": 5,
+                "timeout": 90,
+                "method": {
+                    "http": {
+                        "http_response_code": "201"
                     }
                 },
                 "name_expressions": [
                     {
                         "regex": "hm1",
                         "json": {
-                            "monitor": {
-                                "timeout": 8,
-                                "method": {
-                                    "http": {
-                                        "http_host": "my.test.com"
-                                    }
+                            "timeout": 8,
+                            "method": {
+                                "http": {
+                                    "http_host": "my.test.com"
                                 }
                             }
                         }
@@ -257,12 +245,10 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
     def test_health_monitor_update_with_flavor_and_config_task(self):
         flavor = {
             "health_monitor": {
-                "monitor": {
-                    "retry": 5,
-                    "method": {
-                        "http": {
-                            "http_response_code": "201"
-                        }
+                "retry": 5,
+                "method": {
+                    "http": {
+                        "http_response_code": "201"
                     }
                 }
             }
@@ -285,12 +271,10 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
     def test_health_monitor_update_with_flavor_task(self):
         flavor = {
             "health_monitor": {
-                "monitor": {
-                    "retry": 5,
-                    "method": {
-                        "http": {
-                            "http_response_code": "201"
-                        }
+                "retry": 5,
+                "method": {
+                    "http": {
+                        "http_response_code": "201"
                     }
                 }
             }
@@ -311,24 +295,20 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
     def test_health_monitor_update_with_flavor_regex_task(self):
         flavor = {
             "health_monitor": {
-                "monitor": {
-                    "retry": 5,
-                    "method": {
-                        "http": {
-                            "http_response_code": "201"
-                        }
+                "retry": 5,
+                "method": {
+                    "http": {
+                        "http_response_code": "201"
                     }
                 },
                 "name_expressions": [
                     {
                         "regex": "hm1",
                         "json": {
-                            "monitor": {
-                                "timeout": 8,
-                                "method": {
-                                    "http": {
-                                        "http_host": "my.test.com"
-                                    }
+                            "timeout": 8,
+                            "method": {
+                                "http": {
+                                    "http_host": "my.test.com"
                                 }
                             }
                         }
@@ -353,25 +333,21 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
     def test_health_monitor_update_with_regex_overwrite_flavor_task(self):
         flavor = {
             "health_monitor": {
-                "monitor": {
-                    "retry": 5,
-                    "timeout": 90,
-                    "method": {
-                        "http": {
-                            "http_response_code": "201"
-                        }
+                "retry": 5,
+                "timeout": 90,
+                "method": {
+                    "http": {
+                        "http_response_code": "201"
                     }
                 },
                 "name_expressions": [
                     {
                         "regex": "hm1",
                         "json": {
-                            "monitor": {
-                                "timeout": 8,
-                                "method": {
-                                    "http": {
-                                        "http_host": "my.test.com"
-                                    }
+                            "timeout": 8,
+                            "method": {
+                                "http": {
+                                    "http_host": "my.test.com"
                                 }
                             }
                         }


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description:
1. 'method' axapi argument in flavor should not merge with other flavor (when 2 or more flavor is matched). Since different protocol and method has different axapi keys, merge them together will not work.
2. For HM flavor,  user should not need to encapsulate axapi arguments in 'monitor'. Like other slb objects, a10-octavia should do it for user.
for example:
for flavor-data
```
{
  "health-monitor" : {
    "monitor":{
      "retry":5,
    }
  }
}
```
user should just use:
```
{   
  "health-monitor":{
    "retry":5,
  }
}
```

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2009

## Technical Approach
1. For health monitor flavor, user should not need to encapsulate axapi arguments in 'monitor'. Like other slb objects, a10-octavia should do it for user.
2. Don’t for multiple matched flavors, don’t merge ‘method’ axapi argument together. Use latest instead. (different protocol  and method has different axapi arguments, we should not merge them.)


## Config Changes
- Example flavor
<pre>
<b>
{
  "service-group": {
	"lb-method": "fastest-response",
  },
  "health-monitor":{
    "retry":5,
    "method":{
      "http":{
        "http-response-code":"201"
      }
    },
    "name-expressions":[
    {
      "regex":"hm1",
      "json":{
        "timeout":8,
        "method":{
          "http":{
            "http-host":"my.test.com"
          }
        }
      }
    }
    ]
  }
}
</b>
</pre>


## Test Cases
Unit-test document is updated:
https://teams.microsoft.com/l/file/E84B76C6-48D8-441C-B375-51B010F42EB3?tenantId=91d27ab9-8c5e-41d4-82e8-3d1bf81fcb2f&fileType=docx&objectUrl=https%3A%2F%2Fa10networks.sharepoint.com%2Fsites%2FOpenstack%2FShared Documents%2FDevelopment%2FResearch %26 Design%2FFlavor Support%2FRD unit-test notes.docx&baseUrl=https%3A%2F%2Fa10networks.sharepoint.com%2Fsites%2FOpenstack&serviceName=teams&threadId=19:0f1acbb173d74758b05ee8bacb000d68@thread.tacv2&groupId=37bbf3ad-c05a-4e67-b0cc-12bcd1479beb

1.  use flavor-data described above
2. create 2 health-monitor, which on thunder the options will configure correctly.
3. test set/update command for health-monitor, should also works on thunder
4. For health-monitor 'hm1', it will only use method in regex. But for common flavor "'retry': 5" will still apply to it. Since regex didn't define it.

## Manual Testing
```
openstack loadbalancer flavorprofile create --name fp_hm1 --provider a10 --flavor-data '{"service-group": {"lb-method": "fastest-response"}, "health-monitor": {"retry":5, "method": { "http": {"http-response-code":"201"}}, "name-expressions": [{"regex": "hm1", "json": {"timeout":8, "method": { "http": {"http-host":"my.test.com"}}}}]}}'
openstack loadbalancer flavor create --name f_hm1 --flavorprofile fp_hm1 --description "hm test1" --enable
openstack loadbalancer create --flavor f_hm1 --vip-subnet-id f25ce642-f953-4058-8c46-98fdd72fb129 --vip-address 192.168.91.56 --name vip1
openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name vport1 vip1
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener vport1 --name sg1
openstack loadbalancer healthmonitor create --delay 30 --timeout 3 --max-retries 3 --type HTTP sg1 --name hm1

openstack loadbalancer listener create --protocol HTTP --protocol-port 8080 --name vport2 vip1
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener vport2 --name sg2
openstack loadbalancer healthmonitor create --delay 30 --timeout 3 --max-retries 3 --type HTTP sg2 --name hm2

openstack loadbalancer healthmonitor set --delay 50 hm1
```

- result:
```
health monitor 05ba1984-c23a-4783-9215-4f8e7bedcc0a
  retry 5
  override-port 80
  interval 50 timeout 8
  method http port 80 expect response-code 200 host my.test.com url GET /
!
health monitor 4b3da84c-f1f4-480b-94e5-fd38793111a1
  retry 5
  override-port 8080
  interval 30 timeout 3
  method http port 8080 expect response-code 201 url GET /
!
slb service-group 237ebbfe-f2dd-4e12-9206-f1575e52ec39 tcp
  method fastest-response
  health-check 05ba1984-c23a-4783-9215-4f8e7bedcc0a
!
slb service-group b904e527-19b5-450a-8f5f-ba47a32b774b tcp
  method fastest-response
  health-check 4b3da84c-f1f4-480b-94e5-fd38793111a1
!
slb virtual-server 763eec3a-446e-4ca3-82e5-da7eb1ee202b 192.168.91.56
  port 80 http
    name 9c04c0cc-5392-4b89-9687-86ce41481c02
    conn-limit 555000
    extended-stats
    source-nat auto
    service-group 237ebbfe-f2dd-4e12-9206-f1575e52ec39
  port 8080 http
    name f97a4344-8000-405e-9e09-c24fdb4e44a9
    conn-limit 555000
    extended-stats
    source-nat auto
    service-group b904e527-19b5-450a-8f5f-ba47a32b774b
!
```