### PR TITLE
[BUG][STACK-2046]: Corrected lb_method configuring for lb-algorithm SOURCE_IP for pool

### DIFF
--- a/a10_octavia/common/openstack_mappings.py
+++ b/a10_octavia/common/openstack_mappings.py
@@ -30,7 +30,7 @@ def service_group_lb_method(c, os_method):
     lb_methods = {
         'ROUND_ROBIN': z.ROUND_ROBIN,
         'LEAST_CONNECTIONS': z.LEAST_CONNECTION,
-        'SOURCE_IP': z.SOURCE_IP_HASH_ONLY,
+        'SOURCE_IP': z.SOURCE_IP_HASH,
         'WEIGHTED_ROUND_ROBIN': z.WEIGHTED_ROUND_ROBIN,
         'WEIGHTED_LEAST_CONNECTION': z.WEIGHTED_LEAST_CONNECTION,
         'LEAST_CONNECTION_ON_SERVICE_PORT':

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_service_group_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_service_group_tasks.py
@@ -215,7 +215,7 @@ class TestHandlerServiceGroupTasks(BaseTaskTestCase):
         mock_pool.revert(POOL, VTHUNDER)
         self.client_mock.slb.service_group.delete.assert_called_with(POOL.id)
 
-    def test_create_lb_algorithm_source_ip_hash_only(self):
+    def test_create_lb_algorithm_source_ip_hash(self):
         mock_pool = task.PoolCreate()
         mock_pool.axapi_client = self.client_mock
         mock_pool.CONF = self.conf

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_service_group_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_service_group_tasks.py
@@ -226,7 +226,7 @@ class TestHandlerServiceGroupTasks(BaseTaskTestCase):
         self.client_mock.slb.service_group.create.assert_called_with(
             a10constants.MOCK_POOL_ID,
             protocol=mock.ANY,
-            lb_method=mock_pool.axapi_client.slb.service_group.SOURCE_IP_HASH_ONLY,
+            lb_method=mock_pool.axapi_client.slb.service_group.SOURCE_IP_HASH,
             service_group_templates=mock.ANY,
             hm_name=None,
             mem_list=None,


### PR DESCRIPTION
## Description
- Severity Level: Medium
- For pool, lb-algorithm SOURCE_IP was getting configured as src-ip-only-hash instead of src-ip-hash on thunder.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2046

## Technical Approach
Modified the lb_method for `SOURCE_IP` from `SOURCE_IP_HASH_ONLY` to `SOURCE_IP_HASH` to get method **src-ip-hash** on thunder.

## Test Cases
Given lb-algorithm as SOURCE_IP, when a pool is created with it, then method src-ip-hash will get configured to it on thunder

## Manual Testing
1. Create a loadbalancer.
openstack loadbalancer create --name lb1 --vip-subnet-id provider-vlan-11-subnet

2. Create a listener.
openstack loadbalancer listener create --name l1 --protocol HTTP --protocol-port 82 lb1

3. Create a pool with lb-algorithm as SOURCE_IP
openstack loadbalancer pool create --protocol HTTP --lb-algorithm SOURCE_IP --listener l1 --name pool1

Result:
![image](https://user-images.githubusercontent.com/58077446/105693136-66ea6c80-5f25-11eb-9156-931f43db1d83.png)

