### PR TITLE
[STACK-2283][STACK-2298] vcs retry and timeout option type error

### DIFF
--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -261,11 +261,11 @@ A10_CONTROLLER_WORKER_OPTS = [
                help=_('Load balancer topology configuration. '
                       'SINGLE - One vthunder per load balancer. '
                       'ACTIVE_STANDBY - Two vthunder per load balancer.')),
-    cfg.StrOpt('amp_vcs_wait_sec',
+    cfg.IntOpt('amp_vcs_wait_sec',
                default=20,
                help=_('Seconds to wait between checks on whether an VThunder '
                       'vcs negotiation is ready')),
-    cfg.StrOpt('amp_vcs_retries',
+    cfg.IntOpt('amp_vcs_retries',
                default=5,
                help=_('Retry attempts to wait for VThunder vcs negotiation'))
 ]


### PR DESCRIPTION
- Required: Severity Level High
- Required: Issue Description
config option define by wrong type, vcs_wait_sec and retry should be int not string

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2298
https://a10networks.atlassian.net/browse/STACK-2283


## Technical Approach
use IntOpt insteadd of StrOpt for amp_vcs_retries and amp_vcs_wait_sec


## Config Changes
<pre>
<b>[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
#default_axapi_timeout = 600

[a10_controller_worker]
amp_image_owner_id = 99c9c2304f114685a32db30769c8a7e2
amp_secgroup_list = 2d0a3480-7f08-4184-b96f-c39bb444dd38
amp_flavor_id = 69995a83-c47a-427f-bf70-e9d9752aa915
amp_boot_network_list = 7f8ddd7f-c5c3-463a-b1c3-596f988480a4
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 200
amp_active_wait_sec = 10
amp_image_id = 0a845873-bd91-4f8c-ad58-cf5d5afde09c
loadbalancer_topology = SINGLE
#loadbalancer_topology = ACTIVE_STANDBY

[a10_health_manager]
udp_server_ip_address = 10.64.28.68
bind_port = 5550
bind_ip = 10.64.28.68
heartbeat_interval = 5
heartbeat_key = insecure
heartbeat_timeout = 90
health_check_interval = 3
failover_timeout = 600
health_check_timeout = 3
health_check_max_retries = 5

[a10_house_keeping]
load_balancer_expiry_age = 3600
amphorae_expiry_age = 3600
#use_periodic_write_memory = 'enable'
#write_mem_interval = 300

[a10_global]
network_type = "flat"
#network_type = "vlan"
vrid_floating_ip = "dhcp"
</b>
</pre>

## Test Cases
- Test
CONF.a10_controller_worker.amp_vcs_retries
CONF.a10_controller_worker.amp_vcs_wait_sec
can be treat as integer in a10-octavia

## Manual Testing
Use PDB verify flowing code can work properly:
```
        retrys = CONF.a10_controller_worker.amp_vcs_retries
        retrys = retrys + 1
        time.sleep(timeout)
        time.sleep(CONF.a10_controller_worker.amp_vcs_wait_sec)
        import rpdb; rpdb.set_trace()

```