### PR TITLE
[STACK-2220] acos-client timeout too short

### DIFF
--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -60,6 +60,9 @@ A10_VTHUNDER_OPTS = [
     cfg.IntOpt('default_axapi_version',
                default=30,
                help=_('VThunder axapi version')),
+    cfg.IntOpt('default_axapi_timeout',
+               default=300,
+               help=_('VThunder axapi timeout')),
 ]
 
 A10_SLB_OPTS = [

--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -138,7 +138,7 @@ def get_axapi_client(vthunder):
     api_ver = acos_client.AXAPI_21 if vthunder.axapi_version == 21 else acos_client.AXAPI_30
     axapi_client = acos_client.Client(vthunder.ip_address, api_ver,
                                       vthunder.username, vthunder.password,
-                                      timeout=30)
+                                      timeout=CONF.vthunder.default_axapi_timeout)
     return axapi_client
 
 

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -825,14 +825,14 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
         if vrid_list:
             vrid_floating_ip_list = [vrid.vrid_floating_ip for vrid in vrid_list]
 
-            if vrid_floating_ip_list:
-                vrid_value = CONF.a10_global.vrid
-                try:
-                    self.update_device_vrid_fip(
-                        vthunder, vrid_floating_ip_list, vrid_value)
-                except Exception as e:
-                    LOG.error("Failed to update VRID floating IPs %s due to %s",
-                              vrid_floating_ip_list, str(e))
+        if vrid_floating_ip_list:
+            vrid_value = CONF.a10_global.vrid
+            try:
+                self.update_device_vrid_fip(
+                    vthunder, vrid_floating_ip_list, vrid_value)
+            except Exception as e:
+                LOG.error("Failed to update VRID floating IPs %s due to %s",
+                          vrid_floating_ip_list, str(e))
 
     def update_device_vrid_fip(
             self,

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -825,14 +825,14 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
         if vrid_list:
             vrid_floating_ip_list = [vrid.vrid_floating_ip for vrid in vrid_list]
 
-        if vrid_floating_ip_list:
-            vrid_value = CONF.a10_global.vrid
-            try:
-                self.update_device_vrid_fip(
-                    vthunder, vrid_floating_ip_list, vrid_value)
-            except Exception as e:
-                LOG.error("Failed to update VRID floating IPs %s due to %s",
-                          vrid_floating_ip_list, str(e))
+            if vrid_floating_ip_list:
+                vrid_value = CONF.a10_global.vrid
+                try:
+                    self.update_device_vrid_fip(
+                        vthunder, vrid_floating_ip_list, vrid_value)
+                except Exception as e:
+                    LOG.error("Failed to update VRID floating IPs %s due to %s",
+                              vrid_floating_ip_list, str(e))
 
     def update_device_vrid_fip(
             self,

--- a/a10_octavia/controller/worker/tasks/common.py
+++ b/a10_octavia/controller/worker/tasks/common.py
@@ -38,7 +38,7 @@ class BaseVThunderTask(task.Task):
             str(vthunder.axapi_version),
             vthunder.username,
             vthunder.password,
-            timeout=30)
+            timeout=CONF.vthunder.default_axapi_timeout)
         return c
 
     def meta(self, lbaas_obj, key, default):

--- a/a10_octavia/controller/worker/tasks/decorators.py
+++ b/a10_octavia/controller/worker/tasks/decorators.py
@@ -39,7 +39,7 @@ def axapi_client_decorator(func):
             api_ver = acos_client.AXAPI_21 if vthunder.axapi_version == 21 else acos_client.AXAPI_30
             self.axapi_client = acos_client.Client(vthunder.ip_address, api_ver,
                                                    vthunder.username, vthunder.password,
-                                                   timeout=300)
+                                                   timeout=CONF.vthunder.default_axapi_timeout)
 
             if use_shared_partition or vthunder.partition_name == 'shared':
                 activate_partition(self.axapi_client, "shared")
@@ -71,7 +71,7 @@ def axapi_client_decorator_for_revert(func):
             api_ver = acos_client.AXAPI_21 if vthunder.axapi_version == 21 else acos_client.AXAPI_30
             self.axapi_client = acos_client.Client(vthunder.ip_address, api_ver,
                                                    vthunder.username, vthunder.password,
-                                                   timeout=300)
+                                                   timeout=CONF.vthunder.default_axapi_timeout)
 
             try:
                 if use_shared_partition or vthunder.partition_name == 'shared':

--- a/a10_octavia/controller/worker/tasks/decorators.py
+++ b/a10_octavia/controller/worker/tasks/decorators.py
@@ -39,7 +39,7 @@ def axapi_client_decorator(func):
             api_ver = acos_client.AXAPI_21 if vthunder.axapi_version == 21 else acos_client.AXAPI_30
             self.axapi_client = acos_client.Client(vthunder.ip_address, api_ver,
                                                    vthunder.username, vthunder.password,
-                                                   timeout=30)
+                                                   timeout=300)
 
             if use_shared_partition or vthunder.partition_name == 'shared':
                 activate_partition(self.axapi_client, "shared")
@@ -71,7 +71,7 @@ def axapi_client_decorator_for_revert(func):
             api_ver = acos_client.AXAPI_21 if vthunder.axapi_version == 21 else acos_client.AXAPI_30
             self.axapi_client = acos_client.Client(vthunder.ip_address, api_ver,
                                                    vthunder.username, vthunder.password,
-                                                   timeout=30)
+                                                   timeout=300)
 
             try:
                 if use_shared_partition or vthunder.partition_name == 'shared':

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -506,7 +506,8 @@ class TagInterfaceBaseTask(VThunderBaseTask):
             api_ver = acos_client.AXAPI_21 if vthunder.axapi_version == 21 else acos_client.AXAPI_30
             device_obj = vthunder.device_network_map[1]
             client = acos_client.Client(device_obj.mgmt_ip_address, api_ver,
-                                        vthunder.username, vthunder.password, timeout=30)
+                                        vthunder.username, vthunder.password,
+                                        timeout=CONF.vthunder.default_axapi_timeout)
             if vthunder.partition_name != "shared":
                 activate_partition(client, vthunder.partition_name)
             close_axapi_client = True


### PR DESCRIPTION
## Description
**acos-client side PR: https://github.com/a10networks/acos-client/pull/340**
**a10-octavia side PR: https://github.com/a10networks/a10-octavia/pull/363**

If Bug Fix:
- Required: Severity Level Low
- Required: Issue Description:  Failed to create LB for public-subnet

According to the audi log:
```
vThunder(NOLICENSE)#show audi
Apr 13 2021 10:46:53  [admin] axapi: [7:192.168.0.127:34384] RESP HTTP status 400  Bad Request : Failed to acquire a DHCP offer from DHCP server.
Apr 13 2021 10:46:53  [admin] axapi: [7:192.168.0.127:34384] payload section 1
{"ethernet": {"action": "enable", "ip": {"dhcp": 1}, "ifnum": "1", "name": "DataPort"}}
Apr 13 2021 10:45:50  [admin] axapi: [7:192.168.0.127:34384] POST: /axapi/v3/interface/ethernet/1
```

- **Root Cause:**
1. The acos-client timeout is 30 seconds, but Thunder response this AXAPI request after 63 seconds.
2. the public-subnet didn’t enable dhcp service

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2220

## Technical Approach
1. set acos-client default timeout to 300, which is in another PR
2. public_subnet should enable dhcp
3. Fix some mirror issue in our revert flow

## Config Changes
<pre>
<b>N/A</b>
</pre>


## Test Cases
- Run following command
```shell
openstack loadbalancer create --vip-subnet-id public-subnet --name vip1
```


## Manual Testing
**After the patch, we can see the axapi response with the error message now (which is DHCP failed)**
```shell
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: WARNING a10_octavia.controller.worker.controller_worker [-] Flow 'octavia-create-loadbalancer-flow' (ff8cff27-6f22-4637-85ce-360e57621c8f) transitioned into state 'REVERTED' from state 'RUNNING'
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server [-] Exception during message handling: DhcpAcquireFailed: 654311505 Failed to acquire a DHCP offer from DHCP server.
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server Traceback (most recent call last):
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/server.py", line 166, in _process_incoming
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     res = self.dispatcher.dispatch(message)
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 265, in dispatch
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     return self._do_dispatch(endpoint, method, ctxt, args)
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 194, in _do_dispatch
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     result = func(ctxt, **new_args)
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/opt/stack/source/a10-octavia/vThunder/a10_octavia/controller/queue/endpoint.py", line 45, in create_load_balancer
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     self.worker.create_load_balancer(load_balancer_id, flavor)
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 292, in wrapped_f
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     return self.call(f, *args, **kw)
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 358, in call
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     do = self.iter(retry_state=retry_state)
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 319, in iter
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     return fut.result()
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/concurrent/futures/_base.py", line 455, in result
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     return self.__get_result()
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 361, in call
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     result = fn(*args, **kwargs)
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/opt/stack/source/a10-octavia/vThunder/a10_octavia/controller/worker/controller_worker.py", line 312, in create_load_balancer
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     create_lb_tf.run()
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 247, in run
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     for _state in self.run_iter(timeout=timeout):
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 340, in run_iter
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     failure.Failure.reraise_if_any(er_failures)
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 339, in reraise_if_any
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     failures[0].reraise()
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 346, in reraise
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     six.reraise(*self._exc_info)
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     result = task.execute(**arguments)
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/opt/stack/source/a10-octavia/vThunder/a10_octavia/controller/worker/tasks/decorators.py", line 52, in wrapper
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     result = func(self, *args, **kwargs)
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/opt/stack/source/a10-octavia/vThunder/a10_octavia/controller/worker/tasks/vthunder_tasks.py", line 182, in execute
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     raise e
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server DhcpAcquireFailed: 654311505 Failed to acquire a DHCP offer from DHCP server.
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server

```

