### PR TITLE
[Bug][STACK-2067] NAT pool deletion check for HMT

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -170,7 +170,8 @@ class LoadBalancerFlows(object):
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
             provides=constants.FLAVOR_DATA))
         delete_LB_flow.add(a10_database_tasks.CountLoadbalancersWithFlavor(
-            requires=constants.LOADBALANCER, provides=a10constants.LB_COUNT))
+            requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
+            provides=a10constants.LB_COUNT))
         delete_LB_flow.add(nat_pool_tasks.NatPoolDelete(
             requires=(constants.LOADBALANCER,
                       a10constants.VTHUNDER, a10constants.LB_COUNT, constants.FLAVOR_DATA)))

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -819,18 +819,17 @@ class CountLoadbalancersWithFlavor(BaseDatabaseTask):
 
     def execute(self, loadbalancer, vthunder):
         try:
+            project_list = []
             if vthunder.hierarchical_multitenancy == 'enable':
                 project_list = self.vthunder_repo.get_project_list_using_partition(
                     db_apis.get_session(),
                     partition_name=vthunder.partition_name,
                     ip_address=vthunder.ip_address)
-                return self.loadbalancer_repo.get_hmt_lb_count_by_flavor(
-                    db_apis.get_session(),
-                    project_list, loadbalancer.flavor_id)
             else:
-                return self.loadbalancer_repo.get_lb_count_by_flavor(
-                    db_apis.get_session(),
-                    loadbalancer.project_id, loadbalancer.flavor_id)
+                project_list = [loadbalancer.project_id]
+
+            return self.loadbalancer_repo.get_lb_count_by_flavor(
+                db_apis.get_session(), project_list, loadbalancer.flavor_id)
         except Exception as e:
             LOG.exception("Failed to get LB count for flavor %s due to %s ",
                           loadbalancer.flavor_id, str(e))

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -817,11 +817,20 @@ class DeleteNatPoolEntry(BaseDatabaseTask):
 
 class CountLoadbalancersWithFlavor(BaseDatabaseTask):
 
-    def execute(self, loadbalancer):
+    def execute(self, loadbalancer, vthunder):
         try:
-            return self.loadbalancer_repo.get_lb_count_by_flavor(
-                db_apis.get_session(),
-                loadbalancer.project_id, loadbalancer.flavor_id)
+            if vthunder.hierarchical_multitenancy == 'enable':
+                project_list = self.vthunder_repo.get_project_list_using_partition(
+                    db_apis.get_session(),
+                    partition_name=vthunder.partition_name,
+                    ip_address=vthunder.ip_address)
+                return self.loadbalancer_repo.get_hmt_lb_count_by_flavor(
+                    db_apis.get_session(),
+                    project_list, loadbalancer.flavor_id)
+            else:
+                return self.loadbalancer_repo.get_lb_count_by_flavor(
+                    db_apis.get_session(),
+                    loadbalancer.project_id, loadbalancer.flavor_id)
         except Exception as e:
             LOG.exception("Failed to get LB count for flavor %s due to %s ",
                           loadbalancer.flavor_id, str(e))

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -350,6 +350,13 @@ class LoadBalancerRepository(repo.LoadBalancerRepository):
                 or_(self.model_class.provisioning_status == consts.PENDING_DELETE,
                     self.model_class.provisioning_status == consts.ACTIVE)).count()
 
+    def get_hmt_lb_count_by_flavor(self, session, project_ids, flavor_id):
+        return session.query(self.model_class).filter(
+            self.model_class.project_id.in_(project_ids)).filter(
+                self.model_class.flavor_id == flavor_id,
+                or_(self.model_class.provisioning_status == consts.PENDING_DELETE,
+                    self.model_class.provisioning_status == consts.ACTIVE)).count()
+
 
 class VRIDRepository(BaseRepository):
     model_class = models.VRID

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -343,14 +343,7 @@ class LoadBalancerRepository(repo.LoadBalancerRepository):
                  or_(self.model_class.provisioning_status == consts.PENDING_DELETE,
                      self.model_class.provisioning_status == consts.ACTIVE))).count()
 
-    def get_lb_count_by_flavor(self, session, project_id, flavor_id):
-        return session.query(self.model_class).filter(
-            self.model_class.project_id == project_id).filter(
-                self.model_class.flavor_id == flavor_id,
-                or_(self.model_class.provisioning_status == consts.PENDING_DELETE,
-                    self.model_class.provisioning_status == consts.ACTIVE)).count()
-
-    def get_hmt_lb_count_by_flavor(self, session, project_ids, flavor_id):
+    def get_lb_count_by_flavor(self, session, project_ids, flavor_id):
         return session.query(self.model_class).filter(
             self.model_class.project_id.in_(project_ids)).filter(
                 self.model_class.flavor_id == flavor_id,

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -538,7 +538,7 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         mock_count_lb = task.CountLoadbalancersWithFlavor()
         mock_count_lb.loadbalancer_repo.get_lb_count_by_flavor = mock.Mock()
         mock_count_lb.loadbalancer_repo.get_lb_count_by_flavor.return_value = 2
-        lb_count = mock_count_lb.execute(LB)
+        lb_count = mock_count_lb.execute(LB, VTHUNDER)
         self.assertEqual(2, lb_count)
 
     def test_SetThunderUpdatedAt_execute_update(self):


### PR DESCRIPTION
## Description
- Required: Severity Level LOW
- Required: Issue Description
ip nat pools were deleted when there's still lb using this nat pool list (it happened when two child projects in parent partition).if nat pool flavor used by multiple lbs and but single project, this issue is not existed. both nat pool and nat pool list all have this issue.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2067

## Technical Approach
For get_lb_count_by_flavor(), provide another version of API to support HMT (which count lb with same flavor in all projects with same partition_name, ip_address)

## Config Changes

<pre>
<b>[a10_global]
use_parent_partition=True

[hardware_thunder]
devices = [
                    {
                     "project_id": "3d21c71c4e4040599933bda62a76ae2f",
                     "ip_address": "192.168.90.46",
                     "username": "admin",
                     "password": "a10",
                     "partition_name": "p7",
                     "device_name": "ytsai-Thunder"
                     },
                    {
                     "project_id": "9955a18b75fa4c30bb865d72b5a86a6a",
                     "ip_address": "192.168.90.46",
                     "username": "admin",
                     "password": "a10",
                     "partition_name": "p7",
                     "device_name": "ytsai-Thunder",
                     "hierarchical_multitenancy": "enable"
                     },
                    {
                     "project_id": "b612261c15374f1a896f4c3830042f48",
                     "ip_address": "192.168.90.46",
                     "username": "admin",
                     "password": "a10",
                     "partition_name": "p7",
                     "device_name": "ytsai-Thunder",
                     "hierarchical_multitenancy": "enable",
                     }
             ]

</b>
</pre>


## Test Cases
Same as QA

## Manual Testing
```
openstack project create --parent admin child1
openstack project create --parent admin child2
stack@ytsai-openstack:~/source/a10-octavia/STACK-1990$ openstack project list
+----------------------------------+--------------------+
| ID                               | Name               |
+----------------------------------+--------------------+
| 2824d8e196c640af9b3863c3d9b7b0d8 | alt_demo           |
| 2aae8b6e8ddd4e2991b6c342824056b0 | demo               |
| 3d21c71c4e4040599933bda62a76ae2f | admin              |
| 9955a18b75fa4c30bb865d72b5a86a6a | child1             |
| a9dbace62afb483898e7c4077d8c75d6 | invisible_to_admin |
| b612261c15374f1a896f4c3830042f48 | child2             |
| c377bd3ba07e43898018ef4f27b0ce0c | project_b          |
| c45ca1e789844ca0a0ea14da21d9a97e | service            |
| d97d24bfc7584be28b56acbdb793d89e | project_a          |
+----------------------------------+--------------------+
stack@ytsai-openstack:~/source/a10-octavia/STACK-1990$ openstack project show child1
+-------------+----------------------------------+
| Field       | Value                            |
+-------------+----------------------------------+
| description |                                  |
| domain_id   | default                          |
| enabled     | True                             |
| id          | 9955a18b75fa4c30bb865d72b5a86a6a |
| is_domain   | False                            |
| name        | child1                           |
| parent_id   | 3d21c71c4e4040599933bda62a76ae2f |
| tags        | []                               |
+-------------+----------------------------------+
stack@ytsai-openstack:~/source/a10-octavia/STACK-1990$ openstack project show child2
+-------------+----------------------------------+
| Field       | Value                            |
+-------------+----------------------------------+
| description |                                  |
| domain_id   | default                          |
| enabled     | True                             |
| id          | b612261c15374f1a896f4c3830042f48 |
| is_domain   | False                            |
| name        | child2                           |
| parent_id   | 3d21c71c4e4040599933bda62a76ae2f |
| tags        | []                               |
+-------------+----------------------------------+

openstack loadbalancer create --project child1 --flavor f_snat_list --vip-subnet-id f25ce642-f953-4058-8c46-98fdd72fb129 --vip-address 192.168.91.57 --name vip2
openstack loadbalancer create --project child2 --flavor f_snat_list --vip-subnet-id f25ce642-f953-4058-8c46-98fdd72fb129 --vip-address 192.168.91.58 --name vip3

openstack loadbalancer delete vip3
```

On thunder:
```
AX1030[3d21c71c4e4040]#show running-config
!Current configuration: 388 bytes
!Configuration last updated at 16:55:28 CST Tue Feb 2 2021
!Configuration last saved at 16:55:42 CST Tue Feb 2 2021
!
active-partition 3d21c71c4e4040
!
!
!
ip nat pool pool1 192.168.90.201 192.168.90.210 netmask /24 gateway 192.168.90.1
!
ip nat pool pool2 192.168.90.211 192.168.90.220 netmask /24 gateway 192.168.90.1
!
ip nat pool pool3 192.168.90.221 192.168.90.230 netmask /24 gateway 192.168.90.1
!
slb virtual-server 430360e2-b0bc-4ac3-9eda-68e5b5b637a8 192.168.91.58
!
slb virtual-server abbd6e80-926f-4da6-a2c8-02eb8578b9cb 192.168.91.57
!
end
!Current config commit point for partition 12 is 0 & config mode is classical-mode
AX1030[3d21c71c4e4040]#show running-config
!Current configuration: 317 bytes
!Configuration last updated at 16:57:54 CST Tue Feb 2 2021
!Configuration last saved at 16:55:42 CST Tue Feb 2 2021
!
active-partition 3d21c71c4e4040
!
!
!
ip nat pool pool1 192.168.90.201 192.168.90.210 netmask /24 gateway 192.168.90.1
!
ip nat pool pool2 192.168.90.211 192.168.90.220 netmask /24 gateway 192.168.90.1
!
ip nat pool pool3 192.168.90.221 192.168.90.230 netmask /24 gateway 192.168.90.1
!
slb virtual-server abbd6e80-926f-4da6-a2c8-02eb8578b9cb 192.168.91.57
!
end
!Current config commit point for partition 12 is 0 & config mode is classical-mode
```
