### PR TITLE
[STACK-2253] ACTIVE-STANDBY VRID FIP issue

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -75,7 +75,6 @@ class MemberFlows(object):
                     constants.ADDED_PORTS,
                     constants.LOADBALANCER,
                     a10constants.VTHUNDER]))
-        create_member_flow.add(self.handle_vrid_for_member_subflow())
         # configure member flow for HA
         if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
             create_member_flow.add(
@@ -101,6 +100,7 @@ class MemberFlows(object):
                         constants.ADDED_PORTS, constants.LOADBALANCER], rebind={
                         a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
 
+        create_member_flow.add(self.handle_vrid_for_member_subflow())
         create_member_flow.add(a10_database_tasks.CountMembersWithIP(
             requires=constants.MEMBER, provides=a10constants.MEMBER_COUNT_IP
         ))


### PR DESCRIPTION
## Description
If Bug Fix:
- Required: Severity Level Critical
- Required: Issue Description
When vrid_floating_ip is configured in [a10_global], member creation will failed in ACTIVE-STANDBY mode.

[Root Cause]
In current flow, we do handle_vrid_for_member_subflow() after master reload but before blade reload. So, a10-octavia try to set VRID FIP when vthunder is still as BLADE. And axapi will return failed for blade is not allow to do configuration.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2253

## Technical Approach
Move handle_vrid_for_member_subflow() after both master and blade are reloaded. (so, the vthunder is master now and able to do configuration)


## Config Changes
<pre>
<b>[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
#default_axapi_timeout = 600

[a10_controller_worker]
amp_image_owner_id = 99c9c2304f114685a32db30769c8a7e2
amp_secgroup_list = 2d0a3480-7f08-4184-b96f-c39bb444dd38
amp_flavor_id = 69995a83-c47a-427f-bf70-e9d9752aa915
amp_boot_network_list = 7f8ddd7f-c5c3-463a-b1c3-596f988480a4
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 200
amp_active_wait_sec = 10
amp_image_id = 0a845873-bd91-4f8c-ad58-cf5d5afde09c
#loadbalancer_topology = SINGLE
loadbalancer_topology = ACTIVE_STANDBY

[a10_health_manager]
udp_server_ip_address = 10.64.28.68
bind_port = 5550
bind_ip = 10.64.28.68
heartbeat_interval = 5
heartbeat_key = insecure
heartbeat_timeout = 90
health_check_interval = 3
failover_timeout = 600
health_check_timeout = 3
health_check_max_retries = 5

[a10_house_keeping]
load_balancer_expiry_age = 3600
amphorae_expiry_age = 3600
#use_periodic_write_memory = 'enable'
#write_mem_interval = 300

[a10_global]
network_type = "flat"
#network_type = "vlan"
vrid_floating_ip = "dhcp"</b>
</pre>


## Test Cases
- Same as QA (**need to configure vrid_floating_ip to reproduce this bug**)
```shell
openstack loadbalancer create --vip-subnet-id tp91 --name vip1
openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name vport1 vip1
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener vport1 --name sg1
openstack loadbalancer member create --address 192.168.90.132 --subnet-id tp90 --protocol-port 80 --name srv1 sg1
```

## Manual Testing
Result:
- openstack side
```
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer member list sg1
+--------------------------------------+------+----------------------------------+---------------------+----------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address        | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+----------------+---------------+------------------+--------+
| 8198417d-0f2b-4384-9fb2-f62824d6c19a | srv1 | 99c9c2304f114685a32db30769c8a7e2 | ACTIVE              | 192.168.90.132 |            80 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+----------------+---------------+------------------+--------+
```
- vthunder
```shell
vrrp-a vrid 0
  floating-ip 192.168.90.237
  floating-ip 192.168.91.213
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.28.68
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server 99c9c_192_168_90_132 192.168.90.132
  port 80 tcp
!
slb server octavia_health_manager_controller 10.64.28.68
  health-check octavia_health_monitor
!
slb service-group 3fe6f492-a023-4068-b825-037ea3441782 tcp
  member 99c9c_192_168_90_132 80
!
slb virtual-server 966f88de-9d9e-4b2e-86c5-3005525d6ad1 192.168.91.71
  port 80 http
    name 388d8cbc-82b4-4b3d-ac26-2fdd1e1116a0
    extended-stats
    service-group 3fe6f492-a023-4068-b825-037ea3441782
!

```