### PR TITLE
[STACK-2262][STACK-2283] active-standby stabilize

### DIFF
--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -117,6 +117,7 @@ CONNECTIVITY_WAIT_FOR_BACKUP_VTHUNDER = 'connectivity-wait-for-backup-vthunder'
 GET_VTHUNDER_MASTER = 'get-vthunder-master'
 WAIT_FOR_MASTER_VCS_RELOAD = 'wait-for-master-vcs-reload'
 WAIT_FOR_BACKUP_VCS_RELOAD = 'wait-for-backup-vcs-reload'
+VCS_SYNC_WAIT = "wait-for-vcs_ready"
 GET_COMPUTE_FOR_PROJECT = 'get-compute-for-project'
 CREATE_VTHUNDER_ENTRY = 'create-vthunder-entry'
 UPDATE_ACOS_VERSION_IN_VTHUNDER_ENTRY = 'update-acos-version-in-vthunder-entry'

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -277,6 +277,8 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                                            id=listener_id)
         load_balancer = listener.load_balancer
 
+        topology = CONF.a10_controller_worker.loadbalancer_topology
+
         if listener.project_id in CONF.hardware_thunder.devices:
             delete_listener_tf = self._taskflow_load(
                 self._listener_flows.get_delete_rack_listener_flow(),
@@ -285,7 +287,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         else:
             busy = self._vthunder_busy_check(listener.project_id, False, None)
             delete_listener_tf = self._taskflow_load(
-                self._listener_flows.get_delete_listener_flow(),
+                self._listener_flows.get_delete_listener_flow(topology),
                 store={constants.LOADBALANCER: load_balancer,
                        a10constants.COMPUTE_BUSY: busy,
                        constants.LISTENER: listener})
@@ -312,10 +314,12 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         load_balancer = listener.load_balancer
 
+        topology = CONF.a10_controller_worker.loadbalancer_topology
+
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(listener.project_id, False, None)
         update_listener_tf = self._taskflow_load(self._listener_flows.
-                                                 get_update_listener_flow(),
+                                                 get_update_listener_flow(topology),
                                                  store={constants.LISTENER:
                                                         listener,
                                                         a10constants.COMPUTE_BUSY: busy,
@@ -561,6 +565,8 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         listeners = pool.listeners
         load_balancer = pool.load_balancer
 
+        topology = CONF.a10_controller_worker.loadbalancer_topology
+
         if member.project_id in CONF.hardware_thunder.devices:
             update_member_tf = self._taskflow_load(self._member_flows.
                                                    get_rack_vthunder_update_member_flow(),
@@ -573,7 +579,8 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                                                           constants.UPDATE_DICT: member_updates})
         else:
             busy = self._vthunder_busy_check(member.project_id, False, None)
-            update_member_tf = self._taskflow_load(self._member_flows.get_update_member_flow(),
+            update_member_tf = self._taskflow_load(self._member_flows.
+                                                   get_update_member_flow(topology=topology),
                                                    store={constants.MEMBER: member,
                                                           constants.LISTENERS:
                                                           listeners,
@@ -615,10 +622,12 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             default_listener = pool.listeners[0]
         load_balancer = pool.load_balancer
 
+        topology = CONF.a10_controller_worker.loadbalancer_topology
+
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(pool.project_id, False, None)
         create_pool_tf = self._taskflow_load(self._pool_flows.
-                                             get_create_pool_flow(),
+                                             get_create_pool_flow(topology=topology),
                                              store={constants.POOL: pool,
                                                     constants.LISTENERS:
                                                         listeners,
@@ -663,10 +672,11 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                 self._pool_flows.get_delete_pool_rack_flow(
                     members, health_monitor, store), store=store)
         else:
+            topology = CONF.a10_controller_worker.loadbalancer_topology
             busy = self._vthunder_busy_check(pool.project_id, False, store)
             delete_pool_tf = self._taskflow_load(
                 self._pool_flows.get_delete_pool_flow(
-                    members, health_monitor, store), store=store)
+                    members, health_monitor, store, topology), store=store)
             self._register_flow_notify_handler(delete_pool_tf, pool.project_id, False, busy)
 
         with tf_logging.DynamicLoggingListener(delete_pool_tf,
@@ -700,10 +710,12 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             default_listener = pool.listeners[0]
         load_balancer = pool.load_balancer
 
+        topology = CONF.a10_controller_worker.loadbalancer_topology
+
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(pool.project_id, False, None)
         update_pool_tf = self._taskflow_load(self._pool_flows.
-                                             get_update_pool_flow(),
+                                             get_update_pool_flow(topology),
                                              store={constants.POOL: pool,
                                                     constants.LISTENERS:
                                                         listeners,

--- a/a10_octavia/controller/worker/flows/a10_listener_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_listener_flows.py
@@ -92,7 +92,7 @@ class ListenerFlows(object):
     def _check_ssl_data(self, history):
         return list(history.values())[0]
 
-    def get_delete_listener_flow(self):
+    def get_delete_listener_flow(self, topology):
         """Flow to delete a listener"""
 
         delete_listener_flow = linear_flow.Flow(constants.DELETE_LISTENER_FLOW)
@@ -103,6 +103,11 @@ class ListenerFlows(object):
         delete_listener_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
+        if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+            delete_listener_flow.add(vthunder_tasks.GetMasterVThunder(
+                name=a10constants.GET_MASTER_VTHUNDER,
+                requires=a10constants.VTHUNDER,
+                provides=a10constants.VTHUNDER))
         delete_listener_flow.add(self.handle_ssl_cert_flow(flow_type='delete'))
         delete_listener_flow.add(virtual_port_tasks.ListenerDelete(
             requires=[constants.LOADBALANCER, constants.LISTENER, a10constants.VTHUNDER]))
@@ -166,7 +171,7 @@ class ListenerFlows(object):
             requires=a10constants.VTHUNDER))
         return delete_listener_flow
 
-    def get_update_listener_flow(self):
+    def get_update_listener_flow(self, topology):
         """Flow to update a listener"""
 
         update_listener_flow = linear_flow.Flow(constants.UPDATE_LISTENER_FLOW)
@@ -177,6 +182,11 @@ class ListenerFlows(object):
         update_listener_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
+        if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+            update_listener_flow.add(vthunder_tasks.GetMasterVThunder(
+                name=a10constants.GET_MASTER_VTHUNDER,
+                requires=a10constants.VTHUNDER,
+                provides=a10constants.VTHUNDER))
         update_listener_flow.add(self.handle_ssl_cert_flow(flow_type='update'))
         update_listener_flow.add(a10_database_tasks.GetFlavorData(
             rebind={a10constants.LB_RESOURCE: constants.LISTENER},

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -375,6 +375,17 @@ class LoadBalancerFlows(object):
                     provides=constants.DELTAS))
                 new_LB_net_subflow.add(a10_network_tasks.HandleNetworkDeltas(
                     requires=constants.DELTAS, provides=constants.ADDED_PORTS))
+
+                # Make sure vcs ready before first probe-network-devices on Master
+                new_LB_net_subflow.add(
+                    vthunder_tasks.VThunderComputeConnectivityWait(
+                        name="backup-compute-conn-wait-before-probe-device",
+                        rebind={
+                            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
+                        requires=constants.AMPHORA))
+                new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
+                    name="wait-vcs-ready-before-probe-device",
+                    requires=a10constants.VTHUNDER))
                 new_LB_net_subflow.add(vthunder_tasks.AmphoraePostVIPPlug(
                     name=a10constants.AMPHORAE_POST_VIP_PLUG_FOR_MASTER,
                     requires=(constants.LOADBALANCER, a10constants.VTHUNDER,

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -244,6 +244,11 @@ class LoadBalancerFlows(object):
                     name=a10constants.VTHUNDER_CONNECTIVITY_WAIT,
                     requires=(a10constants.VTHUNDER, constants.AMPHORA)))
             if lb.topology == "ACTIVE_STANDBY":
+                delete_LB_flow.add(
+                    vthunder_tasks.VThunderComputeConnectivityWait(
+                        name=a10constants.BACKUP_CONNECTIVITY_WAIT + "-before-unplug",
+                        rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
+                        requires=constants.AMPHORA))
                 delete_LB_flow.add(vthunder_tasks.AmphoraePostNetworkUnplug(
                     name=a10constants.AMPHORA_POST_NETWORK_UNPLUG_FOR_BACKUP_VTHUNDER,
                     requires=(constants.LOADBALANCER, constants.ADDED_PORTS),
@@ -253,6 +258,9 @@ class LoadBalancerFlows(object):
                         name=a10constants.BACKUP_CONNECTIVITY_WAIT,
                         rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
                         requires=constants.AMPHORA))
+                delete_LB_flow.add(vthunder_tasks.VCSSyncWait(
+                    name="vip-unplug-wait-vcs-ready",
+                    requires=a10constants.VTHUNDER))
                 delete_LB_flow.add(vthunder_tasks.GetMasterVThunder(
                     name=a10constants.GET_VTHUNDER_MASTER,
                     requires=a10constants.VTHUNDER,
@@ -371,6 +379,19 @@ class LoadBalancerFlows(object):
                     name=a10constants.AMPHORAE_POST_VIP_PLUG_FOR_MASTER,
                     requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
                               constants.ADDED_PORTS)))
+                new_LB_net_subflow.add(
+                    vthunder_tasks.VThunderComputeConnectivityWait(
+                        name="active-compute-conn-wait-before-plug-backup",
+                        requires=(a10constants.VTHUNDER, constants.AMPHORA)))
+                new_LB_net_subflow.add(
+                    vthunder_tasks.VThunderComputeConnectivityWait(
+                        name="backup-compute-conn-wait-before-plug-backup",
+                        rebind={
+                            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
+                        requires=constants.AMPHORA))
+                new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
+                    name="active-plug-wait-vcs-ready",
+                    requires=a10constants.VTHUNDER))
                 new_LB_net_subflow.add(vthunder_tasks.AmphoraePostVIPPlug(
                     name=a10constants.AMPHORAE_POST_VIP_PLUG_FOR_BACKUP,
                     requires=(constants.LOADBALANCER, constants.ADDED_PORTS),
@@ -385,6 +406,9 @@ class LoadBalancerFlows(object):
                         rebind={
                             a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
                         requires=constants.AMPHORA))
+                new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
+                    name="backup-plug-wait-vcs-ready",
+                    requires=a10constants.VTHUNDER))
                 new_LB_net_subflow.add(vthunder_tasks.GetVThunderInterface(
                     name=a10constants.GET_MASTER_VTHUNDER_INTERFACE,
                     requires=a10constants.VTHUNDER,
@@ -418,6 +442,9 @@ class LoadBalancerFlows(object):
                         rebind={
                             a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
                         requires=constants.AMPHORA))
+                new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
+                    name="vcs-reload-wait-vcs-ready",
+                    requires=a10constants.VTHUNDER))
                 new_LB_net_subflow.add(vthunder_tasks.GetMasterVThunder(
                     name=a10constants.GET_MASTER_VTHUNDER,
                     requires=a10constants.VTHUNDER,
@@ -436,6 +463,9 @@ class LoadBalancerFlows(object):
                         rebind={
                             a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
                         requires=constants.AMPHORA))
+                new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
+                    name="int-sync-reload-wait-vcs-ready",
+                    requires=a10constants.VTHUNDER))
                 new_LB_net_subflow.add(vthunder_tasks.GetMasterVThunder(
                     name=a10constants.GET_VTHUNDER_MASTER,
                     requires=a10constants.VTHUNDER,

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -429,6 +429,9 @@ class LoadBalancerFlows(object):
                     name=a10constants.MASTER_VTHUNDER,
                     requires=a10constants.VTHUNDER,
                     provides=a10constants.VTHUNDER))
+                new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
+                    name="wait-vcs-ready-before-vcs-reload",
+                    requires=a10constants.VTHUNDER))
                 new_LB_net_subflow.add(vthunder_tasks.VCSReload(
                     name=a10constants.VCS_RELOAD,
                     requires=(a10constants.VTHUNDER)))

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -63,6 +63,20 @@ class MemberFlows(object):
         create_member_flow.add(a10_network_tasks.HandleNetworkDeltas(
             requires=constants.DELTAS, provides=constants.ADDED_PORTS))
         # managing interface additions here
+        if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+            # Make sure vcs ready before first probe-network-devices on Master
+            create_member_flow.add(
+                a10_database_tasks.GetBackupVThunderByLoadBalancer(
+                    name="get_backup_vThunder",
+                    requires=constants.LOADBALANCER,
+                    provides=a10constants.BACKUP_VTHUNDER))
+            create_member_flow.add(vthunder_tasks.VThunderComputeConnectivityWait(
+                name="backup_compute_conn_wait_before_probe_device",
+                requires=constants.AMPHORA,
+                rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
+            create_member_flow.add(vthunder_tasks.VCSSyncWait(
+                name="vcs_sync_wait_before_probe_device",
+                requires=a10constants.VTHUNDER))
         create_member_flow.add(
             vthunder_tasks.AmphoraePostMemberNetworkPlug(
                 requires=(
@@ -80,11 +94,6 @@ class MemberFlows(object):
                     a10constants.VTHUNDER]))
         # configure member flow for HA
         if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
-            create_member_flow.add(
-                a10_database_tasks.GetBackupVThunderByLoadBalancer(
-                    name="get_backup_vThunder",
-                    requires=constants.LOADBALANCER,
-                    provides=a10constants.BACKUP_VTHUNDER))
             create_member_flow.add(vthunder_tasks.VThunderComputeConnectivityWait(
                 name="backup_compute_conn_wait_before_plug",
                 requires=constants.AMPHORA,
@@ -489,7 +498,7 @@ class MemberFlows(object):
 
         return handle_vrid_for_member_subflow
 
-    def get_update_member_flow(self):
+    def get_update_member_flow(self, topology):
         """Flow to update a member
 
         :returns: The flow for updating a member
@@ -508,6 +517,11 @@ class MemberFlows(object):
         update_member_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
+        if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+            update_member_flow.add(vthunder_tasks.GetMasterVThunder(
+                name=a10constants.GET_MASTER_VTHUNDER,
+                requires=a10constants.VTHUNDER,
+                provides=a10constants.VTHUNDER))
         update_member_flow.add(self.handle_vrid_for_member_subflow())
         update_member_flow.add(a10_database_tasks.GetFlavorData(
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -86,9 +86,9 @@ class MemberFlows(object):
                     requires=constants.LOADBALANCER,
                     provides=a10constants.BACKUP_VTHUNDER))
             create_member_flow.add(vthunder_tasks.VThunderComputeConnectivityWait(
-                    name="backup_compute_conn_wait_before_plug",
-                    requires=constants.AMPHORA,
-                    rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
+                name="backup_compute_conn_wait_before_plug",
+                requires=constants.AMPHORA,
+                rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
             create_member_flow.add(
                 vthunder_tasks.AmphoraePostMemberNetworkPlug(
                     name="backup_amphora_network_plug", requires=[

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -356,6 +356,10 @@ class VThunderFlows(object):
         configure_vrrp_subflow.add(vthunder_tasks.ConfigureaVCSBackup(
             name=sf_name + '-' + a10constants.CONFIGURE_AVCS_SYNC_FOR_BACKUP,
             rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
+        # Wait for aVCS sync
+        configure_vrrp_subflow.add(vthunder_tasks.VCSSyncWait(
+            name=sf_name + '-' + a10constants.VCS_SYNC_WAIT,
+            requires=a10constants.VTHUNDER))
         return configure_vrrp_subflow
 
     def get_rack_vthunder_for_lb_subflow(

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -314,6 +314,7 @@ class ConfigureaVCSBackup(VThunderBaseTask):
                                    floating_ip, floating_ip_mask)
                     attempts = 0
                     LOG.debug("Configured the backup vThunder for aVCS: %s", vthunder.id)
+                    break
                 except req_exceptions.ReadTimeout as e:
                     # Don't retry for ReadTimout, since acos-client already already have
                     # tries and timeout for axapi request. And it will take very long to

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -306,19 +306,24 @@ class ConfigureaVCSBackup(VThunderBaseTask):
     def execute(self, vthunder, device_id=2, device_priority=100,
                 floating_ip="192.168.0.100", floating_ip_mask="255.255.255.0"):
         try:
-            attempts = 30
-            while attempts > 0:
-                # TODO(omkartelee01): Need this loop to be moved in acos_client with
-                # proper exception handling with all other API call loops.
-                # Currently resolves "System is Busy" error
+            attempts = CONF.a10_controller_worker.amp_vcs_retries
+            while attempts >= 0:
                 try:
+                    attempts = attempts - 1
                     configure_avcs(self.axapi_client, device_id, device_priority,
                                    floating_ip, floating_ip_mask)
                     attempts = 0
                     LOG.debug("Configured the backup vThunder for aVCS: %s", vthunder.id)
-                except (req_exceptions.ConnectionError, acos_errors.ACOSException,
-                        http_client.BadStatusLine, req_exceptions.ReadTimeout):
-                    attempts = attempts - 1
+                except req_exceptions.ReadTimeout as e:
+                    # Don't retry for ReadTimout, since acos-client already already have
+                    # tries and timeout for axapi request. And it will take very long to
+                    # response this error.
+                    if attempts < 0
+                        raise e
+                except Exception as e:
+                    if attempts < 0
+                        raise e
+                    time.sleep(CONF.a10_controller_worker.amp_vcs_wait_sec)
         except (acos_errors.ACOSException, req_exceptions.ConnectionError) as e:
             LOG.exception("Failed to configure backup vThunder aVCS: %s", str(e))
             raise e
@@ -1051,11 +1056,12 @@ class VCSSyncWait(VThunderBaseTask):
                 # Don't retry for ReadTimout, since acos-client already already have
                 # tries and timeout for axapi request. And it will take very long to
                 # response this error.
-                LOG.exception("Failed to get Master vThunder: %s", str(e))
-                raise e
+                if attempts < 0:
+                    LOG.exception("Failed to connect VCS device: %s", str(e))
+                    raise e
             except Exception as e:
                 if attempts < 0:
-                    LOG.exception("Failed to get Master vThunder: %s", str(e))
+                    LOG.exception("VCS not ready after timeout: %s", str(e))
                     raise e
                 time.sleep(CONF.a10_controller_worker.amp_vcs_wait_sec)
 
@@ -1085,8 +1091,9 @@ class GetMasterVThunder(VThunderBaseTask):
                 # Don't retry for ReadTimout, since acos-client already already have
                 # tries and timeout for axapi request. And it will take very long to
                 # response this error.
-                LOG.exception("Failed to get Master vThunder: %s", str(e))
-                raise e
+                if attempts < 0:
+                    LOG.exception("Failed to get Master vThunder: %s", str(e))
+                    raise e
             except Exception as e:
                 if attempts < 0:
                     LOG.exception("Failed to get Master vThunder: %s", str(e))
@@ -1119,8 +1126,9 @@ class GetBackupVThunder(VThunderBaseTask):
                 # Don't retry for ReadTimout, since acos-client already already have
                 # tries and timeout for axapi request. And it will take very long to
                 # response this error.
-                LOG.exception("Failed to get Master vThunder: %s", str(e))
-                raise e
+                if attempts < 0:
+                    LOG.exception("Failed to get Master vThunder: %s", str(e))
+                    raise e
             except Exception as e:
                 if attempts < 0:
                     LOG.exception("Failed to get Backup vThunder: %s", str(e))

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -318,10 +318,10 @@ class ConfigureaVCSBackup(VThunderBaseTask):
                     # Don't retry for ReadTimout, since acos-client already already have
                     # tries and timeout for axapi request. And it will take very long to
                     # response this error.
-                    if attempts < 0
+                    if attempts < 0:
                         raise e
                 except Exception as e:
-                    if attempts < 0
+                    if attempts < 0:
                         raise e
                     time.sleep(CONF.a10_controller_worker.amp_vcs_wait_sec)
         except (acos_errors.ACOSException, req_exceptions.ConnectionError) as e:

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -1030,7 +1030,7 @@ class VCSSyncWait(VThunderBaseTask):
         attempts = CONF.a10_controller_worker.amp_vcs_retries
         while attempts >= 0:
             vmaster_ready = False
-            vblade_read = False
+            vblade_ready = False
             try:
                 attempts = attempts - 1
                 vcs_summary = {}
@@ -1041,8 +1041,8 @@ class VCSSyncWait(VThunderBaseTask):
                     if role == "vMaster":
                         vmaster_ready = True
                     if role == "vBlade":
-                        vblade_read = True
-                    if vmaster_ready is True and vblade_read is True:
+                        vblade_ready = True
+                    if vmaster_ready is True and vblade_ready is True:
                         break
                 else:
                     raise acos_errors.AxapiJsonFormatErrora(


### PR DESCRIPTION
## Description
- Severity Level Critical
- Issue Description
For reload/reboot, vcs reload, vcs configuration sync, a10-octavia will sleep for 20 or 30 seconds. But a10-octavia should check both active and standby are up and vcs ready after the sleep or we will have problem for slow server.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2262
https://a10networks.atlassian.net/browse/STACK-2283

## Technical Approach
In active-standby mode, after reload/reboot, vcs reload or vcs configuration sync. check device is up and vcs ready after sleep.

## Config Changes
<pre>
<b>[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
#default_axapi_timeout = 600

[a10_controller_worker]
amp_image_owner_id = 99c9c2304f114685a32db30769c8a7e2
amp_secgroup_list = 2d0a3480-7f08-4184-b96f-c39bb444dd38
amp_flavor_id = 69995a83-c47a-427f-bf70-e9d9752aa915
amp_boot_network_list = 7f8ddd7f-c5c3-463a-b1c3-596f988480a4
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 150
amp_active_wait_sec = 10
amp_busy_wait_sec = 0
amp_image_id = 0a845873-bd91-4f8c-ad58-cf5d5afde09c
#loadbalancer_topology = SINGLE
loadbalancer_topology = ACTIVE_STANDBY

[a10_health_manager]
udp_server_ip_address = 10.64.28.68
bind_port = 5550
bind_ip = 10.64.28.68
heartbeat_interval = 5
heartbeat_key = insecure
heartbeat_timeout = 90
health_check_interval = 3
failover_timeout = 600
health_check_timeout = 3
health_check_max_retries = 5

[a10_house_keeping]
load_balancer_expiry_age = 3600
amphorae_expiry_age = 3600
#use_periodic_write_memory = 'enable'
#write_mem_interval = 300

[a10_global]
network_type = "flat"
#network_type = "vlan"
vrid_floating_ip = "dhcp"
</b>
</pre>


## Test Cases
- create 2 LB with different subnet at the same time
- delete 2 LB with different subnet at the same time

Not tested yet: (TODO)
- create normal active-standby LB
- create members with different subnet
- delete members with different subnet

## Manual Testing
- Required: List of steps to manually test feature or fix 
