### PR TITLE
[Bug][STACK-2027] fix degrade by previous patch

### DIFF
--- a/a10_octavia/controller/housekeeping/house_keeping.py
+++ b/a10_octavia/controller/housekeeping/house_keeping.py
@@ -105,17 +105,12 @@ class WriteMemory(object):
 
     def perform_memory_writes(self):
         thunders = self.thunder_repo.get_recently_updated_thunders(db_api.get_session())
-        ip_partition_list = set()
-        write_mem_list = []
         reload_check_list = []
         for thunder in thunders:
-            ip_partition = str(thunder.ip_address) + ":" + str(thunder.partition_name)
-            reload_check_failed = False
             if (thunder.status != 'DELETED' and
                     thunder.loadbalancer_id is not None):
                 if thunder.last_write_mem is not None:
                     reload_check_list.append(thunder)
-                    reload_check_failed = True
                 elif thunder.updated_at > self.svc_up_time:
                     # For new lb, it didn't have last_write_mem yet, so if
                     #  - it's latest update is after this service starts, then
@@ -124,15 +119,20 @@ class WriteMemory(object):
                     #    we can't make sure it has config not save or not. Because
                     #    periodical write memory may not enabled at that time.
                     reload_check_list.append(thunder)
-                    reload_check_failed = True
-            if reload_check_failed is False and ip_partition not in ip_partition_list:
-                ip_partition_list.add(ip_partition)
-                write_mem_list.append(thunder)
 
         if reload_check_list:
             LOG.info("Check configuration lost for Thunders : %s", list(reload_check_list))
             self.cw.perform_reload_check(reload_check_list)
             LOG.info("Finished conf lost check for {} thunders...".format(len(reload_check_list)))
+
+        thunders = self.thunder_repo.get_recently_updated_thunders(db_api.get_session())
+        ip_partition_list = set()
+        write_mem_list = []
+        for thunder in thunders:
+            ip_partition = str(thunder.ip_address) + ":" + str(thunder.partition_name)
+            if ip_partition not in ip_partition_list:
+                ip_partition_list.add(ip_partition)
+                write_mem_list.append(thunder)
 
         if write_mem_list:
             LOG.info("Write Memory for Thunders : %s", list(ip_partition_list))

--- a/a10_octavia/controller/housekeeping/house_keeping.py
+++ b/a10_octavia/controller/housekeeping/house_keeping.py
@@ -105,8 +105,11 @@ class WriteMemory(object):
 
     def perform_memory_writes(self):
         thunders = self.thunder_repo.get_recently_updated_thunders(db_api.get_session())
+        ip_partition_list = set()
+        write_mem_list = []
         reload_check_list = []
         for thunder in thunders:
+            ip_partition = str(thunder.ip_address) + ":" + str(thunder.partition_name)
             if (thunder.status != 'DELETED' and
                     thunder.loadbalancer_id is not None):
                 if thunder.last_write_mem is not None:
@@ -119,20 +122,14 @@ class WriteMemory(object):
                     #    we can't make sure it has config not save or not. Because
                     #    periodical write memory may not enabled at that time.
                     reload_check_list.append(thunder)
+            if ip_partition not in ip_partition_list:
+                ip_partition_list.add(ip_partition)
+                write_mem_list.append(thunder)
 
         if reload_check_list:
             LOG.info("Check configuration lost for Thunders : %s", list(reload_check_list))
             self.cw.perform_reload_check(reload_check_list)
             LOG.info("Finished conf lost check for {} thunders...".format(len(reload_check_list)))
-
-        thunders = self.thunder_repo.get_recently_updated_thunders(db_api.get_session())
-        ip_partition_list = set()
-        write_mem_list = []
-        for thunder in thunders:
-            ip_partition = str(thunder.ip_address) + ":" + str(thunder.partition_name)
-            if ip_partition not in ip_partition_list:
-                ip_partition_list.add(ip_partition)
-                write_mem_list.append(thunder)
 
         if write_mem_list:
             LOG.info("Write Memory for Thunders : %s", list(ip_partition_list))


### PR DESCRIPTION
## Description
- Required: Severity Level Critical
- Required: Issue Description
previous patch: https://github.com/a10networks/a10-octavia/pull/314/files
cause write memory can't work properly for newly created thudners/loadbalancers

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2027

## Technical Approach
In perform_memory_writes(), thunders in reload_check_list didn't mean it will failed for reload_check. We should not remove it from write_mem_list.

## Config Changes
<pre>
<b>
[a10_house_keeping]
use_periodic_write_memory = 'enable'
write_mem_interval = 300
</b>
</pre>


## Test Cases
1. Normal write memory case
2. Test newly create lb
steps:
- create loadbalancers 
- reload thunder before the write memory period
- loadbalancer status should be ERROR after reload-check
3. Test normal reload/reboot cases
Steps:
 - set on loadbalancers (which already have last_write_mem value in vthunder table)
 - reload thunder
 - loadbalancer status should be ERROR after reload-check

## Manual Testing
1.
```
openstack loadbalancer create --vip-subnet-id f25ce642-f953-4058-8c46-98fdd72fb129 --vip-address 192.168.91.56 --name vip1
mysql> select * from vthunders where status = 'ACTIVE';
+-----+--------------------------------------+------------+---------------+---------------+----------+----------+---------------+------------+--------------------------------------+----------------------------------+------------+------------+--------+---------------------+--------+---------------------+---------------------+----------------+---------------------------+---------------------+
| id  | vthunder_id                          | amphora_id | device_name   | ip_address    | username | password | axapi_version | undercloud | loadbalancer_id                      | project_id                       | compute_id | topology   | role   | last_udp_update     | status | created_at          | updated_at          | partition_name | hierarchical_multitenancy | last_write_mem      |
+-----+--------------------------------------+------------+---------------+---------------+----------+----------+---------------+------------+--------------------------------------+----------------------------------+------------+------------+--------+---------------------+--------+---------------------+---------------------+----------------+---------------------------+---------------------+
| 208 | 1639b9e8-4aea-45a7-97b3-7fe61d1cb63c | NULL       | ytsai-Thunder | 192.168.90.46 | admin    | a10      |            30 |          1 | f9bc74b8-bbae-4797-9e4f-60550ffa211c | 3d21c71c4e4040599933bda62a76ae2f | NULL       | STANDALONE | MASTER | 2021-01-29 04:09:17 | ACTIVE | 2021-01-29 04:09:17 | 2021-01-29 04:09:38 | p7             | disable                   | 2021-01-29 04:12:15 |
+-----+--------------------------------------+------------+---------------+---------------+----------+----------+---------------+------------+--------------------------------------+----------------------------------+------------+------------+--------+---------------------+--------+---------------------+---------------------+----------------+---------------------------+---------------------+
1 row in set (0.00 sec)
```

2.
```
openstack loadbalancer create --vip-subnet-id f25ce642-f953-4058-8c46-98fdd72fb129 --vip-address 192.168.91.56 --name vip1
stack@ytsai-openstack:~/source/a10-octavia/STACK-1990$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| caeddc37-43a3-43c3-879d-8c79a3d877f3 | vip1 | 3d21c71c4e4040599933bda62a76ae2f | 192.168.91.56 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
stack@ytsai-openstack:~/source/a10-octavia/STACK-1990$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| caeddc37-43a3-43c3-879d-8c79a3d877f3 | vip1 | 3d21c71c4e4040599933bda62a76ae2f | 192.168.91.56 | ERROR               | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
```

3.
```
stack@ytsai-openstack:~/source/a10-octavia/STACK-1990$ openstack loadbalancer set vip2
stack@ytsai-openstack:~/source/a10-octavia/STACK-1990$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| 699d8f86-c76e-47a9-b517-ea7829753fe1 | vip2 | 3d21c71c4e4040599933bda62a76ae2f | 192.168.91.57 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
stack@ytsai-openstack:~/source/a10-octavia/STACK-1990$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| 699d8f86-c76e-47a9-b517-ea7829753fe1 | vip2 | 3d21c71c4e4040599933bda62a76ae2f | 192.168.91.57 | ERROR               | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
```
