### PR TITLE
[Bug][STACK-2037] Fix health manger bugs

### DIFF
--- a/a10_octavia/cmd/a10_health_manager.py
+++ b/a10_octavia/cmd/a10_health_manager.py
@@ -67,7 +67,8 @@ def hm_health_check(exit_event):
     signal.signal(signal.SIGINT, hm_exit)
     LOG.warning("Pausing before starting health check")
     exit_event.wait(CONF.a10_health_manager.heartbeat_timeout)
-    health_check.start()
+    # disable vthunder health check in this release
+    # health_check.start()
 
 
 def main():

--- a/a10_octavia/cmd/a10_health_manager.py
+++ b/a10_octavia/cmd/a10_health_manager.py
@@ -67,7 +67,7 @@ def hm_health_check(exit_event):
     signal.signal(signal.SIGINT, hm_exit)
     LOG.warning("Pausing before starting health check")
     exit_event.wait(CONF.a10_health_manager.heartbeat_timeout)
-    # disable vthunder health check in this release
+    # TODO(ytsai-a10) Update health manager code from octavia and enable it
     # health_check.start()
 
 

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -834,7 +834,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                                      "ip_address": vthunder.ip_address}]}
             lock_session.commit()
             LOG.info(str(status))
-        lock_session.close()
+        # TODO(ytsai-a10) check if we need to call lock_session.close() to release db lock
 
     def failover_amphora(self, vthunder_id):
         """Perform failover operations for an vThunder.

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -834,6 +834,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                                      "ip_address": vthunder.ip_address}]}
             lock_session.commit()
             LOG.info(str(status))
+        lock_session.close()
 
     def failover_amphora(self, vthunder_id):
         """Perform failover operations for an vThunder.

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -196,7 +196,6 @@ class VThunderRepository(BaseRepository):
             self.model_class.created_at < initial_setup_wait_time).filter(
             self.model_class.last_udp_update < failover_wait_time).filter(
             self.model_class.status == 'ACTIVE').filter(
-            self.model_class.topology != 'STANDALONE').filter(
             or_(self.model_class.role == "MASTER",
                 self.model_class.role == "BACKUP"))
         if model is None:

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -197,11 +197,10 @@ class VThunderRepository(BaseRepository):
             self.model_class.last_udp_update < failover_wait_time).filter(
             self.model_class.status == 'ACTIVE').filter(
             or_(self.model_class.role == "MASTER",
-                self.model_class.role == "BACKUP"))
+                self.model_class.role == "BACKUP")).first()
         if model is None:
             return None
-        model = model.options(noload('*'))
-        return model.all()
+        return model.to_data_model()
 
     def get_vthunder_from_lb(self, session, lb_id):
         model = session.query(self.model_class).filter(

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -196,11 +196,13 @@ class VThunderRepository(BaseRepository):
             self.model_class.created_at < initial_setup_wait_time).filter(
             self.model_class.last_udp_update < failover_wait_time).filter(
             self.model_class.status == 'ACTIVE').filter(
+            self.model_class.topology != 'STANDALONE').filter(
             or_(self.model_class.role == "MASTER",
-                self.model_class.role == "BACKUP")).first()
+                self.model_class.role == "BACKUP"))
         if model is None:
             return None
-        return model.to_data_model()
+        model = model.options(noload('*'))
+        return model.all()
 
     def get_vthunder_from_lb(self, session, lb_id):
         model = session.query(self.model_class).filter(


### PR DESCRIPTION
## Description
- Severity Level:  Critical
- Issue Description:
mysql database vthunder table is locked by a10-health-manager service. And db migration will failed and cause unexpected results. The problem cause table lock are:
1. For STANDALONE thunders, a10-octavia will not create heartbeat HM on thunders. So, last_udp_update column will never updated and will always trigger failover.
2. When failover these STANDALONE vthunders, it will failed since no standby device for it. And db session is not closed in failed case.

Another issue is: for ```A10HealthManager.health_check()```, it calls ```get_stale_vthunders()``` to get the first query result.  So, the while loop will always get the same vthunder (which is the first matched one) until  ```len(futs) == self.threads```. 

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2037

## Technical Approach
***As discussed we just disable health-check in this release.***

## Config Changes
**This is only required if the config has been updated in this PR**
- Required: Provide example config snippet within pre block

<pre>
<b>
[a10_controller_worker]
network_driver = a10_octavia_neutron_driver

[listener]
autosnat = True

[health_monitor]
post_data = "abc=1"

[a10_house_keeping]
use_periodic_write_memory = 'enable'
write_mem_interval = 300

[hardware_thunder]
devices = [
                    {
                     "project_id": "3d21c71c4e4040599933bda62a76ae2f",
                     "ip_address": "192.168.90.46",
                     "username": "admin",
                     "password": "a10",
                     "device_name": "ytsai-Thunder"
                     }
             ]

</b>
</pre>

## Test Cases
1. Start a10-health-manager service, check in mysql and check table is not locked.
2. For multiple thunder match failover criteria, all thunders will do failover not just first one

## Manual Testing
1. Result: (mysql table will not be locked anymore)
```shell
mysql> select * from information_schema.innodb_trx;
Empty set (0.00 sec)

mysql> select * from information_schema.innodb_trx;
Empty set (0.00 sec)

mysql> select * from information_schema.innodb_trx;
Empty set (0.00 sec)

mysql> select * from information_schema.innodb_trx;
Empty set (0.00 sec)

mysql> select * from information_schema.innodb_trx;
Empty set (0.00 sec)
```

2. Result log for try multiple thunder failover in a period
```
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: DEBUG futurist.periodics [-] Submitting periodic callback 'a10_octavia.cmd.a10_health_manager.periodic_health_check' {{(pid=13455) _process_scheduled /usr/local/lib/python2.7/dist-packages/futurist/periodics.py:639}}
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: INFO a10_octavia.controller.healthmanager.a10_health_manager [-] Stale vThunder's id is: 495b9471-2ca4-4cba-85f0-60f2d82274dd
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: INFO a10_octavia.controller.healthmanager.a10_health_manager [-] Stale vThunder's id is: 3290a51a-9c1f-478c-a048-0429539e7123
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: INFO a10_octavia.controller.healthmanager.a10_health_manager [-] Stale vThunder's id is: 3fa0bafc-dbab-45e7-b61f-3246839368ec
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: INFO a10_octavia.controller.healthmanager.a10_health_manager [-] Stale vThunder's id is: 1db2715c-3332-4822-9870-fa5f324ce768
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: INFO a10_octavia.controller.healthmanager.a10_health_manager [-] Stale vThunder's id is: bc609cdd-f2ad-466f-8f58-60e6737ba2ee
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: INFO a10_octavia.controller.healthmanager.a10_health_manager [-] Stale vThunder's id is: 574b85c7-06ee-4d7b-a01e-798d5a984cc2
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: INFO a10_octavia.controller.healthmanager.a10_health_manager [-] Waiting for 6 failovers to finish
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: INFO a10_octavia.controller.worker.controller_worker [-] Starting Failover process on 192.168.90.46
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: INFO a10_octavia.controller.worker.controller_worker [-] Master vThunder 192.168.90.46 has failed, searching for existing backup vThunder.
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: INFO a10_octavia.controller.worker.controller_worker [-] Starting Failover process on 192.168.90.46
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: INFO a10_octavia.controller.worker.controller_worker [-] Master vThunder 192.168.90.46 has failed, searching for existing backup vThunder.
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: INFO a10_octavia.controller.worker.controller_worker [-] Starting Failover process on 192.168.90.46
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: INFO a10_octavia.controller.worker.controller_worker [-] Master vThunder 192.168.90.46 has failed, searching for existing backup vThunder.
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: INFO a10_octavia.controller.worker.controller_worker [-] Starting Failover process on 192.168.90.46
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: INFO a10_octavia.controller.worker.controller_worker [-] Starting Failover process on 192.168.90.46
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: INFO a10_octavia.controller.worker.controller_worker [-] Master vThunder 192.168.90.46 has failed, searching for existing backup vThunder.
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: INFO a10_octavia.controller.worker.controller_worker [-] Master vThunder 192.168.90.46 has failed, searching for existing backup vThunder.
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: INFO a10_octavia.controller.worker.controller_worker [-] Starting Failover process on 192.168.90.46
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: INFO a10_octavia.controller.worker.controller_worker [-] Master vThunder 192.168.90.46 has failed, searching for existing backup vThunder.
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: WARNING a10_octavia.controller.worker.controller_worker [-] No backup found for failed MASTER 192.168.90.46
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: WARNING a10_octavia.controller.worker.controller_worker [-] No backup found for failed MASTER 192.168.90.46
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: WARNING a10_octavia.controller.worker.controller_worker [-] No backup found for failed MASTER 192.168.90.46
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: WARNING a10_octavia.controller.worker.controller_worker [-] No backup found for failed MASTER 192.168.90.46
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: WARNING a10_octavia.controller.worker.controller_worker [-] No backup found for failed MASTER 192.168.90.46
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: WARNING a10_octavia.controller.worker.controller_worker [-] No backup found for failed MASTER 192.168.90.46
Jan 26 23:03:58 ytsai-openstack a10-health-manager[13430]: INFO a10_octavia.controller.healthmanager.a10_health_manager [-] Successfully completed failover for VThunders.
```
mysql table is not locked in this case
```shell
mysql> select * from information_schema.innodb_trx;
Empty set (0.00 sec)

mysql> select * from information_schema.innodb_trx;
Empty set (0.00 sec)

mysql> select * from information_schema.innodb_trx;
Empty set (0.00 sec)

mysql> select * from information_schema.innodb_trx;
Empty set (0.00 sec)

mysql> select * from information_schema.innodb_trx;
Empty set (0.00 sec)
```