### PR TITLE
[STACK-2323][STACK-2342] do not delete amp_boot_network_list ports when DeallocateVIP

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -463,9 +463,13 @@ class CountLoadbalancersInProjectBySubnet(BaseDatabaseTask):
     def execute(self, subnet, partition_project_list):
         if partition_project_list:
             try:
-                return self.loadbalancer_repo.get_lb_count_by_subnet(
+                count = self.loadbalancer_repo.get_lb_count_by_subnet(
                     db_apis.get_session(),
                     project_ids=partition_project_list, subnet_id=subnet.id)
+                fixed_subnets = CONF.a10_controller_worker.amp_boot_network_list[:]
+                if subnet.network_id in fixed_subnets:
+                    count = count + 1
+                return count
             except Exception as e:
                 LOG.exception("Failed to get LB count for subnet %s due to %s ",
                               subnet.id, str(e))

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -80,10 +80,12 @@ class CalculateAmphoraDelta(BaseNetworkTask):
             if loadbalancer.vip.subnet_id
         ]
         desired_network_ids.update(loadbalancer_networks)
+        LOG.debug("[NetIF] desired_network_ids.update{0}".format(desired_network_ids))
 
         nics = self.network_driver.get_plugged_networks(amphora.compute_id)
         # assume we don't have two nics in the same network
         actual_network_nics = dict((nic.network_id, nic) for nic in nics)
+        LOG.debug("[NetIF] actual_network_nics {0}".format(actual_network_nics))
 
         del_ids = set(actual_network_nics) - desired_network_ids
         delete_nics = list(
@@ -293,6 +295,7 @@ class HandleNetworkDeltas(BaseNetworkTask):
         for amp_id, delta in six.iteritems(deltas):
             added_ports[amp_id] = []
             for nic in delta.add_nics:
+                LOG.debug("[NetIF] plug_network %s on %s", nic.network_id, delta.compute_id)
                 interface = self.network_driver.plug_network(delta.compute_id,
                                                              nic.network_id)
                 port = self.network_driver.get_port(interface.port_id)
@@ -303,6 +306,7 @@ class HandleNetworkDeltas(BaseNetworkTask):
                 added_ports[amp_id].append(port)
             for nic in delta.delete_nics:
                 try:
+                    LOG.debug("[NetIF] unplug_network %s on %s", nic.network_id, delta.compute_id)
                     self.network_driver.unplug_network(delta.compute_id,
                                                        nic.network_id)
                     network = self.network_driver.get_network(nic.network_id)


### PR DESCRIPTION
## Description
If Bug Fix:
- Required: Severity Level Critical
- Required: Issue Description
network in amp_boot_network_list is deleted by DeallocateVIP when LB deletion.


## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2342

## Technical Approach
- For LB count for subnet, when the subnet is in amp_boot_network_list we should +1 on the counter to prevent interface port deleted by neutron.

## Config Changes
```
[a10_controller_worker]
amp_boot_network_list = 7f8ddd7f-c5c3-463a-b1c3-596f988480a4, 61305531-6e3a-44b4-8e67-05e93363dddc, a66685db-31ee-46c6-928a-ac034d87dc63, ec33a88d-3290-4ad6-95cc-226fcd2a4458
```

## Test Cases
- do following commands and then check interface on vthunder

```
openstack loadbalancer create --vip-subnet-id tp92 --name vip2
openstack loadbalancer delete vip2
```

## Manual Testing
```
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer create --vip-subnet-id tp92 --name vip2
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-05-14T03:47:48                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 8c1e4aab-e4f8-4861-bd0f-8f4125e64643 |
| listeners           |                                      |
| name                | vip2                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 99c9c2304f114685a32db30769c8a7e2     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.92.117                       |
| vip_network_id      | ec33a88d-3290-4ad6-95cc-226fcd2a4458 |
| vip_port_id         | 52186bd2-b631-4329-a735-d3c0c82d6a46 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 65b4be82-364f-4315-bc63-a0779a33d304 |
+---------------------+--------------------------------------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address    | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| 83ccfebc-5c22-4d12-827d-c411d0816b2a | vip1 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.44  | ACTIVE              | a10      |
| 8c1e4aab-e4f8-4861-bd0f-8f4125e64643 | vip2 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.92.117 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer delete vip2
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| 83ccfebc-5c22-4d12-827d-c411d0816b2a | vip1 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.44 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
```

```
stack@openstack-4:~/source/a10-octavia/vThunder$ ssh admin@192.168.0.38
Password:
Last login: Fri May 14 04:49:29 2021 from 192.168.0.127

System is ready now.

[type ? for help]

vThunder-vMaster[1/2](NOLICENSE)>en
Password:
vThunder-vMaster[1/2](NOLICENSE)#show in
vThunder-vMaster[1/2](NOLICENSE)#show interfaces bri
vThunder-vMaster[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e51.4ad2  192.168.0.38/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3ec9.2b17  192.168.91.234/24     1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e7b.b5a0  192.168.90.222/24     1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e46.7dbd  192.168.92.200/24     1  DataPort

Global Throughput:28824 bits/sec (3603 bytes/sec)
Throughput:28824 bits/sec (3603 bytes/sec)

```
