### PR TITLE
[BUG][Stack 2261]: [vthunder mode switch] Return error response when vthunder has loadbalancer with topology

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -71,6 +71,14 @@ class LoadBalancerFlows(object):
         lb_create_flow.add(lifecycle_tasks.LoadBalancerIDToErrorOnRevertTask(
             requires=constants.LOADBALANCER_ID))
 
+        lb_create_flow.add(database_tasks.ReloadLoadBalancer(
+            requires=constants.LOADBALANCER_ID,
+            provides=constants.LOADBALANCER))
+
+        lb_create_flow.add(a10_database_tasks.CheckExistingVthunderTopology(
+            requires=constants.LOADBALANCER,
+            inject={"topology": topology}))
+
         # Attaching vThunder to LB in database
         if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
             lb_create_flow.add(*self._create_active_standby_topology())

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -934,6 +934,7 @@ class GetLoadBalancerListByProjectID(BaseDatabaseTask):
 
 
 class CheckExistingVthunderTopology(BaseDatabaseTask):
+    """This task only meant to use with vthunder flow[amphora]"""
 
     def execute(self, loadbalancer, topology):
         vthunder = self.vthunder_repo.get_vthunder_by_project_id(

--- a/a10_octavia/tests/common/a10constants.py
+++ b/a10_octavia/tests/common/a10constants.py
@@ -68,3 +68,4 @@ MOCK_L7POLICY_ID = "mock-l7-policy-1"
 MOCK_L7RULE_ID = "mock-l7-rule-1"
 
 MOCK_TLS_CERTIFICATE_ID = "mock_tls_certificate_id"
+MOCK_TOPOLOGY_ACTIVE_STANDBY = "ACTIVE_STANDBY"

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -25,6 +25,7 @@ from oslo_config import fixture as oslo_fixture
 from oslo_utils import uuidutils
 
 from octavia.common import data_models as o_data_models
+from octavia.common import exceptions as o_exceptions
 from octavia.network import data_models as n_data_models
 from octavia.tests.common import constants as t_constants
 
@@ -35,6 +36,7 @@ from a10_octavia.common import utils
 from a10_octavia.controller.worker.tasks import a10_database_tasks as task
 from a10_octavia.tests.common import a10constants
 from a10_octavia.tests.unit import base
+
 
 VTHUNDER = data_models.VThunder()
 HW_THUNDER = data_models.HardwareThunder(
@@ -609,3 +611,11 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         lb_task.loadbalancer_repo.update = mock.Mock()
         lb_task.execute(lb_list)
         lb_task.loadbalancer_repo.update.assert_not_called()
+
+    def test_CheckExistingVthunderTopology_execute_raised_exception(self):
+        lb_task = task.CheckExistingVthunderTopology()
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.topology = a10constants.MOCK_TOPOLOGY_ACTIVE_STANDBY
+        lb_task.vthunder_repo = mock.MagicMock()[1:999]
+        lb_task.vthunder_repo.get_vthunder_by_project_id.return_value = vthunder
+        self.assertRaises(o_exceptions.InvalidTopology, lb_task.execute, LB, "SINGLE")

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -37,7 +37,6 @@ from a10_octavia.controller.worker.tasks import a10_database_tasks as task
 from a10_octavia.tests.common import a10constants
 from a10_octavia.tests.unit import base
 
-
 VTHUNDER = data_models.VThunder()
 HW_THUNDER = data_models.HardwareThunder(
     project_id=a10constants.MOCK_PROJECT_ID,


### PR DESCRIPTION
## Description
Severity Level Medium
Issue Description: [vthunder: mode switch] failed to create lb and get "AttributeError: 'NoneType' object has no attribute 'id' when change from single to active-standby

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-2261

## Technical Approach
- Limitation:
1. Don't support for changing topology when loadbalancer already created on vThunder instance.
2. Response error to user when existing vthunder has lb with differnet topology

- Added CheckExistingVthunderTopology task in a10_database_tasks.py file. This task will compare the topology from config file to the topology of existing lb in vthunder. If topology does not match then exception will be raised.


## Test Cases
- Added test_CheckExistingVthunderTopology_execute_raised_exception in test_a10_database_tasks.py file

## Manual Testing
1) Create lbs in active standby topology
```
stack@adeeb:~$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| a44740f5-75b9-4213-a324-61a6500d484a | lb1  | 5327a262f3dd48f48a3fa4c9c9016894 | 10.0.11.196 | ACTIVE              | a10      |
| 223c7715-f3bd-4fcb-ae1b-818114c97f5c | lb2  | 5327a262f3dd48f48a3fa4c9c9016894 | 10.0.12.114 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```

2) Change the topology to single in config file, restart the controller service and create the loadbalancer
```
loadbalancer_topology = SINGLE

openstack loadbalancer create --vip-subnet-id provider-vlan-13-subnet --name lb3

logs:
Apr 21 04:21:46 adeeb a10-octavia-worker[22675]: INFO a10_octavia.controller.queue.endpoint [-] Creating load balancer 'c26dde1f-fe5e-434d-b567-480f2b52bb1b'...
Apr 21 04:21:46 adeeb a10-octavia-worker[22675]: INFO a10_octavia.controller.worker.flows.a10_load_balancer_flows [-] TOPOLOGY ===SINGLE
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR a10_octavia.controller.worker.tasks.a10_database_tasks [-] Other loadbalancer exists in vthunder with: ACTIVE_STANDBY topology
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'a10_octavia.controller.worker.tasks.a10_database_tasks.CheckExistingVthunderTopology' (1fc8eacb-09a2-4829-8baf-f1b21b6530cc) transitioned into state 'FAILURE' from state 'RUNNING'
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: 3 predecessors (most recent first):
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]:   Atom 'octavia.controller.worker.tasks.database_tasks.ReloadLoadBalancer' {'intention': 'EXECUTE', 'state': 'SUCCESS', 'requires': {'loadbalancer_id': u'c26dde1f-fe5e-434d-b567-480f2b52bb1b'}, 'provides': <octavia.common.data_models.LoadBalancer object at 0x7f621f187b50>}
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]:   |__Atom 'octavia.controller.worker.tasks.lifecycle_tasks.LoadBalancerIDToErrorOnRevertTask' {'intention': 'EXECUTE', 'state': 'SUCCESS', 'requires': {'loadbalancer_id': u'c26dde1f-fe5e-434d-b567-480f2b52bb1b'}, 'provides': None}
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]:      |__Flow 'octavia-create-loadbalancer-flow': InvalidTopology: Invalid topology specified: vthunder has other loadbalancer with ACTIVE_STANDBY topology
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR a10_octavia.controller.worker.controller_worker Traceback (most recent call last):
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR a10_octavia.controller.worker.controller_worker   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR a10_octavia.controller.worker.controller_worker     result = task.execute(**arguments)
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR a10_octavia.controller.worker.controller_worker   File "/opt/stack/adeeb/a10-octavia/a10_octavia/controller/worker/tasks/a10_database_tasks.py", line 948, in execute
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR a10_octavia.controller.worker.controller_worker     raise oct_excep.InvalidTopology(topology=msg)
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR a10_octavia.controller.worker.controller_worker InvalidTopology: Invalid topology specified: vthunder has other loadbalancer with ACTIVE_STANDBY topology
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR a10_octavia.controller.worker.controller_worker
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'a10_octavia.controller.worker.tasks.a10_database_tasks.CheckExistingVthunderTopology' (1fc8eacb-09a2-4829-8baf-f1b21b6530cc) transitioned into state 'REVERTED' from state 'REVERTING'
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'octavia.controller.worker.tasks.database_tasks.ReloadLoadBalancer' (ea5e1b4f-6db8-49e9-ab40-66c74927c51f) transitioned into state 'REVERTED' from state 'REVERTING'
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'octavia.controller.worker.tasks.lifecycle_tasks.LoadBalancerIDToErrorOnRevertTask' (05d82107-88c8-45b3-91d6-e3d42d8522e9) transitioned into state 'REVERTED' from state 'REVERTING'
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: WARNING a10_octavia.controller.worker.controller_worker [-] Flow 'octavia-create-loadbalancer-flow' (efee761d-8743-478c-8e4c-a242a440ddac) transitioned into state 'REVERTED' from state 'RUNNING'
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server [-] Exception during message handling: InvalidTopology: Invalid topology specified: vthunder has other loadbalancer with ACTIVE_STANDBY topology
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server Traceback (most recent call last):
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/server.py", line 166, in _process_incoming
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server     res = self.dispatcher.dispatch(message)
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 265, in dispatch
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server     return self._do_dispatch(endpoint, method, ctxt, args)
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 194, in _do_dispatch
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server     result = func(ctxt, **new_args)
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server   File "/opt/stack/adeeb/a10-octavia/a10_octavia/controller/queue/endpoint.py", line 45, in create_load_balancer
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server     self.worker.create_load_balancer(load_balancer_id, flavor)
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 292, in wrapped_f
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server     return self.call(f, *args, **kw)
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 358, in call
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server     do = self.iter(retry_state=retry_state)
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 319, in iter
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server     return fut.result()
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/concurrent/futures/_base.py", line 455, in result
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server     return self.__get_result()
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 361, in call
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server     result = fn(*args, **kwargs)
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server   File "/opt/stack/adeeb/a10-octavia/a10_octavia/controller/worker/controller_worker.py", line 312, in create_load_balancer
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server     create_lb_tf.run()
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 247, in run
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server     for _state in self.run_iter(timeout=timeout):
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 340, in run_iter
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server     failure.Failure.reraise_if_any(er_failures)
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 339, in reraise_if_any
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server     failures[0].reraise()
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 346, in reraise
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server     six.reraise(*self._exc_info)
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server     result = task.execute(**arguments)
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server   File "/opt/stack/adeeb/a10-octavia/a10_octavia/controller/worker/tasks/a10_database_tasks.py", line 948, in execute
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server     raise oct_excep.InvalidTopology(topology=msg)
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server InvalidTopology: Invalid topology specified: vthunder has other loadbalancer with ACTIVE_STANDBY topology
Apr 21 04:21:47 adeeb a10-octavia-worker[22675]: ERROR oslo_messaging.rpc.server

stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| a44740f5-75b9-4213-a324-61a6500d484a | lb1  | 5327a262f3dd48f48a3fa4c9c9016894 | 10.0.11.196 | ACTIVE              | a10      |
| 223c7715-f3bd-4fcb-ae1b-818114c97f5c | lb2  | 5327a262f3dd48f48a3fa4c9c9016894 | 10.0.12.114 | ACTIVE              | a10      |
| c26dde1f-fe5e-434d-b567-480f2b52bb1b | lb3  | 5327a262f3dd48f48a3fa4c9c9016894 | 10.0.13.118 | ERROR               | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```

SINGLE==> ACTIVE_STANDBY
1) Create loadbalancers in single topology
```
stack@adeeb:~$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 81e44dbb-8f89-49bb-acda-b301f095d06e | v1   | 5327a262f3dd48f48a3fa4c9c9016894 | 10.0.11.162 | ACTIVE              | a10      |
| 9df071cc-4ea0-4aaa-8fef-d8566de4b602 | v2   | 5327a262f3dd48f48a3fa4c9c9016894 | 10.0.12.129 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```
2) Change the topology to active_standby, restart the a10-controller service and create the loadbalancer.
```
loadbalancer_topology = ACTIVE_STANDBY

sudo systemctl restart a10-controller-worker.service

openstack loadbalancer create --vip-subnet-id provider-vlan-13-subnet --name v3

logs:
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: INFO a10_octavia.controller.queue.endpoint [-] Creating load balancer 'a6ae5441-0461-4635-a847-24a3c8475793'...
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: INFO a10_octavia.controller.worker.flows.a10_load_balancer_flows [-] TOPOLOGY ===ACTIVE_STANDBY
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR a10_octavia.controller.worker.tasks.a10_database_tasks [-] Other loadbalancer exists in vthunder with: SINGLE topology
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'a10_octavia.controller.worker.tasks.a10_database_tasks.CheckExistingVthunderTopology' (7ba03d4c-163d-416a-80f7-e3449a5f2460) transitioned into state 'FAILURE' from state 'RUNNING'
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: 3 predecessors (most recent first):
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]:   Atom 'octavia.controller.worker.tasks.database_tasks.ReloadLoadBalancer' {'intention': 'EXECUTE', 'state': 'SUCCESS', 'requires': {'loadbalancer_id': u'a6ae5441-0461-4635-a847-24a3c8475793'}, 'provides': <octavia.common.data_models.LoadBalancer object at 0x7fafa79d94d0>}
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]:   |__Atom 'octavia.controller.worker.tasks.lifecycle_tasks.LoadBalancerIDToErrorOnRevertTask' {'intention': 'EXECUTE', 'state': 'SUCCESS', 'requires': {'loadbalancer_id': u'a6ae5441-0461-4635-a847-24a3c8475793'}, 'provides': None}
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]:      |__Flow 'octavia-create-loadbalancer-flow': InvalidTopology: Invalid topology specified: vthunder has other loadbalancer with SINGLE topology
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR a10_octavia.controller.worker.controller_worker Traceback (most recent call last):
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR a10_octavia.controller.worker.controller_worker   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR a10_octavia.controller.worker.controller_worker     result = task.execute(**arguments)
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR a10_octavia.controller.worker.controller_worker   File "/opt/stack/adeeb/a10-octavia/a10_octavia/controller/worker/tasks/a10_database_tasks.py", line 949, in execute
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR a10_octavia.controller.worker.controller_worker     raise octavia_exceptions.InvalidTopology(topology=msg)
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR a10_octavia.controller.worker.controller_worker InvalidTopology: Invalid topology specified: vthunder has other loadbalancer with SINGLE topology
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR a10_octavia.controller.worker.controller_worker
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'a10_octavia.controller.worker.tasks.a10_database_tasks.CheckExistingVthunderTopology' (7ba03d4c-163d-416a-80f7-e3449a5f2460) transitioned into state 'REVERTED' from state 'REVERTING'
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'octavia.controller.worker.tasks.database_tasks.ReloadLoadBalancer' (f67930dc-c723-4ba4-baf4-9a7633b6aa47) transitioned into state 'REVERTED' from state 'REVERTING'
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'octavia.controller.worker.tasks.lifecycle_tasks.LoadBalancerIDToErrorOnRevertTask' (8775f16d-5b29-4a50-8b29-ad0025e0d5cd) transitioned into state 'REVERTED' from state 'REVERTING'
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: WARNING a10_octavia.controller.worker.controller_worker [-] Flow 'octavia-create-loadbalancer-flow' (fc5c1f27-7470-4391-aa16-6ea467eed717) transitioned into state 'REVERTED' from state 'RUNNING'
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server [-] Exception during message handling: InvalidTopology: Invalid topology specified: vthunder has other loadbalancer with SINGLE topology
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server Traceback (most recent call last):
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/server.py", line 166, in _process_incoming
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server     res = self.dispatcher.dispatch(message)
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 265, in dispatch
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server     return self._do_dispatch(endpoint, method, ctxt, args)
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 194, in _do_dispatch
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server     result = func(ctxt, **new_args)
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server   File "/opt/stack/adeeb/a10-octavia/a10_octavia/controller/queue/endpoint.py", line 45, in create_load_balancer
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server     self.worker.create_load_balancer(load_balancer_id, flavor)
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 292, in wrapped_f
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server     return self.call(f, *args, **kw)
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 358, in call
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server     do = self.iter(retry_state=retry_state)
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 319, in iter
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server     return fut.result()
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/concurrent/futures/_base.py", line 455, in result
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server     return self.__get_result()
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 361, in call
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server     result = fn(*args, **kwargs)
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server   File "/opt/stack/adeeb/a10-octavia/a10_octavia/controller/worker/controller_worker.py", line 312, in create_load_balancer
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server     create_lb_tf.run()
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 247, in run
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server     for _state in self.run_iter(timeout=timeout):
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 340, in run_iter
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server     failure.Failure.reraise_if_any(er_failures)
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 339, in reraise_if_any
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server     failures[0].reraise()
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 346, in reraise
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server     six.reraise(*self._exc_info)
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server     result = task.execute(**arguments)
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server   File "/opt/stack/adeeb/a10-octavia/a10_octavia/controller/worker/tasks/a10_database_tasks.py", line 949, in execute
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server     raise octavia_exceptions.InvalidTopology(topology=msg)
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server InvalidTopology: Invalid topology specified: vthunder has other loadbalancer with SINGLE topology
Apr 21 09:20:44 adeeb a10-octavia-worker[25372]: ERROR oslo_messaging.rpc.server

stack@adeeb:~$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 81e44dbb-8f89-49bb-acda-b301f095d06e | v1   | 5327a262f3dd48f48a3fa4c9c9016894 | 10.0.11.162 | ACTIVE              | a10      |
| 9df071cc-4ea0-4aaa-8fef-d8566de4b602 | v2   | 5327a262f3dd48f48a3fa4c9c9016894 | 10.0.12.129 | ACTIVE              | a10      |
| a6ae5441-0461-4635-a847-24a3c8475793 | v3   | 5327a262f3dd48f48a3fa4c9c9016894 | 10.0.13.179 | ERROR               | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```