### PR TITLE
[STACK-2066]  [Database Migration Enhancement] a10-octavis overwrite octavia database alembic version

### DIFF
--- a/a10_octavia/db/migration/alembic_migrations/env.py
+++ b/a10_octavia/db/migration/alembic_migrations/env.py
@@ -4,10 +4,19 @@ from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
+import sqlalchemy as sa
 
-from alembic import context
+from alembic import context, command
+from alembic.script import ScriptDirectory
+from alembic.operations import Operations
+
 from a10_octavia import a10_config
 from a10_octavia.db import base_models
+
+VERSION_TABLE = 'alembic_version_a10'
+LOG_INFO = "INFO  [a10-octavia.db.migration] "
+LOG_ERR = "ERROR  [a10-octavia.db.migration] "
+
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
@@ -31,6 +40,51 @@ if getattr(config, 'connection', None) is None:
 # can be acquired:
 # my_important_option = config.get_main_option("my_important_option")
 # ... etc.
+
+
+def get_octavia_revision(ctx, op):
+    current_rev = 0
+    try:
+        conn = op.get_bind()
+        current_rev = conn.execute("select version_num from alembic_version").scalar()
+    except:
+        config.print_stdout("%sFailed to get octavia alembic revision", LOG_ERR)
+
+    return current_rev
+
+def a10_revision_migration(ctx):
+    """ Check a10 database revision from 'alembic_version' table
+
+    In a10-octavia v1.1 and earlier vrersions, a10-octavia use 
+    'alembic_version' table as alembic version table (which will
+    overwrite octavia alembic revisions). 
+
+    To migrate from these versions, we need to copy the revision
+    from'alembic_version' to 'alembic_version_a10'.
+
+    """
+    op = Operations(ctx)
+    octavia_rev = get_octavia_revision(ctx, op)
+    script = ScriptDirectory.from_config(config)
+    dest_rev = 0
+    try:
+        rev = script.get_revision(octavia_rev)
+        config.print_stdout("%soctavia revision %s is a10 revision", LOG_INFO, rev.revision)
+        dest_rev = rev.revision
+    except:
+        config.print_stdout("%s%s is not a10 revision", LOG_INFO, octavia_rev)
+        return
+
+    try:
+        ctx.stamp(script, dest_rev)
+        config.print_stdout("%sstamp a10_revision to %s", LOG_INFO, dest_rev)
+
+        # Since revision is copy to alembic_version_a10, remove a10 revision in octavia table.
+        # Keep a10 vision in octavia may cause issue after a10-octavia do `alembic downgrade base`
+        conn = op.get_bind()
+        conn.execute("delete from alembic_version")
+    except:
+        config.print_stdout("%smigrate version from alembic_version failed", LOG_ERR)
 
 def run_migrations_offline():
     """Run migrations in 'offline' mode.
@@ -68,8 +122,19 @@ def run_migrations_online():
 
     with connectable.connect() as connection:
         context.configure(
-            connection=connection, target_metadata=target_metadata
+            connection=connection,
+            version_table=VERSION_TABLE,
+            target_metadata=target_metadata
         )
+
+        # a10-octavia revision checks
+        ctx = context.get_context()
+        a10_revision = ctx.get_current_revision()
+        if a10_revision is None:
+            config.print_stdout("%sNo a10_revision yet.", LOG_INFO)
+            a10_revision_migration(ctx=ctx)
+        else:
+            config.print_stdout("%scurrent a10_revision: %s", LOG_INFO, a10_revision)
 
         with context.begin_transaction():
             context.run_migrations()

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,8 @@ install_command = pip install -U {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
        sqlalchemy_utils
+       uhashring==1.2
+       cryptography<=3.3.1
 commands =
   nosetests {posargs} -a '!db'
 
@@ -28,12 +30,14 @@ deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
        pyrsistent>0.15.4,<=0.16.0
        alembic==1.4.3
+       uhashring==1.2
 
 [testenv:pep8]
 commands = flake8
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
        pyrsistent>0.15.4,<=0.16.0
+       uhashring==1.2
 
 [flake8]
 #ignore = E122,E125,E126,E128,E129,E251,E265,E713,F402,F811,F812,H104,H237,H302,H304,H305,H307,H401,H402,H404,H405,H904


### PR DESCRIPTION
## Description
Before a10-octavia v1.2, a10-octavia didn’t have its own alembic version_table in database. So it overwrites the octavia alembic versions, and make octavia hard to upgrade. So, for this release a10-octaiva will have its own alembic version_table.

Design Document: [Teams Link](https://teams.microsoft.com/l/file/20225A2D-9D1D-474D-8800-2F2DFCE775A7?tenantId=91d27ab9-8c5e-41d4-82e8-3d1bf81fcb2f&fileType=docx&objectUrl=https%3A%2F%2Fa10networks.sharepoint.com%2Fsites%2FOpenstack%2FShared%20Documents%2FDevelopment%2FResearch%20%26%20Design%2Fa10-octavia%20v1.2%2Fa10%20alembic%20version%20table%2Fdesign%20document.docx&baseUrl=https%3A%2F%2Fa10networks.sharepoint.com%2Fsites%2FOpenstack&serviceName=teams&threadId=19:0f1acbb173d74758b05ee8bacb000d68@thread.tacv2&groupId=37bbf3ad-c05a-4e67-b0cc-12bcd1479beb)
Story: https://a10networks.atlassian.net/browse/STACK-2066

## Technical Approach
1.	For database version numbers, a10-octavia use alembic_version_a10 table instead of alembic_version. So, it won’t overwrite Octavia alembic version number.
2.	For upgrade database we need to consider these cases:
  - No any a10-octavia installed before: alembic_version table is Octavia alembic revision.
  - The database upgrade from a10-octavia v1.2 or later versions: a10-octavia alembic revision is already in alembic_version_a10 
  - The database upgrade from a10-octavia v1.1 or earlier versions: database already have a10 tables and entries, and alembic_version table is a10-octavia alembic revision. In this case we need to create alembic_version_a10 table, move alembic revision from alembic_version to alembic_version_a10 (version in alembic_version will be removed). and then run migrations.
3.	The migration script will not affect exist entries in database. 


## Config Changes
<pre>
<b>N/A</b>
</pre>


## Test Cases
1.	Run alembic current 

case | alembic_version | alembic_version_a10 | Expect result
-- | -- | -- | --
1-1 | Octavia revision | No table yet | -   No   result
1-2 | Octavia revision | empty | - No result
1-3 | Octavia revision | Old a10   revision | - print old   a10 revision
1-4 | Octavia revision | HEAD | - print a10   HEAD revision
1-5 | old a10   revision | No table yet | - create   alembic_version_a10   - old a10   revision will move to the table   - print old   a10 revision
1-6 | old a10   revision | empty | - old a10   revision will move to the table   - print old   a10 revision
1-7 | old a10   revision | Old a10   revision | - print old   a10 revision in alembic_version_a10
1-8 | old a10   revision | HEAD | - print HEAD   a10 revision
1-9 | HEAD a10   revision | No table yet | - create   alembic_version_a10   - HEAD a10   revision will move to the table   - print a10   HEAD revision
1-10 | HEAD a10   revision | empty | - a10 HEAD   revision will move to the table   - print a10   HEAD revision
1-11 | HEAD a10   revision | Old a10   revision | - print old a10   revision in
1-12 | HEAD a10   revision | HEAD | - print HEAD   a10 revision

2.	Run alembic upgrade HEAD

case | alembic_version | alembic_version_a10 | Expect result
-- | -- | -- | --
2-1 | Octavia revision | No table yet | -     create alembic_version_a10   -     upgrade to HEAD
2-2 | Octavia revision | empty | - upgrade to   HEAD
2-3 | Octavia revision | Old a10   revision | - upgrade to   HEAD
2-4 | Octavia revision | HEAD | - do nothinga
2-5 | old a10   revision | No table yet | - create   alembic_version_a10   - upgrade   from old revision to HEAD
2-6 | old a10   revision | empty | - upgrade   from old revision to HEAD
2-7 | old a10   revision | Old a10   revision | - Upgrade   from old a10 revision in alembic_version_a10 to HEAD
2-8 | old a10   revision | HEAD | - do nothing
2-9 | HEAD a10   revision | No table yet | - create   alembic_version_a10 with HEAD revision
2-10 | HEAD a10   revision | empty | - update alembic_version_a10   to HEAD revision
2-11 | HEAD a10   revision | Old a10   revision | - upgrade from   old revision to HEAD
2-12 | HEAD a10   revision | HEAD | - do nothing

3.	Run alembic downgrade BASE


case | alembic_version | alembic_version_a10 | Expect result
-- | -- | -- | --
3-1 | With Octavia revision | No table yet | -   Do   nothing
3-2 | With Octavia revision | empty | - Do nothing
3-3 | With Octavia revision | Old a10   revision | - downgrade   from old revision to BASE
3-4 | With Octavia revision | HEAD | - downgrade   from HEAD to BASE
3-5 | With old a10   revision | No table yet | - create   alembic_version_a10   - old a10   revision will move to the table   - downgrade   from old revision to BASE
3-6 | With old a10   revision | empty | - old a10   revision will move to the table   - downgrade   from old revision to BASE
3-7 | With old a10   revision | Old a10   revision | - downgrade   from old revision to BASE
3-8 | With old a10   revision | HEAD | - downgrade   from HEAD to BASE
3-9 | With HEAD a10   revision | No table yet | - create   alembic_version_a10   - a10 HEAD   revision will move to the table   - downgrade   from HEAD to BASE
3-10 | With HEAD a10   revision | empty | - old a10   revision will move to the table   - downgrade   from HEAD to BASE
3-11 | With HEAD a10   revision | Old a10   revision | - downgrade   from old revision to BASE
3-12 | With HEAD a10   revision | HEAD | - downgrade   from HEAD to BASE



## Manual Testing

```
alembic history
alembic current
alembic upgrade head
alembic upgrade +1/+2/+3/...
alembic downgrade base
alembic downgrade -1/-2/-3/...
```
