### PR TITLE
[STACK-2066] [Database Migration Enhancement] a10-octavis overwrite octavia database alembic version

### DIFF
--- a/a10_octavia/db/migration/alembic_migrations/env.py
+++ b/a10_octavia/db/migration/alembic_migrations/env.py
@@ -10,6 +10,9 @@ from a10_octavia import a10_config
 from a10_octavia.db import base_models
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
+
+VERSION_TABLE = 'alembic_version_a10'
+
 config = context.config
 
 # Interpret the config file for Python logging.
@@ -68,7 +71,9 @@ def run_migrations_online():
 
     with connectable.connect() as connection:
         context.configure(
-            connection=connection, target_metadata=target_metadata
+            connection=connection,
+            version_table=VERSION_TABLE,
+            target_metadata=target_metadata
         )
 
         with context.begin_transaction():

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,7 @@ commands = flake8
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
        pyrsistent>0.15.4,<=0.16.0
+       uhashring==1.2
 
 [flake8]
 #ignore = E122,E125,E126,E128,E129,E251,E265,E713,F402,F811,F812,H104,H237,H302,H304,H305,H307,H401,H402,H404,H405,H904


### PR DESCRIPTION
## Description
Before a10-octavia v1.2, a10-octavia didn’t have its own alembic version_table in database. So it overwrites the octavia alembic versions, and make octavia hard to upgrade. So, for this release a10-octaiva will have its own alembic version_table.

Story: https://a10networks.atlassian.net/browse/STACK-2066
DD: [Link](https://teams.microsoft.com/l/file/87A78E5D-FF9F-4087-8769-FA4635B6A74A?tenantId=91d27ab9-8c5e-41d4-82e8-3d1bf81fcb2f&fileType=docx&objectUrl=https%3A%2F%2Fa10networks.sharepoint.com%2Fsites%2FOpenstack%2FShared%20Documents%2FDevelopment%2FResearch%20%26%20Design%2Fa10-octavia%20v1.2%2Fa10%20alembic%20version%20table%2Fdesign%20document.docx&baseUrl=https%3A%2F%2Fa10networks.sharepoint.com%2Fsites%2FOpenstack&serviceName=teams&threadId=19:0f1acbb173d74758b05ee8bacb000d68@thread.tacv2&groupId=37bbf3ad-c05a-4e67-b0cc-12bcd1479beb)

## Technical Approach
- Use **alembic_version_a10** as version table for a10-octavia alembic migration


## Config Changes
<pre>
<b>N/A</b>
</pre>


## Test Cases
1. run alembic upgrade head with the patch
Steps:
- use original a10-octaiva downgrade database to base
- run alembic upgrade head with this patch
- check database see alembic_version_a10 is created and with head revision in it.



## Manual Testing

```shell
alembic upgrade head
```

- Result:

```shell
mysql> show tables;
+----------------------------+
| Tables_in_octavia          |
+----------------------------+
| alembic_version            |
| alembic_version_a10        |
| algorithm                  |
| amphora                    |
| amphora_build_request      |
| amphora_build_slots        |
| amphora_health             |
| amphora_roles              |
| client_authentication_mode |
| flavor                     |
| flavor_profile             |
| health_monitor             |
| health_monitor_type        |
| l7policy                   |
| l7policy_action            |
| l7rule                     |
| l7rule_compare_type        |
| l7rule_type                |
| lb_topology                |
| listener                   |
| listener_statistics        |
| load_balancer              |
| member                     |
| nat_pool                   |
| operating_status           |
| pool                       |
| protocol                   |
| provisioning_status        |
| quotas                     |
| session_persistence        |
| session_persistence_type   |
| sni                        |
| spares_pool                |
| tags                       |
| vip                        |
| vrid                       |
| vrrp_auth_method           |
| vrrp_group                 |
| vthunders                  |
+----------------------------+
39 rows in set (0.00 sec)

mysql> select * from alembic_version;
Empty set (0.00 sec)

mysql> select * from alembic_version_a10;
+--------------+
| version_num  |
+--------------+
| aa1984742932 |
+--------------+
1 row in set (0.00 sec)

```
