### PR TITLE
[BUG][STACK-2211]: Fixed KeyError issue sometimes getting while creating LB in Active-Standby mode

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -333,7 +333,8 @@ class LoadBalancerFlows(object):
                           constants.ADDED_PORTS)))
         new_LB_net_subflow.add(vthunder_tasks.EnableInterface(
             name=a10constants.ENABLE_MASTER_VTHUNDER_INTERFACE,
-            requires=(a10constants.VTHUNDER, constants.LOADBALANCER)))
+            inject={constants.ADDED_PORTS: {}},
+            requires=(a10constants.VTHUNDER, constants.LOADBALANCER, constants.ADDED_PORTS)))
         new_LB_net_subflow.add(a10_database_tasks.MarkVThunderStatusInDB(
             name=a10constants.MARK_VTHUNDER_MASTER_ACTIVE_IN_DB,
             requires=a10constants.VTHUNDER,
@@ -386,9 +387,8 @@ class LoadBalancerFlows(object):
                     provides=(a10constants.IFNUM_MASTER, a10constants.IFNUM_BACKUP)))
                 new_LB_net_subflow.add(vthunder_tasks.EnableInterface(
                     name=a10constants.MASTER_ENABLE_INTERFACE,
-                    requires=(a10constants.VTHUNDER, constants.LOADBALANCER,
-                              a10constants.IFNUM_MASTER, a10constants.IFNUM_BACKUP,
-                              constants.ADDED_PORTS)))
+                    requires=(a10constants.VTHUNDER, constants.LOADBALANCER, constants.ADDED_PORTS,
+                              a10constants.IFNUM_MASTER, a10constants.IFNUM_BACKUP)))
                 new_LB_net_subflow.add(vthunder_tasks.VCSReload(
                     name=a10constants.VCS_RELOAD,
                     requires=(a10constants.VTHUNDER)))
@@ -434,13 +434,13 @@ class LoadBalancerFlows(object):
                     provides=a10constants.VTHUNDER))
                 new_LB_net_subflow.add(vthunder_tasks.EnableInterface(
                     name=a10constants.BACKUP_ENABLE_INTERFACE,
-                    requires=(a10constants.VTHUNDER, constants.LOADBALANCER,
-                              a10constants.IFNUM_MASTER, a10constants.IFNUM_BACKUP,
-                              constants.ADDED_PORTS)))
+                    requires=(a10constants.VTHUNDER, constants.LOADBALANCER, constants.ADDED_PORTS,
+                              a10constants.IFNUM_MASTER, a10constants.IFNUM_BACKUP)))
             new_LB_net_subflow.add(vthunder_tasks.EnableInterface(
                 name=a10constants.ENABLE_BACKUP_VTHUNDER_INTERFACE,
                 rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-                requires=(constants.LOADBALANCER)))
+                inject={constants.ADDED_PORTS: {}},
+                requires=(constants.LOADBALANCER, constants.ADDED_PORTS)))
             new_LB_net_subflow.add(a10_database_tasks.MarkVThunderStatusInDB(
                 name=a10constants.MARK_VTHUNDER_BACKUP_ACTIVE_IN_DB,
                 rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -777,15 +777,16 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
                             raise e
                     vrid_floating_ips.append(vrid.vrid_floating_ip)
         else:
-            for vrid in vrid_list:
-                try:
-                    self.network_driver.delete_port(vrid.vrid_port_id)
-                except Exception as e:
-                    LOG.error(
-                        "Failed to delete neutron port for VRID FIP: %s",
-                        vrid.vrid_floating_ip)
-                    raise e
-                update_vrid_flag = True
+            if vrid_list:
+                for vrid in vrid_list:
+                    try:
+                        self.network_driver.delete_port(vrid.vrid_port_id)
+                    except Exception as e:
+                        LOG.error(
+                            "Failed to delete neutron port for VRID FIP: %s",
+                            vrid.vrid_floating_ip)
+                        raise e
+                    update_vrid_flag = True
             vrid_list = []
         if (prev_vrid_value is not None) and (prev_vrid_value != vrid_value):
             self.update_device_vrid_fip(vthunder, [], prev_vrid_value)
@@ -821,7 +822,9 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
                     str(e))
 
         # Normalize old vrid entries
-        vrid_floating_ip_list = [vrid.vrid_floating_ip for vrid in vrid_list]
+        if vrid_list:
+            vrid_floating_ip_list = [vrid.vrid_floating_ip for vrid in vrid_list]
+
         if vrid_floating_ip_list:
             vrid_value = CONF.a10_global.vrid
             try:

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -145,7 +145,7 @@ class EnableInterface(VThunderBaseTask):
     """Task to configure vThunder ports"""
 
     @axapi_client_decorator
-    def execute(self, vthunder, loadbalancer, ifnum_master=None, ifnum_backup=None, added_ports={}):
+    def execute(self, vthunder, loadbalancer, added_ports, ifnum_master=None, ifnum_backup=None):
         topology = CONF.a10_controller_worker.loadbalancer_topology
         amphora_id = loadbalancer.amphorae[0].id
         compute_id = loadbalancer.amphorae[0].compute_id
@@ -1020,6 +1020,7 @@ class GetMasterVThunder(VThunderBaseTask):
     @axapi_client_decorator
     def execute(self, vthunder):
         try:
+            time.sleep(20)
             vcs_summary = {}
             vcs_summary = self.axapi_client.system.action.get_vcs_summary_oper()
             vcs_member_list = vcs_summary['vcs-summary']['oper']['member-list']


### PR DESCRIPTION
- Severity Level: Highest
- Issue description:
   Sometimes while creating 2nd or 3rd loadbalancer, there was a KeyError occurring for added_ports where it should go as an empty dictionary.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2211

## Technical Approach
- As `added_ports` are not required for the first and last call of the `EnableInterface` task in `get_new_lb_networking_subflow`, injecting the `ADDED_PORTS` as {}.
- Removed the default value for `added_ports` from `EnableInterface` task as it is being injected where it is required to be None
- Added a check for `vrid_list` in `HandleVRIDFloatingIP` task as it was breaking when `partition_project_list` is None.
- Added time.sleep(20) in `GetMasterVThunder` task as sometimes the master's VCS config takes some time after its reload  to get back as earlier 

## Manual Testing
Step1: Create lb1 with vip_subnet1
openstack loadbalancer create --vip-subnet vip_subnet1 --name lb1

Step2: Create lb2 with vip_subnet1
openstack loadbalancer create --vip-subnet vip_subnet1 --name lb2

Step3: Create lb3 with vip_subnet2
openstack loadbalancer create --vip-subnet vip_subnet2 --name lb3

Result: 

```
vThunder-vMaster[1/2](NOLICENSE)#show running-config
!Current configuration: 781 bytes
!Configuration last updated at 12:44:34 IST Mon Apr 12 2021
!Configuration last saved at 12:44:38 IST Mon Apr 12 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.129
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb virtual-server 0f69c770-dcb0-4527-afbe-b463aff66fa6 192.168.12.147
!
slb virtual-server 3b4bc03f-03fe-40b4-b89b-721e93718902 192.168.12.96
!
slb virtual-server fee52d5d-3cdf-4bf2-a9f8-1849678b7ee4 192.168.8.81
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
```

```
vThunder-vBlade[1/1](NOLICENSE)#show running-config
!Current configuration: 781 bytes
!Configuration last updated at 12:44:35 IST Mon Apr 12 2021
!Configuration last saved at 12:42:41 IST Mon Apr 12 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.129
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb virtual-server 0f69c770-dcb0-4527-afbe-b463aff66fa6 192.168.12.147
!
slb virtual-server 3b4bc03f-03fe-40b4-b89b-721e93718902 192.168.12.96
!
slb virtual-server fee52d5d-3cdf-4bf2-a9f8-1849678b7ee4 192.168.8.81
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
```