### PR TITLE
[STACK-2238] remove ve interface after LB deletion

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -205,12 +205,6 @@ class LoadBalancerFlows(object):
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
             provides=a10constants.LB_COUNT))
         delete_LB_flow.add(self.get_delete_lb_vrid_subflow())
-        if CONF.a10_global.network_type == 'vlan':
-            delete_LB_flow.add(
-                vthunder_tasks.DeleteInterfaceTagIfNotInUseForLB(
-                    requires=[
-                        constants.LOADBALANCER,
-                        a10constants.VTHUNDER]))
 
         # delete_LB_flow.add(listeners_delete)
         # delete_LB_flow.add(network_tasks.UnplugVIP(
@@ -572,12 +566,6 @@ class LoadBalancerFlows(object):
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
             provides=a10constants.LB_COUNT))
         delete_LB_flow.add(self.get_delete_lb_vrid_subflow())
-        if CONF.a10_global.network_type == 'vlan':
-            delete_LB_flow.add(
-                vthunder_tasks.DeleteInterfaceTagIfNotInUseForLB(
-                    requires=[
-                        constants.LOADBALANCER,
-                        a10constants.VTHUNDER]))
 
         # delete_LB_flow.add(listeners_delete)
         # delete_LB_flow.add(network_tasks.UnplugVIP(
@@ -589,6 +577,12 @@ class LoadBalancerFlows(object):
         delete_LB_flow.add(nat_pool_tasks.NatPoolDelete(
             requires=(constants.LOADBALANCER,
                       a10constants.VTHUNDER, a10constants.LB_COUNT, constants.FLAVOR_DATA)))
+        if CONF.a10_global.network_type == 'vlan':
+            delete_LB_flow.add(
+                vthunder_tasks.DeleteInterfaceTagIfNotInUseForLB(
+                    requires=[
+                        constants.LOADBALANCER,
+                        a10constants.VTHUNDER]))
         if deleteCompute:
             delete_LB_flow.add(compute_tasks.DeleteAmphoraeOnLoadBalancer(
                 requires=constants.LOADBALANCER))


### PR DESCRIPTION
## Description
If Bug Fix:
- Required: Severity Level High
- Required: Issue Description 
ve/vlan interface is not removed after loadbalancer deletion

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2238

## Technical Approach
1. In get_delete_rack_vthunder_load_balancer_flow, move DeleteInterfaceTagIfNotInUseForLB task after DeleteVirtualServerTask task otherwise the virtual server is still there when a10-octavia try to remove the ve/vlan interface (The vlan subnet still in used, so is_vlan_deletable() will return False and cause vlan/ve deletion  bypassed).
2. For vThunder flow the vlan is not supported, so remove DeleteInterfaceTagIfNotInUseForLB task from vthunder LB delete flow.

## Config Changes
- rack flow
<pre>
<b>[a10_health_manager]
udp_server_ip_address = 10.64.28.68
bind_port = 5550
bind_ip = 10.64.28.68
heartbeat_interval = 5
heartbeat_key = insecure
heartbeat_timeout = 90
health_check_interval = 3
failover_timeout = 600
health_check_timeout = 3
health_check_max_retries = 5

[a10_house_keeping]
load_balancer_expiry_age = 3600
amphorae_expiry_age = 3600

[a10_global]
network_type = "vlan"

[hardware_thunder]
devices = [
                    {
                     "project_id": "99c9c2304f114685a32db30769c8a7e2",
                     "interface_vlan_map": {
                        "device_1": {
                               "vcs_device_id": 1,
                               "mgmt_ip_address": "192.168.90.46",
                               "trunk_interfaces": [{
                                   "interface_num": 1,
                                   "vlan_map": [
                                       {"vlan_id": 6, "ve_ip": ".10"}
                                   ]
                               }],
                               "ethernet_interfaces": [{
                                   "interface_num": 1,
                                   "vlan_map": [
                                       {"vlan_id": 6, "ve_ip": ".199"}
                                   ]
                               }],
                        }
                     },
                     "ip_address": "192.168.90.46",
                     "username": "admin",
                     "password": "a10",
                     "device_name": "AX46"
                     }
             ]

</b>
</pre>

- vthunder flow
<pre>
<b>[a10_health_manager]
udp_server_ip_address = 10.64.28.68
bind_port = 5550
bind_ip = 10.64.28.68
heartbeat_interval = 5
heartbeat_key = insecure
heartbeat_timeout = 90
health_check_interval = 3
failover_timeout = 600
health_check_timeout = 3
health_check_max_retries = 5

[a10_house_keeping]
load_balancer_expiry_age = 3600
amphorae_expiry_age = 3600

[a10_global]
network_type = "vlan"
</b>
</pre>

## Test Cases
- rack flow
1. create loadbalancer with vlan/ve interface created
```
$ openstack loadbalancer create --vip-subnet-id tp92 --name vip1
```
2. delete loadbalancer and check vlan/ve interfaces also removed
```
$ openstack loadbalancer delete vip1
```

- vthunder flow
1. create loadbalancer and delete it, test loadbalancer deletion still works
```
$ openstack loadbalancer create --vip-subnet-id tp92 --name vip1
$ openstack loadbalancer delete vip1
```

## Manual Testing
- rack flow
1. create LB
```shell
AX1030#show running-config
!Current configuration: 731 bytes
!Configuration last updated at 23:44:05 CST Wed Apr 14 2021
!Configuration last saved at 23:44:08 CST Wed Apr 14 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 16 (Mar-19-2021,12:52)
!
vlan 6
  tagged ethernet 1
  router-interface ve 6
!
timezone Asia/Taipei
!
interface management
  ip address xxxx 255.255.255.0
  ip default-gateway xxxx
  enable
!
interface ethernet 1
  enable
!
interface ethernet 2
!
interface ethernet 3
!
interface ethernet 4
!
interface ethernet 5
!
interface ethernet 6
!
interface ethernet 7
!
interface ethernet 8
!
interface ve 6
  ip address 192.168.92.10 255.255.255.0
!
!
slb virtual-server d643ef64-5555-437d-b9ae-7dfcf2c93289 192.168.92.9
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode

AX1030#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    Full  1000   N/A   N/A  N/A       000d.480a.b644  192.168.90.46/24      1
1                   Up    Full  100    none  Tag  N/A       000d.480a.b643  0.0.0.0/0             0
2                   Up    Full  100    none  1    N/A       000d.480a.b642  192.168.91.29/24      1
3                   Up    Full  100    none  1    N/A       000d.480a.b641  192.168.92.115/24     1
4                   Disb  None  None   none  1    N/A       000d.480a.b640  0.0.0.0/0             0
5                   Disb  None  None   none  1    N/A       000d.480a.b63f  0.0.0.0/0             0
6                   Disb  None  None   none  1    N/A       000d.480a.b63e  0.0.0.0/0             0
7                   Disb  None  None   none  1    N/A       000d.480a.b63d  0.0.0.0/0             0
8                   Disb  None  None   none  1    N/A       000d.480a.b63c  0.0.0.0/0             0
ve6                 Up    N/A   N/A    N/A   6    N/A       000d.480a.b63d  192.168.92.10/24      1

```

2. delete LB

```shell
AX1030#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    Full  1000   N/A   N/A  N/A       000d.480a.b644  192.168.90.46/24      1
1                   Up    Full  100    none  1    N/A       000d.480a.b643  0.0.0.0/0             0
2                   Up    Full  100    none  1    N/A       000d.480a.b642  192.168.91.29/24      1
3                   Up    Full  100    none  1    N/A       000d.480a.b641  192.168.92.115/24     1
4                   Disb  None  None   none  1    N/A       000d.480a.b640  0.0.0.0/0             0
5                   Disb  None  None   none  1    N/A       000d.480a.b63f  0.0.0.0/0             0
6                   Disb  None  None   none  1    N/A       000d.480a.b63e  0.0.0.0/0             0
7                   Disb  None  None   none  1    N/A       000d.480a.b63d  0.0.0.0/0             0
8                   Disb  None  None   none  1    N/A       000d.480a.b63c  0.0.0.0/0             0

```
