### PR TITLE
[BUG][STACK-2166][LoadBalancer]: Unable delete LB when it is in error state.

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -820,7 +820,7 @@ class CountLoadbalancersWithFlavor(BaseDatabaseTask):
     def execute(self, loadbalancer, vthunder):
         try:
             project_list = []
-            if vthunder.hierarchical_multitenancy == 'enable':
+            if vthunder and vthunder.hierarchical_multitenancy == 'enable':
                 project_list = self.vthunder_repo.get_project_list_using_partition(
                     db_apis.get_session(),
                     partition_name=vthunder.partition_name,


### PR DESCRIPTION
## Description
- Required: High
- Required: When VRID is not created, tried creating LB which fails causes LB to enter ERROR state. When we try to delete LB  an error is caused. The reason is vthunder object is not created before accessing it.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2166

## Technical Approach
- Checked the logs for deletion of LB.

## Manual Testing
- Deletion of LB which is in error state.