### PR TITLE
[STACK-2104]: Verification of write memory feature for active standby topology

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -215,6 +215,16 @@ class LoadBalancerFlows(object):
                 requires=a10constants.VTHUNDER))
         delete_LB_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
+        delete_LB_flow.add(a10_database_tasks.GetBackupVThunderByLoadBalancer(
+            requires=constants.LOADBALANCER,
+            provides=a10constants.BACKUP_VTHUNDER))
+        delete_LB_flow.add(a10_database_tasks.MarkVThunderStatusInDB(
+            name="DELETED_BACKUP",
+            rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
+            inject={"status": constants.DELETED}))
+        delete_LB_flow.add(a10_database_tasks.SetThunderUpdatedAt(
+            name="SET_BACKUP_UPDATEDAT",
+            rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
         return (delete_LB_flow, store)
 
     def get_new_lb_networking_subflow(self, topology):

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -187,6 +187,8 @@ class VThunderRepository(BaseRepository):
         query = session.query(self.model_class).filter(
             or_(self.model_class.updated_at >= self.model_class.last_write_mem,
                 self.model_class.last_write_mem == None)).filter(
+            or_(self.model_class.role == "STANDALONE",
+                self.model_class.role == "MASTER")).filter(
             or_(self.model_class.status == 'ACTIVE', self.model_class.status == 'DELETED'))
         query = query.options(noload('*'))
         return query.all()


### PR DESCRIPTION
## Description
Modified the a10_load_balancer_flows for marking the status(deleted) of backup vthunder after deleting the vthunder.
Modified the periodic write memory flow to fetch only MASTER and STANDALONE recently updated vthunder from vthunder table.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2104

## Technical Approach
1) Fetch the backup vthunder corresponding to loadbalancer  then mark the status of backup vthunder deleted.
2) Update the query to only fetch master and standalone vthunder.
 
## Manual Testing
**Create loadbalancer objects**
```
openstack loadbalancer create --vip-subnet-id vip_subnet --name lb1

openstack loadbalancer listener create --protocol TCP --protocol-port 8080 lb1 --name listener1

openstack loadbalancer listener create --protocol UDP --protocol-port 8081 lb1 --name listener2

openstack loadbalancer listener create --protocol HTTP --protocol-port 8082 lb1 --name listener3

openstack loadbalancer listener create --protocol TERMINATED_HTTPS --default-tls-container-ref http://10.64.3.129/key-manager/v1/containers/edc3754b-3934-4783-8737-c653deb4b3e7 --protocol-port 9001 lb1 --name listener4

openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener listener1 --name pool1

openstack loadbalancer member create --address 192.168.0.66 --subnet-id vip_subnet --protocol-port 80 --name member1 pool1

openstack loadbalancer member create --address 192.168.0.67 --subnet-id vip_subnet --protocol-port 80 --name member2 pool1

openstack loadbalancer l7policy create --action REJECT listener3 --name l7policy1

openstack loadbalancer l7rule create --type HEADER --compare-type EQUAL_TO --key abc --value xyz e90621ff-3da8-4ce9-948d-8e900b7cc509
```
**Result of master vthunder**
```
vThunder-vMaster[1/1](NOLICENSE)#show startup-config
slb server fb1f7_192_168_0_66 192.168.0.66
  port 80 tcp
    exit-module
  exit-module
!
slb server fb1f7_192_168_0_67 192.168.0.67
  port 80 tcp
    exit-module
  exit-module
!
slb server octavia_health_manager_controller 10.64.3.129
  health-check octavia_health_monitor
  exit-module
!
slb service-group 9efd3eea-711e-40e2-a13c-48f4213f0db4 tcp
  member fb1f7_192_168_0_66 80
    exit-module
  member fb1f7_192_168_0_67 80
    exit-module
  exit-module
!
slb template client-ssl 519e4488-0dca-4517-99c9-af5cf1eb0822
  cert mycert
  key mykey
  exit-module
!
slb virtual-server b553b3a1-f216-444b-a8aa-41c1c78ecf6f 192.168.8.26
  port 8080 tcp
    name d1b5be6d-b5d1-4a10-8f72-108560a93051
    conn-limit 6000
    extended-stats
    service-group 9efd3eea-711e-40e2-a13c-48f4213f0db4
    exit-module
  port 8081 udp
    name 13c540e5-9704-4b71-a797-17d5c6132e37
    conn-limit 6000
    extended-stats
    exit-module
  port 8082 http
    name 631b71fa-1eea-4127-80f4-0dd61af2f3e6
    extended-stats
    aflex e90621ff-3da8-4ce9-948d-8e900b7cc509
    exit-module
  port 9001 https
    name 519e4488-0dca-4517-99c9-af5cf1eb0822
    conn-limit 6000
    extended-stats
    template client-ssl 519e4488-0dca-4517-99c9-af5cf1eb0822
    exit-module
  exit-module
  ```
**Result on blade vthunder**
```
vThunder-vBlade[1/2](NOLICENSE)#show startup-config

slb server fb1f7_192_168_0_66 192.168.0.66
  port 80 tcp
    exit-module
  exit-module
!
slb server fb1f7_192_168_0_67 192.168.0.67
  port 80 tcp
    exit-module
  exit-module
!
slb server octavia_health_manager_controller 10.64.3.129
  health-check octavia_health_monitor
  exit-module
!
slb service-group 9efd3eea-711e-40e2-a13c-48f4213f0db4 tcp
  member fb1f7_192_168_0_66 80
    exit-module
  member fb1f7_192_168_0_67 80
    exit-module
  exit-module
!
slb template client-ssl 519e4488-0dca-4517-99c9-af5cf1eb0822
  cert mycert
  key mykey
  exit-module
!
slb virtual-server b553b3a1-f216-444b-a8aa-41c1c78ecf6f 192.168.8.26
  port 8080 tcp
    name d1b5be6d-b5d1-4a10-8f72-108560a93051
    conn-limit 6000
    extended-stats
    service-group 9efd3eea-711e-40e2-a13c-48f4213f0db4
    exit-module
  port 8081 udp
    name 13c540e5-9704-4b71-a797-17d5c6132e37
    conn-limit 6000
    extended-stats
    exit-module
  port 8082 http
    name 631b71fa-1eea-4127-80f4-0dd61af2f3e6
    extended-stats
    aflex e90621ff-3da8-4ce9-948d-8e900b7cc509
    exit-module
  port 9001 https
    name 519e4488-0dca-4517-99c9-af5cf1eb0822
    conn-limit 6000
    extended-stats
    template client-ssl 519e4488-0dca-4517-99c9-af5cf1eb0822
    exit-module
  exit-module
```
![image](https://user-images.githubusercontent.com/76765492/109131256-9f75a400-7778-11eb-9318-1c2e6a65a702.png)


![image](https://user-images.githubusercontent.com/76765492/109131293-a997a280-7778-11eb-9241-e1ce6f6fba1f.png)
