### PR TITLE
STACK-2070/STACK-2075: Code update for vthunder loadbalancer update and delete flow.

### DIFF
--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -219,10 +219,12 @@ def get_patched_ip_address(ip, cidr):
 
 
 def get_vrid_floating_ip_for_project(project_id):
-    device_info = CONF.hardware_thunder.devices.get(project_id)
-    if device_info:
-        vrid_fp = device_info.vrid_floating_ip
-        return CONF.a10_global.vrid_floating_ip if not vrid_fp else vrid_fp
+    vrid_fp = None
+    if CONF.hardware_thunder.devices:
+        device_info = CONF.hardware_thunder.devices.get(project_id)
+        if device_info:
+            vrid_fp = device_info.vrid_floating_ip
+    return CONF.a10_global.vrid_floating_ip if not vrid_fp else vrid_fp
 
 
 def validate_vcs_device_info(device_network_map):

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -204,8 +204,9 @@ class LoadBalancerFlows(object):
             requires=constants.LOADBALANCER))
         delete_LB_flow.add(database_tasks.DecrementLoadBalancerQuota(
             requires=constants.LOADBALANCER))
-        delete_LB_flow.add(vthunder_tasks.WriteMemory(
-            requires=a10constants.VTHUNDER))
+        if not deleteCompute:
+            delete_LB_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         delete_LB_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return (delete_LB_flow, store)

--- a/a10_octavia/tests/unit/common/test_utils.py
+++ b/a10_octavia/tests/unit/common/test_utils.py
@@ -331,6 +331,12 @@ class TestUtils(base.BaseTaskTestCase):
         self.assertEqual(utils.get_vrid_floating_ip_for_project(
             a10constants.MOCK_PROJECT_ID), '10.10.0.75')
 
+    def test_get_vrid_floating_ip_for_project_with_vthunder_flow(self):
+        self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
+                         vrid_floating_ip='10.10.0.72')
+        self.assertEqual(utils.get_vrid_floating_ip_for_project(
+            a10constants.MOCK_PROJECT_ID), '10.10.0.72')
+
     def test_validate_interface_vlan_map(self):
         self.assertEqual(utils.validate_interface_vlan_map(HARDWARE_VLAN_INFO), DEVICE_NETWORK_MAP)
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,8 @@ install_command = pip install -U {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
        sqlalchemy_utils
+       uhashring==1.2
+       cryptography<=3.3.1
 commands =
   nosetests {posargs} -a '!db'
 
@@ -28,6 +30,7 @@ deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
        pyrsistent>0.15.4,<=0.16.0
        alembic==1.4.3
+       uhashring==1.2
 
 [testenv:pep8]
 commands = flake8


### PR DESCRIPTION
## Description
Modified update and delete loadbalancer flows for supporting vthunder 

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2070
https://a10networks.atlassian.net/browse/STACK-2075

## Technical Approach
- For Loadbalancer update flow=> check the harware_thunder list whether empty or not.
- For Loadbalancer delete flow=> If "deleteCompute" flag is true then skip the write memory task.

## Test Cases
- Given a loadbalancer, tested the output of "get_vrid_floating_ip_for_project" for vthunder/hardware devices.


 ## Manual Testing

1. Created a loadbalancer.
`openstack loadbalancer create --vip-subnet-id 19f09075-0dbd-415a-b488-e78d6260e351 --name lb1`

Result:
```
Feb 09 05:44:08 adeeb-dev a10-octavia-worker[15311]: INFO a10_octavia.controller.queue.endpoint [-] Creating load balancer '6c1b2cc9-7188-4b2b-b0dc-fc40677ab3dd'...
Feb 09 05:44:08 adeeb-dev a10-octavia-worker[15311]: INFO a10_octavia.controller.worker.flows.a10_load_balancer_flows [-] TOPOLOGY ===SINGLE
Feb 09 05:44:08 adeeb-dev a10-octavia-worker[15311]: INFO octavia.controller.worker.tasks.database_tasks [-] Created Amphora in DB with id ecbf7816-6131-4cde-81ed-f52b801ec03b
Feb 09 05:44:08 adeeb-dev a10-octavia-worker[15311]: INFO octavia.network.drivers.neutron.allowed_address_pairs [-] Port 9e15c1cd-27a3-4333-bb29-86946a467a30 already exists. Nothing to be done.
Feb 09 05:44:23 adeeb-dev a10-octavia-worker[15311]: INFO a10_octavia.controller.worker.tasks.a10_database_tasks [-] Successfully created vthunder entry in database.
Feb 09 05:44:23 adeeb-dev a10-octavia-worker[15311]: INFO octavia.controller.worker.tasks.database_tasks [-] Mark ALLOCATED in DB for amphora: ecbf7816-6131-4cde-81ed-f52b801ec03b with compute id 22e9de28-e545-4cb8-b1a3-c6918473bc4b for load balancer: 6c1b2cc9-7188-4b2b-b0dc-fc40677ab3dd
Feb 09 05:44:26 adeeb-dev a10-octavia-worker[15311]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Attempting to connect vThunder device for connection.
Feb 09 05:49:35 adeeb-dev a10-octavia-worker[15311]: INFO octavia.controller.worker.tasks.database_tasks [-] Mark ACTIVE in DB for load balancer id: 6c1b2cc9-7188-4b2b-b0dc-fc40677ab3dd
Feb 09 05:49:35 adeeb-dev a10-octavia-worker[15311]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.0.98:None

vThunder(config)(NOLICENSE)#show running-config slb virtual-server
!Section configuration: 73 bytes
!
slb virtual-server 6c1b2cc9-7188-4b2b-b0dc-fc40677ab3dd 192.168.8.102
!
vThunder(config)(NOLICENSE)#
```

2. Update the loadbalancer
`stack@adeeb-dev:~/adeeb/a10-octavia$ openstack loadbalancer set --description "Updatelb1" lb1`

Result:
```
Feb 09 05:52:07 adeeb-dev a10-octavia-worker[15311]: INFO a10_octavia.controller.queue.endpoint [-] Updating load balancer '6c1b2cc9-7188-4b2b-b0dc-fc40677ab3dd'...
Feb 09 05:52:33 adeeb-dev a10-octavia-worker[15311]: INFO octavia.controller.worker.tasks.database_tasks [-] Mark ACTIVE in DB for load balancer id: 6c1b2cc9-7188-4b2b-b0dc-fc40677ab3dd
Feb 09 05:52:33 adeeb-dev a10-octavia-worker[15311]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.0.98:None

vThunder(config)(NOLICENSE)#show running-config slb virtual-server
!Section configuration: 99 bytes
!
slb virtual-server 6c1b2cc9-7188-4b2b-b0dc-fc40677ab3dd 192.168.8.102
  description "Updatelb1"
!
vThunder(config)(NOLICENSE)#
```

3. Delete the loadbalancer
`stack@adeeb-dev:~/adeeb/a10-octavia$ openstack loadbalancer delete lb1`  

Result
```
Feb 09 05:53:45 adeeb-dev a10-octavia-worker[15311]: INFO a10_octavia.controller.queue.endpoint [-] Deleting load balancer '6c1b2cc9-7188-4b2b-b0dc-fc40677ab3dd'...
Feb 09 05:53:47 adeeb-dev a10-octavia-worker[15311]: INFO a10_octavia.controller.worker.tasks.a10_network_tasks [-] VRID floating IP: 192.168.8.130 deleted
Feb 09 05:53:47 adeeb-dev a10-octavia-worker[15311]: INFO octavia.network.drivers.neutron.allowed_address_pairs [-] Removing security group 3b1302ea-fb95-403a-a603-cde4359b7da6 from port 9e15c1cd-27a3-4333-bb29-86946a467a30
Feb 09 05:53:48 adeeb-dev a10-octavia-worker[15311]: INFO octavia.network.drivers.neutron.allowed_address_pairs [-] Deleted security group 3b1302ea-fb95-403a-a603-cde4359b7da6
```
