### PR TITLE
[BUG][STACK-2233][STACK-2209]code update for security group/port creation/deletion

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -277,6 +277,8 @@ class LoadBalancerFlows(object):
         delete_LB_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             name=a10constants.SET_THUNDER_UPDATE_AT,
             requires=a10constants.VTHUNDER))
+        delete_LB_flow.add(network_tasks.DeallocateVIP(
+            requires=constants.LOADBALANCER))
         delete_LB_flow.add(a10_database_tasks.MarkVThunderStatusInDB(
             name=a10constants.MARK_VTHUNDER_BACKUP_DELETED_IN_DB,
             rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
@@ -290,6 +292,9 @@ class LoadBalancerFlows(object):
         """Subflow to setup networking for amphora"""
         new_LB_net_subflow = linear_flow.Flow(constants.
                                               LOADBALANCER_NETWORKING_SUBFLOW)
+        new_LB_net_subflow.add(a10_network_tasks.PlugVIP(
+            requires=constants.LOADBALANCER,
+            provides=constants.AMPS_DATA))
         new_LB_net_subflow.add(a10_network_tasks.ApplyQos(
             requires=(constants.LOADBALANCER, constants.AMPS_DATA,
                       constants.UPDATE_DICT)))

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -277,8 +277,6 @@ class LoadBalancerFlows(object):
         delete_LB_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             name=a10constants.SET_THUNDER_UPDATE_AT,
             requires=a10constants.VTHUNDER))
-        delete_LB_flow.add(a10_network_tasks.DeallocateVIP(
-            requires=constants.LOADBALANCER))
         delete_LB_flow.add(a10_database_tasks.MarkVThunderStatusInDB(
             name=a10constants.MARK_VTHUNDER_BACKUP_DELETED_IN_DB,
             rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -277,7 +277,7 @@ class LoadBalancerFlows(object):
         delete_LB_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             name=a10constants.SET_THUNDER_UPDATE_AT,
             requires=a10constants.VTHUNDER))
-        delete_LB_flow.add(network_tasks.DeallocateVIP(
+        delete_LB_flow.add(a10_network_tasks.DeallocateVIP(
             requires=constants.LOADBALANCER))
         delete_LB_flow.add(a10_database_tasks.MarkVThunderStatusInDB(
             name=a10constants.MARK_VTHUNDER_BACKUP_DELETED_IN_DB,

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -23,7 +23,6 @@ import socket
 import struct
 from taskflow import task
 from taskflow.types import failure
-import time
 
 from octavia.common import constants
 from octavia.controller.worker import task_utils
@@ -309,7 +308,6 @@ class HandleNetworkDeltas(BaseNetworkTask):
                                                        nic.network_id)
                     network = self.network_driver.get_network(nic.network_id)
                     added_ports[amp_id].append(network)
-                    time.sleep(30)
                 except base.NetworkNotFound:
                     LOG.debug("Network %d not found ", nic.network_id)
                 except Exception as e:

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -23,6 +23,7 @@ import socket
 import struct
 from taskflow import task
 from taskflow.types import failure
+import time
 
 from octavia.common import constants
 from octavia.controller.worker import task_utils
@@ -308,6 +309,7 @@ class HandleNetworkDeltas(BaseNetworkTask):
                                                        nic.network_id)
                     network = self.network_driver.get_network(nic.network_id)
                     added_ports[amp_id].append(network)
+                    time.sleep(30)
                 except base.NetworkNotFound:
                     LOG.debug("Network %d not found ", nic.network_id)
                 except Exception as e:


### PR DESCRIPTION
## Description:
1)Severity Level: High
Issue Description: security group and port are not deleted when deleting vthunder instance
2)Severity Level: High
Issue Description: failed to create listener for lb and get error: MissingVIPSecurityGroup: VIP security group is missing for load balancer

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-2209
- https://a10networks.atlassian.net/browse/STACK-2233

## Technical Approach
1)Added call to DeallocateVIP task in delete loadbalancer flow
2)Added call to PlugVip task in create loadbalancer flow
 
## Manual Testing
1) Active Standby Vthunder flow
a) Create loadbalancers
```
openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name lb1
openstack loadbalancer create --vip-subnet-id provider-vlan-12-subnet --name lb2
stack@adeeb:~$ openstack loadbalancer  list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 508586bc-4ac0-439f-b9de-7040bb98c3a1 | lb1  | 9559822352a04462a5833821dfcd72d2 | 10.0.11.178 | ACTIVE              | a10      |
| 112bd57c-2f64-46f2-952d-e0b52730985c | lb2  | 9559822352a04462a5833821dfcd72d2 | 10.0.12.181 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+

vThunder-vBlade[1/1](NOLICENSE)#show interfaces brief
Port    Link  Dupl  Speed  Trunk Vlan MAC             IP Address          IPs Flags  Name
-----------------------------------------------------------------------------------------
mgmt    Up    auto  auto   N/A   N/A  fa16.3e58.9937  192.168.0.157/24      1
1       Up    Full  10000  none  1    fa16.3e21.37b6  10.0.11.156/24        1  DataPort
2       Up    Full  10000  none  1    fa16.3e4b.2a2f  10.0.12.165/24        1  DataPort

Global Throughput:21136 bits/sec (2642 bytes/sec)
Throughput:21136 bits/sec (2642 bytes/sec)

vThunder-vMaster[1/2](NOLICENSE)#show interfaces brief
Port    Link  Dupl  Speed  Trunk Vlan MAC             IP Address          IPs Flags  Name
-----------------------------------------------------------------------------------------
mgmt    Up    auto  auto   N/A   N/A  fa16.3e42.53bc  192.168.0.82/24       1
1       Up    Full  10000  none  1    fa16.3eb8.eb4c  10.0.11.139/24        1  DataPort
2       Up    Full  10000  none  1    fa16.3ec9.c173  10.0.12.103/24        1  DataPort

Global Throughput:19176 bits/sec (2397 bytes/sec)
Throughput:19176 bits/sec (2397 bytes/sec)
```
![image](https://user-images.githubusercontent.com/76765492/114739374-6f08ba00-9d66-11eb-94b2-12558861af39.png)
Security group attached to active 
![image](https://user-images.githubusercontent.com/76765492/114739481-8b0c5b80-9d66-11eb-89f3-ee6efd322917.png)
security group attached to standby
![image](https://user-images.githubusercontent.com/76765492/114739511-92cc0000-9d66-11eb-9678-e35d29336e9a.png)

b) Delete the loadbalancer 
```
openstack loadbalancer delete lb12
vThunder-vBlade[1/2](NOLICENSE)#show interfaces brief
Port    Link  Dupl  Speed  Trunk Vlan MAC             IP Address          IPs Flags  Name
-----------------------------------------------------------------------------------------
mgmt    Up    auto  auto   N/A   N/A  fa16.3e42.53bc  192.168.0.82/24       1
1       Up    Full  10000  none  1    fa16.3eb8.eb4c  10.0.11.139/24        1  DataPort
2       Down  None  None   none  1    0000.0000.0000  0.0.0.0/0             1  DataPort

Global Throughput:9592 bits/sec (1199 bytes/sec)
Throughput:9592 bits/sec (1199 bytes/sec)

vThunder-vMaster[1/1](NOLICENSE)#show interfaces brief
Port    Link  Dupl  Speed  Trunk Vlan MAC             IP Address          IPs Flags  Name
-----------------------------------------------------------------------------------------
mgmt    Up    auto  auto   N/A   N/A  fa16.3e58.9937  192.168.0.157/24      1
1       Up    Full  10000  none  1    fa16.3e21.37b6  10.0.11.156/24        1  DataPort
2       Down  None  None   none  1    0000.0000.0000  0.0.0.0/0             1  DataPort

Global Throughput:10336 bits/sec (1292 bytes/sec)
Throughput:10336 bits/sec (1292 bytes/sec)
vThunder-vMaster[1/1](NOLICENSE)

```
lb2 Security group is deattached from both vthunders:
![image](https://user-images.githubusercontent.com/76765492/114742493-6d8cc100-9d69-11eb-950a-f7333f23186f.png)
![image](https://user-images.githubusercontent.com/76765492/114742515-741b3880-9d69-11eb-8a42-ee60218870b5.png)


c) Delete another loadbalancer
```
openstack loadbalancer delete lb1

Apr 14 15:17:42 adeeb a10-octavia-worker[30401]: INFO a10_octavia.controller.queue.endpoint [-] Deleting load balancer '418e8f2e-9f4f-487c-8726-3e467383c185'...
Apr 14 15:17:46 adeeb a10-octavia-worker[30401]: INFO octavia.network.drivers.neutron.allowed_address_pairs [-] Removing security group 56d042da-a48d-4e1f-8e91-355789db63d6 from port cc371b45-cc13-45df-8167-8b26a5338a65
Apr 14 15:17:46 adeeb a10-octavia-worker[30401]: WARNING octavia.network.drivers.neutron.allowed_address_pairs [-] Attempt 1 to remove security group 56d042da-a48d-4e1f-8e91-355789db63d6 failed.: Conflict: Security Group 56d042da-a48d-4e1f-8e91-355789db63d6 in use.
Apr 14 15:17:48 adeeb a10-octavia-worker[30401]: INFO octavia.network.drivers.neutron.allowed_address_pairs [-] Deleted security group 56d042da-a48d-4e1f-8e91-355789db63d6
```
Security groups are delete 
![image](https://user-images.githubusercontent.com/76765492/114742856-c2c8d280-9d69-11eb-92b1-99cdfc251586.png)



2) SINGLE Topology Vthunder
a) Create loadbalancers
```
openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name lb1
openstack loadbalancer create --vip-subnet-id provider-vlan-12-subnet --name lb2

vThunder(NOLICENSE)#show interfaces brief
Port    Link  Dupl  Speed  Trunk Vlan MAC             IP Address          IPs Flags  Name
-----------------------------------------------------------------------------------------
mgmt    Up    auto  auto   N/A   N/A  fa16.3e31.e1c6  192.168.0.57/24       1
1       Up    Full  10000  none  1    fa16.3e6b.3ed3  10.0.11.166/24        1  DataPort
2       Up    Full  10000  none  1    fa16.3ec3.90f0  10.0.12.165/24        1  DataPort

Global Throughput:256 bits/sec (32 bytes/sec)
Throughput:256 bits/sec (32 bytes/sec)
```
![image](https://user-images.githubusercontent.com/76765492/114743805-a711fc00-9d6a-11eb-8e8b-43784922a7fc.png)

b) Create listener
```
openstack loadbalancer listener create --name l1 --protocol TCP --protocol-port 8 lb1

Apr 14 16:15:35 adeeb a10-octavia-worker[3170]: INFO a10_octavia.controller.queue.endpoint [-] Creating listener 'd689d4f2-608b-4260-b024-d0e0f1f1dac7'...
Apr 14 16:15:36 adeeb a10-octavia-worker[3170]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.0.5:shared
```

c) Delete the loadbalancer
```
openstack loadbalancer delete lb2

vThunder(NOLICENSE)#show interfaces brief
Port    Link  Dupl  Speed  Trunk Vlan MAC             IP Address          IPs Flags  Name
-----------------------------------------------------------------------------------------
mgmt    Up    auto  auto   N/A   N/A  fa16.3e31.e1c6  192.168.0.57/24       1
1       Up    Full  10000  none  1    fa16.3e6b.3ed3  10.0.11.166/24        1  DataPort
2       Down  None  None   none  1    0000.0000.0000  0.0.0.0/0             1  DataPort

Global Throughput:0 bits/sec (0 bytes/sec)
Throughput:0 bits/sec (0 bytes/sec)

openstack loadbalancer delete lb1
logs:
Apr 14 15:40:56 adeeb a10-octavia-worker[3170]: INFO a10_octavia.controller.queue.endpoint [-] Deleting load balancer '09250d87-7e51-4c76-b3f5-500b21c57c7b'...
Apr 14 15:40:58 adeeb a10-octavia-worker[3170]: INFO octavia.network.drivers.neutron.allowed_address_pairs [-] Removing security group d71ba439-70ae-49b5-b4f0-6a6c666635c0 from port a81738db-9dc1-4e10-9e1e-ce798447cfcb
Apr 14 15:40:59 adeeb a10-octavia-worker[3170]: WARNING octavia.network.drivers.neutron.allowed_address_pairs [-] Attempt 1 to remove security group d71ba439-70ae-49b5-b4f0-6a6c666635c0 failed.: Conflict: Security Group d71ba439-70ae-49b5-b4f0-6a6c666635c0 in use.
Apr 14 15:41:00 adeeb a10-octavia-worker[3170]: INFO octavia.network.drivers.neutron.allowed_address_pairs [-] Deleted security group d71ba439-70ae-49b5-b4f0-6a6c666635c0
```

**Another test results:**
a) Create loadbalancers:
```
stack@neha:~/adeeb/a10-octavia$ openstack loadbalancer  list
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address    | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| 456d7229-688f-4a4b-a2d8-e1d76fd6c9b3 | lb1  | fff1a92846274a47b3e0fc70be022cd4 | 192.168.8.25   | ACTIVE              | a10      |
| 05d550ad-f6f8-4956-9db3-007b287bb829 | lb2  | fff1a92846274a47b3e0fc70be022cd4 | 192.168.12.212 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
vThunder(NOLICENSE)#show running-config
!Current configuration: 241 bytes
!Configuration last updated at 07:10:34 IST Thu Apr 15 2021
!Configuration last saved at 07:10:37 IST Thu Apr 15 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 192.168.8.153
  floating-ip 192.168.12.192
!
slb virtual-server 05d550ad-f6f8-4956-9db3-007b287bb829 192.168.12.212
!
slb virtual-server 456d7229-688f-4a4b-a2d8-e1d76fd6c9b3 192.168.8.25
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode

vThunder(NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e4d.437b  192.168.0.71/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3e61.6bb8  192.168.8.109/24      1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e4c.57b5  192.168.12.123/24     1  DataPort

Global Throughput:528 bits/sec (66 bytes/sec)
Throughput:528 bits/sec (66 bytes/sec)
```
b) Delete the loadbalancer
```
openstack loadbalancer delete lb2
vThunder(NOLICENSE)#show running-config
!Current configuration: 169 bytes
!Configuration last updated at 07:13:13 IST Thu Apr 15 2021
!Configuration last saved at 07:13:16 IST Thu Apr 15 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 192.168.8.153
!
slb virtual-server 456d7229-688f-4a4b-a2d8-e1d76fd6c9b3 192.168.8.25
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode

vThunder(NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e4d.437b  192.168.0.71/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3e61.6bb8  192.168.8.109/24      1  DataPort

Global Throughput:264 bits/sec (33 bytes/sec)
Throughput:264 bits/
```

c) Delete the loadbalancer lb1
```
openstack loadbalancer delete lb1
Apr 15 06:14:29 neha a10-octavia-worker[4458]: INFO a10_octavia.controller.queue.endpoint [-] Deleting load balancer '456d7229-688f-4a4b-a2d8-e1d76fd6c9b3'...
Apr 15 06:14:30 neha a10-octavia-worker[4458]: INFO a10_octavia.controller.worker.tasks.a10_network_tasks [-] VRID floating IP: 192.168.8.153 deleted
Apr 15 06:14:31 neha a10-octavia-worker[4458]: INFO octavia.network.drivers.neutron.allowed_address_pairs [-] Removing security group 2c956969-ef10-42db-802f-cb1090178c34 from port 0173da8a-5d9a-4ed8-9ddd-c2b3f15eef2b
Apr 15 06:14:32 neha a10-octavia-worker[4458]: WARNING octavia.network.drivers.neutron.allowed_address_pairs [-] Attempt 1 to remove security group 2c956969-ef10-42db-802f-cb1090178c34 failed.: Conflict: Security Group 2c956969-ef10-42db-802f-cb1090178c34 in use.
Apr 15 06:14:33 neha a10-octavia-worker[4458]: INFO octavia.network.drivers.neutron.allowed_address_pairs [-] Deleted security group 2c956969-ef10-42db-802f-cb1090178c34
```


3) Rack flow
a) Create loadbalancers
```
openstack loadbalancer create --vip-subnet-id vip_subnet --name lb1
openstack loadbalancer create --vip-subnet-id vip_subnet --name lb1

stack@adeeb:~$ openstack loadbalancer  list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| c0cb906b-893b-4624-9aa5-cbfefd559fee | lb1  | 9559822352a04462a5833821dfcd72d2 | 192.168.8.181 | ACTIVE              | a10      |
| 84098edb-98ce-431d-8551-74e8c387e63f | lb2  | 9559822352a04462a5833821dfcd72d2 | 192.168.8.130 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
logs:
Apr 13 11:27:08 adeeb a10-octavia-worker[21483]: INFO a10_octavia.controller.queue.endpoint [-] Creating load balancer 'c0cb906b-893b-4624-9aa5-cbfefd559fee'...
Apr 13 11:27:08 adeeb a10-octavia-worker[21483]: INFO a10_octavia.controller.worker.tasks.a10_database_tasks [-] Successfully created vthunder entry in database.
Apr 13 11:27:10 adeeb a10-octavia-worker[21483]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Partition shared created
Apr 13 11:27:11 adeeb a10-octavia-worker[21483]: INFO octavia.controller.worker.tasks.database_tasks [-] Mark ACTIVE in DB for load balancer id: c0cb906b-893b-4624-9aa5-cbfefd559fee
Apr 13 11:27:11 adeeb a10-octavia-worker[21483]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 10.0.0.73:shared

Apr 13 11:27:20 adeeb a10-octavia-worker[21483]: INFO a10_octavia.controller.queue.endpoint [-] Creating load balancer '84098edb-98ce-431d-8551-74e8c387e63f'...
Apr 13 11:27:20 adeeb a10-octavia-worker[21483]: INFO a10_octavia.controller.worker.tasks.a10_database_tasks [-] Successfully created vthunder entry in database.
Apr 13 11:27:22 adeeb a10-octavia-worker[21483]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Partition shared created
Apr 13 11:27:22 adeeb a10-octavia-worker[21483]: INFO octavia.controller.worker.tasks.database_tasks [-] Mark ACTIVE in DB for load balancer id: 84098edb-98ce-431d-8551-74e8c387e63f
Apr 13 11:27:22 adeeb a10-octavia-worker[21483]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 10.0.0.73:shared
```
![image](https://user-images.githubusercontent.com/76765492/114557200-0f87ad00-9c87-11eb-8b87-fe94ca33d4ec.png)


b) Create listener
```
openstack loadbalancer listener create --name l1 --protocol TCP --protocol-port 8 lb2
logs:
Apr 13 11:27:42 adeeb a10-octavia-worker[21483]: INFO a10_octavia.controller.queue.endpoint [-] Creating listener '6afe2015-1a5d-4c58-bcc2-f7cb7d8d67f9'...
Apr 13 11:27:42 adeeb a10-octavia-worker[21483]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 10.0.0.73:shared
```

c) Delete the lbs
```
stack@adeeb:~$ openstack loadbalancer delete lb1
stack@adeeb:~$ openstack loadbalancer delete lb2  --cascade
logs:
Apr 13 11:30:43 adeeb a10-octavia-worker[21483]: INFO a10_octavia.controller.queue.endpoint [-] Deleting load balancer 'c0cb906b-893b-4624-9aa5-cbfefd559fee'...
Apr 13 11:30:43 adeeb a10-octavia-worker[21483]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Attempting to connect vThunder device for connection.
Apr 13 11:30:44 adeeb a10-octavia-worker[21483]: WARNING a10_octavia.controller.worker.tasks.nat_pool_tasks [-] Cannot delete Nat-pool(s) in flavor None as they are in use by another loadbalancer(s)
Apr 13 11:30:44 adeeb a10-octavia-worker[21483]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 10.0.0.73:shared
Apr 13 11:30:52 adeeb a10-octavia-worker[21483]: INFO a10_octavia.controller.queue.endpoint [-] Deleting load balancer '84098edb-98ce-431d-8551-74e8c387e63f'...
Apr 13 11:30:52 adeeb a10-octavia-worker[21483]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Attempting to connect vThunder device for connection.
Apr 13 11:30:52 adeeb a10-octavia-worker[21483]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 10.0.0.73:shared
```
![image](https://user-images.githubusercontent.com/76765492/114557137-01399100-9c87-11eb-9c83-a3311af48056.png)


