### PR TITLE
[BUG][STACK-2279]: Fixed an issue of failing listener creation in ACTIVE_STANDBY mode.

### DIFF
--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -197,6 +197,8 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         parent_project_list = utils.get_parent_project_list()
         listener_parent_proj = utils.get_parent_project(listener.project_id)
 
+        topology = CONF.a10_controller_worker.loadbalancer_topology
+
         if (listener.project_id in parent_project_list or
                 (listener_parent_proj and listener_parent_proj in parent_project_list)
                 or listener.project_id in CONF.hardware_thunder.devices):
@@ -209,7 +211,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                                                             listener})
         else:
             create_listener_tf = self._taskflow_load(self._listener_flows.
-                                                     get_create_listener_flow(),
+                                                     get_create_listener_flow(topology=topology),
                                                      store={constants.LOADBALANCER:
                                                             load_balancer,
                                                             constants.LISTENER:

--- a/a10_octavia/controller/worker/flows/a10_listener_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_listener_flows.py
@@ -32,7 +32,7 @@ from a10_octavia.controller.worker.tasks import vthunder_tasks
 
 class ListenerFlows(object):
 
-    def get_create_listener_flow(self):
+    def get_create_listener_flow(self, topology):
         """Flow to create a listener"""
 
         create_listener_flow = linear_flow.Flow(constants.CREATE_LISTENER_FLOW)
@@ -41,6 +41,11 @@ class ListenerFlows(object):
         create_listener_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
+        if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+            create_listener_flow.add(vthunder_tasks.GetMasterVThunder(
+                name=a10constants.GET_MASTER_VTHUNDER,
+                requires=a10constants.VTHUNDER,
+                provides=a10constants.VTHUNDER))
         create_listener_flow.add(self.handle_ssl_cert_flow(flow_type='create'))
         create_listener_flow.add(a10_database_tasks.GetFlavorData(
             rebind={a10constants.LB_RESOURCE: constants.LISTENER},

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ deps = -r{toxinidir}/requirements.txt
 
 [flake8]
 #ignore = E122,E125,E126,E128,E129,E251,E265,E713,F402,F811,F812,H104,H237,H302,H304,H305,H307,H401,H402,H404,H405,H904
-ignore = W504,W503,H202,H401,H404,H405
+ignore = W504,W503,H202,H401,H404,H405,H216
 show-source = true
 builtins = _
 exclude = .eggs,.git,.tox,__pycache__,docs,build,dist,a10_octavia/etc/*,a10_octavia/db/*,a10_octavia/cmd/service.py,


### PR DESCRIPTION
## Description
- Severity Level: Highest
- Issue Description: Listener creation is failing when a listener is created for a loadbalancer with different subnet than that of latest created loadbalancer due to the reload and role switching happening for the vThunders in ACTIVE_STANDBY topology.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2279

## Technical Approach
- Passing **topology** in `get_create_listener_flow`.
- If the topology is **ACTIVE_STANDBY**, then `GetMasterVThunder` is called before listener creation for getting correct vMaster vThunder based on the current vcs_summary sothat the listener will be always created on vMaster without throwing the error.

## Manual Testing
1. openstack loadbalancer create --name v1 --vip-subnet-id vip_subnet
2. openstack loadbalancer create --name v2 --vip-subnet-id vip_subnet
3. openstack loadbalancer create --name v3 --vip-subnet-id vip_subnet
4. openstack loadbalancer create --name v4 --vip-subnet-id vip_subnet2

Result:
stack@neha:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| 364a7df9-bde6-42c8-98cb-d593905bf85b | v1   | dc180e5107ba4d339b729f7e75f3f76e | 192.168.8.50  | ACTIVE              | a10      |
| 754b8212-d415-4e6f-bc63-4ccb48b5f4a5 | v2   | dc180e5107ba4d339b729f7e75f3f76e | 192.168.8.246 | ACTIVE              | a10      |
| 85863e81-8e4b-465d-aa17-cce5a63db93f | v3   | dc180e5107ba4d339b729f7e75f3f76e | 192.168.8.14  | ACTIVE              | a10      |
| c3452195-5511-4ca3-99aa-506eece7c438 | v4   | dc180e5107ba4d339b729f7e75f3f76e | 192.168.12.89 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+

```
5. stack@neha:~$ openstack loadbalancer listener create --name l1 --protocol TCP --protocol-port 8 v1
```
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-04-21T11:35:58                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 5c216615-246c-4bc3-a7ee-66ba3fd43efd |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 364a7df9-bde6-42c8-98cb-d593905bf85b |
| name                        | l1                                   |
| operating_status            | OFFLINE                              |
| project_id                  | dc180e5107ba4d339b729f7e75f3f76e     |
| protocol                    | TCP                                  |
| protocol_port               | 8                                    |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
+-----------------------------+--------------------------------------+
```
Result:
Listener is created successfully.

stack@neha:~$ openstack loadbalancer listener show l1
```
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-04-21T11:35:58                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 5c216615-246c-4bc3-a7ee-66ba3fd43efd |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 364a7df9-bde6-42c8-98cb-d593905bf85b |
| name                        | l1                                   |
| operating_status            | OFFLINE                              |
| project_id                  | dc180e5107ba4d339b729f7e75f3f76e     |
| protocol                    | TCP                                  |
| protocol_port               | 8                                    |
| provisioning_status         | ACTIVE                               |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | 2021-04-21T11:36:20                  |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
+-----------------------------+--------------------------------------+
```

```
vThunder-vMaster[1/2](NOLICENSE)#show running-config
!Current configuration: 780 bytes
!Configuration last updated at 12:36:18 IST Wed Apr 21 2021
!Configuration last saved at 12:36:25 IST Wed Apr 21 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 192.168.12.126
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.129
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb virtual-server 364a7df9-bde6-42c8-98cb-d593905bf85b 192.168.8.50
  port 8 tcp
    name 5c216615-246c-4bc3-a7ee-66ba3fd43efd
    extended-stats
!
slb virtual-server 754b8212-d415-4e6f-bc63-4ccb48b5f4a5 192.168.8.246
!
slb virtual-server 85863e81-8e4b-465d-aa17-cce5a63db93f 192.168.8.14
!
slb virtual-server c3452195-5511-4ca3-99aa-506eece7c438 192.168.12.89
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```
