### PR TITLE
[Bug][STACK-1975] revert previous patch

### DIFF
--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -48,7 +48,7 @@ class ListenersParent(object):
         config_data['status'] = status
 
         conn_limit = CONF.listener.conn_limit
-        if update_dict and "connection_limit" in update_dict:
+        if listener.connection_limit != -1:
             conn_limit = listener.connection_limit
         if conn_limit < 1 or conn_limit > 64000000:
             LOG.warning('The specified member server connection limit '

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
@@ -460,7 +460,7 @@ class TestHandlerVirtualPortTasks(base.BaseTaskTestCase):
         self.assertEqual(kwargs['conn_limit'], 1000)
 
     def test_set_http_virtual_port_conn_limit_with_config(self):
-        listener = self._mock_listener('HTTP', 1000)
+        listener = self._mock_listener('HTTP', -1)
 
         listener_task = task.ListenerUpdate()
         listener_task.axapi_client = self.client_mock


### PR DESCRIPTION
## Description
- Required: Severity Level High
- Required: Issue Description
The previous behavior is expected, don't need to change it.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1975

## Technical Approach
Revert some changes from previous patch

## Config Changes
<pre>
<b>[listener]
autosnat = True
conn_limit=20000
</b>
</pre>

## Test Cases
- Required: List edge cases tested against in unit tests 

## Manual Testing
```
stack@ytsai-openstack:~/source/a10-octavia/STACK-1990$ openstack loadbalancer listener create --protocol TCP --connection-limit 600 --protocol-port 8000 --name vport1 vip1
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | 600                                  |
| created_at                  | 2021-01-29T05:50:57                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 1f67310b-e668-4729-abf1-9486607f3683 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 398d2774-da6c-4000-8641-8aef228220e1 |
| name                        | vport1                               |
| operating_status            | OFFLINE                              |
| project_id                  | 3d21c71c4e4040599933bda62a76ae2f     |
| protocol                    | TCP                                  |
| protocol_port               | 8000                                 |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
+-----------------------------+--------------------------------------+
```
```
slb virtual-server 398d2774-da6c-4000-8641-8aef228220e1 192.168.91.56
  port 8000 tcp
    name 1f67310b-e668-4729-abf1-9486607f3683
    conn-limit 600
    extended-stats
    source-nat auto
!
```

```
stack@ytsai-openstack:~/source/a10-octavia/STACK-1990$ openstack loadbalancer listener set vport1
stack@ytsai-openstack:~/source/a10-octavia/STACK-1990$ openstack loadbalancer listener show vport1
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | 600                                  |
| created_at                  | 2021-01-29T05:50:57                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 1f67310b-e668-4729-abf1-9486607f3683 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 398d2774-da6c-4000-8641-8aef228220e1 |
| name                        | vport1                               |
| operating_status            | OFFLINE                              |
| project_id                  | 3d21c71c4e4040599933bda62a76ae2f     |
| protocol                    | TCP                                  |
| protocol_port               | 8000                                 |
| provisioning_status         | ACTIVE                               |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | 2021-01-29T05:53:14                  |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
+-----------------------------+--------------------------------------+
```

```
slb virtual-server 398d2774-da6c-4000-8641-8aef228220e1 192.168.91.56
  port 8000 tcp
    name 1f67310b-e668-4729-abf1-9486607f3683
    conn-limit 600
    extended-stats
    source-nat auto
!
```


```
stack@ytsai-openstack:~/source/a10-octavia/STACK-1990$ openstack loadbalancer listener set --connection-limit 666 vport1
stack@ytsai-openstack:~/source/a10-octavia/STACK-1990$ openstack loadbalancer listener show vport1
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | 666                                  |
| created_at                  | 2021-01-29T05:50:57                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 1f67310b-e668-4729-abf1-9486607f3683 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 398d2774-da6c-4000-8641-8aef228220e1 |
| name                        | vport1                               |
| operating_status            | OFFLINE                              |
| project_id                  | 3d21c71c4e4040599933bda62a76ae2f     |
| protocol                    | TCP                                  |
| protocol_port               | 8000                                 |
| provisioning_status         | ACTIVE                               |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | 2021-01-29T05:54:08                  |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
+-----------------------------+--------------------------------------+
```

```
slb virtual-server 398d2774-da6c-4000-8641-8aef228220e1 192.168.91.56
  port 8000 tcp
    name 1f67310b-e668-4729-abf1-9486607f3683
    conn-limit 666
    extended-stats
    source-nat auto
!
```