### PR TITLE
[STACK-2241][STACK-2262][STACK-2264][STACK-2284][STACK-2293] Provide thread-safe mechanism for vthunder flow

### DIFF
--- a/a10_octavia/cmd/a10_octavia_worker.py
+++ b/a10_octavia/cmd/a10_octavia_worker.py
@@ -25,16 +25,19 @@ from octavia import version
 from a10_octavia.cmd import service as octavia_service
 from a10_octavia.controller.queue import consumer
 
+import multiprocessing
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
-
+mp_mgr = multiprocessing.Manager()
+ctx_map = mp_mgr.dict()
+ctx_lock = mp_mgr.Lock()
 
 def main():
     octavia_service.prepare_service(sys.argv)
     gmr.TextGuruMeditation.setup_autorun(version)
     sm = cotyledon.ServiceManager()
     sm.add(consumer.ConsumerService, workers=CONF.a10_controller_worker.workers,
-           args=(CONF,))
+           args=(CONF, ctx_map, ctx_lock))
     oslo_config_glue.setup(sm, CONF, reload_method="mutate")
     sm.run()

--- a/a10_octavia/cmd/a10_octavia_worker.py
+++ b/a10_octavia/cmd/a10_octavia_worker.py
@@ -33,6 +33,7 @@ mp_mgr = multiprocessing.Manager()
 ctx_map = mp_mgr.dict()
 ctx_lock = mp_mgr.Lock()
 
+
 def main():
     octavia_service.prepare_service(sys.argv)
     gmr.TextGuruMeditation.setup_autorun(version)

--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -66,6 +66,7 @@ FLAT = "flat"
 SUPPORTED_NETWORK_TYPE = [FLAT, VLAN]
 SSL_TEMPLATE = "ssl_template"
 
+COMPUTE_BUSY = "compute_busy"
 # Taskflow flow and task names
 
 BACKUP_AMPHORA_PLUG = 'backup-amphora-plug'

--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -260,7 +260,14 @@ A10_CONTROLLER_WORKER_OPTS = [
                choices=constants.SUPPORTED_LB_TOPOLOGIES,
                help=_('Load balancer topology configuration. '
                       'SINGLE - One vthunder per load balancer. '
-                      'ACTIVE_STANDBY - Two vthunder per load balancer.'))
+                      'ACTIVE_STANDBY - Two vthunder per load balancer.')),
+    cfg.StrOpt('amp_vcs_wait_sec',
+               default=20,
+               help=_('Seconds to wait between checks on whether an VThunder '
+                      'vcs negotiation is ready')),
+    cfg.StrOpt('amp_vcs_retries',
+               default=5,
+               help=_('Retry attempts to wait for VThunder vcs negotiation'))
 ]
 
 A10_HOUSE_KEEPING_OPTS = [

--- a/a10_octavia/controller/queue/consumer.py
+++ b/a10_octavia/controller/queue/consumer.py
@@ -28,7 +28,7 @@ LOG = logging.getLogger(__name__)
 class ConsumerService(cotyledon.Service):
     name = "a10-octavia"
 
-    def __init__(self, worker_id, conf):
+    def __init__(self, worker_id, conf, ctx_map, ctx_lock):
         super(ConsumerService, self).__init__(worker_id)
         self.conf = conf
         self.topic = "a10_octavia"
@@ -36,12 +36,14 @@ class ConsumerService(cotyledon.Service):
         self.endpoints = []
         self.access_policy = dispatcher.DefaultRPCAccessPolicy
         self.message_listener = None
+        self.ctx_map = ctx_map
+        self.ctx_lock = ctx_lock
 
     def run(self):
         LOG.info('Starting consumer...')
         target = messaging.Target(topic=self.topic, server=self.server,
                                   fanout=False)
-        self.endpoints = [endpoint.Endpoint()]
+        self.endpoints = [endpoint.Endpoint(self.ctx_map, self.ctx_lock)]
         self.message_listener = rpc.get_server(
             target, self.endpoints,
             executor='threading',

--- a/a10_octavia/controller/queue/endpoint.py
+++ b/a10_octavia/controller/queue/endpoint.py
@@ -33,12 +33,13 @@ class Endpoint(object):
         namespace=constants.RPC_NAMESPACE_CONTROLLER_AGENT,
         version='1.0')
 
-    def __init__(self):
+    def __init__(self, ctx_map, ctx_lock):
         self.worker = stevedore_driver.DriverManager(
             namespace='a10.plugins',
             name='a10_octavia_plugin',
             invoke_on_load=True
         ).driver
+        self.worker.a10_worker_ctx_init(ctx_map, ctx_lock)
 
     def create_load_balancer(self, context, load_balancer_id, flavor=None):
         LOG.info('Creating load balancer \'%s\'...', load_balancer_id)

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -14,6 +14,7 @@
 
 from sqlalchemy.orm import exc as db_exceptions
 import tenacity
+import threading
 import urllib3
 
 from oslo_config import cfg
@@ -39,7 +40,6 @@ from a10_octavia.controller.worker.flows import a10_pool_flows
 from a10_octavia.controller.worker.flows import vthunder_flows
 from a10_octavia.db import repositories as a10repo
 
-
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 RETRY_ATTEMPTS = 15
@@ -50,6 +50,35 @@ RETRY_MAX = 5
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
 
+def flow_notification_handler(state, details, **kwargs):
+    key = kwargs.get('ctx_key', None)
+    try:
+        if state == 'SUCCESS' or state == 'REVERTED' or state == 'FAILURE':
+            thrd_may_reload_vthunder = kwargs.get('thrd_may_reload_vthunder')
+            ctx_lock = kwargs.get('ctx_lock')
+            ctx_map = kwargs.get('ctx_map')
+            if ctx_lock is None or ctx_map is None:
+                raise
+
+            ctx_lock.acquire()
+            ctx = ctx_map.get(key)
+            if ctx is None:
+                ctx_lock.release()
+                raise
+
+            normal_thrd_num, reload_thrd_num = ctx
+            LOG.debug('[state: %s] vthunder %s ctx: normal_thrd(%d), reload_thrd(%d)',
+                state, key, normal_thrd_num, reload_thrd_num)
+            if thrd_may_reload_vthunder:
+                reload_thrd_num = reload_thrd_num - 1
+            else:
+                normal_thrd_num = normal_thrd_num - 1
+            LOG.debug('[state: %s] vthunder %s ctx: normal_thrd(%d), reload_thrd(%d)',
+                state, key, normal_thrd_num, reload_thrd_num)
+            ctx_map[key] = (normal_thrd_num, reload_thrd_num)
+            ctx_lock.release()
+    except Exception:
+        LOG.error("Unable to find vThunder instance (%s) context", key)
 
 class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
@@ -71,6 +100,8 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         self._vthunder_flows = vthunder_flows.VThunderFlows()
         self._vthunder_repo = a10repo.VThunderRepository()
         self._exclude_result_logging_tasks = ()
+        self.ctx_map = None
+        self.ctx_lock = None
         super(A10ControllerWorker, self).__init__()
 
     def create_amphora(self):
@@ -110,13 +141,17 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         pool.health_monitor = health_mon
         load_balancer = pool.load_balancer
 
+        # rack flow _vthunder_busy_check() will always return False
+        busy = self._vthunder_busy_check(health_mon.project_id, False, None)
         create_hm_tf = self._taskflow_load(
             self._health_monitor_flows.get_create_health_monitor_flow(),
             store={constants.HEALTH_MON: health_mon,
                    constants.POOL: pool,
                    constants.LISTENERS: listeners,
                    constants.LOADBALANCER: load_balancer,
+                   a10constants.COMPUTE_BUSY: busy,
                    a10constants.WRITE_MEM_SHARED_PART: True})
+        self._register_flow_notify_handler(create_hm_tf, l7policy.project_id, False, busy)
         with tf_logging.DynamicLoggingListener(create_hm_tf,
                                                log=LOG):
             create_hm_tf.run()
@@ -135,13 +170,17 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         listeners = pool.listeners
         load_balancer = pool.load_balancer
 
+        # rack flow _vthunder_busy_check() will always return False
+        busy = self._vthunder_busy_check(health_mon.project_id, False, None)
         delete_hm_tf = self._taskflow_load(
             self._health_monitor_flows.get_delete_health_monitor_flow(),
             store={constants.HEALTH_MON: health_mon,
                    constants.POOL: pool,
                    constants.LISTENERS: listeners,
                    constants.LOADBALANCER: load_balancer,
+                   a10constants.COMPUTE_BUSY: busy,
                    a10constants.WRITE_MEM_SHARED_PART: True})
+        self._register_flow_notify_handler(delete_hm_tf, health_mon.project_id, False, busy)
         with tf_logging.DynamicLoggingListener(delete_hm_tf,
                                                log=LOG):
             delete_hm_tf.run()
@@ -171,14 +210,18 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         pool.health_monitor = health_mon
         load_balancer = pool.load_balancer
 
+        # rack flow _vthunder_busy_check() will always return False
+        busy = self._vthunder_busy_check(health_mon.project_id, False, None)
         update_hm_tf = self._taskflow_load(
             self._health_monitor_flows.get_update_health_monitor_flow(),
             store={constants.HEALTH_MON: health_mon,
                    constants.POOL: pool,
                    constants.LISTENERS: listeners,
                    constants.LOADBALANCER: load_balancer,
+                   a10constants.COMPUTE_BUSY: busy,
                    constants.UPDATE_DICT: health_monitor_updates,
                    a10constants.WRITE_MEM_SHARED_PART: True})
+        self._register_flow_notify_handler(update_hm_tf, health_mon.project_id, False, busy)
         with tf_logging.DynamicLoggingListener(update_hm_tf,
                                                log=LOG):
             update_hm_tf.run()
@@ -208,12 +251,16 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                                                             constants.LISTENER:
                                                             listener})
         else:
+            busy = self._vthunder_busy_check(listener.project_id, False, None)
             create_listener_tf = self._taskflow_load(self._listener_flows.
                                                      get_create_listener_flow(),
                                                      store={constants.LOADBALANCER:
                                                             load_balancer,
+                                                            a10constants.COMPUTE_BUSY: busy,
                                                             constants.LISTENER:
                                                             listener})
+            self._register_flow_notify_handler(create_listener_tf, listener.project_id,
+                                               False, busy)
 
         with tf_logging.DynamicLoggingListener(create_listener_tf,
                                                log=LOG):
@@ -232,10 +279,14 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                 store={constants.LOADBALANCER: load_balancer,
                        constants.LISTENER: listener})
         else:
+            busy = self._vthunder_busy_check(listener.project_id, False, None)
             delete_listener_tf = self._taskflow_load(
                 self._listener_flows.get_delete_listener_flow(),
                 store={constants.LOADBALANCER: load_balancer,
+                       a10constants.COMPUTE_BUSY: busy,
                        constants.LISTENER: listener})
+            self._register_flow_notify_handler(delete_listener_tf, listener.project_id,
+                                               False, busy)
         with tf_logging.DynamicLoggingListener(delete_listener_tf,
                                                log=LOG):
             delete_listener_tf.run()
@@ -257,15 +308,20 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         load_balancer = listener.load_balancer
 
+        # rack flow _vthunder_busy_check() will always return False
+        busy = self._vthunder_busy_check(listener.project_id, False, None)
         update_listener_tf = self._taskflow_load(self._listener_flows.
                                                  get_update_listener_flow(),
                                                  store={constants.LISTENER:
                                                         listener,
+                                                        a10constants.COMPUTE_BUSY: busy,
                                                         constants.LOADBALANCER:
                                                             load_balancer,
                                                         constants.UPDATE_DICT:
                                                             listener_updates
                                                         })
+        self._register_flow_notify_handler(update_listener_tf, listener.project_id,
+                                           False, busy)
         with tf_logging.DynamicLoggingListener(update_listener_tf, log=LOG):
             update_listener_tf.run()
 
@@ -274,7 +330,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         wait=tenacity.wait_incrementing(
             RETRY_INITIAL_DELAY, RETRY_BACKOFF, RETRY_MAX),
         stop=tenacity.stop_after_attempt(RETRY_ATTEMPTS))
-    def create_load_balancer(self, load_balancer_id, flavor=None):
+    def create_load_balancer(self, load_balancer_id, flavor=None, ctx_map=None, ctx_lock=None):
         """Function to create load balancer for A10 provider"""
 
         lb = self._lb_repo.get(db_apis.get_session(), id=load_balancer_id)
@@ -302,9 +358,11 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                 topology=topology, listeners=lb.listeners)
             create_lb_tf = self._taskflow_load(create_lb_flow, store=store)
         else:
+            busy = self._vthunder_busy_check(lb.project_id, True, store)
             create_lb_flow = self._lb_flows.get_create_load_balancer_flow(
                 load_balancer_id, topology=topology, listeners=lb.listeners)
             create_lb_tf = self._taskflow_load(create_lb_flow, store=store)
+            self._register_flow_notify_handler(create_lb_tf, lb.project_id, True, busy)
 
         with tf_logging.DynamicLoggingListener(
                 create_lb_tf, log=LOG,
@@ -336,7 +394,9 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                       constants.VIP: lb.vip,
                       constants.SERVER_GROUP_ID: lb.server_group_id})
 
+        busy = self._vthunder_busy_check(lb.project_id, True, store)
         delete_lb_tf = self._taskflow_load(flow, store=store)
+        self._register_flow_notify_handler(delete_lb_tf, lb.project_id, True, busy)
 
         with tf_logging.DynamicLoggingListener(delete_lb_tf,
                                                log=LOG):
@@ -361,12 +421,16 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             db_apis.get_session(),
             load_balancer_id=load_balancer_id)
 
+        # rack flow _vthunder_busy_check() will always return False
+        busy = self._vthunder_busy_check(lb.project_id, False, None)
         update_lb_tf = self._taskflow_load(
             self._lb_flows.get_update_load_balancer_flow(),
             store={constants.LOADBALANCER: lb,
                    constants.VIP: lb.vip,
+                   a10constants.COMPUTE_BUSY: busy,
                    constants.LISTENERS: listeners,
                    constants.UPDATE_DICT: load_balancer_updates})
+        self._register_flow_notify_handler(update_lb_tf, lb.project_id, False, busy)
 
         with tf_logging.DynamicLoggingListener(update_lb_tf,
                                                log=LOG):
@@ -412,6 +476,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                     constants.LOADBALANCER: load_balancer,
                     constants.POOL: pool})
         else:
+            busy = self._vthunder_busy_check(member.project_id, True, None)
             create_member_tf = self._taskflow_load(self._member_flows.
                                                    get_create_member_flow(
                                                        topology=topology),
@@ -420,7 +485,9 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                                                           listeners,
                                                           constants.LOADBALANCER:
                                                           load_balancer,
+                                                          a10constants.COMPUTE_BUSY: busy,
                                                           constants.POOL: pool})
+            self._register_flow_notify_handler(create_member_tf, member.project_id, True, busy)
 
         with tf_logging.DynamicLoggingListener(create_member_tf,
                                                log=LOG):
@@ -447,11 +514,14 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                        constants.LOADBALANCER: load_balancer, constants.POOL: pool}
             )
         else:
+            busy = self._vthunder_busy_check(member.project_id, True, None)
             delete_member_tf = self._taskflow_load(
                 self._member_flows.get_delete_member_flow(topology=topology),
                 store={constants.MEMBER: member, constants.LISTENERS: listeners,
-                       constants.LOADBALANCER: load_balancer, constants.POOL: pool}
+                       constants.LOADBALANCER: load_balancer, a10constants.COMPUTE_BUSY: busy,
+                       constants.POOL: pool}
             )
+            self._register_flow_notify_handler(create_member_tf, member.project_id, True, busy)
         with tf_logging.DynamicLoggingListener(delete_member_tf,
                                                log=LOG):
             delete_member_tf.run()
@@ -498,16 +568,19 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                                                           constants.POOL: pool,
                                                           constants.UPDATE_DICT: member_updates})
         else:
+            busy = self._vthunder_busy_check(member.project_id, False, None)
             update_member_tf = self._taskflow_load(self._member_flows.get_update_member_flow(),
                                                    store={constants.MEMBER: member,
                                                           constants.LISTENERS:
                                                           listeners,
                                                           constants.LOADBALANCER:
                                                           load_balancer,
+                                                          a10constants.COMPUTE_BUSY: busy,
                                                           constants.POOL:
                                                           pool,
                                                           constants.UPDATE_DICT:
                                                           member_updates})
+            self._register_flow_notify_handler(update_member_tf, member.project_id, False, busy)
 
         with tf_logging.DynamicLoggingListener(update_member_tf,
                                                log=LOG):
@@ -538,6 +611,8 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             default_listener = pool.listeners[0]
         load_balancer = pool.load_balancer
 
+        # rack flow _vthunder_busy_check() will always return False
+        busy = self._vthunder_busy_check(pool.project_id, False, None)
         create_pool_tf = self._taskflow_load(self._pool_flows.
                                              get_create_pool_flow(),
                                              store={constants.POOL: pool,
@@ -545,7 +620,9 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                                                         listeners,
                                                     constants.LISTENER: default_listener,
                                                     constants.LOADBALANCER:
-                                                        load_balancer})
+                                                        load_balancer,
+                                                    a10constants.COMPUTE_BUSY: busy})
+        self._register_flow_notify_handler(create_pool_tf, pool.project_id, False, busy)
         with tf_logging.DynamicLoggingListener(create_pool_tf,
                                                log=LOG):
             create_pool_tf.run()
@@ -582,9 +659,11 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                 self._pool_flows.get_delete_pool_rack_flow(
                     members, health_monitor, store), store=store)
         else:
+            busy = self._vthunder_busy_check(pool.project_id, False, store)
             delete_pool_tf = self._taskflow_load(
                 self._pool_flows.get_delete_pool_flow(
                     members, health_monitor, store), store=store)
+            self._register_flow_notify_handler(delete_pool_tf, pool.project_id, False, busy)
 
         with tf_logging.DynamicLoggingListener(delete_pool_tf,
                                                log=LOG):
@@ -617,6 +696,8 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             default_listener = pool.listeners[0]
         load_balancer = pool.load_balancer
 
+        # rack flow _vthunder_busy_check() will always return False
+        busy = self._vthunder_busy_check(pool.project_id, False, None)
         update_pool_tf = self._taskflow_load(self._pool_flows.
                                              get_update_pool_flow(),
                                              store={constants.POOL: pool,
@@ -625,9 +706,10 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                                                     constants.LISTENER: default_listener,
                                                     constants.LOADBALANCER:
                                                         load_balancer,
-
+                                                    a10constants.COMPUTE_BUSY: busy,
                                                     constants.UPDATE_DICT:
                                                         pool_updates})
+        self._register_flow_notify_handler(update_pool_tf, pool.project_id, False, busy)
         with tf_logging.DynamicLoggingListener(update_pool_tf,
                                                log=LOG):
             update_pool_tf.run()
@@ -654,11 +736,15 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         listeners = [l7policy.listener]
         load_balancer = l7policy.listener.load_balancer
 
+        # rack flow _vthunder_busy_check() will always return False
+        busy = self._vthunder_busy_check(l7policy.project_id, False, None)
         create_l7policy_tf = self._taskflow_load(
             self._l7policy_flows.get_create_l7policy_flow(),
             store={constants.L7POLICY: l7policy,
                    constants.LISTENERS: listeners,
-                   constants.LOADBALANCER: load_balancer})
+                   constants.LOADBALANCER: load_balancer,
+                   a10constants.COMPUTE_BUSY: busy})
+        self._register_flow_notify_handler(create_l7policy_tf, l7policy.project_id, False, busy)
         with tf_logging.DynamicLoggingListener(create_l7policy_tf,
                                                log=LOG):
             create_l7policy_tf.run()
@@ -675,11 +761,15 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         load_balancer = l7policy.listener.load_balancer
         listeners = [l7policy.listener]
 
+        # rack flow _vthunder_busy_check() will always return False
+        busy = self._vthunder_busy_check(l7policy.project_id, False, None)
         delete_l7policy_tf = self._taskflow_load(
             self._l7policy_flows.get_delete_l7policy_flow(),
             store={constants.L7POLICY: l7policy,
                    constants.LISTENERS: listeners,
-                   constants.LOADBALANCER: load_balancer})
+                   constants.LOADBALANCER: load_balancer,
+                   a10constants.COMPUTE_BUSY: busy})
+        self._register_flow_notify_handler(delete_l7policy_tf, l7policy.project_id, False, busy)
         with tf_logging.DynamicLoggingListener(delete_l7policy_tf,
                                                log=LOG):
             delete_l7policy_tf.run()
@@ -708,12 +798,16 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         listeners = [l7policy.listener]
         load_balancer = l7policy.listener.load_balancer
 
+        # rack flow _vthunder_busy_check() will always return False
+        busy = self._vthunder_busy_check(l7policy.project_id, False, None)
         update_l7policy_tf = self._taskflow_load(
             self._l7policy_flows.get_update_l7policy_flow(),
             store={constants.L7POLICY: l7policy,
                    constants.LISTENERS: listeners,
                    constants.LOADBALANCER: load_balancer,
+                   a10constants.COMPUTE_BUSY: busy,
                    constants.UPDATE_DICT: l7policy_updates})
+        self._register_flow_notify_handler(update_l7policy_tf, l7policy.project_id, False, busy)
         with tf_logging.DynamicLoggingListener(update_l7policy_tf,
                                                log=LOG):
             update_l7policy_tf.run()
@@ -741,12 +835,16 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         listeners = [l7policy.listener]
         load_balancer = l7policy.listener.load_balancer
 
+        # rack flow _vthunder_busy_check() will always return False
+        busy = self._vthunder_busy_check(l7rule.project_id, False, None)
         create_l7rule_tf = self._taskflow_load(
             self._l7rule_flows.get_create_l7rule_flow(),
             store={constants.L7RULE: l7rule,
                    constants.L7POLICY: l7policy,
                    constants.LISTENERS: listeners,
-                   constants.LOADBALANCER: load_balancer})
+                   constants.LOADBALANCER: load_balancer,
+                   a10constants.COMPUTE_BUSY: busy})
+        self._register_flow_notify_handler(create_l7rule_tf, l7rule.project_id, False, busy)
         with tf_logging.DynamicLoggingListener(create_l7rule_tf,
                                                log=LOG):
             create_l7rule_tf.run()
@@ -763,12 +861,16 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         load_balancer = l7policy.listener.load_balancer
         listeners = [l7policy.listener]
 
+        # rack flow _vthunder_busy_check() will always return False
+        busy = self._vthunder_busy_check(l7rule.project_id, False, None)
         delete_l7rule_tf = self._taskflow_load(
             self._l7rule_flows.get_delete_l7rule_flow(),
             store={constants.L7RULE: l7rule,
                    constants.L7POLICY: l7policy,
                    constants.LISTENERS: listeners,
-                   constants.LOADBALANCER: load_balancer})
+                   constants.LOADBALANCER: load_balancer,
+                   a10constants.COMPUTE_BUSY: busy})
+        self._register_flow_notify_handler(delete_l7rule_tf, l7rule.project_id, False, busy)
         with tf_logging.DynamicLoggingListener(delete_l7rule_tf,
                                                log=LOG):
             delete_l7rule_tf.run()
@@ -797,13 +899,17 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         listeners = [l7policy.listener]
         load_balancer = l7policy.listener.load_balancer
 
+        # rack flow _vthunder_busy_check() will always return False
+        busy = self._vthunder_busy_check(l7rule.project_id, False, None)
         update_l7rule_tf = self._taskflow_load(
             self._l7rule_flows.get_update_l7rule_flow(),
             store={constants.L7RULE: l7rule,
                    constants.L7POLICY: l7policy,
                    constants.LISTENERS: listeners,
                    constants.LOADBALANCER: load_balancer,
+                   a10constants.COMPUTE_BUSY: busy
                    constants.UPDATE_DICT: l7rule_updates})
+        self._register_flow_notify_handler(update_l7rule_tf, l7rule.project_id, False, busy)
         with tf_logging.DynamicLoggingListener(update_l7rule_tf,
                                                log=LOG):
             update_l7rule_tf.run()
@@ -952,3 +1058,55 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             except Exception:
                 # continue on other thunders (assume exception is logged)
                 pass
+
+    def a10_worker_ctx_init(self, ctx_map, ctx_lock):
+        self.ctx_map = ctx_map
+        self.ctx_lock = ctx_lock
+
+    def _is_rack_flow(self, key):
+        if self.ctx_map is None or self.ctx_lock is None:
+            return True
+        if key in CONF.hardware_thunder.devices:
+            return True
+        return False
+
+    def _vthunder_busy_check(self, key, thrd_may_reload_vthunder, store=None):
+        busy = False
+        if self._is_rack_flow(key):
+            return busy
+        
+        self.ctx_lock.acquire()
+        ctx = self.ctx_map.get(key, None)
+        if ctx is None:
+            ctx = (0, 0)
+        normal_thrd_num, reload_thrd_num = ctx
+        LOG.debug('[busy_check] vthunder %s ctx: normal_thrd(%d), reload_thrd(%d)',
+            key, normal_thrd_num, reload_thrd_num)
+        if thrd_may_reload_vthunder:
+            if reload_thrd_num > 0 or normal_thrd_num > 0:
+                busy = True
+            else:
+                reload_thrd_num = reload_thrd_num + 1
+        else:
+            if reload_thrd_num > 0:
+                busy = True
+            else:
+                normal_thrd_num = normal_thrd_num + 1
+        LOG.debug('[busy_check] vthunder %s ctx: normal_thrd(%d), reload_thrd(%d)',
+            key, normal_thrd_num, reload_thrd_num)
+        self.ctx_map[key] = (normal_thrd_num, reload_thrd_num)
+        self.ctx_lock.release()
+
+        if store is not None:
+            store[a10constants.COMPUTE_BUSY] = busy
+
+        return busy
+
+    def _register_flow_notify_handler(self, engine, key, thrd_may_reload_vthunder, instance_busy):
+        if self._is_rack_flow(key) or instance_busy:
+            return
+        kwargs = {'ctx_key': key, 'may_reload_vthunder': thrd_may_reload_vthunder,
+                  'ctx_lock': self.ctx_lock, 'ctx_map': self.ctx_map,
+                  'thrd_may_reload_vthunder': thrd_may_reload_vthunder}
+        engine.notifier.register('*', flow_notification_handler, kwargs=kwargs)
+

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -50,6 +50,7 @@ RETRY_MAX = 5
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
 
+
 def flow_notification_handler(state, details, **kwargs):
     key = kwargs.get('ctx_key', None)
     try:
@@ -68,17 +69,18 @@ def flow_notification_handler(state, details, **kwargs):
 
             normal_thrd_num, reload_thrd_num = ctx
             LOG.debug('[state: %s] vthunder %s ctx: normal_thrd(%d), reload_thrd(%d)',
-                state, key, normal_thrd_num, reload_thrd_num)
+                      state, key, normal_thrd_num, reload_thrd_num)
             if thrd_may_reload_vthunder:
                 reload_thrd_num = reload_thrd_num - 1
             else:
                 normal_thrd_num = normal_thrd_num - 1
             LOG.debug('[state: %s] vthunder %s ctx: normal_thrd(%d), reload_thrd(%d)',
-                state, key, normal_thrd_num, reload_thrd_num)
+                      state, key, normal_thrd_num, reload_thrd_num)
             ctx_map[key] = (normal_thrd_num, reload_thrd_num)
             ctx_lock.release()
     except Exception:
         LOG.error("Unable to find vThunder instance (%s) context", key)
+
 
 class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
@@ -907,7 +909,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                    constants.L7POLICY: l7policy,
                    constants.LISTENERS: listeners,
                    constants.LOADBALANCER: load_balancer,
-                   a10constants.COMPUTE_BUSY: busy
+                   a10constants.COMPUTE_BUSY: busy,
                    constants.UPDATE_DICT: l7rule_updates})
         self._register_flow_notify_handler(update_l7rule_tf, l7rule.project_id, False, busy)
         with tf_logging.DynamicLoggingListener(update_l7rule_tf,
@@ -1074,14 +1076,14 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         busy = False
         if self._is_rack_flow(key):
             return busy
-        
+
         self.ctx_lock.acquire()
         ctx = self.ctx_map.get(key, None)
         if ctx is None:
             ctx = (0, 0)
         normal_thrd_num, reload_thrd_num = ctx
         LOG.debug('[busy_check] vthunder %s ctx: normal_thrd(%d), reload_thrd(%d)',
-            key, normal_thrd_num, reload_thrd_num)
+                  key, normal_thrd_num, reload_thrd_num)
         if thrd_may_reload_vthunder:
             if reload_thrd_num > 0 or normal_thrd_num > 0:
                 busy = True
@@ -1093,7 +1095,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             else:
                 normal_thrd_num = normal_thrd_num + 1
         LOG.debug('[busy_check] vthunder %s ctx: normal_thrd(%d), reload_thrd(%d)',
-            key, normal_thrd_num, reload_thrd_num)
+                  key, normal_thrd_num, reload_thrd_num)
         self.ctx_map[key] = (normal_thrd_num, reload_thrd_num)
         self.ctx_lock.release()
 
@@ -1109,4 +1111,3 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                   'ctx_lock': self.ctx_lock, 'ctx_map': self.ctx_map,
                   'thrd_may_reload_vthunder': thrd_may_reload_vthunder}
         engine.notifier.register('*', flow_notification_handler, kwargs=kwargs)
-

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -14,7 +14,6 @@
 
 from sqlalchemy.orm import exc as db_exceptions
 import tenacity
-import threading
 import urllib3
 
 from oslo_config import cfg
@@ -153,7 +152,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                    constants.LOADBALANCER: load_balancer,
                    a10constants.COMPUTE_BUSY: busy,
                    a10constants.WRITE_MEM_SHARED_PART: True})
-        self._register_flow_notify_handler(create_hm_tf, l7policy.project_id, False, busy)
+        self._register_flow_notify_handler(create_hm_tf, health_mon.project_id, False, busy)
         with tf_logging.DynamicLoggingListener(create_hm_tf,
                                                log=LOG):
             create_hm_tf.run()
@@ -523,7 +522,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                        constants.LOADBALANCER: load_balancer, a10constants.COMPUTE_BUSY: busy,
                        constants.POOL: pool}
             )
-            self._register_flow_notify_handler(create_member_tf, member.project_id, True, busy)
+            self._register_flow_notify_handler(delete_member_tf, member.project_id, True, busy)
         with tf_logging.DynamicLoggingListener(delete_member_tf,
                                                log=LOG):
             delete_member_tf.run()

--- a/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
@@ -38,6 +38,9 @@ class HealthMonitorFlows(object):
             requires=[constants.HEALTH_MON,
                       constants.LISTENERS,
                       constants.LOADBALANCER]))
+        create_hm_flow.add(vthunder_tasks.VthunderInstanceBusy(
+            requires=a10constants.COMPUTE_BUSY))
+
         create_hm_flow.add(database_tasks.MarkHealthMonitorPendingCreateInDB(
             requires=constants.HEALTH_MON))
         create_hm_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
@@ -75,6 +78,9 @@ class HealthMonitorFlows(object):
             requires=[constants.HEALTH_MON,
                       constants.LISTENERS,
                       constants.LOADBALANCER]))
+        delete_hm_flow.add(vthunder_tasks.VthunderInstanceBusy(
+            requires=a10constants.COMPUTE_BUSY))
+
         delete_hm_flow.add(database_tasks.MarkHealthMonitorPendingDeleteInDB(
             requires=constants.HEALTH_MON))
         delete_hm_flow.add(model_tasks.
@@ -125,6 +131,9 @@ class HealthMonitorFlows(object):
             requires=[constants.HEALTH_MON,
                       constants.LISTENERS,
                       constants.LOADBALANCER]))
+        update_hm_flow.add(vthunder_tasks.VthunderInstanceBusy(
+            requires=a10constants.COMPUTE_BUSY))
+
         update_hm_flow.add(database_tasks.MarkHealthMonitorPendingUpdateInDB(
             requires=constants.HEALTH_MON))
         update_hm_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(

--- a/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
@@ -37,6 +37,9 @@ class L7PolicyFlows(object):
             requires=[constants.L7POLICY,
                       constants.LISTENERS,
                       constants.LOADBALANCER]))
+        create_l7policy_flow.add(vthunder_tasks.VthunderInstanceBusy(
+            requires=a10constants.COMPUTE_BUSY))
+
         create_l7policy_flow.add(database_tasks.MarkL7PolicyPendingCreateInDB(
             requires=constants.L7POLICY))
         create_l7policy_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
@@ -64,6 +67,9 @@ class L7PolicyFlows(object):
             requires=[constants.L7POLICY,
                       constants.LISTENERS,
                       constants.LOADBALANCER]))
+        delete_l7policy_flow.add(vthunder_tasks.VthunderInstanceBusy(
+            requires=a10constants.COMPUTE_BUSY))
+
         delete_l7policy_flow.add(database_tasks.MarkL7PolicyPendingDeleteInDB(
             requires=constants.L7POLICY))
         delete_l7policy_flow.add(model_tasks.DeleteModelObject(
@@ -92,6 +98,9 @@ class L7PolicyFlows(object):
             requires=[constants.L7POLICY,
                       constants.LISTENERS,
                       constants.LOADBALANCER]))
+        update_l7policy_flow.add(vthunder_tasks.VthunderInstanceBusy(
+            requires=a10constants.COMPUTE_BUSY))
+
         update_l7policy_flow.add(database_tasks.MarkL7PolicyPendingUpdateInDB(
             requires=constants.L7POLICY))
         update_l7policy_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(

--- a/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
@@ -37,6 +37,9 @@ class L7RuleFlows(object):
             requires=[constants.L7RULE,
                       constants.LISTENERS,
                       constants.LOADBALANCER]))
+        create_l7rule_flow.add(vthunder_tasks.VthunderInstanceBusy(
+            requires=a10constants.COMPUTE_BUSY))
+
         create_l7rule_flow.add(database_tasks.MarkL7RulePendingCreateInDB(
             requires=constants.L7RULE))
         create_l7rule_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
@@ -65,6 +68,9 @@ class L7RuleFlows(object):
             requires=[constants.L7RULE,
                       constants.LISTENERS,
                       constants.LOADBALANCER]))
+        delete_l7rule_flow.add(vthunder_tasks.VthunderInstanceBusy(
+            requires=a10constants.COMPUTE_BUSY))
+
         delete_l7rule_flow.add(database_tasks.MarkL7RulePendingDeleteInDB(
             requires=constants.L7RULE))
         delete_l7rule_flow.add(model_tasks.DeleteModelObject(
@@ -94,6 +100,9 @@ class L7RuleFlows(object):
             requires=[constants.L7RULE,
                       constants.LISTENERS,
                       constants.LOADBALANCER]))
+        delete_l7rule_flow.add(vthunder_tasks.VthunderInstanceBusy(
+            requires=a10constants.COMPUTE_BUSY))
+
         update_l7rule_flow.add(database_tasks.MarkL7RulePendingUpdateInDB(
             requires=constants.L7RULE))
         update_l7rule_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(

--- a/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
@@ -100,7 +100,7 @@ class L7RuleFlows(object):
             requires=[constants.L7RULE,
                       constants.LISTENERS,
                       constants.LOADBALANCER]))
-        delete_l7rule_flow.add(vthunder_tasks.VthunderInstanceBusy(
+        update_l7rule_flow.add(vthunder_tasks.VthunderInstanceBusy(
             requires=a10constants.COMPUTE_BUSY))
 
         update_l7rule_flow.add(database_tasks.MarkL7RulePendingUpdateInDB(

--- a/a10_octavia/controller/worker/flows/a10_listener_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_listener_flows.py
@@ -38,6 +38,8 @@ class ListenerFlows(object):
         create_listener_flow = linear_flow.Flow(constants.CREATE_LISTENER_FLOW)
         create_listener_flow.add(lifecycle_tasks.ListenerToErrorOnRevertTask(
             requires=[constants.LISTENER]))
+        create_listener_flow.add(vthunder_tasks.VthunderInstanceBusy(
+            requires=a10constants.COMPUTE_BUSY))
         create_listener_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
@@ -91,6 +93,8 @@ class ListenerFlows(object):
         delete_listener_flow = linear_flow.Flow(constants.DELETE_LISTENER_FLOW)
         delete_listener_flow.add(lifecycle_tasks.ListenerToErrorOnRevertTask(
             requires=constants.LISTENER))
+        delete_listener_flow.add(vthunder_tasks.VthunderInstanceBusy(
+            requires=a10constants.COMPUTE_BUSY))
         delete_listener_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
@@ -163,6 +167,8 @@ class ListenerFlows(object):
         update_listener_flow = linear_flow.Flow(constants.UPDATE_LISTENER_FLOW)
         update_listener_flow.add(lifecycle_tasks.ListenerToErrorOnRevertTask(
             requires=[constants.LISTENER]))
+        update_listener_flow.add(vthunder_tasks.VthunderInstanceBusy(
+            requires=a10constants.COMPUTE_BUSY))
         update_listener_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -70,6 +70,8 @@ class LoadBalancerFlows(object):
         lb_create_flow = linear_flow.Flow(f_name)
         lb_create_flow.add(lifecycle_tasks.LoadBalancerIDToErrorOnRevertTask(
             requires=constants.LOADBALANCER_ID))
+        lb_create_flow.add(vthunder_tasks.VthunderInstanceBusy(
+            requires=a10constants.COMPUTE_BUSY))
 
         # Attaching vThunder to LB in database
         if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
@@ -182,6 +184,8 @@ class LoadBalancerFlows(object):
         delete_LB_flow = linear_flow.Flow(constants.DELETE_LOADBALANCER_FLOW)
         delete_LB_flow.add(lifecycle_tasks.LoadBalancerToErrorOnRevertTask(
             requires=constants.LOADBALANCER))
+        delete_LB_flow.add(vthunder_tasks.VthunderInstanceBusy(
+            requires=a10constants.COMPUTE_BUSY))
         delete_LB_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
@@ -455,6 +459,8 @@ class LoadBalancerFlows(object):
         update_LB_flow = linear_flow.Flow(constants.UPDATE_LOADBALANCER_FLOW)
         update_LB_flow.add(lifecycle_tasks.LoadBalancerToErrorOnRevertTask(
             requires=constants.LOADBALANCER))
+        update_LB_flow.add(vthunder_tasks.VthunderInstanceBusy(
+            requires=a10constants.COMPUTE_BUSY))
         update_LB_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -43,6 +43,9 @@ class MemberFlows(object):
                       constants.LISTENERS,
                       constants.LOADBALANCER,
                       constants.POOL]))
+        create_member_flow.add(vthunder_tasks.VthunderInstanceBusy(
+            requires=a10constants.COMPUTE_BUSY))
+
         create_member_flow.add(database_tasks.MarkMemberPendingCreateInDB(
             requires=constants.MEMBER))
         create_member_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
@@ -136,6 +139,9 @@ class MemberFlows(object):
                       constants.LISTENERS,
                       constants.LOADBALANCER,
                       constants.POOL]))
+        delete_member_flow.add(vthunder_tasks.VthunderInstanceBusy(
+            requires=a10constants.COMPUTE_BUSY))
+
         delete_member_flow.add(database_tasks.MarkMemberPendingDeleteInDB(
             requires=constants.MEMBER))
         delete_member_flow.add(model_tasks.
@@ -483,6 +489,9 @@ class MemberFlows(object):
                       constants.LISTENERS,
                       constants.LOADBALANCER,
                       constants.POOL]))
+        update_member_flow.add(vthunder_tasks.VthunderInstanceBusy(
+            requires=a10constants.COMPUTE_BUSY))
+
         update_member_flow.add(database_tasks.MarkMemberPendingUpdateInDB(
             requires=constants.MEMBER))
         update_member_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -48,6 +48,9 @@ class PoolFlows(object):
             requires=[constants.POOL,
                       constants.LISTENERS,
                       constants.LOADBALANCER]))
+        create_pool_flow.add(vthunder_tasks.VthunderInstanceBusy(
+            requires=a10constants.COMPUTE_BUSY))
+
         create_pool_flow.add(database_tasks.MarkPoolPendingCreateInDB(
             requires=constants.POOL))
         create_pool_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
@@ -83,6 +86,9 @@ class PoolFlows(object):
             requires=[constants.POOL,
                       constants.LISTENERS,
                       constants.LOADBALANCER]))
+        delete_pool_flow.add(vthunder_tasks.VthunderInstanceBusy(
+            requires=a10constants.COMPUTE_BUSY))
+
         delete_pool_flow.add(database_tasks.MarkPoolPendingDeleteInDB(
             requires=constants.POOL))
         delete_pool_flow.add(database_tasks.CountPoolChildrenForQuota(
@@ -173,6 +179,9 @@ class PoolFlows(object):
             requires=[constants.POOL,
                       constants.LISTENERS,
                       constants.LOADBALANCER]))
+        update_pool_flow.add(vthunder_tasks.VthunderInstanceBusy(
+            requires=a10constants.COMPUTE_BUSY))
+
         update_pool_flow.add(database_tasks.MarkPoolPendingUpdateInDB(
             requires=constants.POOL))
         update_pool_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -45,18 +45,7 @@ from a10_octavia.db import repositories as a10_repo
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
-"""
-VTHUNDER_CTX_MAP = {}
-VTHUNDER_CTX_MAP_LOCK = threading.Lock()
 
-class VthunderCtx():
-
-    def _init__(self):
-        # num of flow threads that may reload vthunder
-        self.reload_thrd_num = 0
-        # num of flow threads that won't reload vthunder
-        self.normal_thrd_num = 0
-"""
 
 class VThunderBaseTask(task.Task):
 
@@ -1106,99 +1095,3 @@ class VthunderInstanceBusy(VThunderBaseTask):
     def execute(self, compute_busy=False):
         if compute_busy:
             raise Exception('vThunder instance is busy now, try again later.')
-
-
-"""
-class VthunderCtxBasic(task.Task):
-    
-    def get_vthunder_ctx(key):
-        try:
-            ctx = VTHUNDER_CTX_MAP.get(key, None)
-            if ctx is None:
-                ctx = VthunderCtx()
-                VTHUNDER_CTX_MAP[project_id] = ctx
-            return ctx
-        except Exception as e:
-            pass
-        return None
-        
-
-
-class VthunderCtxReloadThrdInc(VthunderCtxBasic):
-
-    def execute(self, project_id):
-        VTHUNDER_CTX_MAP_LOCK.acquire()
-        ctx = self.get_vthunder_ctx(project_id)
-        if ctx is None or ctx.reload_thrd_num > 0 or ctx.normal_thrd_num > 0:
-            VTHUNDER_CTX_MAP_LOCK.release()
-            raise Exception('vThunder instance is busy now, try again later.')
-        ctx.reload_thrd_num = ctx.reload_thrd_num + 1
-        VTHUNDER_CTX_MAP_LOCK.release()
-
-class VthunderCtxReloadThrdDecOnRevertTask(VthunderCtxBasic):
-
-    def execute(self, project_id):
-        pass
-
-    def revert(self, project_id):
-        VTHUNDER_CTX_MAP_LOCK.acquire()
-        ctx = self.get_vthunder_ctx(project_id)
-        if ctx is None:
-            LOG.error("Unable to find vThunder instance (%s) context", project_id)
-        else:
-            ctx.reload_thrd_num = ctx.reload_thrd_num - 1
-        VTHUNDER_CTX_MAP_LOCK.release()
-
-
-class VthunderCtxReloadThrdDec(VthunderCtxBasic):
-
-    def execute(self, project_id):
-        VTHUNDER_CTX_MAP_LOCK.acquire()
-        ctx = self.get_vthunder_ctx(project_id)
-        if ctx is None:
-            VTHUNDER_CTX_MAP_LOCK.release()
-            raise Exception("Unexpected Error: Unable to find vThunder instance (%s) context",
-                project_id)
-        ctx.reload_thrd_num = ctx.reload_thrd_num - 1
-        VTHUNDER_CTX_MAP_LOCK.release()
-
-
-class VthunderCtxNormalThrdInc(VthunderCtxBasic):
-
-    def execute(self, project_id):
-        VTHUNDER_CTX_MAP_LOCK.acquire()
-        ctx = self.get_vthunder_ctx(project_id)
-        if ctx is None or ctx.reload_thrd_num > 0:
-            VTHUNDER_CTX_MAP_LOCK.release()
-            raise Exception('vThunder instance is busy now, try again later.')
-        ctx.normal_thrd_num = ctx.normal_thrd_num + 1
-        VTHUNDER_CTX_MAP_LOCK.release()
-
-
-class VthunderCtxNormalThrdDecOnRevertTask(VthunderCtxBasic):
-
-    def execute(self, project_id):
-        pass
-
-    def revert(self, project_id):
-        VTHUNDER_CTX_MAP_LOCK.acquire()
-        ctx = self.get_vthunder_ctx(project_id)
-        if ctx is None:
-            LOG.error("Unable to find vThunder instance (%s) context", project_id)
-        else:
-            ctx.normal_thrd_num = ctx.normal_thrd_num - 1
-        VTHUNDER_CTX_MAP_LOCK.release()
-
-
-class VthunderCtxNormalThrdDec(VthunderCtxBasic):
-
-    def execute(self, project_id):
-        VTHUNDER_CTX_MAP_LOCK.acquire()
-        ctx = self.get_vthunder_ctx(project_id)
-        if ctx is None:
-            VTHUNDER_CTX_MAP_LOCK.release()
-            raise Exception("Unexpected Error: Unable to find vThunder instance (%s) context",
-                project_id)
-        ctx.normal_thrd_num = ctx.normal_thrd_num - 1
-        VTHUNDER_CTX_MAP_LOCK.release()
-"""

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ deps = -r{toxinidir}/requirements.txt
 
 [flake8]
 #ignore = E122,E125,E126,E128,E129,E251,E265,E713,F402,F811,F812,H104,H237,H302,H304,H305,H307,H401,H402,H404,H405,H904
-ignore = W504,W503,H202,H401,H404,H405
+ignore = W504,W503,H202,H401,H404,H405,H216
 show-source = true
 builtins = _
 exclude = .eggs,.git,.tox,__pycache__,docs,build,dist,a10_octavia/etc/*,a10_octavia/db/*,a10_octavia/cmd/service.py,


### PR DESCRIPTION
[STACK-2241][STACK-2262][STACK-2264][STACK-2284] Provide thread-safe mechanism for vthunder flow

## Description
Severity Level: Critical
Issue Description:

For vThunder flow, vthunder instance may reload during 
- loadbalancer create
- loadbalancer delete
- member create
- member delete
And in these cases, if other works (or a10-octavia controller work threads) also configure something in this project. The configuration may loss on vthunder (since vthunder may be reloaded in any time). So, we need to prevent these kinds of situation.


## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2241
https://a10networks.atlassian.net/browse/STACK-2262
https://a10networks.atlassian.net/browse/STACK-2264
https://a10networks.atlassian.net/browse/STACK-2284
https://a10networks.atlassian.net/browse/STACK-2293

## Technical Approach
**Add a limitation in this release:**
- **If a10-octavia is working on loadbalancer create/delete or member create/delete, then a10-octavia will not allow any other operations on this instance (or project).**
- **If a10-octavia is working on any operations, it will not allow user to loadbalancer create/delete or member create/delete at this time.**
**We will raise an error (something like: "vThunder instance is busy now, try again later.") for this case**

## Config Changes
<pre>
<b>N/A</b>
</pre>

## Test Cases
**Will test more cases later**
- create 2 LB at the same time

## Manual Testing
- create 2 LB at the same time
```shell
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer create --vip-subnet-id tp91 --name vipx1
openstack loadbalancer create --vip-subnet-id tp91 --name vipx2
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-04-21T08:59:43                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 4450ebd2-3367-4a2e-9aa5-a8265394c3fe |
| listeners           |                                      |
| name                | vipx1                                |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 99c9c2304f114685a32db30769c8a7e2     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.91.163                       |
| vip_network_id      | 61305531-6e3a-44b4-8e67-05e93363dddc |
| vip_port_id         | 09f2682a-7dc4-47dc-bd7a-87bddd28ce7c |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 3ea80a1c-5785-4252-b751-c84d614ccb0c |
+---------------------+--------------------------------------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer create --vip-subnet-id tp91 --name vipx2
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-04-21T08:59:50                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 67bcdaa2-ea15-4f11-a7f1-69316270fb43 |
| listeners           |                                      |
| name                | vipx2                                |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 99c9c2304f114685a32db30769c8a7e2     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.91.8                         |
| vip_network_id      | 61305531-6e3a-44b4-8e67-05e93363dddc |
| vip_port_id         | 2aecc958-a804-4204-9460-50dec0d19aad |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 3ea80a1c-5785-4252-b751-c84d614ccb0c |
+---------------------+--------------------------------------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer list
+--------------------------------------+-------+----------------------------------+----------------+---------------------+----------+
| id                                   | name  | project_id                       | vip_address    | provisioning_status | provider |
+--------------------------------------+-------+----------------------------------+----------------+---------------------+----------+
| 4450ebd2-3367-4a2e-9aa5-a8265394c3fe | vipx1 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.163 | ACTIVE              | a10      |
| 67bcdaa2-ea15-4f11-a7f1-69316270fb43 | vipx2 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.8   | ERROR               | a10      |
+--------------------------------------+-------+----------------------------------+----------------+---------------------+----------+
```

```shell
Apr 21 08:59:52 openstack-4 a10-octavia-worker[25039]: INFO a10_octavia.controller.queue.endpoint [-] Creating load balancer '67bcdaa2-ea15-4f11-a7f1-69316270fb43'...
Apr 21 08:59:52 openstack-4 a10-octavia-worker[25039]: ERROR a10_octavia.controller.worker.controller_worker [-] [busy_check] vthunder 99c9c2304f114685a32db30769c8a7e2 ctx: normal_thrd(0), reload_thrd(1)
Apr 21 08:59:53 openstack-4 a10-octavia-worker[25039]: DEBUG a10_octavia.controller.worker.controller_worker [-] Flow 'octavia-create-loadbalancer-flow' (2c30ce8d-5ed5-4cc9-8286-ac206294e874) transitioned into state 'RUNNING' from state 'PENDING' {{(pid=25054) _flow_receiver /usr/local/lib/python2.7/dist-packages/taskflow/listeners/logging.py:145}}
Apr 21 08:59:53 openstack-4 a10-octavia-worker[25039]: DEBUG a10_octavia.controller.worker.controller_worker [-] Task 'octavia.controller.worker.tasks.lifecycle_tasks.LoadBalancerIDToErrorOnRevertTask' (9e02f46a-8032-45d3-93d7-1f8c45d6e8ef) transitioned into state 'RUNNING' from state 'PENDING' {{(pid=25054) _task_receiver /usr/local/lib/python2.7/dist-packages/taskflow/listeners/logging.py:194}}
Apr 21 08:59:53 openstack-4 a10-octavia-worker[25039]: DEBUG a10_octavia.controller.worker.controller_worker [-] Task 'octavia.controller.worker.tasks.lifecycle_tasks.LoadBalancerIDToErrorOnRevertTask' (9e02f46a-8032-45d3-93d7-1f8c45d6e8ef) transitioned into state 'SUCCESS' from state 'RUNNING' with result 'None' {{(pid=25054) _task_receiver /usr/local/lib/python2.7/dist-packages/taskflow/listeners/logging.py:183}}
Apr 21 08:59:53 openstack-4 a10-octavia-worker[25039]: DEBUG a10_octavia.controller.worker.controller_worker [-] Task 'a10_octavia.controller.worker.tasks.vthunder_tasks.VthunderInstanceBusy' (e286fa83-d3c2-47a4-a8dc-65b3587bfc74) transitioned into state 'RUNNING' from state 'PENDING' {{(pid=25054) _task_receiver /usr/local/lib/python2.7/dist-packages/taskflow/listeners/logging.py:194}}
Apr 21 08:59:53 openstack-4 a10-octavia-worker[25039]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'a10_octavia.controller.worker.tasks.vthunder_tasks.VthunderInstanceBusy' (e286fa83-d3c2-47a4-a8dc-65b3587bfc74) transitioned into state 'FAILURE' from state 'RUNNING'
Apr 21 08:59:53 openstack-4 a10-octavia-worker[25039]: 2 predecessors (most recent first):
Apr 21 08:59:53 openstack-4 a10-octavia-worker[25039]:   Atom 'octavia.controller.worker.tasks.lifecycle_tasks.LoadBalancerIDToErrorOnRevertTask' {'intention': 'EXECUTE', 'state': 'SUCCESS', 'requires': {'loadbalancer_id': u'67bcdaa2-ea15-4f11-a7f1-69316270fb43'}, 'provides': None}
Apr 21 08:59:53 openstack-4 a10-octavia-worker[25039]:   |__Flow 'octavia-create-loadbalancer-flow': Exception: vThunder instance is busy now, try again later.
Apr 21 08:59:53 openstack-4 a10-octavia-worker[25039]: ERROR a10_octavia.controller.worker.controller_worker Traceback (most recent call last):
Apr 21 08:59:53 openstack-4 a10-octavia-worker[25039]: ERROR a10_octavia.controller.worker.controller_worker   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Apr 21 08:59:53 openstack-4 a10-octavia-worker[25039]: ERROR a10_octavia.controller.worker.controller_worker     result = task.execute(**arguments)
Apr 21 08:59:53 openstack-4 a10-octavia-worker[25039]: ERROR a10_octavia.controller.worker.controller_worker   File "/opt/stack/source/a10-octavia/vThunder/a10_octavia/controller/worker/tasks/vthunder_tasks.py", line 1108, in execute
Apr 21 08:59:53 openstack-4 a10-octavia-worker[25039]: ERROR a10_octavia.controller.worker.controller_worker     raise Exception('vThunder instance is busy now, try again later.')
Apr 21 08:59:53 openstack-4 a10-octavia-worker[25039]: ERROR a10_octavia.controller.worker.controller_worker Exception: vThunder instance is busy now, try again later.
Apr 21 08:59:53 openstack-4 a10-octavia-worker[25039]: ERROR a10_octavia.controller.worker.controller_worker
Apr 21 08:59:53 openstack-4 a10-octavia-worker[25039]: DEBUG a10_octavia.controller.worker.controller_worker [-] Task 'a10_octavia.controller.worker.tasks.vthunder_tasks.VthunderInstanceBusy'
```

-------------------


[STACK-2241]: https://a10networks.atlassian.net/browse/STACK-2241
[STACK-2262]: https://a10networks.atlassian.net/browse/STACK-2262
[STACK-2264]: https://a10networks.atlassian.net/browse/STACK-2264
[STACK-2284]: https://a10networks.atlassian.net/browse/STACK-2284
[STACK-2293]: https://a10networks.atlassian.net/browse/STACK-2293