### PR TITLE
[Bug] [STACK-2027] [STACK-2041] [STACK-2048] thunder reload detection and bugs fix

### DIFF
--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -109,6 +109,7 @@ DELETE_MEMBERS_SUBFLOW_WITH_POOL_DELETE_FLOW = 'delete-members-subflow-with-pool
 HANDLE_VRID_MEMBER_SUBFLOW = 'handle-vrid-member-subflow'
 SPARE_VTHUNDER_CREATE = 'spare-vthunder-create'
 WRITE_MEMORY_THUNDER_FLOW = 'write-memory-thunder-flow'
+RELOAD_CHECK_THUNDER_FLOW = 'reload-check-thunder-flow'
 LB_TO_VTHUNDER_SUBFLOW = 'lb-to-vthunder-subflow'
 LOADBALANCERS_LIST = 'loadbalancers_list'
 VRID_LIST = 'vrid_list'

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -901,10 +901,25 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         """
         store = {a10constants.WRITE_MEM_SHARED_PART: True}
 
-        write_mem_tf = self._taskflow_load(self._vthunder_flows.get_write_memory_flow(thunders,
-                                                                                      store),
-                                           store=store)
+        for vthunder in thunders:
+            write_mem_tf = self._taskflow_load(self._vthunder_flows.get_write_memory_flow(vthunder,
+                                                                                          store),
+                                               store=store)
 
-        with tf_logging.DynamicLoggingListener(write_mem_tf,
-                                               log=LOG):
-            write_mem_tf.run()
+            with tf_logging.DynamicLoggingListener(write_mem_tf,
+                                                   log=LOG):
+                write_mem_tf.run()
+
+    def perform_reload_check(self, thunders):
+        """Perform check for thunders see if thunder reload before write memory
+
+        :param thunders: group of thunder objects
+        :returns: None
+        """
+        store = {}
+        for vthunder in thunders:
+            reload_check_tf = self._taskflow_load(
+                self._vthunder_flows.get_reload_check_flow(vthunder, store),
+                store=store)
+            with tf_logging.DynamicLoggingListener(reload_check_tf, log=LOG):
+                reload_check_tf.run()

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -423,7 +423,7 @@ class VThunderFlows(object):
 
     def get_reload_check_flow(self, vthunder, store):
         """Perform write memory for thunder """
-        sf_name = 'a10-house-keeper' + '-' + a10constants.WRITE_MEMORY_THUNDER_FLOW
+        sf_name = 'a10-house-keeper' + '-' + a10constants.RELOAD_CHECK_THUNDER_FLOW
 
         reload_check_flow = linear_flow.Flow(sf_name)
         vthunder_store = {}
@@ -436,7 +436,11 @@ class VThunderFlows(object):
                 flow='GetActiveLoadBalancersByThunder'),
             provides=a10constants.LOADBALANCERS_LIST))
         reload_check_flow.add(vthunder_tasks.WriteMemoryThunderStatusCheck(
+            name='{flow}-{id}'.format(
+                id=vthunder.vthunder_id,
+                flow='WriteMemoryThunderStatusCheck'),
             requires=(a10constants.VTHUNDER, a10constants.LOADBALANCERS_LIST),
             rebind={a10constants.VTHUNDER: vthunder.vthunder_id}))
+
         store.update(vthunder_store)
         return reload_check_flow

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -372,42 +372,61 @@ class VThunderFlows(object):
         """
         return history[history.keys()[0]]
 
-    def get_write_memory_flow(self, thunders, store):
-        """Perform write memory for all thunders """
+    def get_write_memory_flow(self, vthunder, store):
+        """Perform write memory for thunder """
         sf_name = 'a10-house-keeper' + '-' + a10constants.WRITE_MEMORY_THUNDER_FLOW
 
         write_memory_flow = linear_flow.Flow(sf_name)
         vthunder_store = {}
-        for vthunder in thunders:
-            vthunder_store[vthunder.vthunder_id] = vthunder
-            write_memory_flow.add(a10_database_tasks.GetActiveLoadBalancersByThunder(
-                requires=a10constants.VTHUNDER,
-                rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
-                name='{flow}-{id}'.format(
-                    id=vthunder.vthunder_id,
-                    flow='GetActiveLoadBalancersByThunder'),
-                provides=a10constants.LOADBALANCERS_LIST))
-            write_memory_flow.add(a10_database_tasks.MarkLoadBalancersPendingUpdateInDB(
-                requires=a10constants.LOADBALANCERS_LIST))
-            write_memory_flow.add(vthunder_tasks.WriteMemoryHouseKeeper(
-                requires=(a10constants.VTHUNDER, a10constants.LOADBALANCERS_LIST),
-                rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
-                name='{flow}-{partition}-{id}'.format(
-                    id=vthunder.vthunder_id,
-                    flow='WriteMemory-' + a10constants.WRITE_MEMORY_THUNDER_FLOW,
-                    partition=a10constants.WRITE_MEM_FOR_LOCAL_PARTITION)))
-            write_memory_flow.add(vthunder_tasks.WriteMemoryHouseKeeper(
-                requires=(a10constants.VTHUNDER, a10constants.LOADBALANCERS_LIST,
-                          a10constants.WRITE_MEM_SHARED_PART),
-                rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
-                name='{flow}-{partition}-{id}'.format(
-                    id=vthunder.vthunder_id,
-                    flow='WriteMemory-' + a10constants.WRITE_MEMORY_THUNDER_FLOW,
-                    partition=a10constants.WRITE_MEM_FOR_SHARED_PARTITION)))
-            write_memory_flow.add(a10_database_tasks.SetThunderLastWriteMem(
-                requires=a10constants.VTHUNDER,
-                rebind={a10constants.VTHUNDER: vthunder.vthunder_id}))
-            write_memory_flow.add(a10_database_tasks.MarkLoadBalancersActiveInDB(
-                requires=a10constants.LOADBALANCERS_LIST))
+        vthunder_store[vthunder.vthunder_id] = vthunder
+        write_memory_flow.add(a10_database_tasks.GetActiveLoadBalancersByThunder(
+            requires=a10constants.VTHUNDER,
+            rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
+            name='{flow}-{id}'.format(
+                id=vthunder.vthunder_id,
+                flow='GetActiveLoadBalancersByThunder'),
+            provides=a10constants.LOADBALANCERS_LIST))
+        write_memory_flow.add(a10_database_tasks.MarkLoadBalancersPendingUpdateInDB(
+            requires=a10constants.LOADBALANCERS_LIST))
+        write_memory_flow.add(vthunder_tasks.WriteMemoryHouseKeeper(
+            requires=(a10constants.VTHUNDER, a10constants.LOADBALANCERS_LIST),
+            rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
+            name='{flow}-{partition}-{id}'.format(
+                id=vthunder.vthunder_id,
+                flow='WriteMemory-' + a10constants.WRITE_MEMORY_THUNDER_FLOW,
+                partition=a10constants.WRITE_MEM_FOR_LOCAL_PARTITION)))
+        write_memory_flow.add(vthunder_tasks.WriteMemoryHouseKeeper(
+            requires=(a10constants.VTHUNDER, a10constants.LOADBALANCERS_LIST,
+                      a10constants.WRITE_MEM_SHARED_PART),
+            rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
+            name='{flow}-{partition}-{id}'.format(
+                id=vthunder.vthunder_id,
+                flow='WriteMemory-' + a10constants.WRITE_MEMORY_THUNDER_FLOW,
+                partition=a10constants.WRITE_MEM_FOR_SHARED_PARTITION)))
+        write_memory_flow.add(a10_database_tasks.SetThunderLastWriteMem(
+            requires=a10constants.VTHUNDER,
+            rebind={a10constants.VTHUNDER: vthunder.vthunder_id}))
+        write_memory_flow.add(a10_database_tasks.MarkLoadBalancersActiveInDB(
+            requires=a10constants.LOADBALANCERS_LIST))
         store.update(vthunder_store)
         return write_memory_flow
+
+    def get_reload_check_flow(self, vthunder, store):
+        """Perform write memory for thunder """
+        sf_name = 'a10-house-keeper' + '-' + a10constants.WRITE_MEMORY_THUNDER_FLOW
+
+        reload_check_flow = linear_flow.Flow(sf_name)
+        vthunder_store = {}
+        vthunder_store[vthunder.vthunder_id] = vthunder
+        reload_check_flow.add(a10_database_tasks.GetActiveLoadBalancersByThunder(
+            requires=a10constants.VTHUNDER,
+            rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
+            name='{flow}-{id}'.format(
+                id=vthunder.vthunder_id,
+                flow='GetActiveLoadBalancersByThunder'),
+            provides=a10constants.LOADBALANCERS_LIST))
+        reload_check_flow.add(vthunder_tasks.WriteMemoryThunderStatusCheck(
+            requires=(a10constants.VTHUNDER, a10constants.LOADBALANCERS_LIST),
+            rebind={a10constants.VTHUNDER: vthunder.vthunder_id}))
+        store.update(vthunder_store)
+        return reload_check_flow

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -852,9 +852,10 @@ class SetThunderLastWriteMem(BaseDatabaseTask):
             if vthunder:
                 LOG.debug("Updated the last_write_mem field for thunder : {}:{}"
                           .format(vthunder.ip_address, vthunder.partition_name))
-                self.vthunder_repo.update(
+                self.vthunder_repo.update_last_write_mem(
                     db_apis.get_session(),
-                    vthunder.id,
+                    vthunder.ip_address,
+                    vthunder.partition_name,
                     last_write_mem=datetime.utcnow())
         except Exception as e:
             LOG.exception('Failed to set last_write_mem field for thunder due to: {}'
@@ -880,6 +881,8 @@ class MarkLoadBalancersPendingUpdateInDB(BaseDatabaseTask):
     def execute(self, loadbalancers_list):
         try:
             for lb in loadbalancers_list:
+                if lb.provisioning_status == constants.ERROR:
+                    continue
                 self.loadbalancer_repo.update(
                     db_apis.get_session(),
                     lb.id,
@@ -894,6 +897,8 @@ class MarkLoadBalancersActiveInDB(BaseDatabaseTask):
     def execute(self, loadbalancers_list):
         try:
             for lb in loadbalancers_list:
+                if lb.provisioning_status == constants.ERROR:
+                    continue
                 self.loadbalancer_repo.update(
                     db_apis.get_session(),
                     lb.id,

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -15,6 +15,7 @@
 
 import acos_client
 from acos_client import errors as acos_errors
+import datetime
 try:
     import http.client as http_client
 except ImportError:
@@ -835,4 +836,43 @@ class WriteMemoryHouseKeeper(VThunderBaseTask):
                     provisioning_status='ACTIVE')
         except Exception as e:
             LOG.exception('Failed to set Loadbalancers to ACTIVE due to '
+                          ': {}'.format(str(e)))
+
+
+class WriteMemoryThunderStatusCheck(VThunderBaseTask):
+
+    @axapi_client_decorator
+    def execute(self, vthunder, loadbalancers_list):
+        if not loadbalancers_list:
+            return
+        try:
+            info = self.axapi_client.system.action.get_thunder_up_time()
+            if ("miscellenious-alb" in info and "oper" in info['miscellenious-alb'] and
+               "uptime" in info['miscellenious-alb']['oper']):
+                uptime = info['miscellenious-alb']['oper']['uptime']
+                uptime_delta = datetime.timedelta(seconds=uptime)
+                reload_time = datetime.datetime.utcnow() - uptime_delta
+                if (vthunder.last_write_mem is not None and
+                        vthunder.last_write_mem <= vthunder.updated_at):
+                    if reload_time > vthunder.updated_at:
+                        self._mark_lb_as_error(vthunder, loadbalancers_list)
+            else:
+                LOG.warning("Write Memory flow failed to detect Thunder status")
+                raise
+        except Exception as e:
+            # log warning but continue the write memory flow
+            LOG.warning("Write Memory flow failed to detect Thunder status: %s ... skipping",
+                        str(e))
+
+    def _mark_lb_as_error(self, vthunder, loadbalancers_list):
+        try:
+            LOG.warning('Detect vThunder %s reload before write memory, '
+                        'set loadbalancer status to ERROR', vthunder.id)
+            for lb in loadbalancers_list:
+                self.loadbalancer_repo.update(
+                    db_apis.get_session(),
+                    lb.id,
+                    provisioning_status='ERROR')
+        except Exception as e:
+            LOG.exception('Failed to set Loadbalancers to ERROR due to '
                           ': {}'.format(str(e)))

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -318,6 +318,10 @@ class VThunderRepository(BaseRepository):
         list_projects = [project[0] for project in queryset_vthunders]
         return list_projects
 
+    def update_last_write_mem(self, session, ip_address, partition, **model_kwargs):
+        with session.begin(subtransactions=True):
+            session.query(self.model_class).filter_by(ip_address=ip_address, partition_name=partition).update(model_kwargs)
+
 
 class LoadBalancerRepository(repo.LoadBalancerRepository):
     thunder_model_class = models.VThunder

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -553,11 +553,10 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
     def test_SetThunderLastWriteMem_execute_update(self):
         db_task = task.SetThunderLastWriteMem()
         vthunder = copy.deepcopy(VTHUNDER)
-        db_task.vthunder_repo.update = mock.Mock()
+        db_task.vthunder_repo.update_last_write_mem = mock.Mock()
         db_task.execute(vthunder)
-        db_task.vthunder_repo.update.assert_called_once_with(mock.ANY,
-                                                             vthunder.id,
-                                                             last_write_mem=mock.ANY)
+        db_task.vthunder_repo.update_last_write_mem.assert_called_once_with(
+            mock.ANY, vthunder.ip_address, vthunder.partition_name, last_write_mem=mock.ANY)
 
     def test_GetActiveLoadBalancersByThunder_return_empty(self):
         lb_task = task.GetActiveLoadBalancersByThunder()


### PR DESCRIPTION
## Description
- Severity Level: High
- Description: 

1. Detect thunder reload and mark ERROR for loadbalancers which has lost configration. (STACK-2027)
2. Fix write memroy to multiple thunders problem (STACK-2048)
3. update last_write_mem for all entries for same thunder (same ip-address, partition-name) (STACK-2041)

**See also: https://github.com/a10networks/acos-client/pull/331 for acos-client part changes**

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2027
https://a10networks.atlassian.net/browse/STACK-2041
https://a10networks.atlassian.net/browse/STACK-2048

## Technical Approach
[STACK-2027]
1. Following aXAPI can show a10lb up time, maybe we can use it to compare with update_at to find reloaded/rebooted thunders. ```/axapi/v3/miscellenious-alb/oper```
2. After find reloaded thunders, mark loadbalancers status as ERROR.
[STACK-2041]
- update last_write_mem for all entries in database which has same ip-address and partition-name. Not just update one.
[STACK-2027]
- Move loop out from get_write_memory_flow() and move it to perform_write_memory()


## Config Changes
<pre>
<b>[a10_house_keeping]
use_periodic_write_memory = 'enable'
write_mem_interval = 600
</b>
</pre>


## Test Cases

- Test reload thunders before write memory period
- Test multiple loadbalancer on thunder and last_write_mem will update at once
- Test multiple thunders run write memory in same period

## Manual Testing
1. [STACK-2027]
 - create 5 loadbalancers and wait write memory
 - set 2 of them
```shell
openstack loadbalancer set vip5
openstack loadbalancer set vip3
```
 - reload thunder and wait next write memory interval
 - check configuration lost thunders will mark as ERROR
```shell
openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| 862e83f9-7155-4a05-9de6-0c6e52e8385e | vip1 | 3d21c71c4e4040599933bda62a76ae2f | 192.168.91.56 | ACTIVE              | a10      |
| bcb68a38-c60b-4343-b66a-23ead86a530c | vip2 | 3d21c71c4e4040599933bda62a76ae2f | 192.168.91.57 | ACTIVE              | a10      |
| d39ed514-df83-496c-b725-80a19ed44b6d | vip3 | 3d21c71c4e4040599933bda62a76ae2f | 192.168.91.58 | ERROR               | a10      |
| d3fd13fa-d637-4e60-aeae-4eedd4b797c0 | vip4 | 3d21c71c4e4040599933bda62a76ae2f | 192.168.91.59 | ACTIVE              | a10      |
| ec52d21d-dd2b-41ea-91cf-a425b7265daa | vip5 | 3d21c71c4e4040599933bda62a76ae2f | 192.168.91.60 | ERROR               | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
```

2. [STACK-2041]
 - Test write memory will update last_write_mem for all thunder entries with same ip-address and partition-name

```shell
mysql> select * from vthunders;
+-----+--------------------------------------+------------+---------------+---------------+----------+----------+---------------+------------+--------------------------------------+----------------------------------+------------+------------+--------+---------------------+---------+---------------------+---------------------+----------------+---------------------------+---------------------+
| id  | vthunder_id                          | amphora_id | device_name   | ip_address    | username | password | axapi_version | undercloud | loadbalancer_id                      | project_id                       | compute_id | topology   | role   | last_udp_update     | status  | created_at          | updated_at          | partition_name | hierarchical_multitenancy | last_write_mem      |
+-----+--------------------------------------+------------+---------------+---------------+----------+----------+---------------+------------+--------------------------------------+----------------------------------+------------+------------+--------+---------------------+---------+---------------------+---------------------+----------------+---------------------------+---------------------+
| 176 | 754944c4-ef29-4a85-92a9-704b75826295 | NULL       | ytsai-Thunder | 192.168.90.46 | admin    | a10      |            30 |          1 | 6306c1ab-ce84-4b3a-aad0-ca62c5c2c4b0 | 3d21c71c4e4040599933bda62a76ae2f | NULL       | STANDALONE | MASTER | 2021-01-19 02:40:01 | DELETED | 2021-01-19 02:40:01 | 2021-01-21 08:22:28 | shared         | disable                   | 2021-01-25 06:11:08 |
| 177 | 1ab73811-51b8-4d72-8f93-c360edbc9eff | NULL       | ytsai-Thunder | 192.168.90.46 | admin    | a10      |            30 |          1 | 1d27119d-7e5b-493a-8aee-fc5bf07d6a13 | 3d21c71c4e4040599933bda62a76ae2f | NULL       | STANDALONE | MASTER | 2021-01-21 08:22:22 | DELETED | 2021-01-21 08:22:22 | 2021-01-21 08:27:48 | shared         | disable                   | 2021-01-25 06:11:08 |
| 178 | 359ead1b-b87e-425d-bd68-cecdf2e415b9 | NULL       | ytsai-Thunder | 192.168.90.46 | admin    | a10      |            30 |          1 | 791d23a3-ae97-4a02-9c3f-7776006d053a | 3d21c71c4e4040599933bda62a76ae2f | NULL       | STANDALONE | MASTER | 2021-01-21 08:28:03 | DELETED | 2021-01-21 08:28:03 | 2021-01-21 08:59:42 | shared         | disable                   | 2021-01-25 06:11:08 |
| 179 | 495b9471-2ca4-4cba-85f0-60f2d82274dd | NULL       | ytsai-Thunder | 192.168.90.46 | admin    | a10      |            30 |          1 | 63944878-a650-4094-8dd2-206984dc7df6 | 3d21c71c4e4040599933bda62a76ae2f | NULL       | STANDALONE | MASTER | 2021-01-21 09:00:00 | ACTIVE  | 2021-01-21 09:00:00 | 2021-01-21 09:00:21 | shared         | disable                   | 2021-01-25 06:11:08 |
| 180 | 3290a51a-9c1f-478c-a048-0429539e7123 | NULL       | ytsai-Thunder | 192.168.90.46 | admin    | a10      |            30 |          1 | ff0dcef1-d766-4f77-ac14-058006ecfd92 | 3d21c71c4e4040599933bda62a76ae2f | NULL       | STANDALONE | MASTER | 2021-01-22 09:08:42 | ACTIVE  | 2021-01-22 09:08:42 | 2021-01-22 09:08:55 | shared         | disable                   | 2021-01-25 06:11:08 |
| 181 | 3fa0bafc-dbab-45e7-b61f-3246839368ec | NULL       | ytsai-Thunder | 192.168.90.46 | admin    | a10      |            30 |          1 | 76f49bda-0b36-4ee3-81ed-d55e414ab6e1 | 3d21c71c4e4040599933bda62a76ae2f | NULL       | STANDALONE | MASTER | 2021-01-22 09:08:42 | ACTIVE  | 2021-01-22 09:08:42 | 2021-01-22 09:08:55 | shared         | disable                   | 2021-01-25 06:11:08 |
| 182 | 1db2715c-3332-4822-9870-fa5f324ce768 | NULL       | ytsai-Thunder | 192.168.90.46 | admin    | a10      |            30 |          1 | 2b46676d-f01a-4804-acaa-a6541cf07704 | 3d21c71c4e4040599933bda62a76ae2f | NULL       | STANDALONE | MASTER | 2021-01-22 09:08:42 | ACTIVE  | 2021-01-22 09:08:42 | 2021-01-22 09:08:55 | shared         | disable                   | 2021-01-25 06:11:08 |
| 183 | 6d8f79f2-9a69-4ac6-b18e-2d48647499f9 | NULL       | ytsai-Thunder | 192.168.90.46 | admin    | a10      |            30 |          1 | 862e83f9-7155-4a05-9de6-0c6e52e8385e | 3d21c71c4e4040599933bda62a76ae2f | NULL       | STANDALONE | MASTER | 2021-01-22 09:14:18 | ACTIVE  | 2021-01-22 09:14:18 | 2021-01-25 05:55:02 | shared         | disable                   | 2021-01-25 06:11:08 |
+-----+--------------------------------------+------------+---------------+---------------+----------+----------+---------------+------------+--------------------------------------+----------------------------------+------------+------------+--------+---------------------+---------+---------------------+---------------------+----------------+---------------------------+---------------------+
8 rows in set (0.00 sec)
```

3. [STACK-2047]
configure multiple thunder and check log write memory update them one by one in a period.

[STACK-2027]: https://a10networks.atlassian.net/browse/STACK-2027
[STACK-2041]: https://a10networks.atlassian.net/browse/STACK-2041
[STACK-2027]: https://a10networks.atlassian.net/browse/STACK-2027
[STACK-2027]: https://a10networks.atlassian.net/browse/STACK-2027