### PR TITLE
[BUG][STACK-2343]: Port missed when created multiple LBs with no wait in between them in active_standby mode

### DIFF
--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -177,13 +177,15 @@ class EnableInterface(VThunderBaseTask):
                     LOG.debug("Configured the ethernet interface for vThunder: %s", vthunder.id)
                 else:
                     if ifnum_master:
-                        self.axapi_client.system.action.setInterface(ifnum_master)
-                        LOG.debug("Configured the ethernet interface for "
-                                  "master vThunder: %s", vthunder.id)
+                        for i in range(len(ifnum_master)):
+                            self.axapi_client.system.action.setInterface(ifnum_master[i])
+                            LOG.debug("Configured the ethernet interface for "
+                                      "master vThunder: %s", vthunder.id)
                     elif ifnum_backup:
-                        self.axapi_client.system.action.setInterface(ifnum_backup)
-                        LOG.debug("Configured the ethernet interface for "
-                                  "backup vThunder: %s", vthunder.id)
+                        for i in range(len(ifnum_backup)):
+                            self.axapi_client.system.action.setInterface(ifnum_backup[i])
+                            LOG.debug("Configured the ethernet interface for "
+                                      "backup vThunder: %s", vthunder.id)
         except(acos_errors.ACOSException, req_exceptions.ConnectionError) as e:
             LOG.exception("Failed to configure ethernet interface vThunder: %s", str(e))
             raise e
@@ -989,9 +991,9 @@ class GetVThunderInterface(VThunderBaseTask):
     def execute(self, vthunder):
         try:
             vcs_summary = {}
-            ifnum = None
-            ifnum_master = None
-            ifnum_backup = None
+            ifnum = []
+            ifnum_master = []
+            ifnum_backup = []
 
             vcs_summary = self.axapi_client.system.action.get_vcs_summary_oper()
             vcs_member_list = vcs_summary['vcs-summary']['oper']['member-list']
@@ -999,7 +1001,7 @@ class GetVThunderInterface(VThunderBaseTask):
 
             for i in range(len(interfaces['interface']['ethernet-list'])):
                 if interfaces['interface']['ethernet-list'][i]['action'] == "disable":
-                    ifnum = interfaces['interface']['ethernet-list'][i]['ifnum']
+                    ifnum = ifnum + [interfaces['interface']['ethernet-list'][i]['ifnum']]
 
             for i in range(len(vcs_member_list)):
                 if vthunder.ip_address in vcs_member_list[i]['ip-list'][0]['ip']:

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -758,7 +758,7 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         thunder.ip_address = "10.0.0.1"
         mock_task.execute(thunder)
         self.client_mock.system.action.setInterface.assert_not_called()
-        self.assertEqual(mock_task.execute(thunder), (1, None))
+        self.assertEqual(mock_task.execute(thunder), ([1], []))
 
     def test_GetVThunderInterface_execute_for_vBlade(self):
         thunder = copy.deepcopy(VTHUNDER)
@@ -769,7 +769,7 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         thunder.ip_address = "10.0.0.2"
         mock_task.execute(thunder)
         self.client_mock.system.action.setInterface.assert_not_called()
-        self.assertEqual(mock_task.execute(thunder), (None, 1))
+        self.assertEqual(mock_task.execute(thunder), ([], [1]))
 
     def test_EnableInterface_execute_for_single_topology(self):
         thunder = copy.deepcopy(VTHUNDER)


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description:  When 3 LBs with different subnets are created with no waits in between them, then interface of 2nd LB is not getting enabled. But only 1st and 3rd LB's interfaces were getting enabled with all 3 LBs present there on vThunder.

     Due to no wait, at the time of 2nd LB creation, the interfaces of both 2nd and 3rd LBs are getting detected as 3rd LB is also in "PENDING_CREATE" state at that moment. And hence the ifnum holds only last got disabled interface i.e 3 and enabling only interface 3 instead of enabling interfaces 2 and 3.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2343

## Technical Approach
- Storing and providing the interfaces which are in disabled state into a list in `GetVThunderInterface` task
- Enabling each interface present in the interface list by iterating over the list in `EnableInterface` task

## Manual Testing
1. Create 3 LBs with 3 different subnets with no wait in between.
stack@openstack-3:~/neha/a10-octavia$ openstack loadbalancer create --name v1 --vip-subnet-id public-11-subnet
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-05-14T08:33:29                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 8882e9a5-7c22-4b4c-b2e4-c886704d6539 |
| listeners           |                                      |
| name                | v1                                   |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 9ef5e94c53c940239a66dbe4a1058eee     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.150                          |
| vip_network_id      | 6df8ee71-7519-4f9d-8300-44acfa2fe325 |
| vip_port_id         | 20e3f2b4-85f0-4b70-8cdd-49196a453cf2 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 184910cd-74d4-4fd5-a3b2-ebad65d4cd44 |
+---------------------+--------------------------------------+
```
stack@openstack-3:~/neha/a10-octavia$ openstack loadbalancer create --name v2 --vip-subnet-id public-12-subnet
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-05-14T08:33:39                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 2601e9d6-3edd-4067-8fee-4fa253007a61 |
| listeners           |                                      |
| name                | v2                                   |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 9ef5e94c53c940239a66dbe4a1058eee     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.12.221                          |
| vip_network_id      | bdeb716e-5466-42ed-b256-b088ad825790 |
| vip_port_id         | c764293c-c137-4057-b4c8-a0de07ea091e |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | da29e3b4-c885-4834-b4ee-228d7d1bfac1 |
+---------------------+--------------------------------------+
```
stack@openstack-3:~/neha/a10-octavia$ openstack loadbalancer create --name v3 --vip-subnet-id public-13-subnet
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-05-14T08:33:49                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 32dd9dee-be26-403f-a691-4fa06b42c6ad |
| listeners           |                                      |
| name                | v3                                   |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 9ef5e94c53c940239a66dbe4a1058eee     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.13.158                          |
| vip_network_id      | 3f286d58-339c-4ca6-a5f7-8723b0e1fd2d |
| vip_port_id         | 6b521119-12b7-4f08-820f-870ffebc7b0b |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 0d4f7a95-d013-4a22-9b8e-6a83b22f8297 |
+---------------------+--------------------------------------+
```

stack@openstack-3:~/neha/a10-octavia$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 8882e9a5-7c22-4b4c-b2e4-c886704d6539 | v1   | 9ef5e94c53c940239a66dbe4a1058eee | 10.0.11.150 | ACTIVE              | a10      |
| 2601e9d6-3edd-4067-8fee-4fa253007a61 | v2   | 9ef5e94c53c940239a66dbe4a1058eee | 10.0.12.221 | ACTIVE              | a10      |
| 32dd9dee-be26-403f-a691-4fa06b42c6ad | v3   | 9ef5e94c53c940239a66dbe4a1058eee | 10.0.13.158 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```

2. Result of vThunders:
```
vThunder-vMaster[1/2](NOLICENSE)#show running-config
!Current configuration: 808 bytes
!Configuration last updated at 09:51:54 IST Fri May 14 2021
!Configuration last saved at 09:51:57 IST Fri May 14 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.17
  floating-ip 10.0.12.3
  floating-ip 10.0.13.11
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.28.67
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.28.67
  health-check octavia_health_monitor
!
slb virtual-server 2601e9d6-3edd-4067-8fee-4fa253007a61 10.0.12.221
!
slb virtual-server 32dd9dee-be26-403f-a691-4fa06b42c6ad 10.0.13.158
!
slb virtual-server 8882e9a5-7c22-4b4c-b2e4-c886704d6539 10.0.11.150
!
!
cloud-services meta-data
  enable
  provider openstack
!
end

```

```
vThunder-vMaster[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e81.bacf  192.168.0.13/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3e8e.b554  10.0.11.18/24         1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e02.a043  10.0.12.67/24         1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e5d.1db6  10.0.13.218/24        1  DataPort
```


```
vThunder-vBlade[1/1](NOLICENSE)#show running-config
!Current configuration: 808 bytes
!Configuration last updated at 09:51:54 IST Fri May 14 2021
!Configuration last saved at 09:46:50 IST Fri May 14 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.17
  floating-ip 10.0.12.3
  floating-ip 10.0.13.11
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.28.67
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.28.67
  health-check octavia_health_monitor
!
slb virtual-server 2601e9d6-3edd-4067-8fee-4fa253007a61 10.0.12.221
!
slb virtual-server 32dd9dee-be26-403f-a691-4fa06b42c6ad 10.0.13.158
!
slb virtual-server 8882e9a5-7c22-4b4c-b2e4-c886704d6539 10.0.11.150
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```


```
vThunder-vBlade[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e67.17cc  192.168.0.30/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3e52.90f1  10.0.11.116/24        1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e38.44e4  10.0.12.207/24        1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e73.5234  10.0.13.5/24          1  DataPort
```
