### PR TITLE
[STACK-2307][STACK-2241][STACK-2282] multiple network in amp_boot_network_list

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -431,18 +431,11 @@ class LoadBalancerFlows(object):
                     name=a10constants.MASTER_ENABLE_INTERFACE,
                     requires=(a10constants.VTHUNDER, constants.LOADBALANCER, constants.ADDED_PORTS,
                               a10constants.IFNUM_MASTER, a10constants.IFNUM_BACKUP)))
-                new_LB_net_subflow.add(vthunder_tasks.GetBackupVThunder(
-                    name=a10constants.GET_BACKUP_VTHUNDER,
-                    requires=a10constants.VTHUNDER,
-                    provides=a10constants.VTHUNDER))
                 new_LB_net_subflow.add(vthunder_tasks.GetVThunderInterface(
                     name=a10constants.GET_BACKUP_VTHUNDER_INTERFACE,
                     requires=a10constants.VTHUNDER,
+                    rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
                     provides=(a10constants.IFNUM_MASTER, a10constants.IFNUM_BACKUP)))
-                new_LB_net_subflow.add(vthunder_tasks.GetMasterVThunder(
-                    name=a10constants.MASTER_VTHUNDER,
-                    requires=a10constants.VTHUNDER,
-                    provides=a10constants.VTHUNDER))
                 new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
                     name="wait-vcs-ready-before-master-reload",
                     requires=a10constants.VTHUNDER))

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -222,9 +222,10 @@ class LoadBalancerFlows(object):
         delete_LB_flow.add(a10_database_tasks.GetLoadBalancerListForDeletion(
             requires=(a10constants.VTHUNDER, constants.LOADBALANCER),
             provides=a10constants.LOADBALANCERS_LIST))
-        delete_LB_flow.add(a10_database_tasks.GetBackupVThunderByLoadBalancer(
-            requires=constants.LOADBALANCER,
-            provides=a10constants.BACKUP_VTHUNDER))
+        if lb.topology == "ACTIVE_STANDBY":
+            delete_LB_flow.add(a10_database_tasks.GetBackupVThunderByLoadBalancer(
+                requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
+                provides=a10constants.BACKUP_VTHUNDER))
         if not deleteCompute:
             delete_LB_flow.add(a10_network_tasks.CalculateDelta(
                 requires=(constants.LOADBALANCER, a10constants.LOADBALANCERS_LIST),
@@ -308,13 +309,14 @@ class LoadBalancerFlows(object):
         delete_LB_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             name=a10constants.SET_THUNDER_UPDATE_AT,
             requires=a10constants.VTHUNDER))
-        delete_LB_flow.add(a10_database_tasks.MarkVThunderStatusInDB(
-            name=a10constants.MARK_VTHUNDER_BACKUP_DELETED_IN_DB,
-            rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-            inject={"status": constants.DELETED}))
-        delete_LB_flow.add(a10_database_tasks.SetThunderUpdatedAt(
-            name=a10constants.SET_THUNDER_BACKUP_UPDATE_AT,
-            rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
+        if lb.topology == "ACTIVE_STANDBY":
+            delete_LB_flow.add(a10_database_tasks.MarkVThunderStatusInDB(
+                name=a10constants.MARK_VTHUNDER_BACKUP_DELETED_IN_DB,
+                rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
+                inject={"status": constants.DELETED}))
+            delete_LB_flow.add(a10_database_tasks.SetThunderUpdatedAt(
+                name=a10constants.SET_THUNDER_BACKUP_UPDATE_AT,
+                rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
         return (delete_LB_flow, store)
 
     def get_new_lb_networking_subflow(self, topology, vthunder):
@@ -378,7 +380,7 @@ class LoadBalancerFlows(object):
             new_LB_net_subflow.add(
                 a10_database_tasks.GetBackupVThunderByLoadBalancer(
                     name=a10constants.BACKUP_VTHUNDER,
-                    requires=constants.LOADBALANCER,
+                    requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
                     provides=a10constants.BACKUP_VTHUNDER))
             if vthunder:
                 new_LB_net_subflow.add(a10_database_tasks.GetLoadBalancerListByProjectID(
@@ -465,6 +467,10 @@ class LoadBalancerFlows(object):
                     name=a10constants.GET_VTHUNDER_MASTER,
                     requires=a10constants.VTHUNDER,
                     provides=a10constants.VTHUNDER))
+                new_LB_net_subflow.add(a10_database_tasks.GetBackupVThunderByLoadBalancer(
+                    name="get-backup-vthunder-after-get-master",
+                    requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
+                    provides=a10constants.BACKUP_VTHUNDER))
                 new_LB_net_subflow.add(vthunder_tasks.EnableInterface(
                     name=a10constants.BACKUP_ENABLE_INTERFACE,
                     requires=(a10constants.VTHUNDER, constants.LOADBALANCER, constants.ADDED_PORTS,

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -84,7 +84,7 @@ class MemberFlows(object):
             create_member_flow.add(
                 a10_database_tasks.GetBackupVThunderByLoadBalancer(
                     name="get_backup_vThunder",
-                    requires=constants.LOADBALANCER,
+                    requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
                     provides=a10constants.BACKUP_VTHUNDER))
             create_member_flow.add(vthunder_tasks.VThunderComputeConnectivityWait(
                 name="backup_compute_conn_wait_before_probe_device",
@@ -118,6 +118,10 @@ class MemberFlows(object):
                 name=a10constants.GET_MASTER_VTHUNDER,
                 requires=a10constants.VTHUNDER,
                 provides=a10constants.VTHUNDER))
+            create_member_flow.add(a10_database_tasks.GetBackupVThunderByLoadBalancer(
+                name="get_backup_vThunder_after_get_master",
+                requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
+                provides=a10constants.BACKUP_VTHUNDER))
             create_member_flow.add(
                 vthunder_tasks.EnableInterfaceForMembers(
                     name=a10constants.ENABLE_MASTER_VTHUNDER_INTERFACE,
@@ -236,7 +240,7 @@ class MemberFlows(object):
             delete_member_flow.add(
                 a10_database_tasks.GetBackupVThunderByLoadBalancer(
                     name=a10constants.GET_BACKUP_VTHUNDER_BY_LB,
-                    requires=constants.LOADBALANCER,
+                    requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
                     provides=a10constants.BACKUP_VTHUNDER))
             delete_member_flow.add(
                 vthunder_tasks.VThunderComputeConnectivityWait(

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -444,7 +444,7 @@ class MemberFlows(object):
         delete_member_vrid_subflow.add(
             a10_database_tasks.CountLoadbalancersInProjectBySubnet(
                 requires=[constants.SUBNET, a10constants.PARTITION_PROJECT_LIST],
-                provides=a10constants.LB_COUNT))
+                provides=a10constants.LB_COUNT_SUBNET))
         delete_member_vrid_subflow.add(
             a10_database_tasks.CountMembersInProjectBySubnet(
                 requires=[constants.SUBNET, a10constants.PARTITION_PROJECT_LIST],
@@ -459,7 +459,7 @@ class MemberFlows(object):
                     a10constants.VTHUNDER,
                     a10constants.VRID_LIST,
                     constants.SUBNET,
-                    a10constants.LB_COUNT,
+                    a10constants.LB_COUNT_SUBNET,
                     a10constants.MEMBER_COUNT],
                 provides=(
                     a10constants.VRID,

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -311,7 +311,7 @@ class VThunderFlows(object):
             provides=a10constants.VTHUNDER))
         vrrp_subflow.add(a10_database_tasks.GetBackupVThunderByLoadBalancer(
             name=sf_name + '-' + a10constants.GET_BACKUP_LOADBALANCER_FROM_DB,
-            requires=constants.LOADBALANCER,
+            requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
             provides=a10constants.BACKUP_VTHUNDER))
         # Make sure devices are ready
         vrrp_subflow.add(vthunder_tasks.VThunderComputeConnectivityWait(

--- a/a10_octavia/controller/worker/tasks/a10_compute_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_compute_tasks.py
@@ -37,7 +37,8 @@ class ComputeCreate(BaseComputeTask):
         network_ids = CONF.a10_controller_worker.amp_boot_network_list[:]
         # Injecting VIP network ID
         if loadbalancer:
-            network_ids.append(loadbalancer.vip.network_id)
+            if loadbalancer.vip.network_id not in network_ids:
+                network_ids.append(loadbalancer.vip.network_id)
         LOG.debug("Compute create execute for amphora with id %s", amphora_id)
         key_name = CONF.a10_controller_worker.amp_ssh_key_name
 

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -218,11 +218,16 @@ class GetVThunderByLoadBalancer(BaseDatabaseTask):
 class GetBackupVThunderByLoadBalancer(BaseDatabaseTask):
     """ Get VThunder details from LoadBalancer"""
 
-    def execute(self, loadbalancer):
+    def execute(self, loadbalancer, vthunder=None):
         loadbalancer_id = loadbalancer.id
-        vthunder = self.vthunder_repo.get_backup_vthunder_from_lb(
+        backup_vthunder = self.vthunder_repo.get_backup_vthunder_from_lb(
             db_apis.get_session(), loadbalancer_id)
-        return vthunder
+
+        # VCS vMaster/vBlade may switched
+        if vthunder and backup_vthunder.ip_address == vthunder.ip_address:
+            backup_vthunder = self.vthunder_repo.get_vthunder_from_lb(
+                db_apis.get_session(), loadbalancer_id)
+        return backup_vthunder
         LOG.info("Successfully fetched vThunder details for LB")
 
 

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -63,8 +63,7 @@ class CalculateAmphoraDelta(BaseNetworkTask):
         # Figure out what networks we want
         # seed with lb network(s)
 
-        desired_network_ids = set()
-        desired_network_ids.update(CONF.controller_worker.amp_boot_network_list)
+        desired_network_ids = set(CONF.a10_controller_worker.amp_boot_network_list[:])
         member_networks = []
         for loadbalancer in loadbalancers_list:
             for pool in loadbalancer.pools:

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -164,9 +164,7 @@ class EnableInterface(VThunderBaseTask):
 
         if not lb_exists_flag:
             added_ports[amphora_id] = []
-            for nic in nics:
-                if nic.network_id == loadbalancer.vip.network_id:
-                    added_ports[amphora_id].append(nic)
+            added_ports[amphora_id].append(nics[1])
 
         try:
             if added_ports and amphora_id in added_ports and len(added_ports[amphora_id]) > 0:

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -164,7 +164,9 @@ class EnableInterface(VThunderBaseTask):
 
         if not lb_exists_flag:
             added_ports[amphora_id] = []
-            added_ports[amphora_id].append(nics[1])
+            for nic in nics:
+                if nic.network_id == loadbalancer.vip.network_id:
+                    added_ports[amphora_id].append(nic)
 
         try:
             if added_ports and amphora_id in added_ports and len(added_ports[amphora_id]) > 0:
@@ -1055,6 +1057,10 @@ class VCSSyncWait(VThunderBaseTask):
                     if vmaster_ready is True and vblade_ready is True:
                         break
                 else:
+                    # TODO(ytsai) maybe reload the device and try again
+                    if vmaster_ready:
+                        raise acos_errors.AxapiJsonFormatError(
+                            msg="vBlade not found in vcs-summary")
                     raise acos_errors.AxapiJsonFormatError(
                         msg="vMaster not found in vcs-summary")
             except req_exceptions.ReadTimeout as e:

--- a/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
+++ b/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
@@ -203,7 +203,7 @@ class A10OctaviaNeutronDriver(allowed_address_pairs.AllowedAddressPairsDriver):
         for port in ports:
             if lb_count_subnet > 1:  # vNIC port is in use by other lbs. Only delete VIP port.
                 if sec_grp:
-                    self._remove_security_group(loadbalancer, port, sec_grp['id'])
+                    self._remove_security_group(port, sec_grp['id'])
                 if port['id'] == vip_port_id:
                     self._cleanup_port(vip_port_id, port)
             elif lb_count_subnet <= 1:  # This is the only lb using vNIC ports


### PR DESCRIPTION
- Severity Level High
- Issue Description:
When multiple networks are specified in amp_boot_network_list, a10-octavia should:
- still able to create slb object correctly.
- when LB vip subnet already in this list, create LB will not need to reload/reboot during creation
- when member subnet already in this list. create member will not need to reload/reboot during creation.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2241
https://a10networks.atlassian.net/browse/STACK-2282
https://a10networks.atlassian.net/browse/STACK-2307

## Technical Approach
Go through our flow to make sure multiple networks in amp_boot_network_list can works as expected.

## Config Changes

<pre>
<b>[a10_controller_worker]
...
amp_boot_network_list = 7f8ddd7f-c5c3-463a-b1c3-596f988480a4, 61305531-6e3a-44b4-8e67-05e93363dddc, a66685db-31ee-46c6-928a-ac034d87dc63, ec33a88d-3290-4ad6-95cc-226fcd2a4458</b>
</pre>


## Test Cases
- create LB and members don't need to reload. 
```
openstack loadbalancer create --vip-subnet-id tp91 --name vip1
openstack loadbalancer create --vip-subnet-id tp92 --name vip2
openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name vport1 vip1
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener vport1 --name sg1
openstack loadbalancer member create --address 192.168.90.132 --subnet-id tp90 --protocol-port 80 --name srv1 sg1
```

## Manual Testing
LOG:
```
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer create --vip-subnet-id tp91 --name vip1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-05-05T07:27:39                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 132e55e1-f863-4a12-bfee-13e70a2a8df5 |
| listeners           |                                      |
| name                | vip1                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 99c9c2304f114685a32db30769c8a7e2     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.91.151                       |
| vip_network_id      | 61305531-6e3a-44b4-8e67-05e93363dddc |
| vip_port_id         | 2200e93e-4e46-49c7-9563-e013f439111e |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 3ea80a1c-5785-4252-b751-c84d614ccb0c |
+---------------------+--------------------------------------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address    | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| 132e55e1-f863-4a12-bfee-13e70a2a8df5 | vip1 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.151 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack server list
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------------------------------------------+-----------+---------+
| ID                                   | Name                                         | Status | Networks                                                                                | Image     | Flavor  |
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------------------------------------------+-----------+---------+
| 9ef50003-ad09-49df-93f8-18fab139f1e1 | amphora-e32fd547-902f-4c64-89f5-9ffab218a4b0 | ACTIVE | lb-mgmt-net=192.168.0.143; tp90=192.168.90.147; tp91=192.168.91.135; tp92=192.168.92.72 | ACOS521p1 | vthuner |
| 039935a3-c94d-4b48-8631-eb919a28cbfa | amphora-d2d9a985-1447-4b41-ab6a-3c763494cf6d | ACTIVE | lb-mgmt-net=192.168.0.57; tp90=192.168.90.5; tp91=192.168.91.85; tp92=192.168.92.125    | ACOS521p1 | vthuner |
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------------------------------------------+-----------+---------+


stack@openstack-4:~/source/a10-octavia/vThunder$ ssh admin@192.168.0.143
The authenticity of host '192.168.0.143 (192.168.0.143)' can't be established.
RSA key fingerprint is SHA256:G1/ZRmj2ELiAkZHD6YKe33TxhDnkW5Nad3BMFp2WBAg.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added '192.168.0.143' (RSA) to the list of known hosts.
Password:

System is ready now.

[type ? for help]

vThunder-vMaster[1/1](NOLICENSE)>en
Password:
vThunder-vMaster[1/1](NOLICENSE)#show in
vThunder-vMaster[1/1](NOLICENSE)#show interfaces br
vThunder-vMaster[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e82.87a4  192.168.0.143/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e5f.7298  192.168.91.135/24     1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3ed7.d386  192.168.90.147/24     1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e32.1947  192.168.92.72/24      1  DataPort

Global Throughput:31064 bits/sec (3883 bytes/sec)
Throughput:31064 bits/sec (3883 bytes/sec)
vThunder-vMaster[1/1](NOLICENSE)#exit
vThunder-vMaster[1/1](NOLICENSE)>exit
Are you sure to quit (N/Y)?: y
Connection to 192.168.0.143 closed.
stack@openstack-4:~/source/a10-octavia/vThunder$ ssh admin@192.168.0.57
The authenticity of host '192.168.0.57 (192.168.0.57)' can't be established.
RSA key fingerprint is SHA256:u1vVeA1araumS+NnRNaaI1aR8e7CSij9BbTg8O1Icy8.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added '192.168.0.57' (RSA) to the list of known hosts.
Password:

System is ready now.

[type ? for help]

vThunder-vBlade[1/2](NOLICENSE)>en
Password:
vThunder-vBlade[1/2](NOLICENSE)#show in
vThunder-vBlade[1/2](NOLICENSE)#show interfaces bri
vThunder-vBlade[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e30.1dee  192.168.0.57/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3e55.d167  192.168.91.85/24      1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e91.65c0  192.168.90.5/24       1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e1b.0b34  192.168.92.125/24     1  DataPort

Global Throughput:29664 bits/sec (3708 bytes/sec)
Throughput:29664 bits/sec (3708 bytes/sec)


stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer create --vip-subnet-id tp92 --name vip2
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-05-05T07:42:54                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 5611fb6a-9506-47cb-a8f7-0312fbdeea82 |
| listeners           |                                      |
| name                | vip2                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 99c9c2304f114685a32db30769c8a7e2     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.92.27                        |
| vip_network_id      | ec33a88d-3290-4ad6-95cc-226fcd2a4458 |
| vip_port_id         | 010e13b1-6375-49b3-9887-95d36d3ef197 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 65b4be82-364f-4315-bc63-a0779a33d304 |
+---------------------+--------------------------------------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address    | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| 132e55e1-f863-4a12-bfee-13e70a2a8df5 | vip1 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.151 | ACTIVE              | a10      |
| 5611fb6a-9506-47cb-a8f7-0312fbdeea82 | vip2 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.92.27  | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack server list
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------------------------------------------+-----------+---------+
| ID                                   | Name                                         | Status | Networks                                                                                | Image     | Flavor  |
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------------------------------------------+-----------+---------+
| 9ef50003-ad09-49df-93f8-18fab139f1e1 | amphora-e32fd547-902f-4c64-89f5-9ffab218a4b0 | ACTIVE | lb-mgmt-net=192.168.0.143; tp90=192.168.90.147; tp91=192.168.91.135; tp92=192.168.92.72 | ACOS521p1 | vthuner |
| 039935a3-c94d-4b48-8631-eb919a28cbfa | amphora-d2d9a985-1447-4b41-ab6a-3c763494cf6d | ACTIVE | lb-mgmt-net=192.168.0.57; tp90=192.168.90.5; tp91=192.168.91.85; tp92=192.168.92.125    | ACOS521p1 | vthuner |
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------------------------------------------+-----------+---------+

vThunder-vMaster[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e82.87a4  192.168.0.143/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e5f.7298  192.168.91.135/24     1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3ed7.d386  192.168.90.147/24     1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e32.1947  192.168.92.72/24      1  DataPort


vThunder-vBlade[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e30.1dee  192.168.0.57/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3e55.d167  0.0.0.0/0             1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e91.65c0  0.0.0.0/0             1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e1b.0b34  0.0.0.0/0             1  DataPort



stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener vport1 --name sg1
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-05-05T09:57:54                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | 7c262608-85d7-4f45-a029-91dffd327ffe |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | 584c030d-e053-4292-8ba8-12381d95e696 |
| loadbalancers        | 73cc85c8-0cb5-4eea-a676-0d3ed140a6ec |
| members              |                                      |
| name                 | sg1                                  |
| operating_status     | OFFLINE                              |
| project_id           | 99c9c2304f114685a32db30769c8a7e2     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
+----------------------+--------------------------------------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer member create --address 192.168.90.132 --subnet-id tp90 --protocol-port 80 --name srv1 sg1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 192.168.90.132                       |
| admin_state_up      | True                                 |
| created_at          | 2021-05-05T10:01:27                  |
| id                  | 6bf5246c-4012-4476-9e02-12453285fe3e |
| name                | srv1                                 |
| operating_status    | NO_MONITOR                           |
| project_id          | 99c9c2304f114685a32db30769c8a7e2     |
| protocol_port       | 80                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 9ed1696e-3a3f-44ec-a0da-2c73b0dc22d4 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer member list sg1
+--------------------------------------+------+----------------------------------+---------------------+----------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address        | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+----------------+---------------+------------------+--------+
| 6bf5246c-4012-4476-9e02-12453285fe3e | srv1 | 99c9c2304f114685a32db30769c8a7e2 | ACTIVE              | 192.168.90.132 |            80 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+----------------+---------------+------------------+--------+

stack@openstack-4:~/source/a10-octavia/vThunder$ ssh admin@192.168.0.17
Password:
Last login: Wed May  5 10:54:45 2021 from 192.168.0.127

System is ready now.

[type ? for help]

vThunder-vBlade[1/2](NOLICENSE)>en
Password:
vThunder-vBlade[1/2](NOLICENSE)#show in
vThunder-vBlade[1/2](NOLICENSE)#show interfaces br
vThunder-vBlade[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3efa.e8d4  192.168.0.17/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3ed1.ee3c  192.168.91.42/24      1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3ed0.b480  192.168.90.19/24      1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e1a.6055  192.168.92.94/24      1  DataPort

Global Throughput:29680 bits/sec (3710 bytes/sec)
Throughput:29680 bits/sec (3710 bytes/sec)
vThunder-vBlade[1/2](NOLICENSE)#exit
vThunder-vBlade[1/2](NOLICENSE)>exit
Are you sure to quit (N/Y)?: y
Connection to 192.168.0.17 closed.
stack@openstack-4:~/source/a10-octavia/vThunder$ ssh admin@192.168.0.185
Password:
Last login: Wed May  5 10:55:12 2021 from 192.168.0.127

System is ready now.

[type ? for help]

vThunder-vMaster[1/1](NOLICENSE)>en
Password:
vThunder-vMaster[1/1](NOLICENSE)#show in
vThunder-vMaster[1/1](NOLICENSE)#show interfaces br
vThunder-vMaster[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e4e.d4d0  192.168.0.185/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e51.2f85  192.168.91.61/24      1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e36.87d1  192.168.90.56/24      1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3eb0.4cb1  192.168.92.251/24     1  DataPort

Global Throughput:31152 bits/sec (3894 bytes/sec)

```
