### PR TITLE
[STACK-2219] failed to reuse a network/subnet for member creation in demo project when it's already in admin project

### DIFF
--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -72,6 +72,9 @@ class VThunderComputeConnectivityWait(VThunderBaseTask):
                 axapi_client = a10_utils.get_axapi_client(vthunder)
                 LOG.info("Attempting to connect vThunder device for connection.")
                 attempts = 30
+                # TODO(ytsai): use another new config option for vthunder booting wait retry
+                if CONF.a10_controller_worker.amp_active_retries > attempts:
+                    attempts = CONF.a10_controller_worker.amp_active_retries
                 while attempts >= 0:
                     try:
                         attempts = attempts - 1
@@ -80,7 +83,11 @@ class VThunderComputeConnectivityWait(VThunderBaseTask):
                     except (req_exceptions.ConnectionError, acos_errors.ACOSException,
                             http_client.BadStatusLine, req_exceptions.ReadTimeout):
                         attemptid = 21 - attempts
-                        time.sleep(20)
+                        sleep_time = 20
+                        # TODO(ytsai): use another new config option for vthunder booting wait sec
+                        if CONF.a10_controller_worker.amp_active_wait_sec > sleep_time:
+                            sleep_time = CONF.a10_controller_worker.amp_active_wait_sec
+                        time.sleep(sleep_time)
                         LOG.debug("VThunder connection attempt - " + str(attemptid))
                         pass
                 if attempts < 0:


### PR DESCRIPTION
## Description
If Bug Fix:
- Required: Medium
- Required: failed to reuse a network/subnet for member creation in demo project when it's already in admin project

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2219

## Technical Approach
- Didn't see this problem in latest code
- But when tested in QA's HC8000 server, the second LB creation is failed because vThunder booting time is too long. 
1. **We should provide the flexibility for user to control the timeout and retry for waiting vthunder booting up** (otherwise customer may have problem create LB for slow servers)
2. use ***amp_active_retries*** and ***amp_active_wait_sec*** for VThunderComputeConnectivityWait to decide vthunder booting timeout and retry.
3. **We should use another option for this, but it is close to release. It is not a good time to add new options now.** But we can consider use new options in the future.

## Config Changes
<pre>
<b>amp_active_retries = 200
amp_active_wait_sec = 10
</b>
</pre>

## Test Cases
- Create Loadbalancer/Listener/Pool/Member in admin project
```
openstack loadbalancer create --vip-subnet-id tp91 --vip-address 192.168.91.56 --name vip1
openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name vport1 vip1
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener vport1 --name sg1
openstack loadbalancer member create --address 192.168.90.132 --subnet-id tp90 --protocol-port 80 --name srv1 sg1
```
- Create Loadbalancer/Listener/Pool/Member in demo project
which use same vip subnet ***tp91*** and member subnet ***tp90***
```
openstack loadbalancer create --vip-subnet-id tp91 --vip-address 192.168.91.57 --name vip2
openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name vport2 vip2
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener vport2 --name sg2
openstack loadbalancer member create --address 192.168.90.133 --subnet-id tp90 --protocol-port 80 --name srv2 sg2
```

## Manual Testing
- Test same scenario as QA
The member in the demo project created successfully with same subnet
```shell
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer member create --address 192.168.90.133 --subnet-id tp90 --protocol-port 80 --name srv2 sg2
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 192.168.90.133                       |
| admin_state_up      | True                                 |
| created_at          | 2021-04-13T07:16:45                  |
| id                  | e2022f6f-3ba4-424f-8ded-8fe21bb846b0 |
| name                | srv2                                 |
| operating_status    | NO_MONITOR                           |
| project_id          | 2a7ce0ea0f8a4580a4268621c2ef0711     |
| protocol_port       | 80                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 9ed1696e-3a3f-44ec-a0da-2c73b0dc22d4 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer member list sg2
+--------------------------------------+------+----------------------------------+---------------------+----------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address        | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+----------------+---------------+------------------+--------+
| e2022f6f-3ba4-424f-8ded-8fe21bb846b0 | srv2 | 2a7ce0ea0f8a4580a4268621c2ef0711 | ACTIVE              | 192.168.90.133 |            80 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+----------------+---------------+------------------+--------+
```
