### PR TITLE
[BUG][STACK-2318][vthunder: active-standby > security group] failed to delete lb --cascade in demo project

### DIFF
--- a/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
+++ b/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
@@ -173,13 +173,9 @@ class A10OctaviaNeutronDriver(allowed_address_pairs.AllowedAddressPairsDriver):
 
     def _get_ports_by_security_group(self, sec_grp_id):
 
-        # Handle backwards compatibility issue with neutronclient
-        try:
-            all_ports = self.neutron_client.list_ports(project_id=self.project_id)
-        except neutron_client_exceptions.BadRequest:
-            all_ports = self.neutron_client.list_ports(project=self.project_id)
-
-        filtered_ports = []
+        all_ports = self.neutron_client.list_ports()
+        
+        filtered_ports = [] 
         for port in all_ports.get('ports', []):
             if sec_grp_id in port.get('security_groups', []):
                 filtered_ports.append(port)

--- a/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
+++ b/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
@@ -174,8 +174,7 @@ class A10OctaviaNeutronDriver(allowed_address_pairs.AllowedAddressPairsDriver):
     def _get_ports_by_security_group(self, sec_grp_id):
 
         all_ports = self.neutron_client.list_ports()
-        
-        filtered_ports = [] 
+        filtered_ports = []
         for port in all_ports.get('ports', []):
             if sec_grp_id in port.get('security_groups', []):
                 filtered_ports.append(port)


### PR DESCRIPTION
- Severity Level: HIGH
- Issue Description: Unable to delete the load balancer created in the DEMO project. The issue also exists for CASCADE delete.
[vthunder: active-standby] failed to create lb in demo project and get AxapiJsonFormatError: 1 vMaster not found in vcs-summary, new error WrappedFailure. New error 1 vBlade not found in vcs-summary 

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2318

## Technical Approach
- The list ports were getting fetched according to the project, which caused demo project ports to be left out.
-  Removed the filtering criteria for list port so that all ports get fetched irrespective of project.

## Manual Testing
- Created LB in DEMO project, and checked the delete operation for the created LB.
![image](https://user-images.githubusercontent.com/66299493/118021855-4da4e900-b379-11eb-93a1-4496a1ee9756.png)

- Created LB, listener, pool, and member and checked the cascade delete operation.
![image](https://user-images.githubusercontent.com/66299493/118023464-336c0a80-b37b-11eb-8dfd-5b29d244cc22.png)

- Created LB in admin project and checked the delete operation on created LB.
![image](https://user-images.githubusercontent.com/66299493/118005594-2396fb00-b368-11eb-8292-a14a5589cacb.png)

- Created LB, listener, pool and member in admin project and checked the cascade delete operation.
![image](https://user-images.githubusercontent.com/66299493/118020525-ca36c800-b377-11eb-93d9-e8d475241475.png)
