### PR TITLE
[BUG][STACK-2244][STACK-2239][vthunder: active-standby]: server in pending_create with error: local variable 'vrid_floating_ip_list' referenced before assignment

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -400,6 +400,7 @@ class CreateSpareVThunderEntry(BaseDatabaseTask):
 class GetVRIDForLoadbalancerResource(BaseDatabaseTask):
 
     def execute(self, partition_project_list):
+        vrid_list = []
         if partition_project_list:
             try:
                 vrid_list = self.vrid_repo.get_vrid_from_project_ids(
@@ -411,6 +412,7 @@ class GetVRIDForLoadbalancerResource(BaseDatabaseTask):
                     partition_project_list,
                     str(e))
                 raise e
+        return vrid_list
 
 
 class UpdateVRIDForLoadbalancerResource(BaseDatabaseTask):

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -777,16 +777,15 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
                             raise e
                     vrid_floating_ips.append(vrid.vrid_floating_ip)
         else:
-            if vrid_list:
-                for vrid in vrid_list:
-                    try:
-                        self.network_driver.delete_port(vrid.vrid_port_id)
-                    except Exception as e:
-                        LOG.error(
-                            "Failed to delete neutron port for VRID FIP: %s",
-                            vrid.vrid_floating_ip)
-                        raise e
-                    update_vrid_flag = True
+            for vrid in vrid_list:
+                try:
+                    self.network_driver.delete_port(vrid.vrid_port_id)
+                except Exception as e:
+                    LOG.error(
+                        "Failed to delete neutron port for VRID FIP: %s",
+                        vrid.vrid_floating_ip)
+                    raise e
+                update_vrid_flag = True
             vrid_list = []
         if (prev_vrid_value is not None) and (prev_vrid_value != vrid_value):
             self.update_device_vrid_fip(vthunder, [], prev_vrid_value)
@@ -821,9 +820,7 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
                     port.id,
                     str(e))
 
-        # Normalize old vrid entries
-        if vrid_list:
-            vrid_floating_ip_list = [vrid.vrid_floating_ip for vrid in vrid_list]
+        vrid_floating_ip_list = [vrid.vrid_floating_ip for vrid in vrid_list]
 
         if vrid_floating_ip_list:
             vrid_value = CONF.a10_global.vrid


### PR DESCRIPTION
## Description
Severity Level: High
Issue Description: In active-standby mode, create lb v1 in public-11-subnet successfully. 2 vthunders are created successfully too
Then create v12-1 & v12-2 in public-12-subnet one by one without waiting for v12-1 creation is done and vthunder reload is done. then you will find ot v12-2 is created, but v12-1 will be in pending_create status and the error log will be seen

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2244
https://a10networks.atlassian.net/browse/STACK-2239

## Technical Approach
- HandleVRIDFloatingIP expects an iterable object as input. 
- enforced GetVRIDForLoadbalancerResource to return a list instead of None object.

## Test Cases
- Created lb1 and wait to boot the vthunder device.
- Created lb2 and lb3 concurrently and wait till pending status of lb2 and lb3 goes to "ERROR" or "ACTIVE"
- Delete the load balancer which is in an error state.

## Manual Testing
- Create loadbalancer lb1 for provider-vlan-11-subnet subnet.
  openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name lb1
- Create load balancer lb2, lb3 concurrently.
  openstack loadbalancer create --vip-subnet-id provider-vlan-12-subnet --name lb2
  openstack loadbalancer create --vip-subnet-id provider-vlan-12-subnet --name lb3
- Delete loadbalancer which is in error state.
![image](https://user-images.githubusercontent.com/66299493/114842512-88f1dd80-9df6-11eb-8a5e-6dd38d029daa.png)
