### PR TITLE
[BUG][STACK-2280]: Deleting ve ip for blade from dashboard on deleting the lb cascade

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -301,10 +301,6 @@ class MemberFlows(object):
     def get_delete_member_vthunder_internal_subflow(self, member_id, pool):
         delete_member_thunder_subflow = linear_flow.Flow(
             a10constants.DELETE_MEMBER_VTHUNDER_INTERNAL_SUBFLOW)
-        delete_member_thunder_subflow.add(vthunder_tasks.SetupDeviceNetworkMap(
-            name='setup_device_network_map_' + member_id,
-            requires=a10constants.VTHUNDER,
-            provides=a10constants.VTHUNDER))
         delete_member_thunder_subflow.add(
             a10_database_tasks.CountMembersWithIPPortProtocol(
                 name='count_members_ip_port_' + member_id,

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -287,6 +287,9 @@ class PoolFlows(object):
             requires=[constants.LOADBALANCER, constants.LISTENER, a10constants.VTHUNDER]))
         delete_pool_flow.add(persist_tasks.DeleteSessionPersistence(
             requires=[a10constants.VTHUNDER, constants.POOL]))
+        delete_pool_flow.add(vthunder_tasks.SetupDeviceNetworkMap(
+            requires=a10constants.VTHUNDER,
+            provides=a10constants.VTHUNDER))
         # Delete pool children
         delete_pool_flow.add(self._get_delete_health_monitor_vthunder_subflow(health_mon))
         delete_pool_flow.add(self._get_delete_member_vthunder_subflow(members, store))

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ deps = -r{toxinidir}/requirements.txt
 
 [flake8]
 #ignore = E122,E125,E126,E128,E129,E251,E265,E713,F402,F811,F812,H104,H237,H302,H304,H305,H307,H401,H402,H404,H405,H904
-ignore = W504,W503,H202,H401,H404,H405
+ignore = W504,W503,H202,H401,H404,H405,H216
 show-source = true
 builtins = _
 exclude = .eggs,.git,.tox,__pycache__,docs,build,dist,a10_octavia/etc/*,a10_octavia/db/*,a10_octavia/cmd/service.py,


### PR DESCRIPTION
## Description
Severity Level: Medium
Issue: [delete_lb-cascade] ve ip of vblade was not released from dashboard when deleting by cascade

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2280

## Technical Approach
- Task _SetupDeviceNetworkMap_ was being executed multiple times in one flow thus appending multiple values in _vthunder.device_network_map_. 
Changed the location _SetupDeviceNetworkMap_ so that it runs one time per flow.

## Manual Testing
1) Create loadbalancer, listener, pool and members.
```
openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name v1
openstack loadbalancer listener create --protocol HTTP --protocol-port 8080 --name l11 v1
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener l11 --name pool11
openstack loadbalancer member create --address 10.0.12.192 --subnet-id provider-vlan-12-subnet --protocol-port 80 --name mem1 pool11
openstack loadbalancer member create --address 10.0.13.192 --subnet-id provider-vlan-13-subnet --protocol-port 81 --name mem2 pool11

AX35-Active-vMaster[1/1]#show running-config slb
!Section configuration: 454 bytes
!
slb server 5327a_10_0_12_192 10.0.12.192
  port 80 tcp
!
slb server 5327a_10_0_13_192 10.0.13.192
  port 81 tcp
!
slb service-group 18c7703f-10bc-4570-a46a-d3bd83d88a8c tcp
  member 5327a_10_0_12_192 80
  member 5327a_10_0_13_192 81
!
slb virtual-server f1121dc0-b1b6-4f70-a594-299f5fc4ece5 10.0.11.174
  port 8080 http
    name a5858c2b-86eb-4b21-b499-8a8b1b8ba9b7
    extended-stats
    service-group 18c7703f-10bc-4570-a46a-d3bd83d88a8c
!
AX35-Active-vMaster[1/1]#show interfaces brief
Port    Link  Dupl  Speed  Trunk Vlan MAC             IP Address          IPs  Name
------------------------------------------------------------------------------------
mgmt    Up    Full  1000   N/A   N/A  001f.a014.5876  10.64.27.35/24        1
1       Disb  None  None   none  1    001f.a014.5875  0.0.0.0/0             0
2       Up    Full  1000   none  Tag  001f.a014.5874  0.0.0.0/0             0
3       Disb  None  None   none  1    001f.a014.5873  0.0.0.0/0             0
4       Disb  None  None   none  1    001f.a014.5872  0.0.0.0/0             0
5       Up    Full  1000   1     Tag  001f.a014.5871  0.0.0.0/0             0
6       Disb  None  None   none  1    001f.a014.5870  0.0.0.0/0             0
7       Disb  None  None   none  1    001f.a014.586f  0.0.0.0/0             0
8       Disb  None  None   none  1    001f.a014.586e  0.0.0.0/0             0
9       Disb  None  None   none  1    001f.a014.586d  0.0.0.0/0             0
10      Disb  None  None   none  1    001f.a014.586c  0.0.0.0/0             0
11      Disb  None  None   none  1    001f.a014.586b  0.0.0.0/0             0
12      Disb  None  None   none  1    001f.a014.586a  0.0.0.0/0             0
ve11    Up    N/A   N/A    N/A   11   001f.a014.586a  10.0.11.61/24         1
ve12    Up    N/A   N/A    N/A   12   001f.a014.5875  10.0.12.61/24         1
ve13    Up    N/A   N/A    N/A   13   001f.a014.5874  10.0.13.61/24         1

Global Throughput:13960 bits/sec (1745 bytes/sec)
Throughput:0 bits/sec (0 bytes/sec)
AX35-Active-vMaster[1/1]#

AX36-Active-vBlade[1/2]#show running-config slb
!Section configuration: 454 bytes
!
slb server 5327a_10_0_12_192 10.0.12.192
  port 80 tcp
!
slb server 5327a_10_0_13_192 10.0.13.192
  port 81 tcp
!
slb service-group 18c7703f-10bc-4570-a46a-d3bd83d88a8c tcp
  member 5327a_10_0_12_192 80
  member 5327a_10_0_13_192 81
!
slb virtual-server f1121dc0-b1b6-4f70-a594-299f5fc4ece5 10.0.11.174
  port 8080 http
    name a5858c2b-86eb-4b21-b499-8a8b1b8ba9b7
    extended-stats
    service-group 18c7703f-10bc-4570-a46a-d3bd83d88a8c
!
AX36-Active-vBlade[1/2]#show interfaces brief
Port    Link  Dupl  Speed  Trunk Vlan MAC             IP Address          IPs  Name
------------------------------------------------------------------------------------
mgmt    Up    Full  1000   N/A   N/A  001f.a013.34e4  10.64.27.36/24        1
1       Disb  None  None   none  1    001f.a013.34e3  0.0.0.0/0             0
2       Up    Full  1000   none  Tag  001f.a013.34e2  0.0.0.0/0             0
3       Disb  None  None   none  1    001f.a013.34e1  0.0.0.0/0             0
4       Disb  None  None   none  1    001f.a013.34e0  0.0.0.0/0             0
5       Up    Full  1000   1     Tag  001f.a013.34df  0.0.0.0/0             0
6       Disb  None  None   none  1    001f.a013.34de  0.0.0.0/0             0
7       Disb  None  None   none  1    001f.a013.34dd  0.0.0.0/0             0
8       Disb  None  None   none  1    001f.a013.34dc  0.0.0.0/0             0
9       Disb  None  None   none  1    001f.a013.34db  0.0.0.0/0             0
10      Disb  None  None   none  1    001f.a013.34da  0.0.0.0/0             0
11      Disb  None  None   none  1    001f.a013.34d9  0.0.0.0/0             0
12      Disb  None  None   none  1    001f.a013.34d8  0.0.0.0/0             0
ve11    Up    N/A   N/A    N/A   11   001f.a013.34d8  10.0.11.41/24         1
ve12    Up    N/A   N/A    N/A   12   001f.a013.34e3  10.0.12.41/24         1
ve13    Up    N/A   N/A    N/A   13   001f.a013.34e2  10.0.13.41/24         1

Global Throughput:13968 bits/sec (1746 bytes/sec)
Throughput:0 bits/sec (0 bytes/sec)
AX36-Active-vBlade[1/2]#
```
![image](https://user-images.githubusercontent.com/76765492/115673366-2f476100-a36a-11eb-9234-93e4f35799fc.png)
![image](https://user-images.githubusercontent.com/76765492/115673408-3a01f600-a36a-11eb-97eb-2ca95ec339a1.png)
![image](https://user-images.githubusercontent.com/76765492/115673453-44bc8b00-a36a-11eb-9844-474f6304217f.png)

2) Delete the loadbalancer with cascade flag
```
stack@adeeb:~$ openstack loadbalancer delete v1 --cascade
Apr 22 07:03:42 adeeb a10-octavia-worker[25961]: INFO a10_octavia.controller.queue.endpoint [-] Deleting load balancer 'f1121dc0-b1b6-4f70-a594-299f5fc4ece5'...
Apr 22 07:03:46 adeeb a10-octavia-worker[25961]: INFO a10_octavia.controller.worker.tasks.a10_network_tasks [-] VRID floating IP: [u'10.0.11.172'] deleted
Apr 22 07:03:47 adeeb a10-octavia-worker[25961]: INFO a10_octavia.controller.worker.tasks.a10_network_tasks [-] VRID floating IP: 10.0.11.172 deleted
Apr 22 07:03:49 adeeb a10-octavia-worker[25961]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 10.64.27.62:shared


AX35-Active-vMaster[1/1]#show running-config slb
!Section configuration: 0 bytes
!
AX35-Active-vMaster[1/1]#show interfaces brief
Port    Link  Dupl  Speed  Trunk Vlan MAC             IP Address          IPs  Name
------------------------------------------------------------------------------------
mgmt    Up    Full  1000   N/A   N/A  001f.a014.5876  10.64.27.35/24        1
1       Disb  None  None   none  1    001f.a014.5875  0.0.0.0/0             0
2       Up    Full  1000   none  1    001f.a014.5874  0.0.0.0/0             0
3       Disb  None  None   none  1    001f.a014.5873  0.0.0.0/0             0
4       Disb  None  None   none  1    001f.a014.5872  0.0.0.0/0             0
5       Up    Full  1000   1     1    001f.a014.5871  0.0.0.0/0             0
6       Disb  None  None   none  1    001f.a014.5870  0.0.0.0/0             0
7       Disb  None  None   none  1    001f.a014.586f  0.0.0.0/0             0
8       Disb  None  None   none  1    001f.a014.586e  0.0.0.0/0             0
9       Disb  None  None   none  1    001f.a014.586d  0.0.0.0/0             0
10      Disb  None  None   none  1    001f.a014.586c  0.0.0.0/0             0
11      Disb  None  None   none  1    001f.a014.586b  0.0.0.0/0             0
12      Disb  None  None   none  1    001f.a014.586a  0.0.0.0/0             0

Global Throughput:0 bits/sec (0 bytes/sec)
Throughput:0 bits/sec (0 bytes/sec)


AX36-Active-vBlade[1/2]#show running-config slb
!Section configuration: 0 bytes
!
AX36-Active-vBlade[1/2]#show interfaces brief
Port    Link  Dupl  Speed  Trunk Vlan MAC             IP Address          IPs  Name
------------------------------------------------------------------------------------
mgmt    Up    Full  1000   N/A   N/A  001f.a013.34e4  10.64.27.36/24        1
1       Disb  None  None   none  1    001f.a013.34e3  0.0.0.0/0             0
2       Up    Full  1000   none  1    001f.a013.34e2  0.0.0.0/0             0
3       Disb  None  None   none  1    001f.a013.34e1  0.0.0.0/0             0
4       Disb  None  None   none  1    001f.a013.34e0  0.0.0.0/0             0
5       Up    Full  1000   1     1    001f.a013.34df  0.0.0.0/0             0
6       Disb  None  None   none  1    001f.a013.34de  0.0.0.0/0             0
7       Disb  None  None   none  1    001f.a013.34dd  0.0.0.0/0             0
8       Disb  None  None   none  1    001f.a013.34dc  0.0.0.0/0             0
9       Disb  None  None   none  1    001f.a013.34db  0.0.0.0/0             0
10      Disb  None  None   none  1    001f.a013.34da  0.0.0.0/0             0
11      Disb  None  None   none  1    001f.a013.34d9  0.0.0.0/0             0
12      Disb  None  None   none  1    001f.a013.34d8  0.0.0.0/0             0

Global Throughput:0 bits/sec (0 bytes/sec)
Throughput:0 bits/sec (0 bytes/sec)
```
![image](https://user-images.githubusercontent.com/76765492/115673763-9b29c980-a36a-11eb-9045-6ad3de851f9a.png)
![image](https://user-images.githubusercontent.com/76765492/115673801-a250d780-a36a-11eb-8baa-3f2ff052616a.png)
![image](https://user-images.githubusercontent.com/76765492/115673828-a8df4f00-a36a-11eb-8069-b74d258e40e3.png)

II) Deleting loadbalancer objects without cascade
1) Create loadbalancer, listener, pool and members.
```
openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name v1
openstack loadbalancer listener create --protocol HTTP --protocol-port 8080 --name l11 v1
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener l11 --name pool11
openstack loadbalancer member create --address 10.0.12.192 --subnet-id provider-vlan-12-subnet --protocol-port 80 --name mem1 pool11
openstack loadbalancer member create --address 10.0.13.192 --subnet-id provider-vlan-13-subnet --protocol-port 81 --name mem2 pool11

AX1030#show running-config slb
!Section configuration: 454 bytes
!
slb server 5327a_10_0_12_192 10.0.12.192
  port 80 tcp
!
slb server 5327a_10_0_13_192 10.0.13.192
  port 81 tcp
!
slb service-group 247bb24b-5848-41bb-b1fb-7552f47fb869 tcp
  member 5327a_10_0_12_192 80
  member 5327a_10_0_13_192 81
!
slb virtual-server f7d9dc11-441d-4a3b-a146-6b1cadad8ccd 10.0.11.181
  port 8080 http
    name abbeeb38-86c1-459a-bfd8-69da1d065153
    extended-stats
    service-group 247bb24b-5848-41bb-b1fb-7552f47fb869
!
```

2) Delete lb objects one by one
```
stack@adeeb:~$ openstack loadbalancer member delete pool11 mem1
stack@adeeb:~$ openstack loadbalancer member delete pool11 mem2
stack@adeeb:~$ openstack loadbalancer pool delete pool11
stack@adeeb:~$ openstack loadbalancer listener delete l11
stack@adeeb:~$ openstack loadbalancer delete v1

Apr 23 05:54:34 adeeb a10-octavia-worker[14856]: INFO a10_octavia.controller.queue.endpoint [-] Deleting member 'cbe4a316-3aa2-4859-968e-8c0aad02cc7a'...
Apr 23 05:54:38 adeeb a10-octavia-worker[14856]: INFO a10_octavia.controller.worker.tasks.a10_network_tasks [-] VRID floating IP: 10.0.12.172 deleted
Apr 23 05:54:39 adeeb a10-octavia-worker[14856]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.90.46:shared
Apr 23 05:55:57 adeeb a10-octavia-worker[14856]: INFO a10_octavia.controller.queue.endpoint [-] Deleting member '87e57ead-9f49-45b4-84a4-18dc9fce1e12'...
Apr 23 05:56:01 adeeb a10-octavia-worker[14856]: INFO a10_octavia.controller.worker.tasks.a10_network_tasks [-] VRID floating IP: 10.0.13.172 deleted
Apr 23 05:56:02 adeeb a10-octavia-worker[14856]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.90.46:shared
Apr 23 05:56:28 adeeb a10-octavia-worker[14856]: INFO a10_octavia.controller.queue.endpoint [-] Deleting pool '247bb24b-5848-41bb-b1fb-7552f47fb869'...
Apr 23 05:56:32 adeeb a10-octavia-worker[14856]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.90.46:shared
Apr 23 05:57:01 adeeb a10-octavia-worker[14856]: INFO a10_octavia.controller.queue.endpoint [-] Deleting listener 'abbeeb38-86c1-459a-bfd8-69da1d065153'...
Apr 23 05:57:03 adeeb a10-octavia-worker[14856]: INFO octavia.controller.worker.tasks.database_tasks [-] Mark ACTIVE in DB for load balancer id: f7d9dc11-441d-4a3b-a146-6b1cadad8ccd
Apr 23 05:57:03 adeeb a10-octavia-worker[14856]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.90.46:shared
Apr 23 05:57:16 adeeb a10-octavia-worker[14856]: INFO a10_octavia.controller.queue.endpoint [-] Deleting load balancer 'f7d9dc11-441d-4a3b-a146-6b1cadad8ccd'...
Apr 23 05:57:17 adeeb a10-octavia-worker[14856]: INFO a10_octavia.controller.worker.tasks.a10_network_tasks [-] VRID floating IP: 10.0.11.172 deleted
Apr 23 05:57:20 adeeb a10-octavia-worker[14856]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.90.46:shared

stack@adeeb:~$ openstack loadbalancer list

stack@adeeb:~$ openstack loadbalancer listener list

stack@adeeb:~$ openstack loadbalancer pool list

stack@adeeb:~$

AX1030#show running-config slb
!Section configuration: 0 bytes
!
```