### PR TITLE
[Bug][STACK-2038]: Prevent calling write memory twice on shared partition by HK

### DIFF
--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -393,13 +393,6 @@ class VThunderFlows(object):
                     flow='MarkLoadBalancersPendingUpdateInDB'),
                 requires=a10constants.LOADBALANCERS_LIST))
             write_memory_flow.add(vthunder_tasks.WriteMemoryHouseKeeper(
-                requires=(a10constants.VTHUNDER, a10constants.LOADBALANCERS_LIST),
-                rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
-                name='{flow}-{partition}-{id}'.format(
-                    id=vthunder.vthunder_id,
-                    flow='WriteMemory-' + a10constants.WRITE_MEMORY_THUNDER_FLOW,
-                    partition=a10constants.WRITE_MEM_FOR_LOCAL_PARTITION)))
-            write_memory_flow.add(vthunder_tasks.WriteMemoryHouseKeeper(
                 requires=(a10constants.VTHUNDER, a10constants.LOADBALANCERS_LIST,
                           a10constants.WRITE_MEM_SHARED_PART),
                 rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
@@ -407,6 +400,13 @@ class VThunderFlows(object):
                     id=vthunder.vthunder_id,
                     flow='WriteMemory-' + a10constants.WRITE_MEMORY_THUNDER_FLOW,
                     partition=a10constants.WRITE_MEM_FOR_SHARED_PARTITION)))
+            write_memory_flow.add(vthunder_tasks.WriteMemoryHouseKeeper(
+                requires=(a10constants.VTHUNDER, a10constants.LOADBALANCERS_LIST),
+                rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
+                name='{flow}-{partition}-{id}'.format(
+                    id=vthunder.vthunder_id,
+                    flow='WriteMemory-' + a10constants.WRITE_MEMORY_THUNDER_FLOW,
+                    partition=a10constants.WRITE_MEM_FOR_LOCAL_PARTITION)))
             write_memory_flow.add(a10_database_tasks.SetThunderLastWriteMem(
                 requires=a10constants.VTHUNDER,
                 rebind={a10constants.VTHUNDER: vthunder.vthunder_id},

--- a/a10_octavia/controller/worker/tasks/decorators.py
+++ b/a10_octavia/controller/worker/tasks/decorators.py
@@ -41,10 +41,11 @@ def axapi_client_decorator(func):
                                                    vthunder.username, vthunder.password,
                                                    timeout=30)
 
-            if vthunder.partition_name != "shared" and not use_shared_partition:
-                activate_partition(self.axapi_client, vthunder.partition_name)
-            else:
+            if use_shared_partition or vthunder.partition_name == 'shared':
                 activate_partition(self.axapi_client, "shared")
+            else:
+                if vthunder.partition_name != "shared":
+                    activate_partition(self.axapi_client, vthunder.partition_name)
 
         else:
             self.axapi_client = None

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -803,16 +803,17 @@ class WriteMemoryHouseKeeper(VThunderBaseTask):
     def execute(self, vthunder, loadbalancers_list, write_mem_shared_part=False):
         try:
             if vthunder:
-                if vthunder.partition_name != "shared" and not write_mem_shared_part:
-                    LOG.info("Performing write memory for thunder - {}:{}"
-                             .format(vthunder.ip_address, vthunder.partition_name))
-                    self.axapi_client.system.action.write_memory(
-                        partition="specified",
-                        specified_partition=vthunder.partition_name)
-                else:
+                if write_mem_shared_part:
                     LOG.info("Performing write memory for thunder - {}:{}"
                              .format(vthunder.ip_address, "shared"))
                     self.axapi_client.system.action.write_memory(partition="shared")
+                else:
+                    if vthunder.partition_name != "shared":
+                        LOG.info("Performing write memory for thunder - {}:{}"
+                                 .format(vthunder.ip_address, vthunder.partition_name))
+                        self.axapi_client.system.action.write_memory(
+                            partition="specified",
+                            specified_partition=vthunder.partition_name)
         except acos_errors.ACOSException:
             LOG.warning('Failed to write memory on thunder device: {} due to ACOSException'
                         '.... skipping'.format(vthunder.ip_address))

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -524,7 +524,7 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         lb_list.append(LB)
         mock_task = task.WriteMemoryHouseKeeper()
         mock_task.axapi_client = self.client_mock
-        mock_task.execute(mock_thunder, lb_list)
+        mock_task.execute(mock_thunder, lb_list, True)
         self.client_mock.system.action.write_memory.assert_called_with(partition='shared')
 
     def test_WriteMemoryHouseKeeper_execute_save_specific_partition_mem(self):


### PR DESCRIPTION
## Description
- Severity Level : **High**
- Description: If `vthunder.partition_name` is `shared`, the `housekeeper`'s `periodic write memory` is called twice on `shared` partition. Need to avoid that.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2038

## Technical Approach
- Changed the flow sequence of Housekeeper vthunder flows to call write memory on `shared` partition first, then on custom partition if `vthunder.partition_name != 'shared'`
- In  `WriteMemoryHouseKeeper` task, changed condition to prevent calling `shared` partition twice
- Adjusted `decorator` to activate the needed partition during such cases

## Config Changes
None

## Test Cases
Prerequisite: Keep `use_periodic_write_memory` as `enable`
<pre>
1. Create/Update/Delete an SLB resource in shared partition and check hk-logs --> Write memory should be called only once to shared.
</pre>


## Manual Testing
<pre>
Step1: Keep `use_periodic_write_memory` as `enable` and `write_mem_interval` as `300`
Step2: Update an existing LB like  <b>openstack loadbalancer set SLB1</b> for a shared partition
Step3: Check hk-logs
</pre>


![image](https://user-images.githubusercontent.com/52992745/105680900-69919580-5f16-11eb-8be0-993f24ef451d.png)
