### PR TITLE
[BUG][STACK-2083][STACK-2095]: Bound session-persistence templates to virtual ports

### DIFF
--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -210,6 +210,7 @@ class ListenerUpdateForPool(ListenersParent, task.Task):
     def execute(self, loadbalancer, listener, vthunder):
         try:
             if listener:
+                c_pers, s_pers = utils.get_sess_pers_templates(listener.default_pool)
                 listener.protocol = openstack_mappings.virtual_port_protocol(
                     self.axapi_client, listener.protocol).lower()
                 self.axapi_client.slb.virtual_server.vport.update(
@@ -217,7 +218,8 @@ class ListenerUpdateForPool(ListenersParent, task.Task):
                     listener.id,
                     listener.protocol,
                     listener.protocol_port,
-                    listener.default_pool_id)
+                    listener.default_pool_id,
+                    s_pers_name=s_pers, c_pers_name=c_pers)
                 LOG.debug("Successfully updated listener: %s", listener.id)
         except (acos_errors.ACOSException, ConnectionError) as e:
             LOG.exception("Failed to update listener: %s", listener.id)

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,8 @@ install_command = pip install -U {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
        sqlalchemy_utils
+       uhashring==1.2
+       cryptography<=3.3.1
 commands =
   nosetests {posargs} -a '!db'
 
@@ -28,6 +30,7 @@ deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
        pyrsistent>0.15.4,<=0.16.0
        alembic==1.4.3
+       uhashring==1.2
 
 [testenv:pep8]
 commands = flake8


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue description:
    When a pool is created/updated with --session-persistence, it is creating slb template persist templates(session persistence templates) on thunder but the templates were not getting bound to virtual port.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2083
https://a10networks.atlassian.net/browse/STACK-2095

## Technical Approach
- Getting session persistence templates, c_pers and s_pers inside ListenerUpdateForPool task.
- Passing those received templates to self.axapi_client.slb.virtual_server.vport.update call sothat the templates will get bounded to the vport when pool is created or updated with session persistence.

## Test Cases
- Given a pool, when it is created with session persistence, the virtual port will get updated with bounding the persist templates created for the pool to it.
- Given a pool, when it is updated with session persistence, the virtual port will get updated with bounding the persist templates created for the pool to it.

## Manual Testing
**For STACK-2083:**
Case 1:
1. Create loadbalancer, listener and pool
```
openstack loadbalancer create --name lb1 --vip-subnet-id vip_subnet

openstack loadbalancer listener create --protocol HTTP --connection-limit 600 --protocol-port 8002 --name listener1 lb1
openstack loadbalancer listener create --protocol HTTP --connection-limit 600 --protocol-port 8003 --name listener2 lb1
openstack loadbalancer listener create --protocol HTTP --connection-limit 600 --protocol-port 8004 --name listener3 lb1

openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener listener1 --name pool1
openstack loadbalancer pool create --protocol HTTP --lb-algorithm SOURCE_IP --listener listener2 --name pool2
openstack loadbalancer pool create --protocol HTTP --lb-algorithm LEAST_CONNECTIONS --listener listener3 --name pool3

```
**Result on thunder:**
![image](https://user-images.githubusercontent.com/58077446/107738149-23b53980-6d2c-11eb-968b-80596ac68b42.png)

2. Set pool with --session-persistence
```
openstack loadbalancer pool set --session-persistence type=HTTP_COOKIE pool1
openstack loadbalancer pool set --session-persistence type=APP_COOKIE,cookie_name=cookie_name1 pool2
openstack loadbalancer pool set --session-persistence type=SOURCE_IP pool3

```
**Result on thunder:**
**Session persistence templates are created bounded to the virtual ports**
![image](https://user-images.githubusercontent.com/58077446/107738385-90c8cf00-6d2c-11eb-8b54-711dbac91c08.png)

![image](https://user-images.githubusercontent.com/58077446/107738519-dab1b500-6d2c-11eb-8e6f-bea336e59f32.png)


Case2:
Create a new listener and  new pool with session-persistence
```
openstack loadbalancer listener create --protocol HTTP --connection-limit 600 --protocol-port 8005 --name listener4 lb1

openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --session-persistence type=APP_COOKIE,cookie_name=cookie1 --listener listener4 --name pool4
```

**Result on thunder:
Session persistence template is created bounded to the virtual port**
![image](https://user-images.githubusercontent.com/58077446/107738779-63305580-6d2d-11eb-8594-4bb3a1aea346.png)


**For STACK-2095:**
In config file, set **use_shared_for_template_lookup = True**

Create a loadbalancer, listener and pool

```
openstack loadbalancer create --name lb1 --vip-subnet-id vip_subnet
openstack loadbalancer listener create --protocol HTTP --connection-limit 600 --protocol-port 8002 --name listener1 lb1
openstack loadbalancer pool create --protocol HTTP --lb-algorithm LEAST_CONNECTIONS --listener listener1 --name pool1
```

Set the pool with session-persistence
openstack loadbalancer pool set --session-persistence type=HTTP_COOKIE pool1

**Result:
Session persistence template is created and bounded to the virtual port**
![image](https://user-images.githubusercontent.com/58077446/107739188-55c79b00-6d2e-11eb-81ac-15f4607eefc4.png)
