### PR TITLE
[BUG][STACK-2250]: Updated code for loadbalancer write-memory in rackflow

### DIFF
--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -327,7 +327,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             cascade = True
         if lb.project_id in CONF.hardware_thunder.devices:
             (flow, store) = self._lb_flows.get_delete_rack_vthunder_load_balancer_flow(
-                lb, deleteCompute, cascade)
+                lb, cascade)
         else:
             (flow, store) = self._lb_flows.get_delete_load_balancer_flow(
                 lb, deleteCompute, cascade)

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -546,7 +546,7 @@ class LoadBalancerFlows(object):
             requires=a10constants.VTHUNDER))
         return lb_create_flow
 
-    def get_delete_rack_vthunder_load_balancer_flow(self, lb, deleteCompute, cascade):
+    def get_delete_rack_vthunder_load_balancer_flow(self, lb, cascade):
         """Flow to delete rack load balancer"""
 
         store = {}
@@ -593,9 +593,6 @@ class LoadBalancerFlows(object):
         delete_LB_flow.add(nat_pool_tasks.NatPoolDelete(
             requires=(constants.LOADBALANCER,
                       a10constants.VTHUNDER, a10constants.LB_COUNT, constants.FLAVOR_DATA)))
-        if deleteCompute:
-            delete_LB_flow.add(compute_tasks.DeleteAmphoraeOnLoadBalancer(
-                requires=constants.LOADBALANCER))
         delete_LB_flow.add(a10_database_tasks.MarkVThunderStatusInDB(
             name=a10constants.MARK_VTHUNDER_MASTER_DELETED_IN_DB,
             requires=a10constants.VTHUNDER,
@@ -608,9 +605,8 @@ class LoadBalancerFlows(object):
             requires=constants.LOADBALANCER))
         delete_LB_flow.add(database_tasks.DecrementLoadBalancerQuota(
             requires=constants.LOADBALANCER))
-        if deleteCompute:
-            delete_LB_flow.add(vthunder_tasks.WriteMemory(
-                requires=a10constants.VTHUNDER))
+        delete_LB_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
         delete_LB_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             name=a10constants.SET_THUNDER_UPDATE_AT,
             requires=a10constants.VTHUNDER))


### PR DESCRIPTION
## Description
Severity Level: Low
Issue Description: [Rackflow] on deleting loadbalancer, write memory is not performed.

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-2250

## Technical Approach
- Removed the deleteCompute flag from the get_delete_rack_vthunder_load_balancer_flow method.

## Manual Testing
1) Create loadbalancer
```
openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name lb1
logs:
Apr 15 11:41:23 adeeb a10-octavia-worker[14045]: INFO a10_octavia.controller.queue.endpoint [-] Creating load balancer 'e21043f0-6e97-45ba-91c5-5e79e35edb0e'...
Apr 15 11:41:23 adeeb a10-octavia-worker[14045]: INFO a10_octavia.controller.worker.tasks.a10_database_tasks [-] Successfully created vthunder entry in database.
Apr 15 11:41:29 adeeb a10-octavia-worker[14045]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Partition shared created
Apr 15 11:41:29 adeeb a10-octavia-worker[14045]: INFO octavia.controller.worker.tasks.database_tasks [-] Mark ACTIVE in DB for load balancer id: e21043f0-6e97-45ba-91c5-5e79e35edb0e
Apr 15 11:41:29 adeeb a10-octavia-worker[14045]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 10.0.0.60:shared

vThunder(NOLICENSE)#show running-config
!Current configuration: 256 bytes
!Configuration last updated at 12:41:28 IST Thu Apr 15 2021
!Configuration last saved at 12:41:31 IST Thu Apr 15 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
!
interface ethernet 2
!
interface ethernet 3
!
interface ethernet 4
!
!
slb virtual-server e21043f0-6e97-45ba-91c5-5e79e35edb0e 10.0.11.108
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#show star
vThunder(NOLICENSE)#show startup-config
Show default startup-config
Building configuration...

!Current configuration: 615 bytes
!Configuration last updated at 12:41:28 IST Thu Apr 15 2021
!Configuration last saved at 12:41:31 IST Thu Apr 15 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
!
!
interface management
  ip address dhcp
  exit-module
!
interface ethernet 1
  exit-module
!
interface ethernet 2
  exit-module
!
interface ethernet 3
  exit-module
!
interface ethernet 4
  exit-module
!
!
slb virtual-server e21043f0-6e97-45ba-91c5-5e79e35edb0e 10.0.11.108
  exit-module

!rba-config-start
!

!rba-config-end
!
cloud-services meta-data
vThunder(NOLICENSE)#

```

2) Delete the loadbalancer
```
openstack loadbalancer delete lb1
logs:
Apr 15 11:43:10 adeeb a10-octavia-worker[14045]: INFO a10_octavia.controller.queue.endpoint [-] Deleting load balancer 'e21043f0-6e97-45ba-91c5-5e79e35edb0e'...
Apr 15 11:43:11 adeeb a10-octavia-worker[14045]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 10.0.0.60:shared

vThunder(NOLICENSE)#show running-config
!Current configuration: 187 bytes
!Configuration last updated at 12:43:09 IST Thu Apr 15 2021
!Configuration last saved at 12:43:14 IST Thu Apr 15 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
!
interface ethernet 2
!
interface ethernet 3
!
interface ethernet 4
!
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode

vThunder(NOLICENSE)#show startup-config
Show default startup-config
Building configuration...

!Current configuration: 530 bytes
!Configuration last updated at 12:43:09 IST Thu Apr 15 2021
!Configuration last saved at 12:43:14 IST Thu Apr 15 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
!
!
interface management
  ip address dhcp
  exit-module
!
interface ethernet 1
  exit-module
!
interface ethernet 2
  exit-module
!
interface ethernet 3
  exit-module
!
interface ethernet 4
  exit-module
!

!rba-config-start
!

!rba-config-end
!
cloud-services meta-data
  enable
  provider openstack
  exit-module
vThunder(NOLICENSE)#
```





