### PR TITLE
[DO NOT MERGE][a10-octavia-v1.3][STACK-2340] Fix for backwards compatibility issue with hm name 

### DIFF
--- a/a10_octavia/tests/common/a10constants.py
+++ b/a10_octavia/tests/common/a10constants.py
@@ -13,7 +13,7 @@
 #    under the License.
 
 
-MOCK_HM_ID = 'mock-hm-1'
+MOCK_HM_ID = 'mock-hm-cd61-49ed-8508-f22a12d770c5'
 MOCK_POOL_ID = 'mock-pool-1'
 MOCK_MEMBER_ID = 'mock-member-1'
 MOCK_LOAD_BALANCER_ID = 'mock-lb-1'

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_health_monitor_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_health_monitor_tasks.py
@@ -23,6 +23,8 @@ from octavia.common import data_models as o_data_models
 from oslo_config import cfg
 from oslo_config import fixture as oslo_fixture
 
+from acos_client import errors as acos_errors
+
 from a10_octavia.common import config_options
 from a10_octavia.common.data_models import VThunder
 from a10_octavia.controller.worker.tasks import health_monitor_tasks as task
@@ -37,6 +39,7 @@ HM = o_data_models.HealthMonitor(id=a10constants.MOCK_HM_ID,
                                  timeout=3,
                                  rise_threshold=8,
                                  http_method='GET')
+
 ARGS = utils.meta(HM, 'hm', {})
 LISTENERS = [o_data_models.Listener(id=a10constants.MOCK_LISTENER_ID, protocol_port=mock.ANY)]
 
@@ -224,7 +227,37 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
                                                           expect_code=None, post_data=None,
                                                           **FLAVOR_WITH_REGEX_ARGS)
 
-    def test_health_monitor_update_task(self):
+    def test_get_hm_name(self):
+        hm = {
+            'monitor': {
+                'name': a10constants.MOCK_HM_ID
+            }
+        }
+        self.client_mock.slb.hm.get.return_value = hm
+        hm_name = task._get_hm_name(self.client_mock, HM)
+        self.assertEqual(a10constants.MOCK_HM_ID, hm_name)
+
+    def test_get_hm_name_backwards_compat(self):
+        hm = {
+            'monitor': {
+                'name': a10constants.MOCK_HM_ID[0:28]
+            }
+        }
+        self.client_mock.slb.hm.get.return_value = hm
+        hm_name = task._get_hm_name(self.client_mock, HM)
+        self.assertEqual(a10constants.MOCK_HM_ID[0:28], hm_name)
+
+    def test_get_hm_name_raise_notfound(self):
+        self.client_mock.slb.hm.get.side_effect = acos_errors.NotFound
+
+        expected_error = acos_errors.NotFound
+        module_func = task._get_hm_name
+        func_args = [self.client_mock, HM]
+        self.assertRaises(expected_error, module_func, *func_args)
+
+    @mock.patch('a10_octavia.controller.worker.tasks.health_monitor_tasks._get_hm_name')
+    def test_health_monitor_update_task(self, mock_hm_name):
+        mock_hm_name.return_value = a10constants.MOCK_HM_ID
         hm_task = task.UpdateHealthMonitor()
         hm_task.axapi_client = self.client_mock
         update_dict = {'delay': '10'}
@@ -248,7 +281,9 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
                                                           expect_code=None, post_data='abc=1',
                                                           **ARGS)
 
-    def test_health_monitor_update_with_flavor_and_config_task(self):
+    @mock.patch('a10_octavia.controller.worker.tasks.health_monitor_tasks._get_hm_name')
+    def test_health_monitor_update_with_flavor_and_config_task(self, mock_hm_name):
+        mock_hm_name.return_value = a10constants.MOCK_HM_ID
         flavor = {
             "health_monitor": {
                 "retry": 5,
@@ -275,7 +310,9 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
                                                           post_data='abc=1',
                                                           expect_code=None, **FLAVOR_ARGS)
 
-    def test_health_monitor_update_with_flavor_task(self):
+    @mock.patch('a10_octavia.controller.worker.tasks.health_monitor_tasks._get_hm_name')
+    def test_health_monitor_update_with_flavor_task(self, mock_hm_name):
+        mock_hm_name.return_value = a10constants.MOCK_HM_ID
         flavor = {
             "health_monitor": {
                 "retry": 5,
@@ -300,7 +337,9 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
                                                           port=mock.ANY, url=None, post_data=None,
                                                           expect_code=None, **FLAVOR_ARGS)
 
-    def test_health_monitor_update_with_flavor_regex_task(self):
+    @mock.patch('a10_octavia.controller.worker.tasks.health_monitor_tasks._get_hm_name')
+    def test_health_monitor_update_with_flavor_regex_task(self, mock_hm_name):
+        mock_hm_name.return_value = a10constants.MOCK_HM_ID
         flavor = {
             "health_monitor": {
                 "retry": 5,
@@ -339,7 +378,9 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
                                                           expect_code=None, post_data=None,
                                                           **FLAVOR_WITH_REGEX_ARGS)
 
-    def test_health_monitor_update_with_regex_overwrite_flavor_task(self):
+    @mock.patch('a10_octavia.controller.worker.tasks.health_monitor_tasks._get_hm_name')
+    def test_health_monitor_update_with_regex_overwrite_flavor_task(self, mock_hm_name):
+        mock_hm_name.return_value = a10constants.MOCK_HM_ID
         flavor = {
             "health_monitor": {
                 "retry": 5,
@@ -379,7 +420,9 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
                                                           expect_code=None, post_data=None,
                                                           **FLAVOR_WITH_REGEX_ARGS)
 
-    def test_health_monitor_delete_task(self):
+    @mock.patch('a10_octavia.controller.worker.tasks.health_monitor_tasks._get_hm_name')
+    def test_health_monitor_delete_task(self, mock_hm_name):
+        mock_hm_name.return_value = a10constants.MOCK_HM_ID
         hm_task = task.DeleteHealthMonitor()
         hm_task.axapi_client = self.client_mock
         mock_hm = copy.deepcopy(HM)


### PR DESCRIPTION
## Description

Severity Level: High

The hm name in a10-neutron-lbaas was set to a length of 28 characters, but the hm name in a10-octavia is set to 32.

## Jira Ticket
- [STACK-2340](https://a10networks.atlassian.net/browse/STACK-2340)

## Technical Approach
- Added a call to get the hm before performing and update or a delete
- Skip if not found during delete

## Config Changes
N/A

## Test Cases
- Confirm _get_hm_name can return full uuid if hm name is full uuid
- Confirm _get_hm_name can return char of uuid if hm name is 28 chars
- Confirm _get_hm_name raises NotFound if not found

## Manual Testing

**Requires a10-nlbaas2oct env setup**

### Step 1: Create slb tree with hm on neutron-lbaas node
```
neutron lbaas-loadbalancer-create --name lb1 private-subnet
neutron lbaas-listener-create --protocol HTTP --protocol-port 80 --name l1-80 --loadbalancer lb1
neutron lbaas-pool-create --lb-algorithm ROUND_ROBIN --protocol http --name p1-80 --listener l1-80
neutron lbaas-healthmonitor-create --delay 10 --timeout 5  --max-retries 4 --type HTTP --pool p1-80 --name hm1
```

#### Confirm hm exists on ACOS device. (Example below)

```
health monitor ed22d59a-12d9-4fc4-a83e-3974
  retry 4
  override-port 80
  interval 10
  method http port 80 expect response-code 200 url GET /
!
slb service-group dd1acb55-6465-4415-ac09-ae0ccee5caa7 tcp
  health-check ed22d59a-12d9-4fc4-a83e-3974
!
slb template persist cookie dd1acb55-6465-4415-ac09-ae0ccee5caa7
!
slb virtual-server 3cf5f88d-8f9f-404d-bc3a-30988bc7be08 10.0.0.60
  port 80 http
    name 64ca05fa-e0f9-456e-887d-9908073476aa
    extended-stats
    service-group dd1acb55-6465-4415-ac09-ae0ccee5caa7
    template persist cookie dd1acb55-6465-4415-ac09-ae0ccee5caa7
!
```

### Step 2: Perform the migration

```
a10_nlbaas2oct --config-file a10_nlbaas2oct.conf --project-id f216973ba21e400595228b9942b4e3c8
```


#### Confirm migration is successful
```
2021-05-13 00:42:25.619 5418 INFO a10_nlbaas2oct [-] Migrating name expressions to flavors
2021-05-13 00:42:25.621 5418 INFO a10_nlbaas2oct [-] Locking load balancer: 3cf5f88d-8f9f-404d-bc3a-30988bc7be08
2021-05-13 00:42:25.622 5418 INFO a10_nlbaas2oct [-] Migrating Thunder device: ax2
2021-05-13 00:42:25.624 5418 INFO a10_nlbaas2oct [-] Migrating VIP port for load balancer: 3cf5f88d-8f9f-404d-bc3a-30988bc7be08
2021-05-13 00:42:25.626 5418 INFO a10_nlbaas2oct [-] Migrating load balancer: 3cf5f88d-8f9f-404d-bc3a-30988bc7be08
2021-05-13 00:42:25.627 5418 INFO a10_nlbaas2oct [-] Migrating VIP for load balancer: 3cf5f88d-8f9f-404d-bc3a-30988bc7be08
2021-05-13 00:42:25.629 5418 DEBUG a10_nlbaas2oct [-] Migrating pool: dd1acb55-6465-4415-ac09-ae0ccee5caa7 main /home/stack/upstream/a10-nlbaas2oct/a10_nlbaas2oct/driver.py:191
2021-05-13 00:42:25.630 5418 DEBUG a10_nlbaas2oct [-] Migrating health manager: ed22d59a-12d9-4fc4-a83e-397438c2df27 main /home/stack/upstream/a10-nlbaas2oct/a10_nlbaas2oct/driver.py:200
2021-05-13 00:42:25.632 5418 DEBUG a10_nlbaas2oct [-] Migrating session persistence for pool: dd1acb55-6465-4415-ac09-ae0ccee5caa7 main /home/stack/upstream/a10-nlbaas2oct/a10_nlbaas2oct/driver.py:207
2021-05-13 00:42:25.634 5418 DEBUG a10_nlbaas2oct [-] Migrating listener: 64ca05fa-e0f9-456e-887d-9908073476aa main /home/stack/upstream/a10-nlbaas2oct/a10_nlbaas2oct/driver.py:230
2021-05-13 00:42:25.638 5418 INFO a10_nlbaas2oct [-] Performing cascading delete on loadbalancer 3cf5f88d-8f9f-404d-bc3a-30988bc7be08.
2021-05-13 00:42:25.644 5418 INFO a10_nlbaas2oct [-] Successful cascading delete of loadbalancer 3cf5f88d-8f9f-404d-bc3a-30988bc7be08.
2021-05-13 00:42:25.646 5418 INFO a10_nlbaas2oct [-] Successful migration of load balancer 3cf5f88d-8f9f-404d-bc3a-30988bc7be08.
2021-05-13 00:42:25.646 5418 INFO a10_nlbaas2oct [-] Unlocking load balancer: 3cf5f88d-8f9f-404d-bc3a-30988bc7be08
```

### Step 3: Perform update of hm on a10-octavia side
```
 openstack loadbalancer healthmonitor set hm1 --max-retries 6
```

#### Confirm on ACOS device

```
health monitor ed22d59a-12d9-4fc4-a83e-3974
  retry 6  <--------------------------------------- changed from 4 to 6
  override-port 80
  interval 10
  method http port 80 expect response-code 200 url GET /
```


### Step 5: Delete HM
```
 openstack loadbalancer healthmonitor delete hm1
```

#### Confirm on ACOS device
````
!
slb service-group dd1acb55-6465-4415-ac09-ae0ccee5caa7 tcp
!
slb template persist cookie dd1acb55-6465-4415-ac09-ae0ccee5caa7
!
slb virtual-server 3cf5f88d-8f9f-404d-bc3a-30988bc7be08 10.0.0.60
  port 80 http
    name 64ca05fa-e0f9-456e-887d-9908073476aa
    extended-stats
    service-group dd1acb55-6465-4415-ac09-ae0ccee5caa7
    template persist cookie dd1acb55-6465-4415-ac09-ae0ccee5caa7
!
````

- service group no longer has health check
- hm is no longer present