### PR TITLE
[BUG][STACK-1819]: For L7rule type "FILE_TYPE", the rulestring is getting created with "[HTTP::path]" instead of [HTTP::uri]

### DIFF
--- a/a10_octavia/controller/worker/tasks/policy.py
+++ b/a10_octavia/controller/worker/tasks/policy.py
@@ -76,9 +76,9 @@ class PolicyUtil(object):
         # rule string static - required for file type rules only
         if l7rule.type == "FILE_TYPE":
             if l7rule.compare_type == "REGEX":
-                ruleString = "([HTTP::path] matches_regex"
+                ruleString = "([HTTP::uri] matches_regex"
             else:
-                ruleString = "([HTTP::path] ends_with"
+                ruleString = "([HTTP::uri] ends_with"
 
         # value
         value_string = l7rule.value

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_policy.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_policy.py
@@ -35,3 +35,23 @@ class TestPolicy(base.TestCase):
         policy_util.createPolicy(L7POLICY)
         self.assertEqual(policy_util.ruleParser(L7RULE),
                          '([HTTP::path] equals "www://abc.com")')
+
+    def test_policy_rule_file_type_regex(self):
+        L7rule_file_type = o_data_models.L7Rule(id=a10constants.MOCK_L7RULE_ID,
+                                                l7policy_id=a10constants.MOCK_L7POLICY_ID,
+                                                type="FILE_TYPE", compare_type="REGEX",
+                                                value=".(html|xml)")
+        L7POLICY.l7rules = [L7rule_file_type]
+        policy_util = policy.PolicyUtil()
+        self.assertEqual(policy_util.ruleParser(L7rule_file_type),
+                         '([HTTP::uri] matches_regex ".(html|xml)")')
+
+    def test_policy_rule_file_type_equals(self):
+        L7rule_file_type = o_data_models.L7Rule(id=a10constants.MOCK_L7RULE_ID,
+                                                l7policy_id=a10constants.MOCK_L7POLICY_ID,
+                                                type="FILE_TYPE", compare_type="EQUAL_TO",
+                                                value="ccccc")
+        L7POLICY.l7rules = [L7rule_file_type]
+        policy_util = policy.PolicyUtil()
+        self.assertEqual(policy_util.ruleParser(L7rule_file_type),
+                         '([HTTP::uri] ends_with "ccccc")')


### PR DESCRIPTION
## Description
Previously added changes for resolving STACK-1818  are required for L7rule type "PATH" but changes were reflecting for type "FILE_TYPE". Due to this for type "FILE_TYPE" the rule string was using "[HTTP::path]" instead of "[HTTP::uri]"

Check the comments for STACK-1819,
https://a10networks.atlassian.net/browse/STACK-1819


## Technical Approach
- Checked URI specification to know about path part of URI
- Reverted the changes done for type "FILE_TYPE"


## Test Cases
- Checked l7 rule for TYPE "FILE_TYPE" and compare type "REGEX".
- TYPE "FILE_TYPE" and compare type "EQUALS_TO"

## Manual Testing
- Created L7 rule for TYPE "FILE_TYPE" and compare type "REGEX".
- Created l7 rule for TYPE "FILE_TYPE" and compare type "EQUALS_TO"
- Created l7 rule for TYPE "PATH" and  compare type "ENDS_WITH"


