### PR TITLE
[STACK-2149] Add additional checks for flavor-data

### DIFF
--- a/a10_octavia/api/drivers/driver.py
+++ b/a10_octavia/api/drivers/driver.py
@@ -256,6 +256,12 @@ class A10ProviderDriver(driver_base.ProviderDriver):
                 operator_fault_string='Failed to get the supported flavor '
                                       'metadata due to: {}'.format(str(e)))
 
+    def _validate_flavor_name_expressions(self, obj_flavor):
+        if 'name-expressions' in obj_flavor:
+            for reg_flavor in obj_flavor['name-expressions']:
+                if 'regex' not in reg_flavor or 'json' not in reg_flavor:
+                    raise Exception('key \'regex\' and \'json\' is mandatory for \'name-expressions\'')
+
     def validate_flavor(self, flavor_dict):
         try:
             validate(flavor_dict, flavor_schema.SUPPORTED_FLAVOR_SCHEMA)
@@ -267,6 +273,7 @@ class A10ProviderDriver(driver_base.ProviderDriver):
                     raise Exception('axapi key \'name\' is not allowed')
                 if 'ip-address' in flavor:
                     raise Exception('axapi key \'ip-address\' is not supported yet')
+                self._validate_flavor_name_expressions(flavor)
             if 'virtual-port' in flavor_dict:
                 flavor = flavor_dict['virtual-port']
                 if 'name' in flavor:
@@ -275,18 +282,22 @@ class A10ProviderDriver(driver_base.ProviderDriver):
                     raise Exception('axapi key \'port-number\' is not allowed')
                 if 'protocol' in flavor:
                     raise Exception('axapi key \'protocol\' is not allowed')
+                self._validate_flavor_name_expressions(flavor)
             if 'service-group' in flavor_dict:
                 flavor = flavor_dict['service-group']
                 if 'name' in flavor:
                     raise Exception('axapi key \'name\' is not allowed')
+                self._validate_flavor_name_expressions(flavor)
             if 'server' in flavor_dict:
                 flavor = flavor_dict['server']
                 if 'name' in flavor:
                     raise Exception('axapi key \'name\' is not allowed')
+                self._validate_flavor_name_expressions(flavor)
             if 'health-monitor' in flavor_dict:
                 flavor = flavor_dict['health-monitor']
                 if 'name' in flavor:
                     raise Exception('axapi key \'name\' is not allowed')
+                self._validate_flavor_name_expressions(flavor)
 
             # validate nat-pool and nat-pool-list keys
             if 'nat-pool' in flavor_dict:


### PR DESCRIPTION
## Description
The flavor support for Victoria.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2149

## Technical Approach
After fix the missing APIs problem (in another PR), the Flavor support feature works fine. So, here we just add additional checks for flavor-data.

## Config Changes
<pre>
<b>N/A</b>
</pre>

## Test Cases
- Test flavor support for virtual-server
- Test flavor support for virtual-port
- Test flavor support for service-group
- Test flavor support for member
- Test flavor support for health monitor 

## Manual Testing
- case 1
[cmd]
```
openstack loadbalancer flavorprofile create --name fp1 --provider a10 --flavor-data '{"virtual-server": {"vport-disable-action":"drop-packet", "name-expressions":[{"regex": "vip1", "json": {"user-tag":"test"}}]}}'
openstack loadbalancer flavor create --name f1 --flavorprofile fp1 --description "vtest" --enable
openstack loadbalancer create --flavor f1 --vip-subnet-id e21b771e-d439-46b2-8fad-fd3c745367a3 --vip-address 192.168.91.56  --name vip1
```

[result]
```
slb virtual-server d12fe09b-2155-4145-9cf4-d65115080376 192.168.91.56
  vport-disable-action drop-packet
  user-tag test
!
```


- case 2
[cmd]
```
openstack loadbalancer flavorprofile create --name fp_all1 --provider a10 --flavor-data '{"virtual-port": {"user-tag": "1", "name-expressions": [{"regex": "vport1",	"json": {"support-http2": 1}}]},"server": {"conn-limit": 65535, "name-expressions": [{"regex": "srv1",	"json": {"conn-resume": 5000}}]}, "service-group": {"lb-method": "fastest-response", "name-expressions": [{"regex": "sg1", "json": {"health-check-disable":1}}]}}'
openstack loadbalancer flavor create --name f_all1 --flavorprofile fp_all1 --description "flaovr all test1" --enable
openstack loadbalancer create --flavor f_all1 --vip-subnet-id e21b771e-d439-46b2-8fad-fd3c745367a3 --vip-address 192.168.91.56 --name vip1
openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name vport1 vip1
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener vport1 --name sg1
openstack loadbalancer member create --address 192.168.90.132 --subnet-id tp90 --protocol-port 80 --name srv1 sg1
```

[result]
```
slb server 0cc31_192_168_90_132 192.168.90.132
  conn-limit 65535
  conn-resume 5000
  port 80 tcp
!
slb service-group fb96aa04-a3f9-426c-97d2-baeb6ae6d1fa tcp
  method fastest-response
  health-check-disable
  member 0cc31_192_168_90_132 80
!
slb virtual-server 4a3c30ae-a0b4-424c-838f-c91fe7205917 192.168.91.56
  port 80 http
    support-http2
    name 95740ff5-30fb-4d7a-b4dc-9b372f6d5e64
    conn-limit 20000
    extended-stats
    source-nat auto
    service-group fb96aa04-a3f9-426c-97d2-baeb6ae6d1fa
    user-tag 1
!
```

- case 3:
[cmd]
```
openstack loadbalancer flavorprofile create --name fp_hm1 --provider a10 --flavor-data '{"service-group": {"lb-method": "fastest-response"}, "health-monitor": {"retry":5, "method": { "http": {"http-response-code":"201"}}, "name-expressions": [{"regex": "hm1", "json": {"timeout":8, "method": { "http": {"http-host":"my.test.com"}}}}]}}'
openstack loadbalancer flavor create --name f_hm1 --flavorprofile fp_hm1 --description "hm test1" --enable
openstack loadbalancer create --flavor f_hm1 --vip-subnet-id e21b771e-d439-46b2-8fad-fd3c745367a3 --vip-address 192.168.91.56 --name vip1
openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name vport1 vip1
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener vport1 --name sg1
openstack loadbalancer healthmonitor create --delay 30 --timeout 3 --max-retries 3 --type HTTP sg1 --name hm1
```

[result]
```
health monitor a0119bce-2e09-4e58-a721-036690c00231
  retry 5
  override-port 80
  interval 30 timeout 8
  method http port 80 expect response-code 200 host my.test.com url GET /
!
slb service-group 789800bf-8cb0-4a67-b203-162ab9b8eb49 tcp
  method fastest-response
  health-check a0119bce-2e09-4e58-a721-036690c00231
!
slb virtual-server 7b13ce65-1157-4f03-a62f-66811e3f9e3e 192.168.91.56
  port 80 http
    name f06aedab-097d-436e-adf5-8029542ea108
    conn-limit 20000
    extended-stats
    source-nat auto
    service-group 789800bf-8cb0-4a67-b203-162ab9b8eb49
!
```