### PR TITLE
[Bug][STACK-2031] : Activate shared partition using use_shared_partition flag in decorator

### DIFF
--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -388,6 +388,9 @@ class VThunderFlows(object):
                     flow='GetActiveLoadBalancersByThunder'),
                 provides=a10constants.LOADBALANCERS_LIST))
             write_memory_flow.add(a10_database_tasks.MarkLoadBalancersPendingUpdateInDB(
+                name='{flow}-{id}'.format(
+                    id=vthunder.vthunder_id,
+                    flow='MarkLoadBalancersPendingUpdateInDB'),
                 requires=a10constants.LOADBALANCERS_LIST))
             write_memory_flow.add(vthunder_tasks.WriteMemoryHouseKeeper(
                 requires=(a10constants.VTHUNDER, a10constants.LOADBALANCERS_LIST),
@@ -406,8 +409,14 @@ class VThunderFlows(object):
                     partition=a10constants.WRITE_MEM_FOR_SHARED_PARTITION)))
             write_memory_flow.add(a10_database_tasks.SetThunderLastWriteMem(
                 requires=a10constants.VTHUNDER,
-                rebind={a10constants.VTHUNDER: vthunder.vthunder_id}))
+                rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
+                name='{flow}-{id}'.format(
+                    id=vthunder.vthunder_id,
+                    flow='SetThunderLastWriteMem')))
             write_memory_flow.add(a10_database_tasks.MarkLoadBalancersActiveInDB(
+                name='{flow}-{id}'.format(
+                    id=vthunder.vthunder_id,
+                    flow='MarkLoadBalancersActiveInDB'),
                 requires=a10constants.LOADBALANCERS_LIST))
         store.update(vthunder_store)
         return write_memory_flow

--- a/a10_octavia/controller/worker/tasks/decorators.py
+++ b/a10_octavia/controller/worker/tasks/decorators.py
@@ -34,14 +34,17 @@ def activate_partition(vthunder_client, partition):
 def axapi_client_decorator(func):
     def wrapper(self, *args, **kwargs):
         vthunder = kwargs.get('vthunder')
+        use_shared_partition = kwargs.get('write_mem_shared_part', False)
         if vthunder:
             api_ver = acos_client.AXAPI_21 if vthunder.axapi_version == 21 else acos_client.AXAPI_30
             self.axapi_client = acos_client.Client(vthunder.ip_address, api_ver,
                                                    vthunder.username, vthunder.password,
                                                    timeout=30)
 
-            if vthunder.partition_name != "shared":
+            if vthunder.partition_name != "shared" and not use_shared_partition:
                 activate_partition(self.axapi_client, vthunder.partition_name)
+            else:
+                activate_partition(self.axapi_client, "shared")
 
         else:
             self.axapi_client = None


### PR DESCRIPTION
## Description
- Severity Level : **Medium**
- Description: Getting `400  Bad Request : Communication error with LB process` on l3v partition while doing periodic write memory by HK.
- Also resolves `Duplicate: Atoms with duplicate names found`

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2031
https://a10networks.atlassian.net/browse/STACK-2045

## Technical Approach
- This is due to while performing `write memory partition shared` in l3v partition which doesn't allow this.
according to https://a10networks.atlassian.net/browse/STACK-2031?focusedCommentId=462195
- Hence need to switch to `shared` partition before making write memory api call
- Earlier decorator `activate_partition` based on `vthunder.partition` and return `axapi_client`. But to make explicit api call to `shared` partition despite different `vthunder.partition`, need to use flag `use_shared_partition` inside decorator.
- This will ensure activating `shared` partition before making `write memory partition shared` call
- Along with this, also added "name" param in task flow tasks to be recognized as different Atoms

## Config Changes
None

## Test Cases
1. Check for case when `vthunder.partition` is `shared`
2. Check for case when `vthunder.partition` is some custom partition.

## Manual Testing
<pre>
1. In a10-octavia.conf
[a10_house_keeping]
 use_periodic_write_memory = 'enable'
 write_mem_interval = 300
 
 2. Create any SLB resource
 3. Check audit log on l3V partition
 </pre>

![image](https://user-images.githubusercontent.com/52992745/105353472-482e6200-5c15-11eb-8843-f472e602a4a9.png)
<pre>
4. Check on shared partition
</pre>
![image](https://user-images.githubusercontent.com/52992745/105353665-8af03a00-5c15-11eb-8b54-e53204f22872.png)
<pre>
5. on housekeeper logs: 
</pre>

![image](https://user-images.githubusercontent.com/52992745/105351728-f5ec4180-5c12-11eb-9810-01acc7862b28.png)
