### PR TITLE
[STACK-2302] active-standby mode LB cascade delete failed after failover

### DIFF
--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -435,10 +435,12 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             db_apis.get_session(),
             load_balancer_id=load_balancer_id)
 
+        topology = CONF.a10_controller_worker.loadbalancer_topology
+
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(lb.project_id, False, None)
         update_lb_tf = self._taskflow_load(
-            self._lb_flows.get_update_load_balancer_flow(),
+            self._lb_flows.get_update_load_balancer_flow(topology=topology),
             store={constants.LOADBALANCER: lb,
                    constants.VIP: lb.vip,
                    a10constants.COMPUTE_BUSY: busy,

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -198,6 +198,11 @@ class LoadBalancerFlows(object):
         delete_LB_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
+        if lb.topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+            delete_LB_flow.add(vthunder_tasks.GetMasterVThunder(
+                name=a10constants.GET_MASTER_VTHUNDER,
+                requires=a10constants.VTHUNDER,
+                provides=a10constants.VTHUNDER))
         delete_LB_flow.add(a10_database_tasks.MarkVThunderStatusInDB(
             requires=a10constants.VTHUNDER,
             inject={"status": constants.PENDING_DELETE}))
@@ -503,7 +508,7 @@ class LoadBalancerFlows(object):
             provides=constants.LOADBALANCER))
         return new_LB_net_subflow
 
-    def get_update_load_balancer_flow(self):
+    def get_update_load_balancer_flow(self, topology):
         """Flow to update load balancer."""
 
         update_LB_flow = linear_flow.Flow(constants.UPDATE_LOADBALANCER_FLOW)
@@ -514,6 +519,11 @@ class LoadBalancerFlows(object):
         update_LB_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
+        if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+            update_LB_flow.add(vthunder_tasks.GetMasterVThunder(
+                name=a10constants.GET_MASTER_VTHUNDER,
+                requires=a10constants.VTHUNDER,
+                provides=a10constants.VTHUNDER))
         update_LB_flow.add(a10_database_tasks.MarkVThunderStatusInDB(
             requires=a10constants.VTHUNDER,
             inject={"status": constants.PENDING_UPDATE}))


### PR DESCRIPTION
## Description
- Severity Level Critical
- Issue Description:
In Active-Standby mode, when master is handover a10-octavia can't configure vthunder correctly for all SLB objects.
 
## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2302

## Technical Approach
Get Master vThunder for all SLB flows (some are already done in other PR)

## Config Changes
<pre>
<b>[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
#default_axapi_timeout = 600

[a10_controller_worker]
amp_image_owner_id = 99c9c2304f114685a32db30769c8a7e2
amp_secgroup_list = 2d0a3480-7f08-4184-b96f-c39bb444dd38
amp_flavor_id = 69995a83-c47a-427f-bf70-e9d9752aa915
amp_boot_network_list = 7f8ddd7f-c5c3-463a-b1c3-596f988480a4
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 150
amp_active_wait_sec = 10
amp_busy_wait_sec = 0
amp_image_id = 0a845873-bd91-4f8c-ad58-cf5d5afde09c
#loadbalancer_topology = SINGLE
loadbalancer_topology = ACTIVE_STANDBY

[a10_health_manager]
udp_server_ip_address = 10.64.28.68
bind_port = 5550
bind_ip = 10.64.28.68
heartbeat_interval = 5
heartbeat_key = insecure
heartbeat_timeout = 90
health_check_interval = 3
failover_timeout = 600
health_check_timeout = 3
health_check_max_retries = 5

[a10_house_keeping]
load_balancer_expiry_age = 3600
amphorae_expiry_age = 3600
#use_periodic_write_memory = 'enable'
#write_mem_interval = 300

[a10_global]
network_type = "flat"
#network_type = "vlan"
vrid_floating_ip = "dhcp"
</b>
</pre>


## Test Cases
- cascade delete after failover
```
openstack loadbalancer create --vip-subnet-id tp91 --vip-address 192.168.91.56 --name vip1
openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name vport1 49c83621-7a07-4ebf-8ee5-ce0863648180
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener vport1 --name sg1
openstack loadbalancer l7policy create --action REJECT --name p2 vport1
openstack loadbalancer l7rule create --compare-type REGEX --type HEADER --key "reject" --value "request" p2
openstack loadbalancer delete 49c83621-7a07-4ebf-8ee5-ce0863648180 --cascade
```
- loadbalancer update
```
openstack loadbalancer set --enable --name vip1
```

## Manual Testing
- cascade delete after failover
```
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| 8768ed74-aa1d-47f8-b662-40a1593fd48c | vip1 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.56 | ERROR               | a10      |
| e2e219a6-352e-4033-9ac2-05636f4d69e4 | vip1 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.56 | ERROR               | a10      |
| 2827c358-7fd8-4644-9558-9b79d207ac5a | vip1 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.56 | ERROR               | a10      |
| 49c83621-7a07-4ebf-8ee5-ce0863648180 | vip1 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.56 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer delete 49c83621-7a07-4ebf-8ee5-ce0863648180 --cascade
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| 8768ed74-aa1d-47f8-b662-40a1593fd48c | vip1 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.56 | ERROR               | a10      |
| e2e219a6-352e-4033-9ac2-05636f4d69e4 | vip1 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.56 | ERROR               | a10      |
| 2827c358-7fd8-4644-9558-9b79d207ac5a | vip1 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.56 | ERROR               | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+

```
