### PR TITLE
[BUG][STACK-1996]: Fixed issue of losing real port configurations after setting the member

### DIFF
--- a/a10_octavia/controller/worker/tasks/server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/server_tasks.py
@@ -77,15 +77,6 @@ class MemberCreate(task.Task):
             raise e
 
         try:
-            protocol = openstack_mappings.service_group_protocol(
-                self.axapi_client, pool.protocol)
-            self.axapi_client.slb.server.port.create(server_name, member.protocol_port, protocol,
-                                                     weight=member.weight)
-        except (acos_errors.ACOSException, exceptions.ConnectionError):
-            LOG.exception("Failed add port in member %s", member.id)
-            # no raise, it will still work even no port. but options for port will missing
-
-        try:
             self.axapi_client.slb.service_group.member.create(
                 pool.id, server_name, member.protocol_port)
             LOG.debug("Successfully associated member %s to pool %s",
@@ -168,12 +159,6 @@ class MemberUpdate(task.Task):
             template_server = None
         server_temp = {'template-server': template_server}
 
-        port_list = None
-        curr_args = self.axapi_client.slb.server.get(server_name)
-        if 'server' in curr_args:
-            if 'port-list' in curr_args['server']:
-                port_list = curr_args['server']['port-list']
-
         if not member.enabled:
             status = False
         else:
@@ -189,15 +174,6 @@ class MemberUpdate(task.Task):
         except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception("Failed to update member: %s", member.id)
             raise e
-
-        try:
-            protocol = openstack_mappings.service_group_protocol(
-                self.axapi_client, pool.protocol)
-            self.axapi_client.slb.server.port.update(server_name, member.protocol_port, protocol,
-                                                     weight=member.weight)
-        except (acos_errors.ACOSException, exceptions.ConnectionError):
-            LOG.exception("Failed add port in member %s", member.id)
-            # no raise, it will still work even no port. but options for port will missing
 
 
 class MemberDeletePool(task.Task):


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue description: Created a member and real port to it by flavor including port-list to it, then set member is making real port config lost.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1996

## Technical Approach
- Removed an api call made for creating a server-port `self.axapi_client.slb.server.port.create` , as `self.axapi_client.slb.server.create` is creating the server-port as per the configurations passed to it by flavor via server_args passed to it.  `self.axapi_client.slb.server.port.create` is trying to create the port with same port and protocol again even after the port creation is done by `self.axapi_client.slb.server.create`
- Also removing the api call made for updating the server-port `self.axapi_client.slb.server.port.update` , as it is overriding the port configurations of flavor passed to it, done via `port_list=port_list` inside `self.axapi_client.slb.server.replace` api call. So it was losing the config done by flavor passed to it.

## Manual Testing
1. create flavorprofile and flavor, added port number 80 and protocol in flavor:

`openstack loadbalancer flavorprofile create --name fp_vsvportsgser_port_more1 --provider a10 --flavor-data '{"virtual-server": {"enable-disable-action":"disable"},"virtual-port":{"conn-limit":200},"service-group":{"lb-method":"dst-ip-only-hash"},"server":{  "slow-start":1, "spoofing-cache":1, "stats-data-action":"stats-data-disable", "extended-stats":1, "port-list":[{"port-number":80, "protocol":"tcp", "support-http2":1, "conn-limit":400, "stats-data-action":"stats-data-disable", "extended-stats":1 }]}}'`

`openstack loadbalancer flavor create --name f_vsvportsgser_port_more1 --flavorprofile fp_vsvportsgser_port_more1`

2. Create a loadbalancer with the flavor:
openstack loadbalancer create --flavor f_vsvportsgser_port_more1 --name v13 --vip-subnet-id provider-vlan-211-subnet

3. Create a listener and pool:
openstack loadbalancer listener create --protocol HTTP --protocol-port 8080 --name l131 v13
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener l131 --name pool131

4. Create a member:
openstack loadbalancer member create --address 10.0.212.192 --subnet-id provider-vlan-212-subnet --protocol-port 80 --name mem1 pool131

Result on Thunder:
![image](https://user-images.githubusercontent.com/58077446/104906917-53ca2080-59aa-11eb-9c57-fea78509b62d.png)

5. Change conn-limit in config file 
[server]
conn_limit=9000

6. Restart the service
sudo systemctl restart a10-controller-worker.service

7. Set member:
openstack loadbalancer member set pool131 mem1

Result on Thunder:
**conn-limit is modified and the previously done real port config is not lost here.**

![image](https://user-images.githubusercontent.com/58077446/104906878-44e36e00-59aa-11eb-8745-ed55dc55ffb1.png)
