### PR TITLE
[STACK-2319] instance deleted when all LB in pending state

### DIFF
--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -391,6 +391,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         vthunder = self._vthunder_repo.get_vthunder_from_lb(db_apis.get_session(),
                                                             load_balancer_id)
         deleteCompute = False
+        busy = self._vthunder_busy_check(lb.project_id, True, None)
         if vthunder:
             deleteCompute = self._vthunder_repo.get_delete_compute_flag(db_apis.get_session(),
                                                                         vthunder.compute_id)
@@ -405,10 +406,10 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                 lb, deleteCompute, cascade)
 
         store.update({constants.LOADBALANCER: lb,
+                      a10constants.COMPUTE_BUSY: busy,
                       constants.VIP: lb.vip,
                       constants.SERVER_GROUP_ID: lb.server_group_id})
 
-        busy = self._vthunder_busy_check(lb.project_id, True, store)
         delete_lb_tf = self._taskflow_load(flow, store=store)
         self._register_flow_notify_handler(delete_lb_tf, lb.project_id, True, busy)
 

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -261,7 +261,7 @@ class VThunderRepository(BaseRepository):
         if compute_id:
             count = session.query(self.model_class).filter(
                 and_(self.model_class.compute_id == compute_id,
-                     self.model_class.status == "ACTIVE")).count()
+                     self.model_class.status != "DELETED")).count()
             if count < 2:
                 return True
 

--- a/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
+++ b/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
@@ -181,8 +181,7 @@ class A10OctaviaNeutronDriver(allowed_address_pairs.AllowedAddressPairsDriver):
 
         filtered_ports = []
         for port in all_ports.get('ports', []):
-            if (sec_grp_id in port.get('security_groups', []) and
-                    port.get('device_owner') == a10constants.OCTAVIA_OWNER):
+            if sec_grp_id in port.get('security_groups', []):
                 filtered_ports.append(port)
         return filtered_ports
 

--- a/a10_octavia/tests/unit/network/drivers/neutron/test_a10_neutron_driver.py
+++ b/a10_octavia/tests/unit/network/drivers/neutron/test_a10_neutron_driver.py
@@ -229,7 +229,7 @@ class TestA10NeutronDriver(base.TestCase):
         self.driver.neutron_client.list_ports.return_value = ports
 
         actual_ports = self.driver._get_ports_by_security_group('sec-grp-1')
-        self.assertEqual([], actual_ports)
+        self.assertEqual(ports['ports'], actual_ports)
 
     def test_get_instance_ports_by_subnet(self):
         ports = {'ports': [{'id': 'instance-port-1',


### PR DESCRIPTION
## Description
- Required: Severity Level High
- Required: Issue Description
1. If we delete all LB together, vthunder instance will be deleted unexpectedly when some of LB are not deleted yet.
2. Also fix LB created failed issue, which degrade by https://github.com/a10networks/a10-octavia/pull/390

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2319

## Technical Approach
1. For the logic to check deleteCompute is not correct, vthunders may in pending or error state and still running. We should not just count ACTIVE thunders.
2. I assume we still need to remove security group for ports not allowed by OCTAVIA. otherwise security group can't be deleted.


## Config Changes

<pre>
<b>N/A</b>
</pre>


## Test Cases
create 3 LB and delete them together.
```
openstack loadbalancer create --vip-subnet-id tp91 --name vip1
openstack loadbalancer create --vip-subnet-id tp91 --name vip2
openstack loadbalancer create --vip-subnet-id tp91 --name vip3
openstack loadbalancer delete vip1
openstack loadbalancer delete vip2
openstack loadbalancer delete vip3
```

## Manual Testing
test log:
```
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address    | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| f0c722c2-1b90-45f5-ba47-4a3dd750d393 | vip1 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.158 | ACTIVE              | a10      |
| 3ac9c829-65b7-488a-bcaf-6ff29f88df0c | vip2 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.155 | ACTIVE              | a10      |
| 9a00b0cc-dfa8-4e84-83db-e205badef595 | vip3 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.11  | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer delete vip1
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer delete vip2
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer delete vip3
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer list


```
