### PR TITLE
[BUG][STACK-2012]: Fixed an issue during listener creation without nat-pool flavor

### DIFF
--- a/a10_octavia/controller/worker/tasks/nat_pool_tasks.py
+++ b/a10_octavia/controller/worker/tasks/nat_pool_tasks.py
@@ -92,9 +92,9 @@ class NatPoolCreate(task.Task):
             except ConnectionError:
                 LOG.exception(
                     "Failed to connect A10 Thunder device: %s", vthunder.ip_address)
-            except Exception as e:
-                LOG.exception("Failed to revert creation of the nat-pool due to: %s",
-                              str(e))
+            except (acos_errors.ACOSException, Exception) as e:
+                LOG.exception("Failed to revert creation of nat-pool %s due to: %s",
+                              pool_name, str(e))
 
 
 class NatPoolDelete(task.Task):

--- a/a10_octavia/controller/worker/tasks/nat_pool_tasks.py
+++ b/a10_octavia/controller/worker/tasks/nat_pool_tasks.py
@@ -82,11 +82,11 @@ class NatPoolCreate(task.Task):
             try:
                 if natpool_flavor_list:
                     for nat_pool in natpool_flavor_list:
-                        pool_name = nat_pool['pool_name']
+                        pool_name = nat_pool.get('pool_name')
                         LOG.warning("Reverting creation of nat-pool: %s", pool_name)
                         self.axapi_client.nat.pool.delete(pool_name)
                 if natpool_flavor:
-                    pool_name = natpool_flavor['pool_name']
+                    pool_name = natpool_flavor.get('pool_name')
                     LOG.warning("Reverting creation of nat-pool: %s", pool_name)
                     self.axapi_client.nat.pool.delete(pool_name)
             except ConnectionError:

--- a/a10_octavia/controller/worker/tasks/nat_pool_tasks.py
+++ b/a10_octavia/controller/worker/tasks/nat_pool_tasks.py
@@ -76,24 +76,25 @@ class NatPoolCreate(task.Task):
 
     @axapi_client_decorator
     def revert(self, loadbalancer, vthunder, flavor_data=None, *args, **kwargs):
-        natpool_flavor_list = flavor_data.get('nat_pool_list')
-        natpool_flavor = flavor_data.get('nat_pool')
-        try:
-            if natpool_flavor_list:
-                for nat_pool in natpool_flavor_list:
-                    pool_name = nat_pool['pool_name']
+        if flavor_data:
+            natpool_flavor_list = flavor_data.get('nat_pool_list')
+            natpool_flavor = flavor_data.get('nat_pool')
+            try:
+                if natpool_flavor_list:
+                    for nat_pool in natpool_flavor_list:
+                        pool_name = nat_pool['pool_name']
+                        LOG.warning("Reverting creation of nat-pool: %s", pool_name)
+                        self.axapi_client.nat.pool.delete(pool_name)
+                if natpool_flavor:
+                    pool_name = natpool_flavor['pool_name']
                     LOG.warning("Reverting creation of nat-pool: %s", pool_name)
                     self.axapi_client.nat.pool.delete(pool_name)
-            if natpool_flavor:
-                pool_name = natpool_flavor['pool_name']
-                LOG.warning("Reverting creation of nat-pool: %s", pool_name)
-                self.axapi_client.nat.pool.delete(pool_name)
-        except ConnectionError:
-            LOG.exception(
-                "Failed to connect A10 Thunder device: %s", vthunder.ip_address)
-        except Exception as e:
-            LOG.exception("Failed to revert creation of the nat-pool due to: %s",
-                          str(e))
+            except ConnectionError:
+                LOG.exception(
+                    "Failed to connect A10 Thunder device: %s", vthunder.ip_address)
+            except Exception as e:
+                LOG.exception("Failed to revert creation of the nat-pool due to: %s",
+                              str(e))
 
 
 class NatPoolDelete(task.Task):


### PR DESCRIPTION
- Severity Level: High
Listener creation was failing when nat-pool flavor is not used.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2012

## Technical Approach
- Executing revert of NatPoolCreate task only when flavor-data is passed while listener creation.

## Manual Testing
Create a loadbalancer without any flavor passed to it.
openstack loadbalancer create --name v11 --vip-subnet-id provider-vlan-11-subnet

Create a listener.
openstack loadbalancer listener create --protocol http --protocol-port 80 --name l1 v11

Result:
Listener l1 created successfully.
