### PR TITLE
[V1][STACK-2101]: Run a10-octavia and openstack victoria, add fixes if required.

### DIFF
--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -300,7 +300,6 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                 vthunder_conf=CONF.hardware_thunder.devices[lb.project_id],
                 topology=topology, listeners=lb.listeners)
             create_lb_tf = self.taskflow_load(create_lb_flow, store=store)
-            self.taskflow_load()
         else:
             create_lb_flow = self._lb_flows.get_create_load_balancer_flow(
                 topology=topology, listeners=lb.listeners)

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -80,7 +80,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         :returns: amphora_id
         """
-        create_vthunder_tf = self._taskflow_load(
+        create_vthunder_tf = self.taskflow_load(
             self._vthunder_flows.get_create_vthunder_flow(),
             store={constants.BUILD_TYPE_PRIORITY:
                    constants.LB_CREATE_SPARES_POOL_PRIORITY}
@@ -110,7 +110,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         pool.health_monitor = health_mon
         load_balancer = pool.load_balancer
 
-        create_hm_tf = self._taskflow_load(
+        create_hm_tf = self.taskflow_load(
             self._health_monitor_flows.get_create_health_monitor_flow(),
             store={constants.HEALTH_MON: health_mon,
                    constants.POOL: pool,
@@ -135,7 +135,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         listeners = pool.listeners
         load_balancer = pool.load_balancer
 
-        delete_hm_tf = self._taskflow_load(
+        delete_hm_tf = self.taskflow_load(
             self._health_monitor_flows.get_delete_health_monitor_flow(),
             store={constants.HEALTH_MON: health_mon,
                    constants.POOL: pool,
@@ -171,7 +171,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         pool.health_monitor = health_mon
         load_balancer = pool.load_balancer
 
-        update_hm_tf = self._taskflow_load(
+        update_hm_tf = self.taskflow_load(
             self._health_monitor_flows.get_update_health_monitor_flow(),
             store={constants.HEALTH_MON: health_mon,
                    constants.POOL: pool,
@@ -200,7 +200,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         if (listener.project_id in parent_project_list or
                 (listener_parent_proj and listener_parent_proj in parent_project_list)
                 or listener.project_id in CONF.hardware_thunder.devices):
-            create_listener_tf = self._taskflow_load(self._listener_flows.
+            create_listener_tf = self.taskflow_load(self._listener_flows.
                                                      get_rack_vthunder_create_listener_flow(
                                                          listener.project_id),
                                                      store={constants.LOADBALANCER:
@@ -208,7 +208,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                                                             constants.LISTENER:
                                                             listener})
         else:
-            create_listener_tf = self._taskflow_load(self._listener_flows.
+            create_listener_tf = self.taskflow_load(self._listener_flows.
                                                      get_create_listener_flow(),
                                                      store={constants.LOADBALANCER:
                                                             load_balancer,
@@ -227,12 +227,12 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         load_balancer = listener.load_balancer
 
         if listener.project_id in CONF.hardware_thunder.devices:
-            delete_listener_tf = self._taskflow_load(
+            delete_listener_tf = self.taskflow_load(
                 self._listener_flows.get_delete_rack_listener_flow(),
                 store={constants.LOADBALANCER: load_balancer,
                        constants.LISTENER: listener})
         else:
-            delete_listener_tf = self._taskflow_load(
+            delete_listener_tf = self.taskflow_load(
                 self._listener_flows.get_delete_listener_flow(),
                 store={constants.LOADBALANCER: load_balancer,
                        constants.LISTENER: listener})
@@ -257,7 +257,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         load_balancer = listener.load_balancer
 
-        update_listener_tf = self._taskflow_load(self._listener_flows.
+        update_listener_tf = self.taskflow_load(self._listener_flows.
                                                  get_update_listener_flow(),
                                                  store={constants.LISTENER:
                                                         listener,
@@ -299,11 +299,12 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             create_lb_flow = self._lb_flows.get_create_rack_vthunder_load_balancer_flow(
                 vthunder_conf=CONF.hardware_thunder.devices[lb.project_id],
                 topology=topology, listeners=lb.listeners)
-            create_lb_tf = self._taskflow_load(create_lb_flow, store=store)
+            create_lb_tf = self.taskflow_load(create_lb_flow, store=store)
+            self.taskflow_load()
         else:
             create_lb_flow = self._lb_flows.get_create_load_balancer_flow(
                 topology=topology, listeners=lb.listeners)
-            create_lb_tf = self._taskflow_load(create_lb_flow, store=store)
+            create_lb_tf = self.taskflow_load(create_lb_flow, store=store)
 
         with tf_logging.DynamicLoggingListener(
                 create_lb_tf, log=LOG,
@@ -326,7 +327,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                       constants.VIP: lb.vip,
                       constants.SERVER_GROUP_ID: lb.server_group_id})
 
-        delete_lb_tf = self._taskflow_load(flow, store=store)
+        delete_lb_tf = self.taskflow_load(flow, store=store)
 
         with tf_logging.DynamicLoggingListener(delete_lb_tf,
                                                log=LOG):
@@ -351,7 +352,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             db_apis.get_session(),
             load_balancer_id=load_balancer_id)
 
-        update_lb_tf = self._taskflow_load(
+        update_lb_tf = self.taskflow_load(
             self._lb_flows.get_update_load_balancer_flow(),
             store={constants.LOADBALANCER: lb,
                    constants.VIP: lb.vip,
@@ -394,7 +395,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         if (member.project_id in parent_project_list or
                 (member_parent_proj and member_parent_proj in parent_project_list)
                 or member.project_id in CONF.hardware_thunder.devices):
-            create_member_tf = self._taskflow_load(
+            create_member_tf = self.taskflow_load(
                 self._member_flows.get_rack_vthunder_create_member_flow(),
                 store={
                     constants.MEMBER: member,
@@ -402,7 +403,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                     constants.LOADBALANCER: load_balancer,
                     constants.POOL: pool})
         else:
-            create_member_tf = self._taskflow_load(self._member_flows.
+            create_member_tf = self.taskflow_load(self._member_flows.
                                                    get_create_member_flow(
                                                        topology=topology),
                                                    store={constants.MEMBER: member,
@@ -430,13 +431,13 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         load_balancer = pool.load_balancer
 
         if member.project_id in CONF.hardware_thunder.devices:
-            delete_member_tf = self._taskflow_load(
+            delete_member_tf = self.taskflow_load(
                 self._member_flows.get_rack_vthunder_delete_member_flow(),
                 store={constants.MEMBER: member, constants.LISTENERS: listeners,
                        constants.LOADBALANCER: load_balancer, constants.POOL: pool}
             )
         else:
-            delete_member_tf = self._taskflow_load(
+            delete_member_tf = self.taskflow_load(
                 self._member_flows.get_delete_member_flow(),
                 store={constants.MEMBER: member, constants.LISTENERS: listeners,
                        constants.LOADBALANCER: load_balancer, constants.POOL: pool}
@@ -477,7 +478,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         load_balancer = pool.load_balancer
 
         if member.project_id in CONF.hardware_thunder.devices:
-            update_member_tf = self._taskflow_load(self._member_flows.
+            update_member_tf = self.taskflow_load(self._member_flows.
                                                    get_rack_vthunder_update_member_flow(),
                                                    store={constants.MEMBER: member,
                                                           constants.LISTENERS:
@@ -487,7 +488,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                                                           constants.POOL: pool,
                                                           constants.UPDATE_DICT: member_updates})
         else:
-            update_member_tf = self._taskflow_load(self._member_flows.get_update_member_flow(),
+            update_member_tf = self.taskflow_load(self._member_flows.get_update_member_flow(),
                                                    store={constants.MEMBER: member,
                                                           constants.LISTENERS:
                                                           listeners,
@@ -527,7 +528,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             default_listener = pool.listeners[0]
         load_balancer = pool.load_balancer
 
-        create_pool_tf = self._taskflow_load(self._pool_flows.
+        create_pool_tf = self.taskflow_load(self._pool_flows.
                                              get_create_pool_flow(),
                                              store={constants.POOL: pool,
                                                     constants.LISTENERS:
@@ -566,7 +567,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                  constants.HEALTH_MON: health_monitor,
                  a10constants.MEMBER_COUNT: mem_count}
 
-        delete_pool_tf = self._taskflow_load(
+        delete_pool_tf = self.taskflow_load(
             self._pool_flows.get_delete_pool_flow(
                 members, health_monitor, store),
             store=store)
@@ -601,7 +602,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             default_listener = pool.listeners[0]
         load_balancer = pool.load_balancer
 
-        update_pool_tf = self._taskflow_load(self._pool_flows.
+        update_pool_tf = self.taskflow_load(self._pool_flows.
                                              get_update_pool_flow(),
                                              store={constants.POOL: pool,
                                                     constants.LISTENERS:
@@ -638,7 +639,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         listeners = [l7policy.listener]
         load_balancer = l7policy.listener.load_balancer
 
-        create_l7policy_tf = self._taskflow_load(
+        create_l7policy_tf = self.taskflow_load(
             self._l7policy_flows.get_create_l7policy_flow(),
             store={constants.L7POLICY: l7policy,
                    constants.LISTENERS: listeners,
@@ -659,7 +660,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         load_balancer = l7policy.listener.load_balancer
         listeners = [l7policy.listener]
 
-        delete_l7policy_tf = self._taskflow_load(
+        delete_l7policy_tf = self.taskflow_load(
             self._l7policy_flows.get_delete_l7policy_flow(),
             store={constants.L7POLICY: l7policy,
                    constants.LISTENERS: listeners,
@@ -692,7 +693,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         listeners = [l7policy.listener]
         load_balancer = l7policy.listener.load_balancer
 
-        update_l7policy_tf = self._taskflow_load(
+        update_l7policy_tf = self.taskflow_load(
             self._l7policy_flows.get_update_l7policy_flow(),
             store={constants.L7POLICY: l7policy,
                    constants.LISTENERS: listeners,
@@ -725,7 +726,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         listeners = [l7policy.listener]
         load_balancer = l7policy.listener.load_balancer
 
-        create_l7rule_tf = self._taskflow_load(
+        create_l7rule_tf = self.taskflow_load(
             self._l7rule_flows.get_create_l7rule_flow(),
             store={constants.L7RULE: l7rule,
                    constants.L7POLICY: l7policy,
@@ -747,7 +748,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         load_balancer = l7policy.listener.load_balancer
         listeners = [l7policy.listener]
 
-        delete_l7rule_tf = self._taskflow_load(
+        delete_l7rule_tf = self.taskflow_load(
             self._l7rule_flows.get_delete_l7rule_flow(),
             store={constants.L7RULE: l7rule,
                    constants.L7POLICY: l7policy,
@@ -781,7 +782,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         listeners = [l7policy.listener]
         load_balancer = l7policy.listener.load_balancer
 
-        update_l7rule_tf = self._taskflow_load(
+        update_l7rule_tf = self.taskflow_load(
             self._l7rule_flows.get_update_l7rule_flow(),
             store={constants.L7RULE: l7rule,
                    constants.L7POLICY: l7policy,
@@ -904,7 +905,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         for vthunder in thunders:
             try:
-                write_mem_tf = self._taskflow_load(
+                write_mem_tf = self.taskflow_load(
                     self._vthunder_flows.get_write_memory_flow(vthunder, store),
                     store=store)
 
@@ -924,7 +925,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         store = {}
         for vthunder in thunders:
             try:
-                reload_check_tf = self._taskflow_load(
+                reload_check_tf = self.taskflow_load(
                     self._vthunder_flows.get_reload_check_flow(vthunder, store),
                     store=store)
                 with tf_logging.DynamicLoggingListener(reload_check_tf, log=LOG):

--- a/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
@@ -16,9 +16,9 @@
 from taskflow.patterns import linear_flow
 
 from octavia.common import constants
-from octavia.controller.worker.tasks import database_tasks
-from octavia.controller.worker.tasks import lifecycle_tasks
-from octavia.controller.worker.tasks import model_tasks
+from octavia.controller.worker.v2.tasks import database_tasks
+from octavia.controller.worker.v2.tasks import lifecycle_tasks
+from octavia.controller.worker.v2.tasks import model_tasks
 
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks

--- a/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
@@ -16,8 +16,8 @@
 from taskflow.patterns import linear_flow
 
 from octavia.common import constants
-from octavia.controller.worker.v2.tasks import database_tasks
-from octavia.controller.worker.v2.tasks import lifecycle_tasks
+from octavia.controller.worker.v1.tasks import database_tasks
+from octavia.controller.worker.v1.tasks import lifecycle_tasks
 from octavia.controller.worker.v1.tasks import model_tasks
 
 from a10_octavia.common import a10constants

--- a/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
@@ -18,7 +18,7 @@ from taskflow.patterns import linear_flow
 from octavia.common import constants
 from octavia.controller.worker.v2.tasks import database_tasks
 from octavia.controller.worker.v2.tasks import lifecycle_tasks
-from octavia.controller.worker.v2.tasks import model_tasks
+from octavia.controller.worker.v1.tasks import model_tasks
 
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks

--- a/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
@@ -17,7 +17,7 @@ from taskflow.patterns import linear_flow
 from octavia.common import constants
 from octavia.controller.worker.v2.tasks import database_tasks
 from octavia.controller.worker.v2.tasks import lifecycle_tasks
-from octavia.controller.worker.v2.tasks import model_tasks
+from octavia.controller.worker.v1.tasks import model_tasks
 
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks

--- a/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
@@ -15,9 +15,9 @@
 from taskflow.patterns import linear_flow
 
 from octavia.common import constants
-from octavia.controller.worker.tasks import database_tasks
-from octavia.controller.worker.tasks import lifecycle_tasks
-from octavia.controller.worker.tasks import model_tasks
+from octavia.controller.worker.v2.tasks import database_tasks
+from octavia.controller.worker.v2.tasks import lifecycle_tasks
+from octavia.controller.worker.v2.tasks import model_tasks
 
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks

--- a/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
@@ -15,8 +15,8 @@
 from taskflow.patterns import linear_flow
 
 from octavia.common import constants
-from octavia.controller.worker.v2.tasks import database_tasks
-from octavia.controller.worker.v2.tasks import lifecycle_tasks
+from octavia.controller.worker.v1.tasks import database_tasks
+from octavia.controller.worker.v1.tasks import lifecycle_tasks
 from octavia.controller.worker.v1.tasks import model_tasks
 
 from a10_octavia.common import a10constants

--- a/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
@@ -16,9 +16,9 @@
 from taskflow.patterns import linear_flow
 
 from octavia.common import constants
-from octavia.controller.worker.tasks import database_tasks
-from octavia.controller.worker.tasks import lifecycle_tasks
-from octavia.controller.worker.tasks import model_tasks
+from octavia.controller.worker.v2.tasks import database_tasks
+from octavia.controller.worker.v2.tasks import lifecycle_tasks
+from octavia.controller.worker.v2.tasks import model_tasks
 
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks

--- a/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
@@ -16,8 +16,8 @@
 from taskflow.patterns import linear_flow
 
 from octavia.common import constants
-from octavia.controller.worker.v2.tasks import database_tasks
-from octavia.controller.worker.v2.tasks import lifecycle_tasks
+from octavia.controller.worker.v1.tasks import database_tasks
+from octavia.controller.worker.v1.tasks import lifecycle_tasks
 from octavia.controller.worker.v1.tasks import model_tasks
 
 from a10_octavia.common import a10constants

--- a/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
@@ -18,7 +18,7 @@ from taskflow.patterns import linear_flow
 from octavia.common import constants
 from octavia.controller.worker.v2.tasks import database_tasks
 from octavia.controller.worker.v2.tasks import lifecycle_tasks
-from octavia.controller.worker.v2.tasks import model_tasks
+from octavia.controller.worker.v1.tasks import model_tasks
 
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks

--- a/a10_octavia/controller/worker/flows/a10_listener_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_listener_flows.py
@@ -17,9 +17,9 @@ from taskflow.patterns import graph_flow
 from taskflow.patterns import linear_flow
 
 from octavia.common import constants
-from octavia.controller.worker.v2.tasks import database_tasks
-from octavia.controller.worker.v2.tasks import lifecycle_tasks
-from octavia.controller.worker.v2.tasks import network_tasks
+from octavia.controller.worker.v1.tasks import database_tasks
+from octavia.controller.worker.v1.tasks import lifecycle_tasks
+from octavia.controller.worker.v1.tasks import network_tasks
 
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks

--- a/a10_octavia/controller/worker/flows/a10_listener_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_listener_flows.py
@@ -17,9 +17,9 @@ from taskflow.patterns import graph_flow
 from taskflow.patterns import linear_flow
 
 from octavia.common import constants
-from octavia.controller.worker.tasks import database_tasks
-from octavia.controller.worker.tasks import lifecycle_tasks
-from octavia.controller.worker.tasks import network_tasks
+from octavia.controller.worker.v2.tasks import database_tasks
+from octavia.controller.worker.v2.tasks import lifecycle_tasks
+from octavia.controller.worker.v2.tasks import network_tasks
 
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -19,14 +19,14 @@ from taskflow.patterns import unordered_flow
 
 from octavia.common import constants
 from octavia.common import exceptions
-from octavia.controller.worker.flows import amphora_flows
-from octavia.controller.worker.flows import listener_flows
-from octavia.controller.worker.flows import member_flows
-from octavia.controller.worker.flows import pool_flows
-from octavia.controller.worker.tasks import compute_tasks
-from octavia.controller.worker.tasks import database_tasks
-from octavia.controller.worker.tasks import lifecycle_tasks
-from octavia.controller.worker.tasks import network_tasks
+from octavia.controller.worker.v2.flows import amphora_flows
+from octavia.controller.worker.v2.flows import listener_flows
+from octavia.controller.worker.v2.flows import member_flows
+from octavia.controller.worker.v2.flows import pool_flows
+from octavia.controller.worker.v2.tasks import compute_tasks
+from octavia.controller.worker.v2.tasks import database_tasks
+from octavia.controller.worker.v2.tasks import lifecycle_tasks
+from octavia.controller.worker.v2.tasks import network_tasks
 
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.flows import vthunder_flows

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -19,14 +19,14 @@ from taskflow.patterns import unordered_flow
 
 from octavia.common import constants
 from octavia.common import exceptions
-from octavia.controller.worker.v2.flows import amphora_flows
-from octavia.controller.worker.v2.flows import listener_flows
-from octavia.controller.worker.v2.flows import member_flows
-from octavia.controller.worker.v2.flows import pool_flows
-from octavia.controller.worker.v2.tasks import compute_tasks
-from octavia.controller.worker.v2.tasks import database_tasks
-from octavia.controller.worker.v2.tasks import lifecycle_tasks
-from octavia.controller.worker.v2.tasks import network_tasks
+from octavia.controller.worker.v1.flows import amphora_flows
+from octavia.controller.worker.v1.flows import listener_flows
+from octavia.controller.worker.v1.flows import member_flows
+from octavia.controller.worker.v1.flows import pool_flows
+from octavia.controller.worker.v1.tasks import compute_tasks
+from octavia.controller.worker.v1.tasks import database_tasks
+from octavia.controller.worker.v1.tasks import lifecycle_tasks
+from octavia.controller.worker.v1.tasks import network_tasks
 
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.flows import vthunder_flows

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -17,9 +17,9 @@ from oslo_config import cfg
 from taskflow.patterns import linear_flow
 
 from octavia.common import constants
-from octavia.controller.worker.tasks import database_tasks
-from octavia.controller.worker.tasks import lifecycle_tasks
-from octavia.controller.worker.tasks import model_tasks
+from octavia.controller.worker.v2.tasks import database_tasks
+from octavia.controller.worker.v2.tasks import lifecycle_tasks
+from octavia.controller.worker.v2.tasks import model_tasks
 
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -19,7 +19,7 @@ from taskflow.patterns import linear_flow
 from octavia.common import constants
 from octavia.controller.worker.v2.tasks import database_tasks
 from octavia.controller.worker.v2.tasks import lifecycle_tasks
-from octavia.controller.worker.v2.tasks import model_tasks
+from octavia.controller.worker.v1.tasks import model_tasks
 
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_database_tasks

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -17,8 +17,8 @@ from oslo_config import cfg
 from taskflow.patterns import linear_flow
 
 from octavia.common import constants
-from octavia.controller.worker.v2.tasks import database_tasks
-from octavia.controller.worker.v2.tasks import lifecycle_tasks
+from octavia.controller.worker.v1.tasks import database_tasks
+from octavia.controller.worker.v1.tasks import lifecycle_tasks
 from octavia.controller.worker.v1.tasks import model_tasks
 
 from a10_octavia.common import a10constants

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -19,7 +19,7 @@ from taskflow.patterns import linear_flow
 from octavia.common import constants
 from octavia.controller.worker.v2.tasks import database_tasks
 from octavia.controller.worker.v2.tasks import lifecycle_tasks
-from octavia.controller.worker.v2.tasks import model_tasks
+from octavia.controller.worker.v1.tasks import model_tasks
 
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.flows import a10_health_monitor_flows

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -17,9 +17,9 @@ from taskflow.patterns import graph_flow
 from taskflow.patterns import linear_flow
 
 from octavia.common import constants
-from octavia.controller.worker.tasks import database_tasks
-from octavia.controller.worker.tasks import lifecycle_tasks
-from octavia.controller.worker.tasks import model_tasks
+from octavia.controller.worker.v2.tasks import database_tasks
+from octavia.controller.worker.v2.tasks import lifecycle_tasks
+from octavia.controller.worker.v2.tasks import model_tasks
 
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.flows import a10_health_monitor_flows

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -17,8 +17,8 @@ from taskflow.patterns import graph_flow
 from taskflow.patterns import linear_flow
 
 from octavia.common import constants
-from octavia.controller.worker.v2.tasks import database_tasks
-from octavia.controller.worker.v2.tasks import lifecycle_tasks
+from octavia.controller.worker.v1.tasks import database_tasks
+from octavia.controller.worker.v1.tasks import lifecycle_tasks
 from octavia.controller.worker.v1.tasks import model_tasks
 
 from a10_octavia.common import a10constants

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -19,7 +19,7 @@ from taskflow.patterns import graph_flow
 from taskflow.patterns import linear_flow
 
 from octavia.common import constants
-from octavia.controller.worker.tasks import database_tasks
+from octavia.controller.worker.v2.tasks import database_tasks
 
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_compute_tasks as compute_tasks

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -19,7 +19,7 @@ from taskflow.patterns import graph_flow
 from taskflow.patterns import linear_flow
 
 from octavia.common import constants
-from octavia.controller.worker.v2.tasks import database_tasks
+from octavia.controller.worker.v1.tasks import database_tasks
 
 from a10_octavia.common import a10constants
 from a10_octavia.controller.worker.tasks import a10_compute_tasks as compute_tasks

--- a/a10_octavia/controller/worker/tasks/a10_compute_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_compute_tasks.py
@@ -20,7 +20,7 @@ from taskflow.types import failure
 
 from octavia.common import constants
 from octavia.common import exceptions
-from octavia.controller.worker.v2.tasks.compute_tasks import BaseComputeTask
+from octavia.controller.worker.v1.tasks.compute_tasks import BaseComputeTask
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)

--- a/a10_octavia/controller/worker/tasks/a10_compute_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_compute_tasks.py
@@ -20,7 +20,7 @@ from taskflow.types import failure
 
 from octavia.common import constants
 from octavia.common import exceptions
-from octavia.controller.worker.tasks.compute_tasks import BaseComputeTask
+from octavia.controller.worker.v2.tasks.compute_tasks import BaseComputeTask
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -25,7 +25,7 @@ from taskflow import task
 from taskflow.types import failure
 
 from octavia.common import constants
-from octavia.controller.worker import task_utils
+from octavia.controller.worker.v2 import task_utils
 from octavia.network import base
 from octavia.network import data_models as n_data_models
 

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -25,7 +25,7 @@ from taskflow import task
 from taskflow.types import failure
 
 from octavia.common import constants
-from octavia.controller.worker.v2 import task_utils
+from octavia.controller.worker import task_utils
 from octavia.network import base
 from octavia.network import data_models as n_data_models
 

--- a/a10_octavia/controller/worker/tasks/common.py
+++ b/a10_octavia/controller/worker/tasks/common.py
@@ -18,7 +18,7 @@ from oslo_config import cfg
 from oslo_log import log as logging
 from taskflow import task
 
-from octavia.controller.worker import task_utils as task_utilities
+from octavia.controller.worker.v2 import task_utils as task_utilities
 
 import acos_client
 

--- a/a10_octavia/install/install-a10-octavia
+++ b/a10_octavia/install/install-a10-octavia
@@ -8,15 +8,7 @@ if [ "$EUID" -ne 0 ]
     exit
 fi
 
-# Figuring out correct pip version
-pip2 -V
-if [ $? -eq 0 ]; then
-   alias pip='pip2'
-else
-   alias pip='pip3'
-fi
-
-SYSTEMD_SCRIPT_DIR=$(pip show a10-octavia | grep Location | awk '{print $2}')
+SYSTEMD_SCRIPT_DIR=$(pip3 show a10-octavia | grep Location | awk '{print $2}')
 SYSTEMD_SCRIPT_DIR="${SYSTEMD_SCRIPT_DIR}/a10_octavia/install"
 
 CONTROLLER="a10-controller-worker.service"

--- a/a10_octavia/install/install-a10-octavia-dev
+++ b/a10_octavia/install/install-a10-octavia-dev
@@ -8,15 +8,7 @@ if [ "$EUID" -ne 0 ]
     exit
 fi
 
-# Figuring out correct pip version
-pip2 -V
-if [ $? -eq 0 ]; then
-   alias pip='pip2'
-else
-   alias pip='pip3'
-fi
-
-SYSTEMD_SCRIPT_DIR=$(pip show a10-octavia | grep Location | awk '{print $2}')
+SYSTEMD_SCRIPT_DIR=$(pip3 show a10-octavia | grep Location | awk '{print $2}')
 SYSTEMD_SCRIPT_DIR="${SYSTEMD_SCRIPT_DIR}/a10_octavia/install"
 
 CONTROLLER="a10-controller-worker.service"

--- a/a10_octavia/tests/unit/controller/worker/flows/test_a10_load_balancer_flows.py
+++ b/a10_octavia/tests/unit/controller/worker/flows/test_a10_load_balancer_flows.py
@@ -40,7 +40,7 @@ RACK_DEVICE = {
 }
 
 
-@mock.patch("octavia.controller.worker.v2.tasks.database_tasks.UpdateAmphoraVIPData")
+@mock.patch("octavia.controller.worker.v1.tasks.database_tasks.UpdateAmphoraVIPData")
 class TestLoadBalancerFlows(base.TestCase):
     def setUp(self):
         super(TestLoadBalancerFlows, self).setUp()

--- a/a10_octavia/tests/unit/controller/worker/flows/test_a10_load_balancer_flows.py
+++ b/a10_octavia/tests/unit/controller/worker/flows/test_a10_load_balancer_flows.py
@@ -40,7 +40,7 @@ RACK_DEVICE = {
 }
 
 
-@mock.patch("octavia.controller.worker.tasks.database_tasks.UpdateAmphoraVIPData")
+@mock.patch("octavia.controller.worker.v2.tasks.database_tasks.UpdateAmphoraVIPData")
 class TestLoadBalancerFlows(base.TestCase):
     def setUp(self):
         super(TestLoadBalancerFlows, self).setUp()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 acos-client>=2.1.0		#
-octavia>=4.1.1,<5.0.0.0rc1	# stein version of octavia
+octavia>=7.0.0			# victoria version of octavia
 octavia-lib			#
 keystone>=15.0.1,<16.0.0
 python-barbicanclient>=4.5.2 	# copied from octavia requirements.txt
 python-glanceclient>=2.8.0 	# Apache-2.0
 python-novaclient>=9.1.0 	# Apache-2.0
-pyOpenSSL>=17.1.0 		# Apache-2.0
+pyOpenSSL>=19.1.0 		# Apache-2.0
 
-taskflow>=2.16.0		# copied from octavia requirements.txt
-tenacity>=4.9.0 		# copied from octavia requirements.txt
+taskflow>=4.4.0			# copied from octavia requirements.txt
+tenacity>=5.0.4 		# copied from octavia requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 acos-client>=2.1.0		#
 octavia>=7.0.0			# victoria version of octavia
 octavia-lib			#
-keystone>=15.0.1,<16.0.0
+keystone==18.0.0
 python-barbicanclient>=4.5.2 	# copied from octavia requirements.txt
 python-glanceclient>=2.8.0 	# Apache-2.0
 python-novaclient>=9.1.0 	# Apache-2.0
@@ -9,3 +9,4 @@ pyOpenSSL>=19.1.0 		# Apache-2.0
 
 taskflow>=4.4.0			# copied from octavia requirements.txt
 tenacity>=5.0.4 		# copied from octavia requirements.txt
+jsonschema>=3.2.0		# 


### PR DESCRIPTION
## Description
While setting up a10-Octavia on OpenStack victoria, the fixes required to a10-octavia according to the new Octavia(7.1.0) version.
This PR uses Amphora V1 provider driver and controller worker.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2101

## Technical Approach
- Installed a10-octavia on victoria 
- Updated the requirements with updated versions of packages.
- While restarting the a10-controller-worker service faced import issues, fixed those issues.

##Manual Testing
- Checked create and delete operation LB, listener, pool, HM, member, L7policy, L7rule.
