### PR TITLE
[Stack 2077] Updated the periodic write memory feature for deleting last lb.

### DIFF
--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -219,10 +219,12 @@ def get_patched_ip_address(ip, cidr):
 
 
 def get_vrid_floating_ip_for_project(project_id):
-    device_info = CONF.hardware_thunder.devices.get(project_id)
-    if device_info:
-        vrid_fp = device_info.vrid_floating_ip
-        return CONF.a10_global.vrid_floating_ip if not vrid_fp else vrid_fp
+    vrid_fp = None
+    if CONF.hardware_thunder.devices:
+        device_info = CONF.hardware_thunder.devices.get(project_id)
+        if device_info:
+            vrid_fp = device_info.vrid_floating_ip
+    return CONF.a10_global.vrid_floating_ip if not vrid_fp else vrid_fp
 
 
 def validate_vcs_device_info(device_network_map):

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -903,9 +903,13 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         store = {a10constants.WRITE_MEM_SHARED_PART: True}
 
         for vthunder in thunders:
+            deleteCompute = False
+            if vthunder.status == 'DELETED' and vthunder.compute_id is not None:
+                deleteCompute = self._vthunder_repo.get_delete_compute_flag(db_apis.get_session(),
+                                                                            vthunder.compute_id)
             try:
                 write_mem_tf = self._taskflow_load(
-                    self._vthunder_flows.get_write_memory_flow(vthunder, store),
+                    self._vthunder_flows.get_write_memory_flow(vthunder, store, deleteCompute),
                     store=store)
 
                 with tf_logging.DynamicLoggingListener(write_mem_tf,

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -204,8 +204,9 @@ class LoadBalancerFlows(object):
             requires=constants.LOADBALANCER))
         delete_LB_flow.add(database_tasks.DecrementLoadBalancerQuota(
             requires=constants.LOADBALANCER))
-        delete_LB_flow.add(vthunder_tasks.WriteMemory(
-            requires=a10constants.VTHUNDER))
+        if not deleteCompute:
+            delete_LB_flow.add(vthunder_tasks.WriteMemory(
+                requires=a10constants.VTHUNDER))
         delete_LB_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
         return (delete_LB_flow, store)

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -372,7 +372,7 @@ class VThunderFlows(object):
         """
         return history[history.keys()[0]]
 
-    def get_write_memory_flow(self, vthunder, store):
+    def get_write_memory_flow(self, vthunder, store, deleteCompute):
         """Perform write memory for thunder """
         sf_name = 'a10-house-keeper' + '-' + a10constants.WRITE_MEMORY_THUNDER_FLOW
 
@@ -391,31 +391,40 @@ class VThunderFlows(object):
                 id=vthunder.vthunder_id,
                 flow='MarkLoadBalancersPendingUpdateInDB'),
             requires=a10constants.LOADBALANCERS_LIST))
-        write_memory_flow.add(vthunder_tasks.WriteMemoryHouseKeeper(
-            requires=(a10constants.VTHUNDER, a10constants.LOADBALANCERS_LIST,
-                      a10constants.WRITE_MEM_SHARED_PART),
-            rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
-            name='{flow}-{partition}-{id}'.format(
-                id=vthunder.vthunder_id,
-                flow='WriteMemory-' + a10constants.WRITE_MEMORY_THUNDER_FLOW,
-                partition=a10constants.WRITE_MEM_FOR_SHARED_PARTITION),
-            provides=a10constants.WRITE_MEM_SHARED))
-        write_memory_flow.add(vthunder_tasks.WriteMemoryHouseKeeper(
-            requires=(a10constants.VTHUNDER, a10constants.LOADBALANCERS_LIST),
-            rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
-            name='{flow}-{partition}-{id}'.format(
-                id=vthunder.vthunder_id,
-                flow='WriteMemory-' + a10constants.WRITE_MEMORY_THUNDER_FLOW,
-                partition=a10constants.WRITE_MEM_FOR_LOCAL_PARTITION),
-            provides=a10constants.WRITE_MEM_PRIVATE))
-        write_memory_flow.add(a10_database_tasks.SetThunderLastWriteMem(
-            requires=(a10constants.VTHUNDER,
-                      a10constants.WRITE_MEM_SHARED,
-                      a10constants.WRITE_MEM_PRIVATE),
-            rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
-            name='{flow}-{id}'.format(
-                id=vthunder.vthunder_id,
-                flow='SetThunderLastWriteMem')))
+        if not deleteCompute:
+            write_memory_flow.add(vthunder_tasks.WriteMemoryHouseKeeper(
+                requires=(a10constants.VTHUNDER, a10constants.LOADBALANCERS_LIST,
+                          a10constants.WRITE_MEM_SHARED_PART),
+                rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
+                name='{flow}-{partition}-{id}'.format(
+                    id=vthunder.vthunder_id,
+                    flow='WriteMemory-' + a10constants.WRITE_MEMORY_THUNDER_FLOW,
+                    partition=a10constants.WRITE_MEM_FOR_SHARED_PARTITION),
+                provides=a10constants.WRITE_MEM_SHARED))
+            write_memory_flow.add(vthunder_tasks.WriteMemoryHouseKeeper(
+                requires=(a10constants.VTHUNDER, a10constants.LOADBALANCERS_LIST),
+                rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
+                name='{flow}-{partition}-{id}'.format(
+                    id=vthunder.vthunder_id,
+                    flow='WriteMemory-' + a10constants.WRITE_MEMORY_THUNDER_FLOW,
+                    partition=a10constants.WRITE_MEM_FOR_LOCAL_PARTITION),
+                provides=a10constants.WRITE_MEM_PRIVATE))
+            write_memory_flow.add(a10_database_tasks.SetThunderLastWriteMem(
+                requires=(a10constants.VTHUNDER,
+                          a10constants.WRITE_MEM_SHARED,
+                          a10constants.WRITE_MEM_PRIVATE),
+                rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
+                name='{flow}-{id}'.format(
+                    id=vthunder.vthunder_id,
+                    flow='SetThunderLastWriteMem')))
+        else:
+            write_memory_flow.add(a10_database_tasks.SetThunderLastWriteMem(
+                requires=(a10constants.VTHUNDER),
+                inject={a10constants.WRITE_MEM_SHARED: True, a10constants.WRITE_MEM_PRIVATE: True},
+                rebind={a10constants.VTHUNDER: vthunder.vthunder_id},
+                name='{flow}-{id}'.format(
+                    id=vthunder.vthunder_id,
+                    flow='SetThunderLastWriteMem')))
         write_memory_flow.add(a10_database_tasks.MarkLoadBalancersActiveInDB(
             name='{flow}-{id}'.format(
                 id=vthunder.vthunder_id,

--- a/a10_octavia/tests/unit/common/test_utils.py
+++ b/a10_octavia/tests/unit/common/test_utils.py
@@ -331,6 +331,12 @@ class TestUtils(base.BaseTaskTestCase):
         self.assertEqual(utils.get_vrid_floating_ip_for_project(
             a10constants.MOCK_PROJECT_ID), '10.10.0.75')
 
+    def test_get_vrid_floating_ip_for_project_with_vthunder_flow(self):
+        self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
+                         vrid_floating_ip='10.10.0.72')
+        self.assertEqual(utils.get_vrid_floating_ip_for_project(
+            a10constants.MOCK_PROJECT_ID), '10.10.0.72')
+
     def test_validate_interface_vlan_map(self):
         self.assertEqual(utils.validate_interface_vlan_map(HARDWARE_VLAN_INFO), DEVICE_NETWORK_MAP)
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,8 @@ install_command = pip install -U {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
        sqlalchemy_utils
+       uhashring==1.2
+       cryptography<=3.3.1
 commands =
   nosetests {posargs} -a '!db'
 
@@ -28,6 +30,7 @@ deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
        pyrsistent>0.15.4,<=0.16.0
        alembic==1.4.3
+       uhashring==1.2
 
 [testenv:pep8]
 commands = flake8


### PR DESCRIPTION
## Description
On deleting the last load balancer, HK will try to perform write memory but it will get connection error because vthunder is already deleted. At each subsequent interval it will be get same error. 

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2077

## Technical Approach
On interval arrival; if the lb is in deleted stated and it has some compute id then count the compute id. And the on the basis of count value, set the flag, if the flag is true then do not perform write memory only update the "last_write_mem" column of vthunders table. 

## Manual Testing
1) Enable the periodic write memory
2) create a loadbalancer 
openstack loadbalancer create --vip-subnet-id 19f09075-0dbd-415a-b488-e78d6260e351 --name lb2
 
3) After interval write memory will be performed
```
Feb 15 12:41:44 adeeb-dev a10-house-keeper[24686]: INFO a10_octavia.controller.housekeeping.house_keeping [-] Write Memory for Thunders : ['192.168.0.125:None']
Feb 15 12:41:44 adeeb-dev a10-house-keeper[24686]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.0.125:shared
Feb 15 12:41:47 adeeb-dev a10-house-keeper[24686]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.0.125:None
Feb 15 12:41:49 adeeb-dev a10-house-keeper[24686]: INFO a10_octavia.controller.housekeeping.house_keeping [-] Finished running write memory for 1 thunders...
``` 

4) Delete the lb
openstack loadbalancer delete e5f2f7d2-f19d-4302-afdc-3f5edc650803

5) On next interval, Logs of HK, skipping the write memory operation and updating the db.
 
```
Feb 15 12:43:19 adeeb-dev a10-house-keeper[24686]: INFO a10_octavia.cmd.a10_house_keeper [-] Initiating the write memory operation for all thunders...
Feb 15 12:43:19 adeeb-dev a10-house-keeper[24686]: INFO a10_octavia.controller.housekeeping.house_keeping [-] Write Memory for Thunders : ['192.168.0.125:None']
Feb 15 12:43:19 adeeb-dev a10-house-keeper[24686]: INFO a10_octavia.controller.housekeeping.house_keeping [-] Finished running write memory for 1 thunders...
```
 <img width="737" alt="delete_2" src="https://user-images.githubusercontent.com/76765492/107974955-5afe4180-6fdd-11eb-9d65-2b5b9fbe74ca.PNG">
