### PR TITLE
[STACK-2269]: Interface is not adding on vblade while creating member

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -63,8 +63,38 @@ class MemberFlows(object):
         create_member_flow.add(a10_network_tasks.HandleNetworkDeltas(
             requires=constants.DELTAS, provides=constants.ADDED_PORTS))
         # managing interface additions here
-        if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+        #if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+        if topology == constants.TOPOLOGY_SINGLE:   
             # Make sure vcs ready before first probe-network-devices on Master
+            #create_member_flow.add(
+            #    a10_database_tasks.GetBackupVThunderByLoadBalancer(
+            #        name="get_backup_vThunder",
+            #        requires=constants.LOADBALANCER,
+            #        provides=a10constants.BACKUP_VTHUNDER))
+            #create_member_flow.add(vthunder_tasks.VThunderComputeConnectivityWait(
+            #    name="backup_compute_conn_wait_before_probe_device",
+            #    requires=constants.AMPHORA,
+            #    rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
+            #create_member_flow.add(vthunder_tasks.VCSSyncWait(
+            #    name="vcs_sync_wait_before_probe_device",
+            #    requires=a10constants.VTHUNDER))
+            create_member_flow.add(
+                vthunder_tasks.AmphoraePostMemberNetworkPlug(
+                    requires=(
+                        constants.LOADBALANCER,
+                        constants.ADDED_PORTS,
+                        a10constants.VTHUNDER)))
+            create_member_flow.add(vthunder_tasks.VThunderComputeConnectivityWait(
+                name=a10constants.VTHUNDER_CONNECTIVITY_WAIT,
+                requires=(a10constants.VTHUNDER, constants.AMPHORA)))
+            create_member_flow.add(
+                vthunder_tasks.EnableInterfaceForMembers(
+                    requires=[
+                        constants.ADDED_PORTS,
+                        constants.LOADBALANCER,
+                        a10constants.VTHUNDER]))
+        # configure member flow for HA
+        if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
             create_member_flow.add(
                 a10_database_tasks.GetBackupVThunderByLoadBalancer(
                     name="get_backup_vThunder",
@@ -77,27 +107,22 @@ class MemberFlows(object):
             create_member_flow.add(vthunder_tasks.VCSSyncWait(
                 name="vcs_sync_wait_before_probe_device",
                 requires=a10constants.VTHUNDER))
-        create_member_flow.add(
-            vthunder_tasks.AmphoraePostMemberNetworkPlug(
-                requires=(
-                    constants.LOADBALANCER,
-                    constants.ADDED_PORTS,
-                    a10constants.VTHUNDER)))
-        create_member_flow.add(vthunder_tasks.VThunderComputeConnectivityWait(
-            name=a10constants.VTHUNDER_CONNECTIVITY_WAIT,
-            requires=(a10constants.VTHUNDER, constants.AMPHORA)))
-        create_member_flow.add(
-            vthunder_tasks.EnableInterfaceForMembers(
-                requires=[
-                    constants.ADDED_PORTS,
-                    constants.LOADBALANCER,
-                    a10constants.VTHUNDER]))
-        # configure member flow for HA
-        if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
-            create_member_flow.add(vthunder_tasks.VThunderComputeConnectivityWait(
-                name="backup_compute_conn_wait_before_plug",
-                requires=constants.AMPHORA,
-                rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
+            create_member_flow.add(
+                vthunder_tasks.AmphoraePostMemberNetworkPlug(
+                    requires=(
+                        constants.LOADBALANCER,
+                        constants.ADDED_PORTS,
+                        a10constants.VTHUNDER)))
+            create_member_flow.add(
+                vthunder_tasks.VThunderComputeConnectivityWait(
+                    name="active-compute-conn-wait-before-plug-backup",
+                    requires=(a10constants.VTHUNDER, constants.AMPHORA)))
+            create_member_flow.add(
+                vthunder_tasks.VThunderComputeConnectivityWait(
+                    name="backup-compute-conn-wait-before-plug-backup",
+                    rebind={
+                        a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
+                    requires=constants.AMPHORA))
             create_member_flow.add(vthunder_tasks.VCSSyncWait(
                 name="member_net_plug_vcs_sync_wait",
                 requires=a10constants.VTHUNDER))
@@ -113,46 +138,20 @@ class MemberFlows(object):
                 name=a10constants.BACKUP_CONNECTIVITY_WAIT,
                 requires=constants.AMPHORA,
                 rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
-
             create_member_flow.add(vthunder_tasks.VCSSyncWait(
-                name="member_net_plug_vcs_sync_wait_1",
+                name="backup-plug-wait-vcs-ready",
                 requires=a10constants.VTHUNDER))
-            # below three task not required
-            create_member_flow.add(vthunder_tasks.GetBackupVThunder(
-                name=a10constants.GET_BACKUP_VTHUNDER,
-                requires=a10constants.VTHUNDER,
-                provides=a10constants.VTHUNDER))
-            create_member_flow.add(vthunder_tasks.GetVThunderInterface(
-                name=a10constants.GET_BACKUP_VTHUNDER_INTERFACE,
-                requires=a10constants.VTHUNDER,
-                provides=(a10constants.IFNUM_MASTER, a10constants.IFNUM_BACKUP)))
             create_member_flow.add(vthunder_tasks.GetMasterVThunder(
-                name=a10constants.MASTER_VTHUNDER,
+                name=a10constants.GET_MASTER_VTHUNDER,
                 requires=a10constants.VTHUNDER,
                 provides=a10constants.VTHUNDER))
-            # create_member_flow.add(vthunder_tasks.VCSSyncWait(
-            #    name="wait-vcs-ready-before-vcs-reload",
-            #    requires=a10constants.VTHUNDER))
-            # create_member_flow.add(vthunder_tasks.VCSReload(
-            #    name=a10constants.VCS_RELOAD,
-            #    requires=(a10constants.VTHUNDER)))
-            # create_member_flow.add(
-            #    vthunder_tasks.VThunderComputeConnectivityWait(
-            #        name=a10constants.WAIT_FOR_MASTER_VCS_RELOAD,
-            #        requires=(a10constants.VTHUNDER, constants.AMPHORA)))
-            # create_member_flow.add(
-            #    vthunder_tasks.VThunderComputeConnectivityWait(
-            #        name=a10constants.WAIT_FOR_BACKUP_VCS_RELOAD,
-            #        rebind={
-            #            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-            #        requires=constants.AMPHORA))
-            # create_member_flow.add(vthunder_tasks.VCSSyncWait(
-            #    name="vcs-reload-wait-vcs-ready",
-            #    requires=a10constants.VTHUNDER))
-            # create_member_flow.add(vthunder_tasks.GetMasterVThunder(
-            #    name=a10constants.GET_MASTER_VTHUNDER,
-            #    requires=a10constants.VTHUNDER,
-            #    provides=a10constants.VTHUNDER))
+            create_member_flow.add(
+                vthunder_tasks.EnableInterfaceForMembers(
+                    name=a10constants.ENABLE_MASTER_VTHUNDER_INTERFACE,
+                    requires=[
+                        constants.ADDED_PORTS,
+                        constants.LOADBALANCER,
+                        a10constants.VTHUNDER]))
             create_member_flow.add(vthunder_tasks.AmphoraePostVIPPlug(
                 name=a10constants.AMP_POST_VIP_PLUG,
                 requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
@@ -174,12 +173,125 @@ class MemberFlows(object):
                 name=a10constants.GET_VTHUNDER_MASTER,
                 requires=a10constants.VTHUNDER,
                 provides=a10constants.VTHUNDER))
-            create_member_flow.add(vthunder_tasks.EnableInterfaceForMembers(
-                name="backup_enable_interface",
-                requires=[
-                    constants.ADDED_PORTS,
-                    constants.LOADBALANCER,
-                    a10constants.VTHUNDER]))
+            create_member_flow.add(
+                vthunder_tasks.EnableInterfaceForMembers(
+                    requires=[
+                        constants.ADDED_PORTS,
+                        constants.LOADBALANCER,
+                        a10constants.VTHUNDER]))
+
+
+            #create_member_flow.add(vthunder_tasks.VThunderComputeConnectivityWait(
+            #    name="backup_compute_conn_wait_before_plug",
+            #    requires=constants.AMPHORA,
+            #    rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
+            #create_member_flow.add(vthunder_tasks.VCSSyncWait(
+            #    name="member_net_plug_vcs_sync_wait",
+            #    requires=a10constants.VTHUNDER))
+            #create_member_flow.add(
+            #    vthunder_tasks.AmphoraePostMemberNetworkPlug(
+            #        name="backup_amphora_network_plug", requires=[
+            #            constants.ADDED_PORTS, constants.LOADBALANCER], rebind={
+            #            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
+            #create_member_flow.add(vthunder_tasks.VThunderComputeConnectivityWait(
+            #    name=a10constants.MASTER_CONNECTIVITY_WAIT,
+            #    requires=(a10constants.VTHUNDER, constants.AMPHORA)))
+            #create_member_flow.add(vthunder_tasks.VThunderComputeConnectivityWait(
+            #    name=a10constants.BACKUP_CONNECTIVITY_WAIT,
+            #    requires=constants.AMPHORA,
+            #    rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
+
+            #create_member_flow.add(vthunder_tasks.VCSSyncWait(
+            #    name="member_net_plug_vcs_sync_wait_1",
+            #    requires=a10constants.VTHUNDER))
+            # below three task not required
+            #create_member_flow.add(vthunder_tasks.GetBackupVThunder(
+            #    name=a10constants.GET_BACKUP_VTHUNDER,
+            #    requires=a10constants.VTHUNDER,
+            #    provides=a10constants.VTHUNDER))
+            #create_member_flow.add(vthunder_tasks.GetVThunderInterface(
+            #    name=a10constants.GET_BACKUP_VTHUNDER_INTERFACE,
+            #    requires=a10constants.VTHUNDER,
+            #    provides=(a10constants.IFNUM_MASTER, a10constants.IFNUM_BACKUP)))
+            #create_member_flow.add(vthunder_tasks.GetMasterVThunder(
+            #    name=a10constants.MASTER_VTHUNDER,
+            #    requires=a10constants.VTHUNDER,
+            #    provides=a10constants.VTHUNDER))
+            #create_member_flow.add(vthunder_tasks.VCSSyncWait(
+            #    name="wait-vcs-ready-before-vcs-reload_1",
+            #    requires=a10constants.VTHUNDER))
+            #create_member_flow.add(vthunder_tasks.VCSReload(
+            #    name=a10constants.VCS_RELOAD,
+            #    requires=(a10constants.VTHUNDER)))
+            #create_member_flow.add(
+            #    vthunder_tasks.VThunderComputeConnectivityWait(
+            #        name=a10constants.WAIT_FOR_MASTER_VCS_RELOAD,
+            #        requires=(a10constants.VTHUNDER, constants.AMPHORA)))
+            #create_member_flow.add(
+            #    vthunder_tasks.VThunderComputeConnectivityWait(
+            #        name=a10constants.WAIT_FOR_BACKUP_VCS_RELOAD,
+            #        rebind={
+            #            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
+            #        requires=constants.AMPHORA))
+            #create_member_flow.add(vthunder_tasks.VCSSyncWait(
+            #    name="vcs-reload-wait-vcs-ready",
+            #    requires=a10constants.VTHUNDER))
+            #create_member_flow.add(vthunder_tasks.GetMasterVThunder(
+            #    name=a10constants.GET_MASTER_VTHUNDER,
+            #    requires=a10constants.VTHUNDER,
+            #    provides=a10constants.VTHUNDER))
+            #create_member_flow.add(vthunder_tasks.AmphoraePostVIPPlug(
+            #    name=a10constants.AMP_POST_VIP_PLUG,
+            #    requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
+            #              constants.ADDED_PORTS)))
+            #create_member_flow.add(
+            #    vthunder_tasks.VThunderComputeConnectivityWait(
+            #        name=a10constants.CONNECTIVITY_WAIT_FOR_MASTER_VTHUNDER,
+            #        requires=(a10constants.VTHUNDER, constants.AMPHORA)))
+            #create_member_flow.add(
+            #    vthunder_tasks.VThunderComputeConnectivityWait(
+            #        name=a10constants.CONNECTIVITY_WAIT_FOR_BACKUP_VTHUNDER,
+            #        rebind={
+            #            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
+            #        requires=constants.AMPHORA))
+            #create_member_flow.add(vthunder_tasks.VCSSyncWait(
+            #    name="member_enable_interface_vcs_sync_wait",
+            #    requires=a10constants.VTHUNDER))
+            #create_member_flow.add(vthunder_tasks.GetMasterVThunder(
+            #    name=a10constants.GET_VTHUNDER_MASTER,
+            #    requires=a10constants.VTHUNDER,
+            #    provides=a10constants.VTHUNDER))
+            #create_member_flow.add(vthunder_tasks.EnableInterfaceForMembers(
+            #    name="backup_enable_interface",
+            #    requires=[
+            #        constants.ADDED_PORTS,
+            #        constants.LOADBALANCER,
+            #        a10constants.VTHUNDER]))
+            
+                
+            #create_member_flow.add(vthunder_tasks.VCSSyncWait(
+            #    name="wait-vcs-ready-before-vcs-reload",
+            #    requires=a10constants.VTHUNDER))
+            #create_member_flow.add(vthunder_tasks.VCSReload(
+            #    name=a10constants.VCS_RELOAD,
+            #    requires=(a10constants.VTHUNDER)))
+            #create_member_flow.add(
+            #    vthunder_tasks.VThunderComputeConnectivityWait(
+            #        name=a10constants.WAIT_FOR_MASTER_VCS_RELOAD,
+            #        requires=(a10constants.VTHUNDER, constants.AMPHORA)))
+            #create_member_flow.add(
+            #    vthunder_tasks.VThunderComputeConnectivityWait(
+            #        name=a10constants.WAIT_FOR_BACKUP_VCS_RELOAD,
+            #        rebind={
+            #            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
+            #        requires=constants.AMPHORA))
+            #create_member_flow.add(vthunder_tasks.VCSSyncWait(
+            #    name="vcs-reload-wait-vcs-ready",
+            #    requires=a10constants.VTHUNDER))
+            #create_member_flow.add(vthunder_tasks.GetMasterVThunder(
+            #    name="master after reload",
+            #    requires=a10constants.VTHUNDER,
+            #    provides=a10constants.VTHUNDER))
             # create_member_flow.add(vthunder_tasks.VCSSyncWait(
             #    name="member_enable_interface_vcs_sync_wait",
             #    requires=a10constants.VTHUNDER))

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -63,21 +63,7 @@ class MemberFlows(object):
         create_member_flow.add(a10_network_tasks.HandleNetworkDeltas(
             requires=constants.DELTAS, provides=constants.ADDED_PORTS))
         # managing interface additions here
-        #if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
-        if topology == constants.TOPOLOGY_SINGLE:   
-            # Make sure vcs ready before first probe-network-devices on Master
-            #create_member_flow.add(
-            #    a10_database_tasks.GetBackupVThunderByLoadBalancer(
-            #        name="get_backup_vThunder",
-            #        requires=constants.LOADBALANCER,
-            #        provides=a10constants.BACKUP_VTHUNDER))
-            #create_member_flow.add(vthunder_tasks.VThunderComputeConnectivityWait(
-            #    name="backup_compute_conn_wait_before_probe_device",
-            #    requires=constants.AMPHORA,
-            #    rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
-            #create_member_flow.add(vthunder_tasks.VCSSyncWait(
-            #    name="vcs_sync_wait_before_probe_device",
-            #    requires=a10constants.VTHUNDER))
+        if topology == constants.TOPOLOGY_SINGLE:
             create_member_flow.add(
                 vthunder_tasks.AmphoraePostMemberNetworkPlug(
                     requires=(
@@ -114,19 +100,6 @@ class MemberFlows(object):
                         constants.ADDED_PORTS,
                         a10constants.VTHUNDER)))
             create_member_flow.add(
-                vthunder_tasks.VThunderComputeConnectivityWait(
-                    name="active-compute-conn-wait-before-plug-backup",
-                    requires=(a10constants.VTHUNDER, constants.AMPHORA)))
-            create_member_flow.add(
-                vthunder_tasks.VThunderComputeConnectivityWait(
-                    name="backup-compute-conn-wait-before-plug-backup",
-                    rebind={
-                        a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-                    requires=constants.AMPHORA))
-            create_member_flow.add(vthunder_tasks.VCSSyncWait(
-                name="member_net_plug_vcs_sync_wait",
-                requires=a10constants.VTHUNDER))
-            create_member_flow.add(
                 vthunder_tasks.AmphoraePostMemberNetworkPlug(
                     name="backup_amphora_network_plug", requires=[
                         constants.ADDED_PORTS, constants.LOADBALANCER], rebind={
@@ -152,10 +125,10 @@ class MemberFlows(object):
                         constants.ADDED_PORTS,
                         constants.LOADBALANCER,
                         a10constants.VTHUNDER]))
-            create_member_flow.add(vthunder_tasks.AmphoraePostVIPPlug(
-                name=a10constants.AMP_POST_VIP_PLUG,
-                requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
-                          constants.ADDED_PORTS)))
+            create_member_flow.add(vthunder_tasks.AmphoraePostMemberNetworkPlug(
+                name="amphorae-post-member-network-plug-for-master",
+                requires=(constants.LOADBALANCER, constants.ADDED_PORTS,
+                          a10constants.VTHUNDER)))
             create_member_flow.add(
                 vthunder_tasks.VThunderComputeConnectivityWait(
                     name=a10constants.CONNECTIVITY_WAIT_FOR_MASTER_VTHUNDER,
@@ -179,128 +152,6 @@ class MemberFlows(object):
                         constants.ADDED_PORTS,
                         constants.LOADBALANCER,
                         a10constants.VTHUNDER]))
-
-
-            #create_member_flow.add(vthunder_tasks.VThunderComputeConnectivityWait(
-            #    name="backup_compute_conn_wait_before_plug",
-            #    requires=constants.AMPHORA,
-            #    rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
-            #create_member_flow.add(vthunder_tasks.VCSSyncWait(
-            #    name="member_net_plug_vcs_sync_wait",
-            #    requires=a10constants.VTHUNDER))
-            #create_member_flow.add(
-            #    vthunder_tasks.AmphoraePostMemberNetworkPlug(
-            #        name="backup_amphora_network_plug", requires=[
-            #            constants.ADDED_PORTS, constants.LOADBALANCER], rebind={
-            #            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
-            #create_member_flow.add(vthunder_tasks.VThunderComputeConnectivityWait(
-            #    name=a10constants.MASTER_CONNECTIVITY_WAIT,
-            #    requires=(a10constants.VTHUNDER, constants.AMPHORA)))
-            #create_member_flow.add(vthunder_tasks.VThunderComputeConnectivityWait(
-            #    name=a10constants.BACKUP_CONNECTIVITY_WAIT,
-            #    requires=constants.AMPHORA,
-            #    rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
-
-            #create_member_flow.add(vthunder_tasks.VCSSyncWait(
-            #    name="member_net_plug_vcs_sync_wait_1",
-            #    requires=a10constants.VTHUNDER))
-            # below three task not required
-            #create_member_flow.add(vthunder_tasks.GetBackupVThunder(
-            #    name=a10constants.GET_BACKUP_VTHUNDER,
-            #    requires=a10constants.VTHUNDER,
-            #    provides=a10constants.VTHUNDER))
-            #create_member_flow.add(vthunder_tasks.GetVThunderInterface(
-            #    name=a10constants.GET_BACKUP_VTHUNDER_INTERFACE,
-            #    requires=a10constants.VTHUNDER,
-            #    provides=(a10constants.IFNUM_MASTER, a10constants.IFNUM_BACKUP)))
-            #create_member_flow.add(vthunder_tasks.GetMasterVThunder(
-            #    name=a10constants.MASTER_VTHUNDER,
-            #    requires=a10constants.VTHUNDER,
-            #    provides=a10constants.VTHUNDER))
-            #create_member_flow.add(vthunder_tasks.VCSSyncWait(
-            #    name="wait-vcs-ready-before-vcs-reload_1",
-            #    requires=a10constants.VTHUNDER))
-            #create_member_flow.add(vthunder_tasks.VCSReload(
-            #    name=a10constants.VCS_RELOAD,
-            #    requires=(a10constants.VTHUNDER)))
-            #create_member_flow.add(
-            #    vthunder_tasks.VThunderComputeConnectivityWait(
-            #        name=a10constants.WAIT_FOR_MASTER_VCS_RELOAD,
-            #        requires=(a10constants.VTHUNDER, constants.AMPHORA)))
-            #create_member_flow.add(
-            #    vthunder_tasks.VThunderComputeConnectivityWait(
-            #        name=a10constants.WAIT_FOR_BACKUP_VCS_RELOAD,
-            #        rebind={
-            #            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-            #        requires=constants.AMPHORA))
-            #create_member_flow.add(vthunder_tasks.VCSSyncWait(
-            #    name="vcs-reload-wait-vcs-ready",
-            #    requires=a10constants.VTHUNDER))
-            #create_member_flow.add(vthunder_tasks.GetMasterVThunder(
-            #    name=a10constants.GET_MASTER_VTHUNDER,
-            #    requires=a10constants.VTHUNDER,
-            #    provides=a10constants.VTHUNDER))
-            #create_member_flow.add(vthunder_tasks.AmphoraePostVIPPlug(
-            #    name=a10constants.AMP_POST_VIP_PLUG,
-            #    requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
-            #              constants.ADDED_PORTS)))
-            #create_member_flow.add(
-            #    vthunder_tasks.VThunderComputeConnectivityWait(
-            #        name=a10constants.CONNECTIVITY_WAIT_FOR_MASTER_VTHUNDER,
-            #        requires=(a10constants.VTHUNDER, constants.AMPHORA)))
-            #create_member_flow.add(
-            #    vthunder_tasks.VThunderComputeConnectivityWait(
-            #        name=a10constants.CONNECTIVITY_WAIT_FOR_BACKUP_VTHUNDER,
-            #        rebind={
-            #            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-            #        requires=constants.AMPHORA))
-            #create_member_flow.add(vthunder_tasks.VCSSyncWait(
-            #    name="member_enable_interface_vcs_sync_wait",
-            #    requires=a10constants.VTHUNDER))
-            #create_member_flow.add(vthunder_tasks.GetMasterVThunder(
-            #    name=a10constants.GET_VTHUNDER_MASTER,
-            #    requires=a10constants.VTHUNDER,
-            #    provides=a10constants.VTHUNDER))
-            #create_member_flow.add(vthunder_tasks.EnableInterfaceForMembers(
-            #    name="backup_enable_interface",
-            #    requires=[
-            #        constants.ADDED_PORTS,
-            #        constants.LOADBALANCER,
-            #        a10constants.VTHUNDER]))
-            
-                
-            #create_member_flow.add(vthunder_tasks.VCSSyncWait(
-            #    name="wait-vcs-ready-before-vcs-reload",
-            #    requires=a10constants.VTHUNDER))
-            #create_member_flow.add(vthunder_tasks.VCSReload(
-            #    name=a10constants.VCS_RELOAD,
-            #    requires=(a10constants.VTHUNDER)))
-            #create_member_flow.add(
-            #    vthunder_tasks.VThunderComputeConnectivityWait(
-            #        name=a10constants.WAIT_FOR_MASTER_VCS_RELOAD,
-            #        requires=(a10constants.VTHUNDER, constants.AMPHORA)))
-            #create_member_flow.add(
-            #    vthunder_tasks.VThunderComputeConnectivityWait(
-            #        name=a10constants.WAIT_FOR_BACKUP_VCS_RELOAD,
-            #        rebind={
-            #            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-            #        requires=constants.AMPHORA))
-            #create_member_flow.add(vthunder_tasks.VCSSyncWait(
-            #    name="vcs-reload-wait-vcs-ready",
-            #    requires=a10constants.VTHUNDER))
-            #create_member_flow.add(vthunder_tasks.GetMasterVThunder(
-            #    name="master after reload",
-            #    requires=a10constants.VTHUNDER,
-            #    provides=a10constants.VTHUNDER))
-            # create_member_flow.add(vthunder_tasks.VCSSyncWait(
-            #    name="member_enable_interface_vcs_sync_wait",
-            #    requires=a10constants.VTHUNDER))
-            # create_member_flow.add(
-            #    vthunder_tasks.EnableInterfaceForMembers(
-            #        name="backup_enable_interface", requires=[
-            #            constants.ADDED_PORTS, constants.LOADBALANCER], rebind={
-            #            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
-
         create_member_flow.add(self.handle_vrid_for_member_subflow())
         create_member_flow.add(a10_database_tasks.CountMembersWithIP(
             requires=constants.MEMBER, provides=a10constants.MEMBER_COUNT_IP
@@ -405,6 +256,10 @@ class MemberFlows(object):
             delete_member_flow.add(vthunder_tasks.VCSSyncWait(
                 name='member-unplug-' + a10constants.VCS_SYNC_WAIT,
                 requires=a10constants.VTHUNDER))
+            delete_member_flow.add(vthunder_tasks.GetMasterVThunder(
+                name=a10constants.GET_VTHUNDER_MASTER,
+                requires=a10constants.VTHUNDER,
+                provides=a10constants.VTHUNDER))
         delete_member_flow.add(server_tasks.MemberFindNatPool(
             requires=[constants.MEMBER, a10constants.VTHUNDER, constants.POOL,
                       constants.FLAVOR], provides=a10constants.NAT_FLAVOR))
@@ -415,10 +270,6 @@ class MemberFlows(object):
             requires=[constants.MEMBER, a10constants.NAT_FLAVOR, a10constants.NAT_POOL]))
         delete_member_flow.add(a10_database_tasks.DeleteNatPoolEntry(
             requires=a10constants.NAT_POOL))
-        delete_member_flow.add(vthunder_tasks.GetMasterVThunder(
-            name=a10constants.GET_VTHUNDER_MASTER,
-            requires=a10constants.VTHUNDER,
-            provides=a10constants.VTHUNDER))
         delete_member_flow.add(
             server_tasks.MemberDelete(
                 requires=(


### PR DESCRIPTION
## Description
- Severity Level: High
- Required: On creating member with the new subnet, interface is not adding on vblade machine

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-2269

## Technical Approach
Updated the create_member_flow similiar to new_LB_net_subflow of loadbalancer create flow.
Added one more reload so that interface can be added to vblade.

## Manual Testing 
**SINGLE TOPOLOGY**
1) Create loadbalancer, listener,pool,member.
```
openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name v1
openstack loadbalancer listener create --name l2 --protocol HTTP --protocol-port 80 v1
openstack loadbalancer pool create --name p2 --protocol HTTP --listener l2 --lb-algorithm least_connections
openstack loadbalancer member create --address 10.0.12.192 --subnet-id provider-vlan-12-subnet --protocol-port 80 --name mem1 p2
vThunder(NOLICENSE)#show running-config
!Current configuration: 99 bytes
!Configuration last updated at 10:32:16 IST Mon May 3 2021
!Configuration last saved at 10:34:32 IST Mon May 3 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.172
  floating-ip 10.0.12.172
!
slb server 5327a_10_0_12_192 10.0.12.192
  port 80 tcp
!
slb service-group afb89ebc-ea12-4501-9cca-5168f96662a5 tcp
  method least-connection
  member 5327a_10_0_12_192 80
!
slb virtual-server 6f98bd0b-f57b-4498-ba44-203c4ebc839c 10.0.11.143
  port 80 http
    name 694d735f-39b1-4393-8aa5-d78069d7a693
    extended-stats
    service-group afb89ebc-ea12-4501-9cca-5168f96662a5
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#
vThunder(NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ed5.93a1  192.168.0.186/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3edc.75c6  10.0.11.104/24        1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e33.5a21  10.0.12.169/24        1  DataPort

Global Throughput:168 bits/sec (21 bytes/sec)
Throughput:168 bits/sec (21 bytes/sec)
vThunder(NOLICENSE)#
```
2) Delete the member
```
openstack loadbalancer member delete p2 mem1

vThunder(NOLICENSE)#show running-config
!Current configuration: 186 bytes
!Configuration last updated at 10:46:44 IST Mon May 3 2021
!Configuration last saved at 10:46:52 IST Mon May 3 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.172
!
slb service-group afb89ebc-ea12-4501-9cca-5168f96662a5 tcp
  method least-connection
!
slb virtual-server 6f98bd0b-f57b-4498-ba44-203c4ebc839c 10.0.11.143
  port 80 http
    name 694d735f-39b1-4393-8aa5-d78069d7a693
    extended-stats
    service-group afb89ebc-ea12-4501-9cca-5168f96662a5
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode

vThunder(NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ed5.93a1  192.168.0.186/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3edc.75c6  10.0.11.104/24        1  DataPort

Global Throughput:0 bits/sec (0 bytes/sec)
Throughput:0 bits/sec (0 bytes/sec)
vThunder(NOLICENSE)#
```

**ACTIVE_STANDBY**
1) Create loadbalancer, listener,pool,member.
```
openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name v1
openstack loadbalancer listener create --name l2 --protocol HTTP --protocol-port 80 v1
openstack loadbalancer pool create --name p2 --protocol HTTP --listener l2 --lb-algorithm least_connections
openstack loadbalancer member create --address 10.0.12.192 --subnet-id provider-vlan-12-subnet --protocol-port 80 --name mem1 p2

vThunder-vMaster[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3eb0.138b  192.168.0.40/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3e87.526b  192.168.8.167/24      1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3ea8.820c  192.168.12.194/24     1  DataPort
    
vThunder-vBlade[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e8f.135e  192.168.0.23/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3ed3.177c  192.168.8.21/24       1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e9c.e9f0  192.168.12.154/24     1  DataPort
    
vThunder-vMaster[1/1](NOLICENSE)#show running-config interface
!Section configuration: 416 bytes
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!

vThunder-vBlade[1/2](NOLICENSE)#show running-config interface
!Section configuration: 416 bytes
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!

```
