### PR TITLE
[BUG][STACK-2320][STACK-2325][vthunder:active_standby]: Fixed ComputeGetException issue getting for 2nd loadbalancer creation.

### DIFF
--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -150,6 +150,7 @@ WAIT_FOR_MASTER_VCS_RELOAD = 'wait-for-master-vcs-reload'
 WAIT_FOR_BACKUP_VCS_RELOAD = 'wait-for-backup-vcs-reload'
 VCS_SYNC_WAIT = "wait-for-vcs_ready"
 GET_COMPUTE_FOR_PROJECT = 'get-compute-for-project'
+VALIDATE_COMPUTE_FOR_PROJECT = 'validate-compute-for-project'
 CREATE_VTHUNDER_ENTRY = 'create-vthunder-entry'
 UPDATE_ACOS_VERSION_IN_VTHUNDER_ENTRY = 'update-acos-version-in-vthunder-entry'
 UPDATE_ACOS_VERSION_FOR_BACKUP_VTHUNDER = 'update-acos-version-for-backup-vthunder'

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -229,6 +229,11 @@ class VThunderFlows(object):
             requires=constants.LOADBALANCER,
             inject={"role": role},
             provides=constants.COMPUTE_ID))
+        vthunder_for_amphora_subflow.add(compute_tasks.ValidateComputeForProject(
+            name=sf_name + '-' + a10constants.VALIDATE_COMPUTE_FOR_PROJECT,
+            requires=(constants.LOADBALANCER, constants.COMPUTE_ID),
+            inject={"role": role},
+            provides=constants.COMPUTE_ID))
         vthunder_for_amphora_subflow.add(database_tasks.UpdateAmphoraComputeId(
             name=sf_name + '-' + constants.UPDATE_AMPHORA_COMPUTEID,
             requires=(constants.AMPHORA_ID, constants.COMPUTE_ID)))

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -224,14 +224,9 @@ class VThunderFlows(object):
         vthunder_for_amphora_subflow.add(database_tasks.CreateAmphoraInDB(
             name=sf_name + '-' + constants.CREATE_AMPHORA_INDB,
             provides=constants.AMPHORA_ID))
-        vthunder_for_amphora_subflow.add(a10_database_tasks.GetComputeForProject(
-            name=sf_name + '-' + a10constants.GET_COMPUTE_FOR_PROJECT,
-            requires=constants.LOADBALANCER,
-            inject={"role": role},
-            provides=constants.COMPUTE_ID))
         vthunder_for_amphora_subflow.add(compute_tasks.ValidateComputeForProject(
             name=sf_name + '-' + a10constants.VALIDATE_COMPUTE_FOR_PROJECT,
-            requires=(constants.LOADBALANCER, constants.COMPUTE_ID),
+            requires=constants.LOADBALANCER,
             inject={"role": role},
             provides=constants.COMPUTE_ID))
         vthunder_for_amphora_subflow.add(database_tasks.UpdateAmphoraComputeId(

--- a/a10_octavia/controller/worker/tasks/a10_compute_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_compute_tasks.py
@@ -90,7 +90,7 @@ class ComputeCreate(BaseComputeTask):
 class ValidateComputeForProject(BaseComputeTask):
     """Validate compute_id got for the project"""
 
-    def execute(self, loadbalancer, compute_id, role):
+    def execute(self, loadbalancer, role):
         self.vthunder_repo = a10_repo.VThunderRepository()
         vthunder_ids = self.vthunder_repo.get_vthunders_by_project_id_and_role(
             db_apis.get_session(), loadbalancer.project_id, role)

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -240,26 +240,6 @@ class GetBackupVThunderByLoadBalancer(BaseDatabaseTask):
 #         LOG.info("Successfully fetched vThunder details for LB")
 
 
-class GetComputeForProject(BaseDatabaseTask):
-    """ Get Compute details form Loadbalancer object -> project ID"""
-
-    def execute(self, loadbalancer, role):
-        vthunder = self.vthunder_repo.get_vthunder_by_project_id_and_role(
-            db_apis.get_session(), loadbalancer.project_id, role)
-        if vthunder is None:
-            vthunder = self.vthunder_repo.get_spare_vthunder(
-                db_apis.get_session())
-            self.vthunder_repo.update(
-                db_apis.get_session(),
-                vthunder.id,
-                status="USED_SPARE",
-                updated_at=datetime.utcnow())
-        amphora_id = vthunder.amphora_id
-        self.amphora_repo.get(db_apis.get_session(), id=amphora_id)
-        compute_id = vthunder.compute_id
-        return compute_id
-
-
 class MapLoadbalancerToAmphora(BaseDatabaseTask):
     """Maps and assigns a load balancer to an amphora in the database."""
 

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -338,6 +338,15 @@ class VThunderRepository(BaseRepository):
 
         return model.to_data_model()
 
+    def get_vthunders_by_project_id_and_role(self, session, project_id, role):
+        model_list = session.query(self.model_class).filter(
+            self.model_class.project_id == project_id).filter(
+            and_(self.model_class.status == "ACTIVE",
+                 self.model_class.role == role))
+
+        id_list = [model.id for model in model_list]
+        return id_list
+
 
 class LoadBalancerRepository(repo.LoadBalancerRepository):
     thunder_model_class = models.VThunder


### PR DESCRIPTION
## Description
- Severity Level: Highest
- Issue Description: Whenever one of the previously deleted BACKUP vThunder entry is having its status as ACTIVE in DB, then while creating 2nd loadbalancer, that vThunder entry is fetched instead of actual ACTIVE vThunder and thus its compute_id is got from GetComputeForProject and throws ComputeGetException at the task ComputeActiveWait.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2320
https://a10networks.atlassian.net/browse/STACK-2325

## Technical Approach
- Created a new task ValidateComputeForProject for validating the compute_id got from GetComputeForProject, before passing the compute_id to ComputeActiveWait.
- In ValidateComputeForProject, getting a list of all vThunders in a particular project with respect to their roles and then checking if the fetched vThunders are valid by getting amphora from them can be.
- By this, only valid vThunder can be fetched and thus the compute_id passed to ComputeActiveWait is also valid..

## Manual Testing
1. Create 1st loadbalancer
```
stack@neha:~$ openstack loadbalancer create --vip-subnet-id vip_subnet --name lb1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-05-10T06:21:32                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 7af2a4d3-912f-4796-a834-1ada39c75a30 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 420eb22620b347ed8e843963487abd4c     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.12.212                       |
| vip_network_id      | 312e5689-f40b-4957-913a-62e913d746a8 |
| vip_port_id         | 134a6e7d-e9d2-4076-a49a-7e823e820921 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 9a0af308-2e64-46a3-8ce2-c310c464980c |
+---------------------+--------------------------------------+
```
2 new vThunder entries are getting added to vthunders table with id 21 and 22.

2. Mark any of the previously deleted vthunder entry as ACTIVE in vthunders table
![image](https://user-images.githubusercontent.com/58077446/117834357-b49ca200-b294-11eb-8bb5-843be3793aa3.png)

3. Create 2nd loadbalancer
stack@neha:~$ openstack loadbalancer create --vip-subnet-id vip_subnet --name lb2
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-05-10T06:36:33                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 69736e49-0005-4c45-8db5-d545c3f30d66 |
| listeners           |                                      |
| name                | lb2                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 420eb22620b347ed8e843963487abd4c     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.12.44                        |
| vip_network_id      | 312e5689-f40b-4957-913a-62e913d746a8 |
| vip_port_id         | dcbfb7c6-ff84-46a1-af95-1419b29fc8e2 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 9a0af308-2e64-46a3-8ce2-c310c464980c |
+---------------------+--------------------------------------+
```

Result:
2nd loadbalancer created successfully with vthunder entries with id 23 and 24 evenif previously deleted vthunder is ACTIVE in DB
stack@neha:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address    | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| 7af2a4d3-912f-4796-a834-1ada39c75a30 | lb1  | 420eb22620b347ed8e843963487abd4c | 192.168.12.212 | ACTIVE              | a10      |
| 69736e49-0005-4c45-8db5-d545c3f30d66 | lb2  | 420eb22620b347ed8e843963487abd4c | 192.168.12.44  | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+----------------+---------------------+---------

```

![image](https://user-images.githubusercontent.com/58077446/117834761-0b09e080-b295-11eb-8894-175eb766b5b2.png)

