### PR TITLE
[Bug][STACK-2049] write memory not perform on exceptions

### DIFF
--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -24,6 +24,8 @@ BACKUP_VRRP_STATUS = 'backup_vrrp_status'
 NAT_POOL = 'nat_pool'
 NAT_FLAVOR = 'nat_flavor'
 SUBNET_PORT = 'subnet_port'
+WRITE_MEM_SHARED = 'write_mem_shared'
+WRITE_MEM_PRIVATE = 'write_mem_private'
 
 FAILED = 'FAILED'
 USED_SPARE = 'USED_SPARE'

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -903,13 +903,17 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         store = {a10constants.WRITE_MEM_SHARED_PART: True}
 
         for vthunder in thunders:
-            write_mem_tf = self._taskflow_load(self._vthunder_flows.get_write_memory_flow(vthunder,
-                                                                                          store),
-                                               store=store)
+            try:
+                write_mem_tf = self._taskflow_load(
+                    self._vthunder_flows.get_write_memory_flow(vthunder, store),
+                    store=store)
 
-            with tf_logging.DynamicLoggingListener(write_mem_tf,
-                                                   log=LOG):
-                write_mem_tf.run()
+                with tf_logging.DynamicLoggingListener(write_mem_tf,
+                                                       log=LOG):
+                    write_mem_tf.run()
+            except Exception:
+                # continue on other thunders (assume exception is logged)
+                pass
 
     def perform_reload_check(self, thunders):
         """Perform check for thunders see if thunder reload before write memory
@@ -919,8 +923,12 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         """
         store = {}
         for vthunder in thunders:
-            reload_check_tf = self._taskflow_load(
-                self._vthunder_flows.get_reload_check_flow(vthunder, store),
-                store=store)
-            with tf_logging.DynamicLoggingListener(reload_check_tf, log=LOG):
-                reload_check_tf.run()
+            try:
+                reload_check_tf = self._taskflow_load(
+                    self._vthunder_flows.get_reload_check_flow(vthunder, store),
+                    store=store)
+                with tf_logging.DynamicLoggingListener(reload_check_tf, log=LOG):
+                    reload_check_tf.run()
+            except Exception:
+                # continue on other thunders (assume exception is logged)
+                pass

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -398,16 +398,20 @@ class VThunderFlows(object):
             name='{flow}-{partition}-{id}'.format(
                 id=vthunder.vthunder_id,
                 flow='WriteMemory-' + a10constants.WRITE_MEMORY_THUNDER_FLOW,
-                partition=a10constants.WRITE_MEM_FOR_SHARED_PARTITION)))
+                partition=a10constants.WRITE_MEM_FOR_SHARED_PARTITION),
+            provides=a10constants.WRITE_MEM_SHARED))
         write_memory_flow.add(vthunder_tasks.WriteMemoryHouseKeeper(
             requires=(a10constants.VTHUNDER, a10constants.LOADBALANCERS_LIST),
             rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
             name='{flow}-{partition}-{id}'.format(
                 id=vthunder.vthunder_id,
                 flow='WriteMemory-' + a10constants.WRITE_MEMORY_THUNDER_FLOW,
-                partition=a10constants.WRITE_MEM_FOR_LOCAL_PARTITION)))
+                partition=a10constants.WRITE_MEM_FOR_LOCAL_PARTITION),
+            provides=a10constants.WRITE_MEM_PRIVATE))
         write_memory_flow.add(a10_database_tasks.SetThunderLastWriteMem(
-            requires=a10constants.VTHUNDER,
+            requires=(a10constants.VTHUNDER,
+                      a10constants.WRITE_MEM_SHARED,
+                      a10constants.WRITE_MEM_PRIVATE),
             rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
             name='{flow}-{id}'.format(
                 id=vthunder.vthunder_id,

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -847,7 +847,9 @@ class SetThunderUpdatedAt(BaseDatabaseTask):
 
 class SetThunderLastWriteMem(BaseDatabaseTask):
 
-    def execute(self, vthunder):
+    def execute(self, vthunder, write_mem_shared=False, write_mem_private=False):
+        if write_mem_shared is False or write_mem_private is False:
+            return
         try:
             if vthunder:
                 LOG.debug("Updated the last_write_mem field for thunder : {}:{}"

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -819,14 +819,18 @@ class WriteMemoryHouseKeeper(VThunderBaseTask):
             LOG.warning('Failed to write memory on thunder device: {} due to ACOSException'
                         '.... skipping'.format(vthunder.ip_address))
             self._revert_lb_to_active(vthunder, loadbalancers_list)
+            return False
         except req_exceptions.ConnectionError:
             LOG.warning('Failed to write memory on thunder device: {} due to ConnectionError'
                         '.... skipping'.format(vthunder.ip_address))
             self._revert_lb_to_active(vthunder, loadbalancers_list)
+            return False
         except Exception as e:
             LOG.warning('Failed to write memory on thunder device: '
                         '{} due to {}...skipping'.format(vthunder.ip_address, str(e)))
             self._revert_lb_to_active(vthunder, loadbalancers_list)
+            return False
+        return True
 
     def _revert_lb_to_active(self, vthunder, loadbalancers_list):
         try:

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -554,7 +554,7 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         db_task = task.SetThunderLastWriteMem()
         vthunder = copy.deepcopy(VTHUNDER)
         db_task.vthunder_repo.update_last_write_mem = mock.Mock()
-        db_task.execute(vthunder)
+        db_task.execute(vthunder, True, True)
         db_task.vthunder_repo.update_last_write_mem.assert_called_once_with(
             mock.ANY, vthunder.ip_address, vthunder.partition_name, last_write_mem=mock.ANY)
 


### PR DESCRIPTION
## Description
If Feature Addition:
- Required: Related user story

If Bug Fix:
- Required: Severity Level HIGH
- Required: Issue Description
When write memory failed, we still set the last_write_mem column and cause write memory will not retry on this thunder.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2049

## Technical Approach
Don't set the last_write_mem when write memory failed on this thunder.

## Config Changes
<pre>
<b>[a10_house_keeping]
use_periodic_write_memory = 'enable'
write_mem_interval = 300
</b>
</pre>


## Test Cases
 - Normal write memory procedure (update laodbalancer, write memory will perform in next period)
 - Connection error case as bug
step:
1. set to lb
2. disable thunder management interface
3. wait next write memory interval
4. enable the management interface again
5. next period write memory will perform on thunder

## Manual Testing
As the update_at and last_write_mem, the last_write_mem is not the next interval of update_at. But after connection problem is fixed.
```
mysql> select * from vthunders where status = 'ACTIVE';
+----+--------------------------------------+------------+-------------+------------+----------+----------+---------------+------------+--------------------------------------+----------------------------------+------------+------------+--------+---------------------+--------+---------------------+---------------------+----------------+---------------------------+---------------------+
| id | vthunder_id                          | amphora_id | device_name | ip_address | username | password | axapi_version | undercloud | loadbalancer_id                      | project_id                       | compute_id | topology   | role   | last_udp_update     | status | created_at          | updated_at          | partition_name | hierarchical_multitenancy | last_write_mem      |
+----+--------------------------------------+------------+-------------+------------+----------+----------+---------------+------------+--------------------------------------+----------------------------------+------------+------------+--------+---------------------+--------+---------------------+---------------------+----------------+---------------------------+---------------------+
| 35 | 13bc2081-a026-4213-aea5-a06c10d323e6 | NULL       | thunder_1   | 10.0.0.76  | admin    | a10      |            30 |          1 | df2e2b65-384d-4f3a-8eb7-5ac2d90af9d9 | 8878f35bed374513a1e6bd7a11350933 | NULL       | STANDALONE | MASTER | 2021-01-29 07:24:29 | ACTIVE | 2021-01-29 07:24:29 | 2021-01-29 07:24:38 | shared         | disable                   | 2021-01-29 07:28:25 |
+----+--------------------------------------+------------+-------------+------------+----------+----------+---------------+------------+--------------------------------------+----------------------------------+------------+------------+--------+---------------------+--------+---------------------+---------------------+----------------+---------------------------+---------------------+
1 row in set (0.00 sec)

```

Log on thunder: (disable / enable management interface)
```
AX1030(config-if:management)#disable
 AX1030 a10logd: [ACOS]<1> Management interface is down
AX1030(config-if:management)#enable
AX1030(config-if:management)# AX1030 a10logd: [ACOS]<1> Management interface is up
```