### PR TITLE
[STACK-2099][Victoria] Add missing APIs for A10 Provider Driver

### DIFF
--- a/a10_octavia/api/drivers/driver.py
+++ b/a10_octavia/api/drivers/driver.py
@@ -45,12 +45,7 @@ class A10ProviderDriver(driver_base.ProviderDriver):
 
     # Load Balancer
     def create_vip_port(self, loadbalancer_id, project_id, vip_dictionary):
-        # No need to implement our create_vip_port() just raise NotImplementedError to
-        # let Octavia to create the port.
-        raise exceptions.NotImplementedError(
-            user_fault_string='',
-            operator_fault_string='create_vip_port() not supported in A10.'
-        )
+        super(A10ProviderDriver, self).create_vip_port(loadbalancer_id, project_id, vip_dictionary, None)
 
     def loadbalancer_create(self, loadbalancer):
         LOG.info('A10 provider load balancer loadbalancer: %s.', loadbalancer.__dict__)

--- a/a10_octavia/api/drivers/driver.py
+++ b/a10_octavia/api/drivers/driver.py
@@ -45,7 +45,8 @@ class A10ProviderDriver(driver_base.ProviderDriver):
 
     # Load Balancer
     def create_vip_port(self, loadbalancer_id, project_id, vip_dictionary):
-        super(A10ProviderDriver, self).create_vip_port(loadbalancer_id, project_id, vip_dictionary, None)
+        super(A10ProviderDriver, self).create_vip_port(loadbalancer_id, project_id,
+                                                       vip_dictionary, None)
 
     def loadbalancer_create(self, loadbalancer):
         LOG.info('A10 provider load balancer loadbalancer: %s.', loadbalancer.__dict__)

--- a/a10_octavia/api/drivers/driver.py
+++ b/a10_octavia/api/drivers/driver.py
@@ -45,8 +45,11 @@ class A10ProviderDriver(driver_base.ProviderDriver):
 
     # Load Balancer
     def create_vip_port(self, loadbalancer_id, project_id, vip_dictionary):
-        super(A10ProviderDriver, self).create_vip_port(loadbalancer_id, project_id,
-                                                       vip_dictionary, None)
+        # raise NotImplementedError to let octavia create port for us.
+        raise exceptions.NotImplementedError(
+            user_fault_string='',
+            operator_fault_string='create_vip_port() not supported in A10.'
+        )
 
     def loadbalancer_create(self, loadbalancer):
         LOG.info('A10 provider load balancer loadbalancer: %s.', loadbalancer.__dict__)
@@ -331,6 +334,7 @@ class A10ProviderDriver(driver_base.ProviderDriver):
         :return: Dictionary of availability zone metadata keys and descriptions
         :raises DriverError: An unexpected error occurred.
         """
+        # return empty dictionary for a10-octavia support nothing.
         props = {}
         return props
 

--- a/a10_octavia/api/drivers/driver.py
+++ b/a10_octavia/api/drivers/driver.py
@@ -47,8 +47,8 @@ class A10ProviderDriver(driver_base.ProviderDriver):
     def create_vip_port(self, loadbalancer_id, project_id, vip_dictionary):
         # raise NotImplementedError to let octavia create port for us.
         raise exceptions.NotImplementedError(
-            user_fault_string='',
-            operator_fault_string='create_vip_port() not supported in A10.'
+            user_fault_string='The a10 provider does not implement custom create_vip_port()',
+            operator_fault_string='The a10 provider does not implement custom create_vip_port()'
         )
 
     def loadbalancer_create(self, loadbalancer):
@@ -163,8 +163,8 @@ class A10ProviderDriver(driver_base.ProviderDriver):
 
     def member_batch_update(self, pool_id, members):
         raise exceptions.NotImplementedError(
-            user_fault_string='member_batch_update() not supported in A10.',
-            operator_fault_string='member_batch_update() not supported in A10.'
+            user_fault_string='The a10 provider does not support batch member update',
+            operator_fault_string='The a10 provider does not support batch member update'
         )
 
     # Health Monitor
@@ -352,8 +352,6 @@ class A10ProviderDriver(driver_base.ProviderDriver):
           one of the availability zone settings.
         """
         raise exceptions.NotImplementedError(
-            user_fault_string='Availability zone feature is not supported '
-                              'by a10-octaiva yet.',
-            operator_fault_string='Availability zone feature is not supported '
-                                  'by a10-octaiva yet.'
+            user_fault_string='The a10 provider does not support Availability zone feature',
+            operator_fault_string='The a10 provider does not support Availability zone feature'
         )


### PR DESCRIPTION
## Description
Add victoria missing APIs for A10 Provider driver

## Jira Ticket
**This is optional if you are an external contributor**
- Required: Add links to tickets closed here

## Technical Approach
Add victoria missing APIs for A10 Provider driver

per https://docs.openstack.org/octavia/latest/contributor/guides/providers.html

> VIP port creation
>
> Some provider drivers will want to create the Neutron port for the VIP, and others will want Octavia to create the port instead. In order to support both use cases, the create_vip_port() method will ask provider drivers to create a VIP port. If the driver expects Octavia to create the port, the driver will raise a NotImplementedError exception. Octavia will call this function before calling loadbalancer_create() in order to determine if it should create the VIP port. Octavia will call create_vip_port() with a loadbalancer ID and a partially defined VIP dictionary. Provider drivers that support port creation will create the port and return a fully populated VIP dictionary.



## Config Changes
<pre>
<b>N/A</b>
</pre>


## Test Cases
 - test `openstack loadbalancer provider capability list a10`
 - test `openstack loadbalancer create`

## Manual Testing
 - test `openstack loadbalancer provider capability list a10`
```
stack@ytsai-victoria:~/source/a10-octavia/victoria$ openstack loadbalancer provider capability list a10
+--------+---------------------------------+----------------------------------------------------------------------------------------------------+
| type   | name                            | description                                                                                        |
+--------+---------------------------------+----------------------------------------------------------------------------------------------------+
| flavor | virtual-server                  | Specify axapi that will apply to the slb virtual-server                                            |
| flavor | virtual-server.name-expressions | Specify name expression to match loadbalancers and axapi that will apply to the slb virtual-server |
| flavor | virtual-port                    | Specify axapi that will apply to the vport                                                         |
| flavor | virtual-port.name-expressions   | Specify name expression to match listeners and axapi that will apply to the vport                  |
| flavor | service-group                   | Specify axapi that will apply to the service-group                                                 |
| flavor | service-group.name-expressions  | Specify name expression to match pools and axapi that will apply to the service-group              |
| flavor | server                          | Specify axapi that will apply to the server                                                        |
| flavor | server.name-expressions         | Specify name expression to match members and axapi that will apply to the server                   |
| flavor | health-monitor                  | Specify axapi that will apply to the health monitor                                                |
| flavor | health-monitor.name-expressions | Specify name expression to match healthmonitor and axapi that will apply to the health monitor     |
| flavor | nat-pool                        | Specify axapi of default nat pool for loadbalancer                                                 |
| flavor | nat-pool-list                   | Specify axapi of nat pools for loadbalancer                                                        |
+--------+---------------------------------+----------------------------------------------------------------------------------------------------+
```

 - test `openstack loadbalancer create`
```
stack@ytsai-victoria:~/source/a10-octavia/victoria$ openstack loadbalancer create --vip-subnet-id e21b771e-d439-46b2-8fad-fd3c745367a3 --vip-address 192.168.91.59 --name vip4
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-03-05T06:17:32                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 04e2bbac-0f8a-4482-9502-d4351b94426b |
| listeners           |                                      |
| name                | vip4                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 0cc3169a379647aea0ce0c10697b75b6     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.91.59                        |
| vip_network_id      | f661c00b-9440-49bd-b4f7-ac033ec8404a |
| vip_port_id         | 95a23aba-25a8-4cac-9d17-618287c6c2ef |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | e21b771e-d439-46b2-8fad-fd3c745367a3 |
+---------------------+--------------------------------------+
stack@ytsai-victoria:~/source/a10-octavia/victoria$ openstack loadbalancer show vip4
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-03-05T06:17:32                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 04e2bbac-0f8a-4482-9502-d4351b94426b |
| listeners           |                                      |
| name                | vip4                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 0cc3169a379647aea0ce0c10697b75b6     |
| provider            | a10                                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-03-05T06:17:36                  |
| vip_address         | 192.168.91.59                        |
| vip_network_id      | f661c00b-9440-49bd-b4f7-ac033ec8404a |
| vip_port_id         | 95a23aba-25a8-4cac-9d17-618287c6c2ef |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | e21b771e-d439-46b2-8fad-fd3c745367a3 |
+---------------------+--------------------------------------+

```