### PR TITLE
[BUG][STACK-2308]: Make sure vThunder is UP and ready while configuring VRRP sync.

### DIFF
--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -1095,7 +1095,7 @@ class GetMasterVThunder(VThunderBaseTask):
                         vthunder.ip_address = vcs_member_list[i]['ip-list'][0]['ip']
                         break
                 else:
-                    raise acos_errors.AxapiJsonFormatErrora(
+                    raise acos_errors.AxapiJsonFormatError(
                         msg="vMaster not found in vcs-summary")
                 return vthunder
             except req_exceptions.ReadTimeout as e:

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -264,7 +264,7 @@ class ConfigureVRRPSync(VThunderBaseTask):
     @axapi_client_decorator
     def execute(self, vthunder, backup_vthunder):
         """Execute to sync up vrrp in two vThunder devices."""
-        attempts = CONF.a10_controller_worker.amp_active_retries
+        attempts = 3
         while attempts >= 0:
             try:
                 attempts = attempts - 1
@@ -279,7 +279,6 @@ class ConfigureVRRPSync(VThunderBaseTask):
                 if attempts < 0:
                     LOG.exception("Failed VRRP sync: %s", str(e))
                     raise e
-                time.sleep(CONF.a10_controller_worker.amp_active_wait_sec)
 
 
 def configure_avcs(axapi_client, device_id, device_priority, floating_ip, floating_ip_mask):


### PR DESCRIPTION
## Description
- Severity Level: Medium
- Issue Description: Sometimes during configuring vrrp sync on backup vThunder, the vThunder is not ready yet and thus Configuration of VRRP sync gets failed.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2308

## Technical Approach
- Added attempts=amp_active_retries for the ConfigureVRRPSync task. 
- Added waits=amp_active_wait_sec if we get any ACOSException for the configSynch untill we complete all given attempts

## Manual Testing
Used following config:
```
[a10_global]
network_type = "flat"
vrid_floating_ip = "dhcp"

[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"

[a10_controller_worker]
amp_image_owner_id = 9ef5e94c53c940239a66dbe4a1058eee
amp_secgroup_list = e8d58350-a82a-407a-8a4e-e87b8d106ca2
amp_flavor_id = bd01b231-7a68-464b-a022-bc4e9b2498d7
amp_boot_network_list = e9aa5348-950c-4db7-ae29-459344a069c5
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 200
amp_active_wait_sec = 10
amp_busy_wait_sec = 0
amp_image_id = ac639bfd-485b-40b0-b8ad-a25fc9a1f942
#loadbalancer_topology = SINGLE
loadbalancer_topology = ACTIVE_STANDBY

[a10_health_manager]
udp_server_ip_address = 10.64.28.67
bind_port = 5550
bind_ip = 10.64.28.67
heartbeat_interval = 5
heartbeat_key = insecure
heartbeat_timeout = 90
health_check_interval = 3
failover_timeout = 600
health_check_timeout = 3
health_check_max_retries = 5

[a10_house_keeping]
load_balancer_expiry_age = 3600
amphorae_expiry_age = 3600
```

1. Create a loadbalancer in admin project
stack@openstack-3:~$ openstack loadbalancer create --name v1 --vip-subnet-id public-11-subnet                                               
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-05-06T09:21:27                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 848b75ff-e334-441d-9a2d-f8f56e8df822 |
| listeners           |                                      |
| name                | v1                                   |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 9ef5e94c53c940239a66dbe4a1058eee     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.195                          |
| vip_network_id      | 6df8ee71-7519-4f9d-8300-44acfa2fe325 |
| vip_port_id         | 45c30450-adc6-4451-a3b8-ee2b73667300 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 184910cd-74d4-4fd5-a3b2-ebad65d4cd44 |
+---------------------+--------------------------------------+

```

```
stack@openstack-3:~$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 848b75ff-e334-441d-9a2d-f8f56e8df822 | v1   | 9ef5e94c53c940239a66dbe4a1058eee | 10.0.11.195 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+

```

2. Create second loadbalancer in demo project
stack@openstack-3:~$ openstack loadbalancer create --name v3 --vip-subnet-id public-13-subnet --project demo
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-05-06T09:37:38                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | c96f8e10-fdc8-41ef-8b2c-1f7958118fd2 |
| listeners           |                                      |
| name                | v3                                   |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 3483e35b39ab457e87953750606c76f6     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.13.246                          |
| vip_network_id      | 3f286d58-339c-4ca6-a5f7-8723b0e1fd2d |
| vip_port_id         | 1d12e9b2-f64e-4d4b-8bcb-6c55d446511d |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 0d4f7a95-d013-4a22-9b8e-6a83b22f8297 |
+---------------------+--------------------------------------+
```

stack@openstack-3:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 848b75ff-e334-441d-9a2d-f8f56e8df822 | v1   | 9ef5e94c53c940239a66dbe4a1058eee | 10.0.11.195 | ACTIVE              | a10      |
| c96f8e10-fdc8-41ef-8b2c-1f7958118fd2 | v3   | 3483e35b39ab457e87953750606c76f6 | 10.0.13.246 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+

```

Both the loadbalancers are created successfully on vMaster and vBlade devices.