### PR TITLE
[Bug][STACK-2028]: Removed unwanted variable initialization for HK db cleanup thread

### DIFF
--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -296,7 +296,6 @@ class VThunderRepository(BaseRepository):
 
         query = session.query(self.model_class).filter(
             self.model_class.updated_at < expiry_time)
-        query = session.query(self.model_class)
         if hasattr(self.model_class, 'status'):
             query = query.filter(or_(self.model_class.status == "USED_SPARE",
                                      self.model_class.status == consts.DELETED))


### PR DESCRIPTION
## Description
- Severity Level : **Highest**
- Issue Description : After deleting last LB, the corresponding `vthunders` record in db was getting deleted by Housekeeper's DB Cleanup thread unexpectedly. As a result, HouseKeeper's Write memory was not able to perform write memory on that vthunder.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2028

## Technical Approach
- It is expected from HouseKeeper's DB cleanup thread to by default consider a `DELETED` status `vthunders` to be expired only after `7 days`, but this was not happening.
- Found that, `query` filter was getting reset while fetching `expired` vthunders in `get_all_deleted_expiring`. Fixed this

## Config Changes
None

## Test Cases
Configs: 
```
[a10_house_keeping]
use_periodic_write_memory = 'enable'
write_mem_interval = 300
```

```
1. Create an LB and delete it after some time keeping above params.
2. Check on Housekeeper, after 5 minutes, the vthunder will be picked up for periodic write memory.
```

## Manual Testing
<pre>
1. Keep config as follows :
<b>[a10_house_keeping]
use_periodic_write_memory = 'enable'
write_mem_interval = 300
</b>
2. Create an LB 
openstack loadbalancer create --name v11 --vip-subnet-id provider-vlan-213-subnet --project  admin_1
3. Delete this LB 
openstack loadbalancer delete v11
4. Check after 5 min on 
<b>sudo journalctl -af --unit a10-house-keeper.service</b>
<b><i>
Jan 20 12:49:54 qa a10-house-keeper[18835]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 10.64.27.62:shared 
Jan 12 012:50:03 qa a10-house-keeper[18835]: INFO a10_octavia.controller.housekeeping.house_keeping [-] Finished running write memory for 1 thunders...
</i></b>

</pre>