### PR TITLE
[BUG][STACK-2213][STACK-2217][STACK-2218][STACK-2215]: When LB in error state, we could not delete LB. VRID FIP for vthunder LB not created.

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -147,6 +147,9 @@ class LoadBalancerFlows(object):
 
         post_create_lb_flow.add(database_tasks.UpdateLoadbalancerInDB(
             requires=[constants.LOADBALANCER, constants.UPDATE_DICT]))
+
+        post_create_lb_flow.add(self.handle_vrid_for_loadbalancer_subflow())
+
         if mark_active:
             post_create_lb_flow.add(database_tasks.MarkLBActiveInDB(
                 name=sf_name + '-' + constants.MARK_LB_ACTIVE_INDB,

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -67,24 +67,25 @@ class VThunderComputeConnectivityWait(VThunderBaseTask):
     def execute(self, vthunder, amphora):
         """Execute get_info routine for a vThunder until it responds."""
         try:
-            axapi_client = a10_utils.get_axapi_client(vthunder)
-            LOG.info("Attempting to connect vThunder device for connection.")
-            attempts = 30
-            while attempts >= 0:
-                try:
-                    attempts = attempts - 1
-                    axapi_client.system.information()
-                    break
-                except (req_exceptions.ConnectionError, acos_errors.ACOSException,
-                        http_client.BadStatusLine, req_exceptions.ReadTimeout):
-                    attemptid = 21 - attempts
-                    time.sleep(20)
-                    LOG.debug("VThunder connection attempt - " + str(attemptid))
-                    pass
-            if attempts < 0:
-                LOG.error("Failed to connect vThunder in expected amount of boot time: %s",
-                          vthunder.id)
-                raise req_exceptions.ConnectionError
+            if vthunder:
+                axapi_client = a10_utils.get_axapi_client(vthunder)
+                LOG.info("Attempting to connect vThunder device for connection.")
+                attempts = 30
+                while attempts >= 0:
+                    try:
+                        attempts = attempts - 1
+                        axapi_client.system.information()
+                        break
+                    except (req_exceptions.ConnectionError, acos_errors.ACOSException,
+                            http_client.BadStatusLine, req_exceptions.ReadTimeout):
+                        attemptid = 21 - attempts
+                        time.sleep(20)
+                        LOG.debug("VThunder connection attempt - " + str(attemptid))
+                        pass
+                if attempts < 0:
+                    LOG.error("Failed to connect vThunder in expected amount of boot time: %s",
+                              vthunder.id)
+                    raise req_exceptions.ConnectionError
 
         except driver_except.TimeOutException as e:
             LOG.exception("Amphora compute instance failed to become reachable. "
@@ -930,16 +931,17 @@ class AmphoraePostNetworkUnplug(VThunderBaseTask):
     def execute(self, added_ports, loadbalancer, vthunder):
         """Execute get_info routine for a vThunder until it responds."""
         try:
-            amphora_id = loadbalancer.amphorae[0].id
-            if len(added_ports[amphora_id]) > 0:
-                self.axapi_client.system.action.write_memory()
-                self.axapi_client.system.action.reload_reboot_for_interface_detachment(
-                    vthunder.acos_version)
-                LOG.debug("Waiting for 30 seconds to trigger vThunder reload/reboot.")
-                time.sleep(30)
-                LOG.debug("Successfully rebooted/reloaded vThunder: %s", vthunder.id)
-            else:
-                LOG.debug("vThunder reboot/relaod is not required for member addition.")
+            if loadbalancer.amphorae:
+                amphora_id = loadbalancer.amphorae[0].id
+                if len(added_ports[amphora_id]) > 0:
+                    self.axapi_client.system.action.write_memory()
+                    self.axapi_client.system.action.reload_reboot_for_interface_detachment(
+                        vthunder.acos_version)
+                    LOG.debug("Waiting for 30 seconds to trigger vThunder reload/reboot.")
+                    time.sleep(30)
+                    LOG.debug("Successfully rebooted/reloaded vThunder: %s", vthunder.id)
+                else:
+                    LOG.debug("vThunder reboot/relaod is not required for member addition.")
         except (acos_errors.ACOSException, req_exceptions.ConnectionError) as e:
             LOG.exception("Failed to reboot/reload vthunder device: %s", str(e))
             raise e

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -713,3 +713,14 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         mock_task.execute(added_ports, LB, thunder)
         self.client_mock.system.action.write_memory.assert_not_called()
         self.client_mock.system.action.reload_reboot_for_interface_detachment.assert_not_called()
+
+    def test_AmphoraePostNetworkUnplug_amophora_not_available(self):
+        mock_thunder = copy.deepcopy(VTHUNDER)
+        mock_LB = copy.deepcopy(LB)
+        mock_LB.amphorae = []
+        added_ports = {}
+        mock_task = task.AmphoraePostNetworkUnplug()
+        mock_task.axapi_client = self.client_mock
+        mock_task.execute(added_ports, mock_LB, mock_thunder)
+        self.client_mock.system.action.write_memory.assert_not_called()
+        self.client_mock.system.action.reload_reboot_for_interface_detachment.assert_not_called()

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ deps = -r{toxinidir}/requirements.txt
        pyrsistent>0.15.4,<=0.16.0
        alembic==1.4.3
        uhashring==1.2
+       decorator==4.4.2
 
 [testenv:pep8]
 commands = flake8


### PR DESCRIPTION
## Description
Severity Level: High
Issue Description: 1. When LB goes into an error state we cannot delete LB.
2. VRID floating IP not getting created for vthunder LB flow. while members are working fine i.e, VRID floating IP is working for vthunder member flow.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2213
https://a10networks.atlassian.net/browse/STACK-2217
https://a10networks.atlassian.net/browse/STACK-2218
https://a10networks.atlassian.net/browse/STACK-2212

## Technical Approach
- Added checks for objects before performing any operations on those objects.

- Logic for handling VRID floating IP is added to vthunder LB create flow. Checked the delete flow it is already integrated with handle VRID logic.

## Test Cases
- When amphorae not available for AmphoraePostNetworkUnplug.

## Manual Testing
When LB in error, we could not delete LB
- Unavailable VRID provided, created LB1 goes to an error state.
- Delete LB1 which is an error state.

VRID FIP not configured for vthunder LB.
- Create LB lb-5 in specific subnet
  `openstack loadbalancer create --vip-subnet-id 9e40a7c8-f027-40dc-b02e-e757cb10fd7e --name lb-5`
  Check vthunder 
   ![vthunder](https://user-images.githubusercontent.com/66299493/113569064-74138e00-962f-11eb-8785-6c33d3cb5312.png)

  Check whether port created or not 
   ![port_create](https://user-images.githubusercontent.com/66299493/113569820-c0ab9900-9630-11eb-962a-40bd6edcce29.png)

- Deletion of LB, configured VRID floating IP should be deleted. 

 

  
 
