### PR TITLE
[STACK-2316][vthunder: active-standby] delete lb will get interface ip deleted but interface still exists on vthunder

### DIFF
--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -393,7 +393,8 @@ class LoadBalancerRepository(repo.LoadBalancerRepository):
         query = session.query(self.model_class).filter(
             self.model_class.project_id == project_id).filter(
             and_(self.model_class.id != id,
-                 self.model_class.provisioning_status != "ERROR"))
+                 self.model_class.provisioning_status != "ERROR",
+                 self.model_class.provisioning_status != "DELETED"))
 
         model_list = query.all()
         for data in model_list:


### PR DESCRIPTION
## Description

Severity Level Medium
Issue Description:
	
	- If we create three LBs with different subnet and delete a LB then interface of that LB was still present on Vthunder
	
## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2316

## Technical Approach
- To fix this, modified "get_all_other_lbs_in_project()" to exclude LBs in "DELETED" state

## Manual Testing
- Create three LBs with different subnets and delete third LB

openstack loadbalancer create --name v1 --vip-subnet-id public-11-subnet
openstack loadbalancer create --name v2 --vip-subnet-id public-12-subnet
openstack loadbalancer create --name v3 --vip-subnet-id public-13-subnet
openstack loadbalancer delete v3

Manual Testing

stack@openstack-2:~$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| 961f8c7c-57bd-4118-90c8-95dbdde9e6d2 | v1   | 6b1e0c27d80f4e5892a5c735726c657a | 172.24.11.70  | ACTIVE              | a10      |
| b687b85f-dade-423d-a058-ffc05d3c9d45 | v2   | 6b1e0c27d80f4e5892a5c735726c657a | 172.24.12.147 | ACTIVE              | a10      |
| 39aaf7e0-d9cd-4d58-a523-922792b29c96 | v3   | 6b1e0c27d80f4e5892a5c735726c657a | 172.24.13.38  | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+

```
vThunder-vMaster[1/2](NOLICENSE)#show running-config
!Current configuration: 813 bytes
!Configuration last updated at 10:20:23 IST Tue May 11 2021
!Configuration last saved at 10:16:26 IST Tue May 11 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 172.24.11.159
  floating-ip 172.24.12.61
  floating-ip 172.24.13.205
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 192.168.0.66
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 192.168.0.66
  health-check octavia_health_monitor
!
slb virtual-server 39aaf7e0-d9cd-4d58-a523-922792b29c96 172.24.13.38
!
slb virtual-server 961f8c7c-57bd-4118-90c8-95dbdde9e6d2 172.24.11.70
!
slb virtual-server b687b85f-dade-423d-a058-ffc05d3c9d45 172.24.12.147
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder-vMaster[1/2](NOLICENSE)#

vThunder-vMaster[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ee8.3c6a  192.168.0.169/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e08.2928  172.24.11.5/24        1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e49.b679  172.24.12.35/24       1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3ea7.85e9  172.24.13.206/24      1  DataPort

Global Throughput:28608 bits/sec (3576 bytes/sec)
Throughput:28608 bits/sec (3576 bytes/sec)


```


```
vThunder-vBlade[1/1](NOLICENSE)#show running-config
!Current configuration: 813 bytes
!Configuration last updated at 10:20:24 IST Tue May 11 2021
!Configuration last saved at 10:22:29 IST Tue May 11 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 172.24.11.159
  floating-ip 172.24.12.61
  floating-ip 172.24.13.205
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 192.168.0.66
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 192.168.0.66
  health-check octavia_health_monitor
!
slb virtual-server 39aaf7e0-d9cd-4d58-a523-922792b29c96 172.24.13.38
!
slb virtual-server 961f8c7c-57bd-4118-90c8-95dbdde9e6d2 172.24.11.70
!
slb virtual-server b687b85f-dade-423d-a058-ffc05d3c9d45 172.24.12.147
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder-vBlade[1/1](NOLICENSE)#

vThunder-vBlade[1/1](NOLICENSE)#show interface brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3eb5.f06f  192.168.0.158/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e2c.d811  172.24.11.240/24      1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3ed2.c858  172.24.12.239/24      1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3eae.1e89  172.24.13.30/24       1  DataPort

Global Throughput:31032 bits/sec (3879 bytes/sec)
Throughput:31032 bits/sec (3879 bytes/sec)


```
![image](https://user-images.githubusercontent.com/83746237/117799358-a38d6a00-b26f-11eb-8399-45f267b079d1.png)


stack@openstack-2:~$ openstack loadbalancer delete v3

```
vThunder-vMaster[1/2](NOLICENSE)#show running-config
!Current configuration: 743 bytes
!Configuration last updated at 10:35:58 IST Tue May 11 2021
!Configuration last saved at 10:31:49 IST Tue May 11 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 172.24.11.159
  floating-ip 172.24.12.61
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 192.168.0.66
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 192.168.0.66
  health-check octavia_health_monitor
!
slb virtual-server 961f8c7c-57bd-4118-90c8-95dbdde9e6d2 172.24.11.70
!
slb virtual-server b687b85f-dade-423d-a058-ffc05d3c9d45 172.24.12.147
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder-vMaster[1/2](NOLICENSE)#
vThunder-vMaster[1/2](NOLICENSE)#
vThunder-vMaster[1/2](NOLICENSE)#show interface brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ee8.3c6a  192.168.0.169/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e08.2928  172.24.11.5/24        1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e49.b679  172.24.12.35/24       1  DataPort

Global Throughput:19056 bits/sec (2382 bytes/sec)
Throughput:19056 bits/sec (2382 bytes/sec)

```

```
vThunder-vBlade[1/1](NOLICENSE)#show running-config
!Current configuration: 743 bytes
!Configuration last updated at 10:35:58 IST Tue May 11 2021
!Configuration last saved at 10:33:46 IST Tue May 11 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 172.24.11.159
  floating-ip 172.24.12.61
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 192.168.0.66
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 192.168.0.66
  health-check octavia_health_monitor
!
slb virtual-server 961f8c7c-57bd-4118-90c8-95dbdde9e6d2 172.24.11.70
!
slb virtual-server b687b85f-dade-423d-a058-ffc05d3c9d45 172.24.12.147
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder-vBlade[1/1](NOLICENSE)#

vThunder-vBlade[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3eb5.f06f  192.168.0.158/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e2c.d811  172.24.11.240/24      1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3ed2.c858  172.24.12.239/24      1  DataPort

Global Throughput:20656 bits/sec (2582 bytes/sec)
Throughput:20656 bits/sec (2582 bytes/sec)

```
![image](https://user-images.githubusercontent.com/83746237/117799790-1d255800-b270-11eb-8059-a958cb9c530b.png)

stack@openstack-2:~$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| 961f8c7c-57bd-4118-90c8-95dbdde9e6d2 | v1   | 6b1e0c27d80f4e5892a5c735726c657a | 172.24.11.70  | ACTIVE              | a10      |
| b687b85f-dade-423d-a058-ffc05d3c9d45 | v2   | 6b1e0c27d80f4e5892a5c735726c657a | 172.24.12.147 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+

