### PR TITLE
STACK-2162  Fix travis and tox unit-test issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,15 @@
 language: python
 jobs:
   include:
-  - name: "2.7 Unit Tests"
-    python: "2.7"
-    env: TOX_ENV=py27
-  - name: "3.5 Unit Tests"
-    python: "3.5"
-    env: TOX_ENV=py35
   - name: "3.6 Unit Tests"
     python: "3.6"
     env: TOX_ENV=py36
   - name: "3.7 Unit Tests"
     python: "3.7"
     env: TOX_ENV=py37
+  - name: "3.8 Unit Tests"
+    python: "3.8"
+    env: TOX_ENV=py38
   - name: "Pep8 tests using Flake8"
     python: "3.7"
     env: TOX_ENV=pep8

--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -14,6 +14,9 @@
 
 GET_VTHUNDER_FOR_LB_SUBFLOW = 'octavia-get-vthunder-for-lb-subflow'
 
+# Octavia taskflow flow and task names (missing name in victoria octavia)
+RELOADLOAD_BALANCER = 'octavia-reloadload-balancer'
+
 VTHUNDER = 'vthunder'
 STATUS = 'status'
 ROLE = 'role'

--- a/a10_octavia/common/defaults.py
+++ b/a10_octavia/common/defaults.py
@@ -14,23 +14,10 @@
 
 DEFAULT = {
     'arp_disable': False,
-    'default_virtual_server_vrid': None,
-    'logging_template': None,
-    'policy_template': None,
-    'template_virtual_server': None,
-    'default_virtual_server_vrid': None,
+    'default_virtual_server_vrid': 0,
     'ipinip': False,
-    'no_dest_nat': None,
-    'ha_conn_mirror': None,
-    'template_virtual_port': None,
-    'template_tcp': None,
-    'template_policy': None,
+    'no_dest_nat': False,
     'autosnat': True,
-    'conn_limit': None,
-    'template_http': None,
-    'templates': None,
-    'conn_limit': None,
-    'conn_resume': None,
-    'templates': None,
+    'conn_limit': 64000000,
     'use_rcv_hop_for_resp': False
 }

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -201,19 +201,19 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                 (listener_parent_proj and listener_parent_proj in parent_project_list)
                 or listener.project_id in CONF.hardware_thunder.devices):
             create_listener_tf = self.taskflow_load(self._listener_flows.
-                                                     get_rack_vthunder_create_listener_flow(
-                                                         listener.project_id),
-                                                     store={constants.LOADBALANCER:
-                                                            load_balancer,
-                                                            constants.LISTENER:
-                                                            listener})
+                                                    get_rack_vthunder_create_listener_flow(
+                                                        listener.project_id),
+                                                    store={constants.LOADBALANCER:
+                                                           load_balancer,
+                                                           constants.LISTENER:
+                                                           listener})
         else:
             create_listener_tf = self.taskflow_load(self._listener_flows.
-                                                     get_create_listener_flow(),
-                                                     store={constants.LOADBALANCER:
-                                                            load_balancer,
-                                                            constants.LISTENER:
-                                                            listener})
+                                                    get_create_listener_flow(),
+                                                    store={constants.LOADBALANCER:
+                                                           load_balancer,
+                                                           constants.LISTENER:
+                                                           listener})
 
         with tf_logging.DynamicLoggingListener(create_listener_tf,
                                                log=LOG):
@@ -258,14 +258,14 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         load_balancer = listener.load_balancer
 
         update_listener_tf = self.taskflow_load(self._listener_flows.
-                                                 get_update_listener_flow(),
-                                                 store={constants.LISTENER:
-                                                        listener,
-                                                        constants.LOADBALANCER:
-                                                            load_balancer,
-                                                        constants.UPDATE_DICT:
-                                                            listener_updates
-                                                        })
+                                                get_update_listener_flow(),
+                                                store={constants.LISTENER:
+                                                       listener,
+                                                       constants.LOADBALANCER:
+                                                           load_balancer,
+                                                       constants.UPDATE_DICT:
+                                                           listener_updates
+                                                       })
         with tf_logging.DynamicLoggingListener(update_listener_tf, log=LOG):
             update_listener_tf.run()
 
@@ -403,14 +403,14 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                     constants.POOL: pool})
         else:
             create_member_tf = self.taskflow_load(self._member_flows.
-                                                   get_create_member_flow(
-                                                       topology=topology),
-                                                   store={constants.MEMBER: member,
-                                                          constants.LISTENERS:
-                                                          listeners,
-                                                          constants.LOADBALANCER:
-                                                          load_balancer,
-                                                          constants.POOL: pool})
+                                                  get_create_member_flow(
+                                                      topology=topology),
+                                                  store={constants.MEMBER: member,
+                                                         constants.LISTENERS:
+                                                         listeners,
+                                                         constants.LOADBALANCER:
+                                                         load_balancer,
+                                                         constants.POOL: pool})
 
         with tf_logging.DynamicLoggingListener(create_member_tf,
                                                log=LOG):
@@ -478,25 +478,25 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         if member.project_id in CONF.hardware_thunder.devices:
             update_member_tf = self.taskflow_load(self._member_flows.
-                                                   get_rack_vthunder_update_member_flow(),
-                                                   store={constants.MEMBER: member,
-                                                          constants.LISTENERS:
-                                                              listeners,
-                                                          constants.LOADBALANCER:
-                                                              load_balancer,
-                                                          constants.POOL: pool,
-                                                          constants.UPDATE_DICT: member_updates})
+                                                  get_rack_vthunder_update_member_flow(),
+                                                  store={constants.MEMBER: member,
+                                                         constants.LISTENERS:
+                                                             listeners,
+                                                         constants.LOADBALANCER:
+                                                             load_balancer,
+                                                         constants.POOL: pool,
+                                                         constants.UPDATE_DICT: member_updates})
         else:
             update_member_tf = self.taskflow_load(self._member_flows.get_update_member_flow(),
-                                                   store={constants.MEMBER: member,
-                                                          constants.LISTENERS:
-                                                          listeners,
-                                                          constants.LOADBALANCER:
-                                                          load_balancer,
-                                                          constants.POOL:
-                                                          pool,
-                                                          constants.UPDATE_DICT:
-                                                          member_updates})
+                                                  store={constants.MEMBER: member,
+                                                         constants.LISTENERS:
+                                                         listeners,
+                                                         constants.LOADBALANCER:
+                                                         load_balancer,
+                                                         constants.POOL:
+                                                         pool,
+                                                         constants.UPDATE_DICT:
+                                                         member_updates})
 
         with tf_logging.DynamicLoggingListener(update_member_tf,
                                                log=LOG):
@@ -528,13 +528,13 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         load_balancer = pool.load_balancer
 
         create_pool_tf = self.taskflow_load(self._pool_flows.
-                                             get_create_pool_flow(),
-                                             store={constants.POOL: pool,
-                                                    constants.LISTENERS:
-                                                        listeners,
-                                                    constants.LISTENER: default_listener,
-                                                    constants.LOADBALANCER:
-                                                        load_balancer})
+                                            get_create_pool_flow(),
+                                            store={constants.POOL: pool,
+                                                   constants.LISTENERS:
+                                                       listeners,
+                                                   constants.LISTENER: default_listener,
+                                                   constants.LOADBALANCER:
+                                                       load_balancer})
         with tf_logging.DynamicLoggingListener(create_pool_tf,
                                                log=LOG):
             create_pool_tf.run()
@@ -602,16 +602,15 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         load_balancer = pool.load_balancer
 
         update_pool_tf = self.taskflow_load(self._pool_flows.
-                                             get_update_pool_flow(),
-                                             store={constants.POOL: pool,
-                                                    constants.LISTENERS:
-                                                        listeners,
-                                                    constants.LISTENER: default_listener,
-                                                    constants.LOADBALANCER:
-                                                        load_balancer,
-
-                                                    constants.UPDATE_DICT:
-                                                        pool_updates})
+                                            get_update_pool_flow(),
+                                            store={constants.POOL: pool,
+                                                   constants.LISTENERS:
+                                                       listeners,
+                                                   constants.LISTENER: default_listener,
+                                                   constants.LOADBALANCER:
+                                                       load_balancer,
+                                                   constants.UPDATE_DICT:
+                                                       pool_updates})
         with tf_logging.DynamicLoggingListener(update_pool_tf,
                                                log=LOG):
             update_pool_tf.run()

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -232,7 +232,7 @@ class LoadBalancerFlows(object):
             requires=constants.LOADBALANCER,
             provides=constants.AMPHORAE_NETWORK_CONFIG))
         new_LB_net_subflow.add(database_tasks.GetAmphoraeFromLoadbalancer(
-            requires=constants.LOADBALANCER,
+            requires=constants.LOADBALANCER_ID,
             provides=constants.AMPHORA))
         new_LB_net_subflow.add(
             vthunder_tasks.VThunderComputeConnectivityWait(

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -127,7 +127,7 @@ class VThunderFlows(object):
             provides=constants.AMPHORA_ID))
         # VIP subnet integration at bootup
         create_amp_for_lb_subflow.add(database_tasks.ReloadLoadBalancer(
-            name=sf_name + '-' + constants.RELOADLOAD_BALANCER,
+            name=sf_name + '-' + a10constants.RELOADLOAD_BALANCER,
             requires=constants.LOADBALANCER_ID,
             provides=constants.LOADBALANCER))
         create_amp_for_lb_subflow.add(a10_network_tasks.AllocateVIP(

--- a/a10_octavia/db/migration/alembic_migrations/env.py
+++ b/a10_octavia/db/migration/alembic_migrations/env.py
@@ -10,6 +10,9 @@ from a10_octavia import a10_config
 from a10_octavia.db import base_models
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
+
+VERSION_TABLE = 'alembic_version_a10'
+
 config = context.config
 
 # Interpret the config file for Python logging.
@@ -68,7 +71,9 @@ def run_migrations_online():
 
     with connectable.connect() as connection:
         context.configure(
-            connection=connection, target_metadata=target_metadata
+            connection=connection,
+            version_table=VERSION_TABLE,
+            target_metadata=target_metadata
         )
 
         with context.begin_transaction():


### PR DESCRIPTION
## Description
- Severity Level: LOW
- Issue Description: fix tox and travis errors

see also acos-client side changes:
https://github.com/a10networks/acos-client/pull/336

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2162

## Technical Approach
Fix errors in tox py38 and pep8 for 
- API changes in octavia
- indent problems
- victoria octavia (https://pypi.org/project/octavia/7.0.0/) requires python >= 3.6, remove travis checks for python < 3.6


## Config Changes
<pre>
<b>N/A</b>
</pre>


## Test Cases
 - sudo tox -e py38
 - sudo tox -e pep8

## Manual Testing
```shell
stack@ytsai-victoria:~/source/a10-octavia/victoria$ sudo tox -e py38
py38 develop-inst-noop: /opt/stack/source/a10-octavia/victoria
py38 installed: -e git+git@github.com:ytsai-a10/a10-octavia.git@f877937f7575753452d3bcf0b31735eb0c057cbb#egg=a10_octavia,acos-client==2.6.1,alembic==1.5.5,amqp==5.0.5,aniso8601==9.0.1,appdirs==1.4.3,attrs==20.3.0,automaton==2.3.0,bcrypt==3.2.0,beautifulsoup4==4.9.3,CacheControl==0.12.6,cachetools==4.2.1,castellan==3.7.0,certifi==2019.11.28,cffi==1.14.5,chardet==3.0.4,click==7.1.2,cliff==3.7.0,cmd2==1.5.0,colorama==0.4.3,contextlib2==0.6.0,cotyledon==1.7.3,cryptography==3.3.1,debtcollector==2.2.0,decorator==4.4.2,defusedxml==0.6.0,distlib==0.3.0,distro==1.4.0,dnspython==1.16.0,dogpile.cache==1.1.2,elementpath==2.2.0,eventlet==0.30.1,extras==1.0.0,fasteners==0.16,fixtures==3.0.0,flake8==3.8.4,Flask==1.1.2,Flask-RESTful==0.3.8,futurist==2.3.0,greenlet==1.0.0,gunicorn==20.0.4,hacking==4.0.0,html5lib==1.0.1,idna==2.8,importlib-resources==5.1.1,ipaddr==2.2.0,iso8601==0.1.14,itsdangerous==1.1.0,Jinja2==2.11.3,jmespath==0.10.0,jsonpatch==1.30,jsonpointer==2.0,jsonschema==3.2.0,keystone==18.0.0,keystoneauth1==4.3.1,keystonemiddleware==9.2.0,kombu==5.0.2,linecache2==1.0.0,lockfile==0.12.2,logutils==0.3.5,Mako==1.1.4,MarkupSafe==1.1.1,mccabe==0.6.1,mock==4.0.3,msgpack==0.6.2,munch==2.5.0,netaddr==0.8.0,netifaces==0.10.9,networkx==2.5,nose==1.3.7,oauthlib==3.1.0,octavia==7.1.0,octavia-lib==2.3.0,openstacksdk==0.53.0,os-client-config==2.1.0,os-service-types==1.7.0,osc-lib==2.3.1,oslo.cache==2.7.0,oslo.concurrency==4.4.0,oslo.config==8.4.0,oslo.context==3.1.1,oslo.db==8.5.0,oslo.i18n==5.0.1,oslo.log==4.4.0,oslo.messaging==12.7.1,oslo.middleware==4.1.1,oslo.policy==3.6.2,oslo.reports==2.2.0,oslo.serialization==4.1.0,oslo.service==2.5.0,oslo.upgradecheck==1.3.0,oslo.utils==4.8.0,osprofiler==3.4.0,packaging==20.9,passlib==1.7.4,Paste==3.5.0,PasteDeploy==2.1.1,pbr==5.5.1,pecan==1.4.0,pep517==0.8.2,prettytable==0.7.2,progress==1.5,psutil==5.8.0,pyasn1==0.4.8,pyasn1-modules==0.2.8,pycadf==3.1.1,pycodestyle==2.6.0,pycparser==2.20,pydot==1.4.2,pyflakes==2.2.0,pyinotify==0.9.6,PyJWT==2.0.1,PyMySQL==0.10.1,pyOpenSSL==20.0.1,pyparsing==2.4.6,pyperclip==1.8.2,pyroute2==0.5.14,pyrsistent==0.17.3,pysaml2==6.5.1,python-barbicanclient==5.0.1,python-cinderclient==7.3.0,python-dateutil==2.8.1,python-editor==1.0.4,python-glanceclient==3.2.2,python-keystoneclient==4.2.0,python-mimeparse==1.6.0,python-neutronclient==7.3.0,python-novaclient==17.3.0,pytoml==0.1.21,pytz==2021.1,PyYAML==5.4.1,repoze.lru==0.7,requests==2.22.0,requestsexceptions==1.4.0,retrying==1.3.3,rfc3986==1.4.0,Routes==2.5.1,scrypt==0.8.17,setproctitle==1.2.2,simplegeneric==0.8.1,simplejson==3.17.2,six==1.14.0,soupsieve==2.2,SQLAlchemy==1.3.23,sqlalchemy-migrate==0.13.0,SQLAlchemy-Utils==0.36.8,sqlparse==0.4.1,statsd==3.3.0,stevedore==3.3.0,taskflow==4.6.0,Tempita==0.5.2,tenacity==6.3.1,testresources==2.0.1,testscenarios==0.5.0,testtools==2.4.0,traceback2==1.4.0,uhashring==1.2,unittest2==1.1.0,urllib3==1.25.8,vine==5.0.0,waitress==1.4.4,warlock==1.3.3,wcwidth==0.2.5,webencodings==0.5.1,WebOb==1.8.7,WebTest==2.0.35,Werkzeug==1.0.1,wrapt==1.12.1,WSME==0.10.0,xmlschema==1.5.1,yappi==1.3.2
py38 run-test-pre: PYTHONHASHSEED='3854041253'
py38 run-test: commands[0] | nosetests -a '!db'
...............................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 239 tests in 3.577s

OK
__________________________________________________________________________________________________________________ summary __________________________________________________________________________________________________________________
  py38: commands succeeded
  congratulations :)
stack@ytsai-victoria:~/source/a10-octavia/victoria$ sudo tox -e pep8
pep8 develop-inst-noop: /opt/stack/source/a10-octavia/victoria
pep8 installed: -e git+git@github.com:ytsai-a10/a10-octavia.git@f877937f7575753452d3bcf0b31735eb0c057cbb#egg=a10_octavia,acos-client==2.6.1,alembic==1.5.5,amqp==5.0.5,aniso8601==9.0.1,appdirs==1.4.3,attrs==20.3.0,automaton==2.3.0,bcrypt==3.2.0,beautifulsoup4==4.9.3,CacheControl==0.12.6,cachetools==4.2.1,castellan==3.7.0,certifi==2019.11.28,cffi==1.14.5,chardet==3.0.4,click==7.1.2,cliff==3.7.0,cmd2==1.5.0,colorama==0.4.3,contextlib2==0.6.0,cotyledon==1.7.3,cryptography==3.4.6,debtcollector==2.2.0,decorator==4.4.2,defusedxml==0.6.0,distlib==0.3.0,distro==1.4.0,dnspython==1.16.0,dogpile.cache==1.1.2,elementpath==2.2.0,eventlet==0.30.1,extras==1.0.0,fasteners==0.16,fixtures==3.0.0,flake8==3.8.4,Flask==1.1.2,Flask-RESTful==0.3.8,futurist==2.3.0,greenlet==1.0.0,gunicorn==20.0.4,hacking==4.0.0,html5lib==1.0.1,idna==2.8,importlib-resources==5.1.1,ipaddr==2.2.0,iso8601==0.1.14,itsdangerous==1.1.0,Jinja2==2.11.3,jmespath==0.10.0,jsonpatch==1.30,jsonpointer==2.0,jsonschema==3.2.0,keystone==18.0.0,keystoneauth1==4.3.1,keystonemiddleware==9.2.0,kombu==5.0.2,linecache2==1.0.0,lockfile==0.12.2,logutils==0.3.5,Mako==1.1.4,MarkupSafe==1.1.1,mccabe==0.6.1,mock==4.0.3,msgpack==0.6.2,munch==2.5.0,netaddr==0.8.0,netifaces==0.10.9,networkx==2.5,nose==1.3.7,oauthlib==3.1.0,octavia==7.1.0,octavia-lib==2.3.0,openstacksdk==0.53.0,os-client-config==2.1.0,os-service-types==1.7.0,osc-lib==2.3.1,oslo.cache==2.7.0,oslo.concurrency==4.4.0,oslo.config==8.4.0,oslo.context==3.1.1,oslo.db==8.5.0,oslo.i18n==5.0.1,oslo.log==4.4.0,oslo.messaging==12.7.1,oslo.middleware==4.1.1,oslo.policy==3.6.2,oslo.reports==2.2.0,oslo.serialization==4.1.0,oslo.service==2.5.0,oslo.upgradecheck==1.3.0,oslo.utils==4.8.0,osprofiler==3.4.0,packaging==20.9,passlib==1.7.4,Paste==3.5.0,PasteDeploy==2.1.1,pbr==5.5.1,pecan==1.4.0,pep517==0.8.2,prettytable==0.7.2,progress==1.5,psutil==5.8.0,pyasn1==0.4.8,pyasn1-modules==0.2.8,pycadf==3.1.1,pycodestyle==2.6.0,pycparser==2.20,pydot==1.4.2,pyflakes==2.2.0,pyinotify==0.9.6,PyJWT==2.0.1,PyMySQL==0.10.1,pyOpenSSL==20.0.1,pyparsing==2.4.6,pyperclip==1.8.2,pyroute2==0.5.14,pyrsistent==0.16.0,pysaml2==6.5.1,python-barbicanclient==5.0.1,python-cinderclient==7.3.0,python-dateutil==2.8.1,python-editor==1.0.4,python-glanceclient==3.2.2,python-keystoneclient==4.2.0,python-mimeparse==1.6.0,python-neutronclient==7.3.0,python-novaclient==17.3.0,pytoml==0.1.21,pytz==2021.1,PyYAML==5.4.1,repoze.lru==0.7,requests==2.22.0,requestsexceptions==1.4.0,retrying==1.3.3,rfc3986==1.4.0,Routes==2.5.1,scrypt==0.8.17,setproctitle==1.2.2,simplegeneric==0.8.1,simplejson==3.17.2,six==1.14.0,soupsieve==2.2,SQLAlchemy==1.3.23,sqlalchemy-migrate==0.13.0,SQLAlchemy-Utils==0.36.8,sqlparse==0.4.1,statsd==3.3.0,stevedore==3.3.0,taskflow==4.6.0,Tempita==0.5.2,tenacity==6.3.1,testresources==2.0.1,testscenarios==0.5.0,testtools==2.4.0,traceback2==1.4.0,uhashring==2.0,unittest2==1.1.0,urllib3==1.25.8,vine==5.0.0,waitress==1.4.4,warlock==1.3.3,wcwidth==0.2.5,webencodings==0.5.1,WebOb==1.8.7,WebTest==2.0.35,Werkzeug==1.0.1,wrapt==1.12.1,WSME==0.10.0,xmlschema==1.5.1,yappi==1.3.2
pep8 run-test-pre: PYTHONHASHSEED='2895865245'
pep8 run-test: commands[0] | flake8
__________________________________________________________________________________________________________________ summary __________________________________________________________________________________________________________________
  pep8: commands succeeded
  congratulations :)

```
