### PR TITLE
STACK-2074: SNAT feature support for vThunder flows.

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_listener_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_listener_flows.py
@@ -42,8 +42,15 @@ class ListenerFlows(object):
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
         create_listener_flow.add(self.handle_ssl_cert_flow(flow_type='create'))
+        create_listener_flow.add(a10_database_tasks.GetFlavorData(
+            rebind={a10constants.LB_RESOURCE: constants.LISTENER},
+            provides=constants.FLAVOR_DATA))
+        create_listener_flow.add(nat_pool_tasks.NatPoolCreate(
+            requires=(constants.LOADBALANCER,
+                      a10constants.VTHUNDER, constants.FLAVOR_DATA)))
         create_listener_flow.add(virtual_port_tasks.ListenerCreate(
-            requires=[constants.LOADBALANCER, constants.LISTENER, a10constants.VTHUNDER]))
+            requires=[constants.LOADBALANCER, constants.LISTENER,
+                      a10constants.VTHUNDER, constants.FLAVOR_DATA]))
         create_listener_flow.add(a10_network_tasks.UpdateVIP(
             requires=constants.LOADBALANCER))
         create_listener_flow.add(a10_database_tasks.

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -75,9 +75,15 @@ class LoadBalancerFlows(object):
         lb_create_flow.add(
             self.get_post_lb_vthunder_association_flow(
                 post_amp_prefix, topology, mark_active=(not listeners)))
-        lb_create_flow.add(virtual_server_tasks.CreateVirtualServerTask(
+        lb_create_flow.add(a10_database_tasks.GetFlavorData(
+            rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
+            provides=constants.FLAVOR_DATA))
+        lb_create_flow.add(nat_pool_tasks.NatPoolCreate(
             requires=(constants.LOADBALANCER,
-                           a10constants.VTHUNDER)))
+                      a10constants.VTHUNDER, constants.FLAVOR_DATA)))
+        lb_create_flow.add(virtual_server_tasks.CreateVirtualServerTask(
+            requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
+                      constants.FLAVOR_DATA)))
         lb_create_flow.add(vthunder_tasks.WriteMemory(
             requires=a10constants.VTHUNDER))
         lb_create_flow.add(a10_database_tasks.SetThunderUpdatedAt(

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ PyMySQL<=0.10.1
 mock
 nose
 hacking
+uhashring==1.2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,4 +2,3 @@ PyMySQL<=0.10.1
 mock
 nose
 hacking
-uhashring==1.2

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
        sqlalchemy_utils
        uhashring==1.2
-       cryptography==3.3.1
+       cryptography<=3.3.1
 commands =
   nosetests {posargs} -a '!db'
 
@@ -30,6 +30,7 @@ deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
        pyrsistent>0.15.4,<=0.16.0
        alembic==1.4.3
+       uhashring==1.2
 
 [testenv:pep8]
 commands = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,8 @@ install_command = pip install -U {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
        sqlalchemy_utils
+       uhashring==1.2
+       cryptography==3.3.1
 commands =
   nosetests {posargs} -a '!db'
 


### PR DESCRIPTION
## Description
Modified vThunder flows(a10_load_balancer_flows, a10_listener_flows and a10_member_flows) to support SNAT feature.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2074

## Technical Approach
- Added tasks `GetFlavorData` and `NatPoolCreate` to a10_load_balancer_flows to create nat-pools during loadbalancer creation
- Added tasks `GetFlavorData` and `NatPoolCreate` to a10_listener_flows
- Added tasks `GetFlavorData`, `MemberFindNatPool`, `GetNatPoolEntry`, `ReserveSubnetAddressForMember`, `UpdateNatPoolDB` to get the nat-pool associated with the specific listener, reserve the addresses of that nat-pool for the member subnet and update the nat-pool entry in nat-pool table in db.
- Added tasks `MemberFindNatPool`, `GetNatPoolEntry`, `ReleaseSubnetAddressForMember` and `DeleteNatPoolEntry` to release the reserved addresses of nat-pool on the member deletion and also to delete the nat-pool entry present in the nat-pool table in db.

## Test Cases
- Given a loadbalancer, when it is created with a nat-pool flavor passed to it, then the nat-pool should be created during the loadbalancer creation.
- Given a listener, when it is created for the lb, then the nat-pool of nat-pool flavor associated with that lb should get associated with the listener.
- Given a member, when it is created, then the IP addresses of the nat-pool attached to the listener should get reserved for the member subnet.
- Given a member, when it is created, then nat-pool entry should be created in nat-pool table in octavia db
- Given a member, when it is deleted, then the IP addresses of the nat-pool attached to the listener should get released from the member subnet.
- Given a member, when it is deleted, then the nat-pool entry member-ref-count should decrease correctly and nat-pool entry should be deleted from nat-pool table in octavia db if member-ref-count becomes 0.

## Manual Testing
1. Create a flavor for nat-pool:
```
stack@neha:~$ openstack loadbalancer flavorprofile create --name fp_snat_list --provider a10 --flavor-data '{"nat-pool":{"pool-name":"pool1", "start-address":"192.168.8.10", "end-address":"192.168.8.11", "netmask":"/24", "gateway":"192.168.8.1"}, "nat-pool-list":[{"pool-name":"pool2", "start-address":"192.168.8.12", "end-address":"192.168.8.13", "netmask":"/24", "gateway":"192.168.8.3"}, {"pool-name":"pool3", "start-address":"192.168.8.14", "end-address":"192.168.8.15", "netmask":"/24", "gateway":"192.168.8.2"}]}'

stack@neha:~$ openstack loadbalancer flavor create --name f_snat_list --flavorprofile fp_snat_list --description "flaovr all test1" --enable
```

2. Create a loadbalancer with above flavor
stack@neha:~$ openstack loadbalancer create --flavor f_snat_list --name lb1 --vip-subnet-id vip_subnet

Result:

stack@neha:~$ sudo journalctl -af --unit a10-controller-worker.service
![image](https://user-images.githubusercontent.com/58077446/107214200-90c88680-6a2f-11eb-8160-6dc7edfc5bfd.png)
![image](https://user-images.githubusercontent.com/58077446/107214303-bc4b7100-6a2f-11eb-8cfb-2d9d976398e8.png)

Result on vThunder:
![image](https://user-images.githubusercontent.com/58077446/107214383-d84f1280-6a2f-11eb-8ae9-694cecf97861.png)

3. Create a listener
stack@neha:~$ openstack loadbalancer listener create --name l1 --protocol TCP --protocol-port 82 lb1

Result on vThunder:
![image](https://user-images.githubusercontent.com/58077446/107214489-fddc1c00-6a2f-11eb-95af-96f563193f53.png)

4. Create a pool and a member
stack@neha:~$ openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener l1 --name pool1

stack@neha:~$ openstack loadbalancer member create --subnet-id vip_subnet --protocol-port 85 --address 192.168.8.30 --name member1 pool1

Result on vThunder:
![image](https://user-images.githubusercontent.com/58077446/107214614-249a5280-6a30-11eb-9d9c-0cdac3fec958.png)

Result in db:
IPs of pool1 are getting reserved for the member subnet
![image](https://user-images.githubusercontent.com/58077446/107214713-514e6a00-6a30-11eb-9f8d-291e187b94ee.png)

nat-pool entry is getting created in nat-pool table
![image](https://user-images.githubusercontent.com/58077446/107214820-7e028180-6a30-11eb-8eb3-3b564aaccfde.png)

5. Delete the member and check the db
stack@neha:~$ openstack loadbalancer member delete pool1 member1

Result:
The reserved IPs of pool1 are getting released from the member subnet
![image](https://user-images.githubusercontent.com/58077446/107215011-c28e1d00-6a30-11eb-8eec-edb62e9f18ba.png)

The nat-pool entry is deleted from the nat-pool table
![image](https://user-images.githubusercontent.com/58077446/107215117-e5203600-6a30-11eb-8189-6ad8c1fd092b.png)

