### PR TITLE
[Bug][STACK-2027] For newly created lb, failed to detect config lost and set status to ERROR

### DIFF
--- a/a10_octavia/controller/housekeeping/house_keeping.py
+++ b/a10_octavia/controller/housekeeping/house_keeping.py
@@ -101,6 +101,7 @@ class WriteMemory(object):
     def __init__(self):
         self.thunder_repo = a10repo.VThunderRepository()
         self.cw = cw.A10ControllerWorker()
+        self.svc_up_time = datetime.datetime.utcnow()
 
     def perform_memory_writes(self):
         thunders = self.thunder_repo.get_recently_updated_thunders(db_api.get_session())
@@ -109,13 +110,22 @@ class WriteMemory(object):
         reload_check_list = []
         for thunder in thunders:
             ip_partition = str(thunder.ip_address) + ":" + str(thunder.partition_name)
-            if ip_partition not in ip_partition_list:
+            reload_check_failed = False
+            if (thunder.status != 'DELETED' and
+                    thunder.loadbalancer_id is not None):
+                if thunder.last_write_mem is not None:
+                    reload_check_list.append(thunder)
+                    reload_check_failed = True
+                elif thunder.updated_at > self.svc_up_time:
+                    # For new lb, it didn't have last_write_mem yet, if
+                    #  - it created after this service, some config is not save yet.
+                    #  - it created before this service, can't make sure it enable
+                    #    periodical write memory or not while lb is created.
+                    reload_check_list.append(thunder)
+                    reload_check_failed = True
+            if reload_check_failed is False and ip_partition not in ip_partition_list:
                 ip_partition_list.add(ip_partition)
                 write_mem_list.append(thunder)
-            if (thunder.status != 'DELETED' and
-                    thunder.loadbalancer_id is not None and
-                    thunder.last_write_mem is not None):
-                reload_check_list.append(thunder)
 
         if reload_check_list:
             LOG.info("Check configuration lost for Thunders : %s", list(reload_check_list))

--- a/a10_octavia/controller/housekeeping/house_keeping.py
+++ b/a10_octavia/controller/housekeeping/house_keeping.py
@@ -117,10 +117,12 @@ class WriteMemory(object):
                     reload_check_list.append(thunder)
                     reload_check_failed = True
                 elif thunder.updated_at > self.svc_up_time:
-                    # For new lb, it didn't have last_write_mem yet, if
-                    #  - it created after this service, some config is not save yet.
-                    #  - it created before this service, can't make sure it enable
-                    #    periodical write memory or not while lb is created.
+                    # For new lb, it didn't have last_write_mem yet, so if
+                    #  - it's latest update is after this service starts, then
+                    #    some config is not save yet.
+                    #  - it's latest update time is before this service starts, then
+                    #    we can't make sure it has config not save or not. Because
+                    #    periodical write memory may not enabled at that time.
                     reload_check_list.append(thunder)
                     reload_check_failed = True
             if reload_check_failed is False and ip_partition not in ip_partition_list:

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -853,10 +853,8 @@ class WriteMemoryThunderStatusCheck(VThunderBaseTask):
                 uptime = info['miscellenious-alb']['oper']['uptime']
                 uptime_delta = datetime.timedelta(seconds=uptime)
                 reload_time = datetime.datetime.utcnow() - uptime_delta
-                if (vthunder.last_write_mem is not None and
-                        vthunder.last_write_mem <= vthunder.updated_at):
-                    if reload_time > vthunder.updated_at:
-                        self._mark_lb_as_error(vthunder, loadbalancers_list)
+                if reload_time > vthunder.updated_at:
+                    self._mark_lb_as_error(vthunder, loadbalancers_list)
             else:
                 LOG.warning("Write Memory flow failed to detect Thunder status")
                 raise


### PR DESCRIPTION
## Description
- Severity Level: Low
- Issue Description: 
For last_write_mem is NULL case. When the latest config update, we can't make sure a10-octavia is in periodical write memory mode or not. So before we didn't set status to ERROR. Now, the behavior change to:
For new lb, it didn't have last_write_mem yet, so if
- it's latest update is after this service starts, then some config is not save yet. We will do relaod_check for it.
- it's latest update time is before this service starts, then we can't make sure it has config not save or not. Because     periodical write memory may not enabled at that time. We will not do reload_check for it.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2027

## Technical Approach
1. Store the time house-keeper thread starts
2. use this thread start time to check the latest update time is after or before it. Then we can decide do reload_check for it or not.

## Config Changes
**This is only required if the config has been updated in this PR**
- Required: Provide example config snippet within pre block

<pre>
<b>
[a10_house_keeping]
 use_periodic_write_memory = 'enable'
 write_mem_interval = 300
</b>
</pre>

## Test Cases
- Test newly create lb
steps:
1. create loadbalancers 
2. reload thunder before the write memory period
3. loadbalancer status should be ERROR after reload-check
- Test normal cases
Steps:
1. set on loadbalancers (which already have last_write_mem value in vthunder table)
2. reload thunder
3. loadbalancer status should be ERROR after reload-check

## Manual Testing

**1. test case1:**
commands:
```
openstack loadbalancer create --vip-subnet-id f25ce642-f953-4058-8c46-98fdd72fb129 --vip-address 192.168.91.56 --name vip1
openstack loadbalancer create --vip-subnet-id f25ce642-f953-4058-8c46-98fdd72fb129 --vip-address 192.168.91.57 --name vip2
```

 - create lbs
```shell
stack@ytsai-openstack:~/source/a10-octavia/STACK-1990$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| 45a7510f-4067-4d41-8d5c-009075abd8dc | vip1 | 3d21c71c4e4040599933bda62a76ae2f | 192.168.91.56 | ACTIVE              | a10      |
| 20f215e1-1c3e-4d5c-b145-c28d1d71a051 | vip2 | 3d21c71c4e4040599933bda62a76ae2f | 192.168.91.57 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+

```
 - reload thunder
 - result
```
stack@ytsai-openstack:~/source/a10-octavia/STACK-1990$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| 45a7510f-4067-4d41-8d5c-009075abd8dc | vip1 | 3d21c71c4e4040599933bda62a76ae2f | 192.168.91.56 | ERROR               | a10      |
| 20f215e1-1c3e-4d5c-b145-c28d1d71a051 | vip2 | 3d21c71c4e4040599933bda62a76ae2f | 192.168.91.57 | ERROR               | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
```

**2. test case2:**
commands:
```
openstack loadbalancer set vip1
```
 - reload thunder
 - result:
```
stack@ytsai-openstack:~/source/a10-octavia/STACK-1990$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| 45a7510f-4067-4d41-8d5c-009075abd8dc | vip1 | 3d21c71c4e4040599933bda62a76ae2f | 192.168.91.56 | ERROR               | a10      |
| 20f215e1-1c3e-4d5c-b145-c28d1d71a051 | vip2 | 3d21c71c4e4040599933bda62a76ae2f | 192.168.91.57 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
```