### PR TITLE
[Bug][STACK-2060] nat-pool flavor overwrite virtual-port flavors

### DIFF
--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -143,7 +143,10 @@ class ListenersParent(object):
                 if pool_flavor and 'pool_name' in pool_flavor:
                     pool_arg = {}
                     pool_arg['pool'] = pool_flavor['pool_name']
-                    vport_args['port'] = pool_arg
+                    if 'port' in vport_args:
+                        vport_args['port'].update(pool_arg)
+                    else:
+                        vport_args['port'] = pool_arg
         config_data.update(template_args)
         config_data.update(vport_args)
 


### PR DESCRIPTION
## Description
- Required: Severity Level High
- Required: Issue Description
nat-pool flavor will overwirte vport flavors.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2060

## Technical Approach
When there is a default NAT pool for listener, we should merge flavor attributes not just overwrite it.

## Config Changes
**This is only required if the config has been updated in this PR**
- Required: Provide example config snippet within pre block

<pre>
<b>
{
"virtual-port":{
"conn-limit":200,
"skip-rev-hash":1,
"name-expressions":[
{
"regex":"vport1",
"json":{
"pool":"pool1"
}
}
]
},
"nat-pool":{
"pool-name":"pool1",
"start-address":"1.1.1.2",
"end-address":"1.1.1.10",
"netmask":"/24",
"ip-rr":0,
"port-overload":1,
"gateway":"1.1.1.1"
}
}
</b>
</pre>

## Test Cases
- same as QA in https://a10networks.atlassian.net/browse/STACK-2060

## Manual Testing
```shell
openstack loadbalancer flavorprofile create --name test11 --provider a10 --flavor-data '{"virtual-port":{"conn-limit":200,"skip-rev-hash":1,"name-expressions":[{"regex":"vport1","json":{"pool":"pool1"}}]},"nat-pool":{"pool-name":"pool1","start-address":"1.1.1.2","end-address":"1.1.1.10","netmask":"/24","ip-rr":0,"port-overload":1,"gateway":"1.1.1.1"}}'
openstack loadbalancer flavor create --name test11 --flavorprofile test11
openstack loadbalancer create --flavor test11 --vip-subnet-id f25ce642-f953-4058-8c46-98fdd72fb129 --vip-address 192.168.91.56 --name vip1
openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name vport1 vip1
openstack loadbalancer listener create --protocol HTTP --protocol-port 8080 --name l31 vip1
```
result:
```
slb virtual-server 731fe3aa-9bd3-4b4e-b982-bb6ce1d348ce 192.168.91.56
  port 8080 http
    name 0b34e373-cefb-458f-8d25-d326a8664c64
    conn-limit 200
    skip-rev-hash
    extended-stats
    source-nat pool pool1
    source-nat auto
!
```