### PR TITLE
[STACK-2302] Get Master vThunder for SLB flows

### DIFF
--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -143,10 +143,12 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         pool.health_monitor = health_mon
         load_balancer = pool.load_balancer
 
+        topology = CONF.a10_controller_worker.loadbalancer_topology
+
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(health_mon.project_id, False, None)
         create_hm_tf = self._taskflow_load(
-            self._health_monitor_flows.get_create_health_monitor_flow(),
+            self._health_monitor_flows.get_create_health_monitor_flow(topology=topology),
             store={constants.HEALTH_MON: health_mon,
                    constants.POOL: pool,
                    constants.LISTENERS: listeners,
@@ -172,10 +174,12 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         listeners = pool.listeners
         load_balancer = pool.load_balancer
 
+        topology = CONF.a10_controller_worker.loadbalancer_topology
+
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(health_mon.project_id, False, None)
         delete_hm_tf = self._taskflow_load(
-            self._health_monitor_flows.get_delete_health_monitor_flow(),
+            self._health_monitor_flows.get_delete_health_monitor_flow(topology=topology),
             store={constants.HEALTH_MON: health_mon,
                    constants.POOL: pool,
                    constants.LISTENERS: listeners,
@@ -212,10 +216,12 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         pool.health_monitor = health_mon
         load_balancer = pool.load_balancer
 
+        topology = CONF.a10_controller_worker.loadbalancer_topology
+
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(health_mon.project_id, False, None)
         update_hm_tf = self._taskflow_load(
-            self._health_monitor_flows.get_update_health_monitor_flow(),
+            self._health_monitor_flows.get_update_health_monitor_flow(topology=topology),
             store={constants.HEALTH_MON: health_mon,
                    constants.POOL: pool,
                    constants.LISTENERS: listeners,
@@ -752,10 +758,12 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         listeners = [l7policy.listener]
         load_balancer = l7policy.listener.load_balancer
 
+        topology = CONF.a10_controller_worker.loadbalancer_topology
+
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(l7policy.project_id, False, None)
         create_l7policy_tf = self._taskflow_load(
-            self._l7policy_flows.get_create_l7policy_flow(),
+            self._l7policy_flows.get_create_l7policy_flow(topology=topology),
             store={constants.L7POLICY: l7policy,
                    constants.LISTENERS: listeners,
                    constants.LOADBALANCER: load_balancer,
@@ -777,10 +785,12 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         load_balancer = l7policy.listener.load_balancer
         listeners = [l7policy.listener]
 
+        topology = CONF.a10_controller_worker.loadbalancer_topology
+
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(l7policy.project_id, False, None)
         delete_l7policy_tf = self._taskflow_load(
-            self._l7policy_flows.get_delete_l7policy_flow(),
+            self._l7policy_flows.get_delete_l7policy_flow(topology=topology),
             store={constants.L7POLICY: l7policy,
                    constants.LISTENERS: listeners,
                    constants.LOADBALANCER: load_balancer,
@@ -814,10 +824,12 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         listeners = [l7policy.listener]
         load_balancer = l7policy.listener.load_balancer
 
+        topology = CONF.a10_controller_worker.loadbalancer_topology
+
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(l7policy.project_id, False, None)
         update_l7policy_tf = self._taskflow_load(
-            self._l7policy_flows.get_update_l7policy_flow(),
+            self._l7policy_flows.get_update_l7policy_flow(topology=topology),
             store={constants.L7POLICY: l7policy,
                    constants.LISTENERS: listeners,
                    constants.LOADBALANCER: load_balancer,
@@ -851,10 +863,12 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         listeners = [l7policy.listener]
         load_balancer = l7policy.listener.load_balancer
 
+        topology = CONF.a10_controller_worker.loadbalancer_topology
+
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(l7rule.project_id, False, None)
         create_l7rule_tf = self._taskflow_load(
-            self._l7rule_flows.get_create_l7rule_flow(),
+            self._l7rule_flows.get_create_l7rule_flow(topology=topology),
             store={constants.L7RULE: l7rule,
                    constants.L7POLICY: l7policy,
                    constants.LISTENERS: listeners,
@@ -877,10 +891,12 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         load_balancer = l7policy.listener.load_balancer
         listeners = [l7policy.listener]
 
+        topology = CONF.a10_controller_worker.loadbalancer_topology
+
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(l7rule.project_id, False, None)
         delete_l7rule_tf = self._taskflow_load(
-            self._l7rule_flows.get_delete_l7rule_flow(),
+            self._l7rule_flows.get_delete_l7rule_flow(topology=topology),
             store={constants.L7RULE: l7rule,
                    constants.L7POLICY: l7policy,
                    constants.LISTENERS: listeners,
@@ -915,10 +931,12 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         listeners = [l7policy.listener]
         load_balancer = l7policy.listener.load_balancer
 
+        topology = CONF.a10_controller_worker.loadbalancer_topology
+
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(l7rule.project_id, False, None)
         update_l7rule_tf = self._taskflow_load(
-            self._l7rule_flows.get_update_l7rule_flow(),
+            self._l7rule_flows.get_update_l7rule_flow(topology=topology),
             store={constants.L7RULE: l7rule,
                    constants.L7POLICY: l7policy,
                    constants.LISTENERS: listeners,

--- a/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_health_monitor_flows.py
@@ -28,7 +28,7 @@ from a10_octavia.controller.worker.tasks import vthunder_tasks
 
 class HealthMonitorFlows(object):
 
-    def get_create_health_monitor_flow(self):
+    def get_create_health_monitor_flow(self, topology):
         """Create a flow to create a health monitor
 
         :returns: The flow for creating a health monitor
@@ -46,6 +46,11 @@ class HealthMonitorFlows(object):
         create_hm_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
+        if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+            create_hm_flow.add(vthunder_tasks.GetMasterVThunder(
+                name=a10constants.GET_MASTER_VTHUNDER,
+                requires=a10constants.VTHUNDER,
+                provides=a10constants.VTHUNDER))
         create_hm_flow.add(a10_database_tasks.GetFlavorData(
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
             provides=constants.FLAVOR))
@@ -68,7 +73,7 @@ class HealthMonitorFlows(object):
             requires=(a10constants.VTHUNDER)))
         return create_hm_flow
 
-    def get_delete_health_monitor_flow(self):
+    def get_delete_health_monitor_flow(self, topology):
         """Create a flow to delete a health monitor
 
         :returns: The flow for deleting a health monitor
@@ -89,6 +94,11 @@ class HealthMonitorFlows(object):
         delete_hm_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
+        if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+            delete_hm_flow.add(vthunder_tasks.GetMasterVThunder(
+                name=a10constants.GET_MASTER_VTHUNDER,
+                requires=a10constants.VTHUNDER,
+                provides=a10constants.VTHUNDER))
         delete_hm_flow.add(self.get_delete_health_monitor_vthunder_subflow())
         delete_hm_flow.add(database_tasks.DeleteHealthMonitorInDB(
             requires=constants.HEALTH_MON))
@@ -121,7 +131,7 @@ class HealthMonitorFlows(object):
             rebind={constants.HEALTH_MON: health_mon}))
         return delete_hm_vthunder_subflow
 
-    def get_update_health_monitor_flow(self):
+    def get_update_health_monitor_flow(self, topology):
         """Create a flow to update a health monitor
 
         :returns: The flow for updating a health monitor
@@ -139,6 +149,11 @@ class HealthMonitorFlows(object):
         update_hm_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
+        if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+            update_hm_flow.add(vthunder_tasks.GetMasterVThunder(
+                name=a10constants.GET_MASTER_VTHUNDER,
+                requires=a10constants.VTHUNDER,
+                provides=a10constants.VTHUNDER))
         update_hm_flow.add(a10_database_tasks.GetFlavorData(
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
             provides=constants.FLAVOR))

--- a/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7policy_flows.py
@@ -27,7 +27,7 @@ from a10_octavia.controller.worker.tasks import vthunder_tasks
 
 class L7PolicyFlows(object):
 
-    def get_create_l7policy_flow(self):
+    def get_create_l7policy_flow(self, topology):
         """Create a flow to create an L7 policy
 
         :returns: The flow for creating an L7 policy
@@ -45,6 +45,11 @@ class L7PolicyFlows(object):
         create_l7policy_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
+        if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+            create_l7policy_flow.add(vthunder_tasks.GetMasterVThunder(
+                name=a10constants.GET_MASTER_VTHUNDER,
+                requires=a10constants.VTHUNDER,
+                provides=a10constants.VTHUNDER))
         create_l7policy_flow.add(l7policy_tasks.CreateL7Policy(
             requires=[constants.L7POLICY, constants.LISTENERS, a10constants.VTHUNDER]))
         create_l7policy_flow.add(database_tasks.MarkL7PolicyActiveInDB(
@@ -57,7 +62,7 @@ class L7PolicyFlows(object):
             requires=a10constants.VTHUNDER))
         return create_l7policy_flow
 
-    def get_delete_l7policy_flow(self):
+    def get_delete_l7policy_flow(self, topology):
         """Create a flow to delete an L7 policy
 
         :returns: The flow for deleting an L7 policy
@@ -77,6 +82,11 @@ class L7PolicyFlows(object):
         delete_l7policy_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
+        if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+            delete_l7policy_flow.add(vthunder_tasks.GetMasterVThunder(
+                name=a10constants.GET_MASTER_VTHUNDER,
+                requires=a10constants.VTHUNDER,
+                provides=a10constants.VTHUNDER))
         delete_l7policy_flow.add(l7policy_tasks.DeleteL7Policy(
             requires=[constants.L7POLICY, a10constants.VTHUNDER]))
         delete_l7policy_flow.add(database_tasks.DeleteL7PolicyInDB(
@@ -89,7 +99,7 @@ class L7PolicyFlows(object):
             requires=a10constants.VTHUNDER))
         return delete_l7policy_flow
 
-    def get_update_l7policy_flow(self):
+    def get_update_l7policy_flow(self, topology):
         """Create a flow to update an L7 policy
         :returns: The flow for updating an L7 policy
         """
@@ -106,6 +116,11 @@ class L7PolicyFlows(object):
         update_l7policy_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
+        if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+            update_l7policy_flow.add(vthunder_tasks.GetMasterVThunder(
+                name=a10constants.GET_MASTER_VTHUNDER,
+                requires=a10constants.VTHUNDER,
+                provides=a10constants.VTHUNDER))
         update_l7policy_flow.add(
             l7policy_tasks.UpdateL7Policy(
                 requires=[

--- a/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_l7rule_flows.py
@@ -28,7 +28,7 @@ from a10_octavia.controller.worker.tasks import vthunder_tasks
 
 class L7RuleFlows(object):
 
-    def get_create_l7rule_flow(self):
+    def get_create_l7rule_flow(self, topology):
         """Create a flow to create an L7 rule
         :returns: The flow for creating an L7 rule
         """
@@ -45,6 +45,11 @@ class L7RuleFlows(object):
         create_l7rule_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
+        if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+            create_l7rule_flow.add(vthunder_tasks.GetMasterVThunder(
+                name=a10constants.GET_MASTER_VTHUNDER,
+                requires=a10constants.VTHUNDER,
+                provides=a10constants.VTHUNDER))
         create_l7rule_flow.add(l7rule_tasks.CreateL7Rule(
             requires=[constants.L7RULE, constants.LISTENERS, a10constants.VTHUNDER]))
         create_l7rule_flow.add(database_tasks.MarkL7RuleActiveInDB(
@@ -59,7 +64,7 @@ class L7RuleFlows(object):
             requires=a10constants.VTHUNDER))
         return create_l7rule_flow
 
-    def get_delete_l7rule_flow(self):
+    def get_delete_l7rule_flow(self, topology):
         """Create a flow to delete an L7 rule
         :returns: The flow for deleting an L7 rule
         """
@@ -77,6 +82,11 @@ class L7RuleFlows(object):
             rebind={constants.OBJECT: constants.L7RULE}))
         delete_l7rule_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER, provides=a10constants.VTHUNDER))
+        if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+            delete_l7rule_flow.add(vthunder_tasks.GetMasterVThunder(
+                name=a10constants.GET_MASTER_VTHUNDER,
+                requires=a10constants.VTHUNDER,
+                provides=a10constants.VTHUNDER))
         delete_l7rule_flow.add(l7rule_tasks.DeleteL7Rule(
             requires=[constants.L7RULE, constants.LISTENERS, a10constants.VTHUNDER]))
         delete_l7rule_flow.add(database_tasks.DeleteL7RuleInDB(
@@ -91,7 +101,7 @@ class L7RuleFlows(object):
             requires=a10constants.VTHUNDER))
         return delete_l7rule_flow
 
-    def get_update_l7rule_flow(self):
+    def get_update_l7rule_flow(self, topology):
         """Create a flow to update an L7 rule
         :returns: The flow for updating an L7 rule
         """
@@ -108,6 +118,10 @@ class L7RuleFlows(object):
         update_l7rule_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
+        if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+            update_l7rule_flow.add(vthunder_tasks.GetMasterVThunder(
+                requires=a10constants.VTHUNDER,
+                provides=a10constants.VTHUNDER))
         update_l7rule_flow.add(
             l7rule_tasks.UpdateL7Rule(
                 requires=[

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -391,19 +391,6 @@ class LoadBalancerFlows(object):
                     name=a10constants.AMPHORAE_POST_VIP_PLUG_FOR_MASTER,
                     requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
                               constants.ADDED_PORTS)))
-                new_LB_net_subflow.add(
-                    vthunder_tasks.VThunderComputeConnectivityWait(
-                        name="active-compute-conn-wait-before-plug-backup",
-                        requires=(a10constants.VTHUNDER, constants.AMPHORA)))
-                new_LB_net_subflow.add(
-                    vthunder_tasks.VThunderComputeConnectivityWait(
-                        name="backup-compute-conn-wait-before-plug-backup",
-                        rebind={
-                            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-                        requires=constants.AMPHORA))
-                new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
-                    name="active-plug-wait-vcs-ready",
-                    requires=a10constants.VTHUNDER))
                 new_LB_net_subflow.add(vthunder_tasks.AmphoraePostVIPPlug(
                     name=a10constants.AMPHORAE_POST_VIP_PLUG_FOR_BACKUP,
                     requires=(constants.LOADBALANCER, constants.ADDED_PORTS),

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -989,7 +989,7 @@ class GetLoadBalancerListForDeletion(BaseDatabaseTask):
     def execute(self, vthunder, loadbalancer):
         try:
             if vthunder:
-                loadbalancers_list = self.loadbalancer_repo.get_all_ohter_lbs_in_project(
+                loadbalancers_list = self.loadbalancer_repo.get_all_other_lbs_in_project(
                     db_apis.get_session(),
                     vthunder.project_id,
                     loadbalancer.id)

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -388,7 +388,7 @@ class LoadBalancerRepository(repo.LoadBalancerRepository):
             lb_list.append(data.to_data_model())
         return lb_list
 
-    def get_all_ohter_lbs_in_project(self, session, project_id, id):
+    def get_all_other_lbs_in_project(self, session, project_id, id):
         lb_list = []
         query = session.query(self.model_class).filter(
             self.model_class.project_id == project_id).filter(


### PR DESCRIPTION
## Description
- Severity Level Critical
- Issue Description:
In Active-Standby mode, when master is handover a10-octavia can't configure vthunder correctly for all SLB objects.
 
## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2302

## Technical Approach
Get Master vThunder for all SLB flows (some are already done in other PR)

## Config Changes
<pre>
<b>[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
#default_axapi_timeout = 600

[a10_controller_worker]
amp_image_owner_id = 99c9c2304f114685a32db30769c8a7e2
amp_secgroup_list = 2d0a3480-7f08-4184-b96f-c39bb444dd38
amp_flavor_id = 69995a83-c47a-427f-bf70-e9d9752aa915
amp_boot_network_list = 7f8ddd7f-c5c3-463a-b1c3-596f988480a4
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 150
amp_active_wait_sec = 10
amp_busy_wait_sec = 0
amp_image_id = 0a845873-bd91-4f8c-ad58-cf5d5afde09c
#loadbalancer_topology = SINGLE
loadbalancer_topology = ACTIVE_STANDBY

[a10_health_manager]
udp_server_ip_address = 10.64.28.68
bind_port = 5550
bind_ip = 10.64.28.68
heartbeat_interval = 5
heartbeat_key = insecure
heartbeat_timeout = 90
health_check_interval = 3
failover_timeout = 600
health_check_timeout = 3
health_check_max_retries = 5

[a10_house_keeping]
load_balancer_expiry_age = 3600
amphorae_expiry_age = 3600
#use_periodic_write_memory = 'enable'
#write_mem_interval = 300

[a10_global]
network_type = "flat"
#network_type = "vlan"
vrid_floating_ip = "dhcp"
</b>
</pre>


## Test Cases
- healthmonitor

```
openstack loadbalancer healthmonitor create --delay 4 --timeout 3 --max-retries 3 --type HTTPS sg1
openstack loadbalancer healthmonitor set --delay 6 68c08bf6-5e6d-43d1-ad92-97cb23d6cbea
openstack loadbalancer healthmonitor delete 68c08bf6-5e6d-43d1-ad92-97cb23d6cbea
```

- l7policy

```
openstack loadbalancer l7policy create --action REJECT --name p2 vport1
openstack loadbalancer l7policy set p2
openstack loadbalancer l7policy delete p2
```


- l7rule

```
openstack loadbalancer l7rule create --compare-type REGEX --type HEADER --key "reject" --value "request" p2
openstack loadbalancer l7rule set --enable p2 314652bc-9f71-4722-851f-e92ddbf73f14
openstack loadbalancer l7rule delete p2 314652bc-9f71-4722-851f-e92ddbf73f14
```

## Manual Testing
- healthmonitor
```
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer healthmonitor create --delay 4 --timeout 3 --max-retries 3 --type HTTPS sg1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| project_id          | 99c9c2304f114685a32db30769c8a7e2     |
| name                |                                      |
| admin_state_up      | True                                 |
| pools               | bd303449-3e25-4580-b066-18a16f4d7974 |
| created_at          | 2021-05-03T09:39:25                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| delay               | 4                                    |
| expected_codes      | 200                                  |
| max_retries         | 3                                    |
| http_method         | GET                                  |
| timeout             | 3                                    |
| max_retries_down    | 3                                    |
| url_path            | /                                    |
| type                | HTTPS                                |
| id                  | 68c08bf6-5e6d-43d1-ad92-97cb23d6cbea |
| operating_status    | OFFLINE                              |
| http_version        | None                                 |
| domain_name         | None                                 |
+---------------------+--------------------------------------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer healthmonitor list
+--------------------------------------+------+----------------------------------+-------+----------------+
| id                                   | name | project_id                       | type  | admin_state_up |
+--------------------------------------+------+----------------------------------+-------+----------------+
| 68c08bf6-5e6d-43d1-ad92-97cb23d6cbea |      | 99c9c2304f114685a32db30769c8a7e2 | HTTPS | True           |
+--------------------------------------+------+----------------------------------+-------+----------------+


stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer healthmonitor show 68c08bf6-5e6d-43d1-ad92-97cb23d6cbea
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| project_id          | 99c9c2304f114685a32db30769c8a7e2     |
| name                |                                      |
| admin_state_up      | True                                 |
| pools               | bd303449-3e25-4580-b066-18a16f4d7974 |
| created_at          | 2021-05-03T09:39:25                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-05-03T09:40:47                  |
| delay               | 4                                    |
| expected_codes      | 200                                  |
| max_retries         | 3                                    |
| http_method         | GET                                  |
| timeout             | 3                                    |
| max_retries_down    | 3                                    |
| url_path            | /                                    |
| type                | HTTPS                                |
| id                  | 68c08bf6-5e6d-43d1-ad92-97cb23d6cbea |
| operating_status    | ONLINE                               |
| http_version        | None                                 |
| domain_name         | None                                 |
+---------------------+--------------------------------------+

stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer healthmonitor set --delay 7 68c08bf6-5e6d-43d1-ad92-97cb23d6cbea
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer healthmonitor show 68c08bf6-5e6d-43d1-ad92-97cb23d6cbea
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| project_id          | 99c9c2304f114685a32db30769c8a7e2     |
| name                |                                      |
| admin_state_up      | True                                 |
| pools               | bd303449-3e25-4580-b066-18a16f4d7974 |
| created_at          | 2021-05-03T09:39:25                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-05-03T09:46:01                  |
| delay               | 7                                    |
| expected_codes      | 200                                  |
| max_retries         | 3                                    |
| http_method         | GET                                  |
| timeout             | 3                                    |
| max_retries_down    | 3                                    |
| url_path            | /                                    |
| type                | HTTPS                                |
| id                  | 68c08bf6-5e6d-43d1-ad92-97cb23d6cbea |
| operating_status    | ONLINE                               |
| http_version        | None                                 |
| domain_name         | None                                 |
+---------------------+--------------------------------------+
stack@openstack-4:~/source/a10-octavia/vThunder$
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer healthmonitor delete 68c08bf6-5e6d-43d1-ad92-97cb23d6cbea
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer healthmonitor list
```

- l7policy

```
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer l7policy create --action REJECT --name p2 vport1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| listener_id         | 1e6c5342-d5ba-463c-9172-8d3af56cfff3 |
| description         |                                      |
| admin_state_up      | True                                 |
| rules               |                                      |
| project_id          | 99c9c2304f114685a32db30769c8a7e2     |
| created_at          | 2021-05-03T15:27:59                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| redirect_pool_id    | None                                 |
| redirect_url        | None                                 |
| redirect_prefix     | None                                 |
| action              | REJECT                               |
| position            | 5                                    |
| id                  | d2cbc753-2c7c-47f6-860f-b5e740af5a2c |
| operating_status    | OFFLINE                              |
| name                | p2                                   |
| redirect_http_code  | None                                 |
+---------------------+--------------------------------------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer l7policy show p2
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| listener_id         | 1e6c5342-d5ba-463c-9172-8d3af56cfff3 |
| description         |                                      |
| admin_state_up      | True                                 |
| rules               |                                      |
| project_id          | 99c9c2304f114685a32db30769c8a7e2     |
| created_at          | 2021-05-03T15:27:59                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-05-03T15:28:00                  |
| redirect_pool_id    | None                                 |
| redirect_url        | None                                 |
| redirect_prefix     | None                                 |
| action              | REJECT                               |
| position            | 5                                    |
| id                  | d2cbc753-2c7c-47f6-860f-b5e740af5a2c |
| operating_status    | ONLINE                               |
| name                | p2                                   |
| redirect_http_code  | None                                 |
+---------------------+--------------------------------------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer l7policy set --enable p2
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer l7policy show p2
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| listener_id         | 1e6c5342-d5ba-463c-9172-8d3af56cfff3 |
| description         |                                      |
| admin_state_up      | True                                 |
| rules               |                                      |
| project_id          | 99c9c2304f114685a32db30769c8a7e2     |
| created_at          | 2021-05-03T15:27:59                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-05-03T15:32:19                  |
| redirect_pool_id    | None                                 |
| redirect_url        | None                                 |
| redirect_prefix     | None                                 |
| action              | REJECT                               |
| position            | 5                                    |
| id                  | d2cbc753-2c7c-47f6-860f-b5e740af5a2c |
| operating_status    | ONLINE                               |
| name                | p2                                   |
| redirect_http_code  | None                                 |
+---------------------+--------------------------------------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer l7policy delete p2
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer l7policy show p2
Unable to locate p2 in l7policies


openstack loadbalancer l7rule create --compare-type REGEX --type HEADER --key "reject" --value "request" p2
openstack loadbalancer l7rule set --enable p2 314652bc-9f71-4722-851f-e92ddbf73f14
openstack loadbalancer l7rule delete p2 314652bc-9f71-4722-851f-e92ddbf73f14



stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer l7rule create --compare-type REGEX --type HEADER --key "reject" --value "request" p2
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| created_at          | 2021-05-03T15:34:56                  |
| compare_type        | REGEX                                |
| provisioning_status | PENDING_CREATE                       |
| invert              | False                                |
| admin_state_up      | True                                 |
| updated_at          | None                                 |
| value               | request                              |
| key                 | reject                               |
| project_id          | 99c9c2304f114685a32db30769c8a7e2     |
| type                | HEADER                               |
| id                  | 314652bc-9f71-4722-851f-e92ddbf73f14 |
| operating_status    | OFFLINE                              |
+---------------------+--------------------------------------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer l7rule list p2
+--------------------------------------+----------------------------------+---------------------+--------------+--------+--------+---------+--------+----------------+
| id                                   | project_id                       | provisioning_status | compare_type | type   | key    | value   | invert | admin_state_up |
+--------------------------------------+----------------------------------+---------------------+--------------+--------+--------+---------+--------+----------------+
| 314652bc-9f71-4722-851f-e92ddbf73f14 | 99c9c2304f114685a32db30769c8a7e2 | ACTIVE              | REGEX        | HEADER | reject | request | False  | True           |
+--------------------------------------+----------------------------------+---------------------+--------------+--------+--------+---------+--------+----------------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer l7rule set --enable p2 314652bc-9f71-4722-851f-e92ddbf73f14
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer l7rule list p2
+--------------------------------------+----------------------------------+---------------------+--------------+--------+--------+---------+--------+----------------+
| id                                   | project_id                       | provisioning_status | compare_type | type   | key    | value   | invert | admin_state_up |
+--------------------------------------+----------------------------------+---------------------+--------------+--------+--------+---------+--------+----------------+
| 314652bc-9f71-4722-851f-e92ddbf73f14 | 99c9c2304f114685a32db30769c8a7e2 | ACTIVE              | REGEX        | HEADER | reject | request | False  | True           |
+--------------------------------------+----------------------------------+---------------------+--------------+--------+--------+---------+--------+----------------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer l7rule delete p2 314652bc-9f71-4722-851f-e92ddbf73f14
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer l7rule list p2
```

- l7rule

```
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer l7rule create --compare-type REGEX --type HEADER --key "reject" --value "request" p2
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| created_at          | 2021-05-03T15:34:56                  |
| compare_type        | REGEX                                |
| provisioning_status | PENDING_CREATE                       |
| invert              | False                                |
| admin_state_up      | True                                 |
| updated_at          | None                                 |
| value               | request                              |
| key                 | reject                               |
| project_id          | 99c9c2304f114685a32db30769c8a7e2     |
| type                | HEADER                               |
| id                  | 314652bc-9f71-4722-851f-e92ddbf73f14 |
| operating_status    | OFFLINE                              |
+---------------------+--------------------------------------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer l7rule list p2
+--------------------------------------+----------------------------------+---------------------+--------------+--------+--------+---------+--------+----------------+
| id                                   | project_id                       | provisioning_status | compare_type | type   | key    | value   | invert | admin_state_up |
+--------------------------------------+----------------------------------+---------------------+--------------+--------+--------+---------+--------+----------------+
| 314652bc-9f71-4722-851f-e92ddbf73f14 | 99c9c2304f114685a32db30769c8a7e2 | ACTIVE              | REGEX        | HEADER | reject | request | False  | True           |
+--------------------------------------+----------------------------------+---------------------+--------------+--------+--------+---------+--------+----------------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer l7rule set --enable p2 314652bc-9f71-4722-851f-e92ddbf73f14
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer l7rule list p2
+--------------------------------------+----------------------------------+---------------------+--------------+--------+--------+---------+--------+----------------+
| id                                   | project_id                       | provisioning_status | compare_type | type   | key    | value   | invert | admin_state_up |
+--------------------------------------+----------------------------------+---------------------+--------------+--------+--------+---------+--------+----------------+
| 314652bc-9f71-4722-851f-e92ddbf73f14 | 99c9c2304f114685a32db30769c8a7e2 | ACTIVE              | REGEX        | HEADER | reject | request | False  | True           |
+--------------------------------------+----------------------------------+---------------------+--------------+--------+--------+---------+--------+----------------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer l7rule delete p2 314652bc-9f71-4722-851f-e92ddbf73f14
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer l7rule list p2
```
