### PR TITLE
[STACK-2294] queue openstack commands when instance busy

### DIFF
--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -270,7 +270,8 @@ A10_CONTROLLER_WORKER_OPTS = [
                help=_('Retry attempts to wait for VThunder vcs negotiation')),
     cfg.IntOpt('amp_busy_wait_sec',
                default=900,
-               help=_('Timeout for waiting when vThunder instance is busy'))
+               help=_('Timeout for waiting when vThunder instance is busy. '
+                      '(0 for no timeout'))
 ]
 
 A10_HOUSE_KEEPING_OPTS = [

--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -213,7 +213,7 @@ A10_CONTROLLER_WORKER_OPTS = [
                default=1, min=1,
                help='Number of workers for the controller-worker service.'),
     cfg.IntOpt('amp_active_retries',
-               default=10,
+               default=90,
                help=_('Retry attempts to wait for VThunder to become active')),
     cfg.IntOpt('amp_active_wait_sec',
                default=10,
@@ -262,12 +262,15 @@ A10_CONTROLLER_WORKER_OPTS = [
                       'SINGLE - One vthunder per load balancer. '
                       'ACTIVE_STANDBY - Two vthunder per load balancer.')),
     cfg.IntOpt('amp_vcs_wait_sec',
-               default=20,
+               default=10,
                help=_('Seconds to wait between checks on whether an VThunder '
                       'vcs negotiation is ready')),
     cfg.IntOpt('amp_vcs_retries',
-               default=5,
-               help=_('Retry attempts to wait for VThunder vcs negotiation'))
+               default=30,
+               help=_('Retry attempts to wait for VThunder vcs negotiation')),
+    cfg.IntOpt('amp_busy_wait_sec',
+               default=900,
+               help=_('Timeout for waiting when vThunder instance is busy'))
 ]
 
 A10_HOUSE_KEEPING_OPTS = [

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -1081,7 +1081,9 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         timeout = CONF.a10_controller_worker.amp_busy_wait_sec
         while timeout >= 0:
-            timeout = timeout - 5
+            # amp_busy_wait_sec 0 for wait forever
+            if CONF.a10_controller_worker.amp_busy_wait_sec is not 0:
+                timeout = timeout - 5
 
             self.ctx_lock.acquire()
             ctx = self.ctx_map.get(key, None)

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -1082,7 +1082,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         timeout = CONF.a10_controller_worker.amp_busy_wait_sec
         while timeout >= 0:
             # amp_busy_wait_sec 0 for wait forever
-            if CONF.a10_controller_worker.amp_busy_wait_sec is not 0:
+            if CONF.a10_controller_worker.amp_busy_wait_sec != 0:
                 timeout = timeout - 5
 
             self.ctx_lock.acquire()

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -194,6 +194,7 @@ class LoadBalancerFlows(object):
             requires=constants.LOADBALANCER))
         delete_LB_flow.add(vthunder_tasks.VthunderInstanceBusy(
             requires=a10constants.COMPUTE_BUSY))
+
         delete_LB_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
@@ -223,8 +224,8 @@ class LoadBalancerFlows(object):
         delete_LB_flow.add(database_tasks.GetAmphoraeFromLoadbalancer(
             requires=constants.LOADBALANCER,
             provides=constants.AMPHORA))
-        delete_LB_flow.add(a10_database_tasks.GetLoadBalancerListByProjectID(
-            requires=a10constants.VTHUNDER,
+        delete_LB_flow.add(a10_database_tasks.GetLoadBalancerListForDeletion(
+            requires=(a10constants.VTHUNDER, constants.LOADBALANCER),
             provides=a10constants.LOADBALANCERS_LIST))
         delete_LB_flow.add(a10_database_tasks.GetBackupVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -933,6 +933,21 @@ class GetLoadBalancerListByProjectID(BaseDatabaseTask):
                           'due to: {}'.format(str(e)))
 
 
+class GetLoadBalancerListForDeletion(BaseDatabaseTask):
+
+    def execute(self, vthunder, loadbalancer):
+        try:
+            if vthunder:
+                loadbalancers_list = self.loadbalancer_repo.get_all_ohter_lbs_in_project(
+                    db_apis.get_session(),
+                    vthunder.project_id,
+                    loadbalancer.id)
+                return loadbalancers_list
+        except Exception as e:
+            LOG.exception('Failed to get active Loadbalancers related to vthunder '
+                          'due to: {}'.format(str(e)))
+
+
 class CheckExistingVthunderTopology(BaseDatabaseTask):
     """This task only meant to use with vthunder flow[amphora]"""
 

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -388,6 +388,18 @@ class LoadBalancerRepository(repo.LoadBalancerRepository):
             lb_list.append(data.to_data_model())
         return lb_list
 
+    def get_all_ohter_lbs_in_project(self, session, project_id, id):
+        lb_list = []
+        query = session.query(self.model_class).filter(
+            self.model_class.project_id == project_id).filter(
+            and_(self.model_class.id != id,
+                 self.model_class.provisioning_status != "ERROR"))
+
+        model_list = query.all()
+        for data in model_list:
+            lb_list.append(data.to_data_model())
+        return lb_list
+
 
 class VRIDRepository(BaseRepository):
     model_class = models.VRID


### PR DESCRIPTION
## Description
If Bug Fix:
- Severity Level High
- Issue Description
When vthunder instance busy, a10-octavia will just raise instance busy error. But it is better we queue the CLI request and wait the instance free.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2294
https://a10networks.atlassian.net/browse/STACK-2241
https://a10networks.atlassian.net/browse/STACK-2262
https://a10networks.atlassian.net/browse/STACK-2264
https://a10networks.atlassian.net/browse/STACK-2271
https://a10networks.atlassian.net/browse/STACK-2284
https://a10networks.atlassian.net/browse/STACK-2293


## Technical Approach
- add a new option ***amp_busy_wait_sec*** 
- and if instance is busy, controller worker will wait amp_busy_wait_sec before raise instance busy error

Notice: the better way is send the command back to the controller queue, but this need more time to survey and implement. Not able to do this at this time.

## Config Changes
<pre>
<b>[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
#default_axapi_timeout = 600

[a10_controller_worker]
amp_image_owner_id = 99c9c2304f114685a32db30769c8a7e2
amp_secgroup_list = 2d0a3480-7f08-4184-b96f-c39bb444dd38
amp_flavor_id = 69995a83-c47a-427f-bf70-e9d9752aa915
amp_boot_network_list = 7f8ddd7f-c5c3-463a-b1c3-596f988480a4
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 150
amp_active_wait_sec = 10
amp_image_id = 0a845873-bd91-4f8c-ad58-cf5d5afde09c
loadbalancer_topology = SINGLE
#loadbalancer_topology = ACTIVE_STANDBY

[a10_health_manager]
udp_server_ip_address = 10.64.28.68
bind_port = 5550
bind_ip = 10.64.28.68
heartbeat_interval = 5
heartbeat_key = insecure
heartbeat_timeout = 90
health_check_interval = 3
failover_timeout = 600
health_check_timeout = 3
health_check_max_retries = 5

[a10_house_keeping]
load_balancer_expiry_age = 3600
amphorae_expiry_age = 3600
#use_periodic_write_memory = 'enable'
#write_mem_interval = 300

[a10_global]
network_type = "flat"
#network_type = "vlan"
vrid_floating_ip = "dhcp"
</b>
</pre>

## Test Cases
- create 2 loadbalancer at the same time, and 2 loadbalancer will be created correctly

## Manual Testing

```
openstack loadbalancer create --vip-subnet-id tp91 --name vip1
openstack loadbalancer create --vip-subnet-id tp91 --name vip2

```

```
stack@openstack-4:~/source/a10-octavia/vthunder2$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address    | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| 5f9582d9-cb19-4acc-9e6b-580ef8c7e0d8 | vip1 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.153 | ACTIVE              | a10      |
| ca72d615-7c77-468e-bfbf-da83d8c7bc82 | vip2 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.91  | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+

```
