### PR TITLE
[BUG][STACK-2281][vthunder: active-standby][DEGRADE]the vrid floating ip isn't right after adding lb from different subnet.

### DIFF
--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -317,7 +317,8 @@ class VThunderRepository(BaseRepository):
             and_(self.model_class.partition_name == partition_name,
                  self.model_class.ip_address == ip_address,
                  or_(self.model_class.role == "STANDALONE",
-                     self.model_class.role == "MASTER")))
+                     self.model_class.role == "MASTER",
+                     self.model_class.role == "BACKUP")))
         list_projects = [project[0] for project in queryset_vthunders]
         return list_projects
 


### PR DESCRIPTION
## Description
Severity Level: High
Issue Description: In active-standby mode, create 4 lb, the 4th one is from a different subnet, which causes the vrid floating IP for the 1st subnet is deleted

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2281

## Technical Approach

- The vthunders entries happen at start of create_lb_flow and those entries are according to the previous master and the backup role and there are several reloads that happen which causes the change in role for those vthunder.
- Identifying the return of task GetChildProjectsOfParentPartition.
- Added "BACKUP" for role field in a query to fetch vthunders entry from vthunder table. 

## Manual Testing
- Created 3 lbs in one subnet and 1 subnet in different subnet. 
 
![image](https://user-images.githubusercontent.com/66299493/115876523-0c997300-a464-11eb-8502-308d2b317c35.png)

- Checked vthunder for VRID FIP configuration.

vThunder-vBlade[1/1](NOLICENSE)#show running-config 
!Current configuration: 855 bytes       
!Configuration last updated at 12:14:50 IST Fri Apr 23 2021
!Configuration last saved at 12:13:05 IST Fri Apr 23 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
vrrp-a common 
  device-id 1 
  set-id 1 
  enable 
!
device-context 1
  vcs enable 
!
device-context 2
  vcs enable 
!
vcs floating-ip 192.168.0.100 255.255.255.0 
!
vcs device 1 
  priority 200 
  interfaces management 
  enable 
!
vcs device 2 
  priority 100 
  interfaces management 
  enable 
!
!
device-context 1
  interface management 
    ip address dhcp 
!
device-context 2
  interface management 
    ip address dhcp 
!       
interface ethernet 1/1 
  name DataPort 
  enable 
  ip address dhcp 
!       
interface ethernet 1/2 
  name DataPort 
  enable 
  ip address dhcp 
!       
interface ethernet 2/1 
  name DataPort 
  enable 
  ip address dhcp 
!       
interface ethernet 2/2 
  name DataPort 
  enable 
  ip address dhcp 
!       
vrrp-a vrid 0 
  floating-ip 192.168.12.128 
  floating-ip 192.168.11.128 
!       
vrrp-a vrid 1 
  device-context 1
    blade-parameters 
      priority 150 
!       
health monitor octavia_health_monitor 
  retry 5 
  override-ipv4 10.64.3.140 
  override-port 5550 
  interval 5 timeout 3 
  method udp port 5550 
!       
slb server octavia_health_manager_controller 10.64.3.140 
  health-check octavia_health_monitor 
!       
slb virtual-server 2c7a6570-597a-45d4-b70d-867e52b38e70 192.168.12.222 
!       
slb virtual-server 55142177-2d9c-44d1-8a02-e703809d1112 192.168.12.137 
!       
slb virtual-server c7084bfc-e792-4974-8ade-daf7030598b9 192.168.12.223 
!       
slb virtual-server e2ef5bc9-3c33-4bb9-927e-77dd1908d73a 192.168.11.40 
!       
!       
cloud-services meta-data 
  enable 
  provider openstack 
!       
end     
!Current config commit point for partition 0 is 0 & config mode is classical-mode