### PR TITLE
[BUG][STACK-2242]: Removed non-required VCS Reload which is causing issues sometimes.

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -442,28 +442,8 @@ class LoadBalancerFlows(object):
                     requires=a10constants.VTHUNDER,
                     provides=a10constants.VTHUNDER))
                 new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
-                    name="wait-vcs-ready-before-vcs-reload",
+                    name="wait-vcs-ready-before-master-reload",
                     requires=a10constants.VTHUNDER))
-                new_LB_net_subflow.add(vthunder_tasks.VCSReload(
-                    name=a10constants.VCS_RELOAD,
-                    requires=(a10constants.VTHUNDER)))
-                new_LB_net_subflow.add(
-                    vthunder_tasks.VThunderComputeConnectivityWait(
-                        name=a10constants.WAIT_FOR_MASTER_VCS_RELOAD,
-                        requires=(a10constants.VTHUNDER, constants.AMPHORA)))
-                new_LB_net_subflow.add(
-                    vthunder_tasks.VThunderComputeConnectivityWait(
-                        name=a10constants.WAIT_FOR_BACKUP_VCS_RELOAD,
-                        rebind={
-                            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-                        requires=constants.AMPHORA))
-                new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
-                    name="vcs-reload-wait-vcs-ready",
-                    requires=a10constants.VTHUNDER))
-                new_LB_net_subflow.add(vthunder_tasks.GetMasterVThunder(
-                    name=a10constants.GET_MASTER_VTHUNDER,
-                    requires=a10constants.VTHUNDER,
-                    provides=a10constants.VTHUNDER))
                 new_LB_net_subflow.add(vthunder_tasks.AmphoraePostVIPPlug(
                     name=a10constants.AMP_POST_VIP_PLUG,
                     requires=(constants.LOADBALANCER, a10constants.VTHUNDER,


### PR DESCRIPTION
## Description
- Severity Level: Highest
- Issue Description: Only sometimes VCS reload is switching roles of the vThunders and then the next subsequent reload(last reload) is getting happened on an incorrect vThunder at that time, which should actually happen on another one for getting blade's 2nd interface. 
Due to this case, ifnum_backup is being passed None to EnableInterface of backup and thus not able to enable it.

**Removal of the VCSReload task is not affecting any of the EnableInterface task(master/backup) now.**

And due to this final role switching is not happening.

The bug is getting reproduced only in the case when roles of vThunders are not getting changed than that of previous ones at the end on an LB creation with different subnet.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2242

## Technical Approach
- Removed the VCSReload task from `get_new_lb_networking_subflow`

## Manual Testing
stack@neha:~$ openstack loadbalancer create --vip-subnet-id vip_subnet --name lb1                                                          ```
```
----------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-04-30T13:30:20                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | a5629895-0b7d-4d0b-b732-9c52153d2dc0 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | dc180e5107ba4d339b729f7e75f3f76e     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.8.56                         |
| vip_network_id      | 7073427a-0044-4def-8c3f-62bf32a2216b |
| vip_port_id         | 23914628-7062-4c67-af98-e6442bb60492 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 3baee221-6ed6-4ccc-a79d-e4d5368022fe |
+---------------------+--------------------------------------+
```

stack@neha:~$ openstack loadbalancer create --vip-subnet-id vip_subnet2 --name lb2
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-04-30T13:39:52                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 88ceb732-d2ab-4f5a-ae9c-efdb84445018 |
| listeners           |                                      |
| name                | lb2                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | dc180e5107ba4d339b729f7e75f3f76e     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.12.124                       |
| vip_network_id      | a5b2bbf1-cab1-4c93-b6b4-7e1d779ce09a |
| vip_port_id         | f062faf1-e776-4be3-b200-a2b9dc3cf35c |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 0f41f287-8b41-467a-a955-5fb2e5c0e263 |
+---------------------+--------------------------------------+
```
stack@neha:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address    | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| a5629895-0b7d-4d0b-b732-9c52153d2dc0 | lb1  | dc180e5107ba4d339b729f7e75f3f76e | 192.168.8.56   | ACTIVE              | a10      |
| 88ceb732-d2ab-4f5a-ae9c-efdb84445018 | lb2  | dc180e5107ba4d339b729f7e75f3f76e | 192.168.12.124 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+

```

vThunder-vMaster[1/2](NOLICENSE)#show running-config
!Current configuration: 710 bytes
!Configuration last updated at 14:45:56 IST Fri Apr 30 2021
!Configuration last saved at 14:45:59 IST Fri Apr 30 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
**interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!**
vrrp-a vrid 0
  floating-ip 192.168.8.126
  floating-ip 192.168.12.126
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.129
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb virtual-server 88ceb732-d2ab-4f5a-ae9c-efdb84445018 192.168.12.124
!
slb virtual-server a5629895-0b7d-4d0b-b732-9c52153d2dc0 192.168.8.56
!
!
cloud-services meta-data
  enable
  provider openstack
!
end


vThunder-vMaster[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ee0.f662  192.168.0.3/24        1
**1                   Up    Full  10000  none  1    N/A       fa16.3e79.685e  192.168.8.40/24       1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e36.178b  192.168.12.211/24     1  DataPort**


vThunder-vBlade[1/1](NOLICENSE)#show running-config
!Current configuration: 710 bytes
!Configuration last updated at 14:46:35 IST Fri Apr 30 2021
!Configuration last saved at 14:46:35 IST Fri Apr 30 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
**interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!**
vrrp-a vrid 0
  floating-ip 192.168.8.126
  floating-ip 192.168.12.126
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.129
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb virtual-server 88ceb732-d2ab-4f5a-ae9c-efdb84445018 192.168.12.124
!
slb virtual-server a5629895-0b7d-4d0b-b732-9c52153d2dc0 192.168.8.56
!
!
cloud-services meta-data
  enable
  provider openstack
!
end


vThunder-vBlade[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ecf.93b3  192.168.0.61/24       1
**1                   Up    Full  10000  none  1    N/A       fa16.3e01.0573  192.168.8.202/24      1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e10.4862  192.168.12.67/24      1  DataPort**




```