### PR TITLE
[BUG][STACK-1791][vrid_floating_ip for 2 thunder clusters] the vrid_floating_ip are mixed for 2 thunder clusters

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -691,7 +691,8 @@ class GetChildProjectsOfParentPartition(BaseDatabaseTask):
             try:
                 partition_project_list = self.vthunder_repo.get_project_list_using_partition(
                     db_apis.get_session(),
-                    partition_name=vthunder.partition_name)
+                    partition_name=vthunder.partition_name,
+                    ip_address=vthunder.ip_address)
                 return partition_project_list
             except Exception as e:
                 LOG.exception(

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -309,9 +309,10 @@ class VThunderRepository(BaseRepository):
         id_list = [model.id for model in model_list]
         return id_list
 
-    def get_project_list_using_partition(self, session, partition_name):
+    def get_project_list_using_partition(self, session, partition_name, ip_address):
         queryset_vthunders = session.query(self.model_class.project_id.distinct()).filter(
             and_(self.model_class.partition_name == partition_name,
+                 self.model_class.ip_address == ip_address,
                  or_(self.model_class.role == "STANDALONE",
                      self.model_class.role == "MASTER")))
         list_projects = [project[0] for project in queryset_vthunders]

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -373,11 +373,13 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
     def test_get_child_projects_for_partition(self):
         vthunder = copy.deepcopy(VTHUNDER)
         vthunder.partition_name = "mock-partition-name"
+        vthunder.ip_address = "mock-ip-addr"
         mock_get_projects = task.GetChildProjectsOfParentPartition()
         mock_get_projects.vthunder_repo.get_project_list_using_partition = mock.Mock()
         mock_get_projects.execute(MEMBER_1, vthunder)
         mock_get_projects.vthunder_repo.get_project_list_using_partition.\
-            assert_called_once_with(mock.ANY, partition_name='mock-partition-name')
+            assert_called_once_with(mock.ANY, partition_name='mock-partition-name',
+                                    ip_address="mock-ip-addr")
 
     def test_flavor_search_loadbalancer_find_flavor(self):
         flavor_task = task.GetFlavorData()

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ install_command = pip install -U {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
        pyrsistent>0.15.4,<=0.16.0
+       alembic==1.4.3
 
 [testenv:pep8]
 commands = flake8


### PR DESCRIPTION
## Description
Severity level: High
Issue Description: When the same partition name is used to create LB or member in different clusters, then the VRID FIP from the first cluster gets duplicated to another cluster when we create LB or member in that other cluster.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1791

## Technical Approach
- Checked the query to fetch projects for a specific partition.
- Added IP-address to the query to fetch project for a partition.

## Manual Testing
- Tested the creation of LBs on different vthunders with the same partition name.
- Tested deletion of LBs on different vthunders with the same partition name.
- Tested creation of members in different vthunders with the same partition name.
- Tested deletion of members in different vthunders with the same partition name.
