### PR TITLE
[STACK-2328] rack flow degrades

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -670,16 +670,17 @@ class LoadBalancerFlows(object):
         delete_LB_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             name=a10constants.SET_THUNDER_UPDATE_AT,
             requires=a10constants.VTHUNDER))
-        delete_LB_flow.add(a10_database_tasks.GetBackupVThunderByLoadBalancer(
-            requires=constants.LOADBALANCER,
-            provides=a10constants.BACKUP_VTHUNDER))
-        delete_LB_flow.add(a10_database_tasks.MarkVThunderStatusInDB(
-            name=a10constants.MARK_VTHUNDER_BACKUP_DELETED_IN_DB,
-            rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-            inject={"status": constants.DELETED}))
-        delete_LB_flow.add(a10_database_tasks.SetThunderUpdatedAt(
-            name=a10constants.SET_THUNDER_BACKUP_UPDATE_AT,
-            rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
+        if lb.topology == "ACTIVE_STANDBY":
+            delete_LB_flow.add(a10_database_tasks.GetBackupVThunderByLoadBalancer(
+                requires=constants.LOADBALANCER,
+                provides=a10constants.BACKUP_VTHUNDER))
+            delete_LB_flow.add(a10_database_tasks.MarkVThunderStatusInDB(
+                name=a10constants.MARK_VTHUNDER_BACKUP_DELETED_IN_DB,
+                rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
+                inject={"status": constants.DELETED}))
+            delete_LB_flow.add(a10_database_tasks.SetThunderUpdatedAt(
+                name=a10constants.SET_THUNDER_BACKUP_UPDATE_AT,
+                rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
         return (delete_LB_flow, store)
 
     def get_post_lb_rack_vthunder_association_flow(self, prefix, topology,

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -224,9 +224,10 @@ class GetBackupVThunderByLoadBalancer(BaseDatabaseTask):
             db_apis.get_session(), loadbalancer_id)
 
         # VCS vMaster/vBlade may switched
-        if vthunder and backup_vthunder.ip_address == vthunder.ip_address:
-            backup_vthunder = self.vthunder_repo.get_vthunder_from_lb(
-                db_apis.get_session(), loadbalancer_id)
+        if vthunder is not None:
+            if backup_vthunder.ip_address == vthunder.ip_address:
+                backup_vthunder = self.vthunder_repo.get_vthunder_from_lb(
+                    db_apis.get_session(), loadbalancer_id)
         return backup_vthunder
         LOG.info("Successfully fetched vThunder details for LB")
 


### PR DESCRIPTION
## Description
- Required: Severity Level Critical
- Required: Issue Description
1. loadbalancer delete failed for rack flow single topology
2. but the issue described in STACK-2328 can't reproduce, asked JiYen to help for reproduce it.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2328

## Technical Approach
1. Only run backup related tasks in ACTIVE-STANDBY mode.

## Config Changes

<pre>
<b>[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
#default_axapi_timeout = 600

[a10_controller_worker]
amp_image_owner_id = 99c9c2304f114685a32db30769c8a7e2
amp_secgroup_list = 2d0a3480-7f08-4184-b96f-c39bb444dd38
amp_flavor_id = 69995a83-c47a-427f-bf70-e9d9752aa915
#amp_boot_network_list = 7f8ddd7f-c5c3-463a-b1c3-596f988480a4
amp_boot_network_list = 7f8ddd7f-c5c3-463a-b1c3-596f988480a4, 61305531-6e3a-44b4-8e67-05e93363dddc, a66685db-31ee-46c6-928a-ac034d87dc63, ec33a88d-3290-4ad6-95cc-226fcd2a4458
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 150
amp_active_wait_sec = 10
amp_busy_wait_sec = 0
amp_image_id = 0a845873-bd91-4f8c-ad58-cf5d5afde09c
loadbalancer_topology = SINGLE
#loadbalancer_topology = ACTIVE_STANDBY

[a10_health_manager]
udp_server_ip_address = 10.64.28.68
bind_port = 5550
bind_ip = 10.64.28.68
heartbeat_interval = 5
heartbeat_key = insecure
heartbeat_timeout = 90
health_check_interval = 3
failover_timeout = 600
health_check_timeout = 3
health_check_max_retries = 5

[a10_house_keeping]
load_balancer_expiry_age = 3600
amphorae_expiry_age = 3600
#use_periodic_write_memory = 'enable'
#write_mem_interval = 300

[a10_global]
network_type = "flat"
#network_type = "vlan"
#vrid_floating_ip = "dhcp"

[hardware_thunder]
devices = [
                    {
                     "project_id": "99c9c2304f114685a32db30769c8a7e2",
                     "ip_address": "192.168.90.46",
                     "username": "admin",
                     "password": "a10",
                     "device_name": "AX46"
                     }
             ]
</b>
</pre>

(Example Snippet - Remove This Before Submission)

<pre>
[rack_vthunder]

devices=[
 {
 "project_id": "fake_uuid",
 "username" : "username",
 "password" : "password",
 "ip_address" : "10.43.12.137",
 "device_name" : "rack_1"
 <b>"example": "change",</b>
 },
 }]
</pre>

## Test Cases
```
openstack loadbalancer flavorprofile create --name fp1 --provider a10 --flavor-data '{"nat-pool":{"pool-name":"pool1","start-address":"192.168.90.230","end-address":"192.168.90.231","netmask":"/24"}}'
openstack loadbalancer flavor create --name f1 --flavorprofile fp1

openstack loadbalancer create --vip-subnet-id tp91 --vip-address 192.168.91.56 --flavor f1 --name vip1
openstack loadbalancer listener create --protocol HTTP --protocol-port 8001 --name vport1 vip1
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener vport1

openstack loadbalancer delete vip1 --cascade
```

## Manual Testing
```
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer delete vip1 --cascade
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer list


```