### PR TITLE
[STACK-2348]wait blade sync. in LB creation flow

### DIFF
--- a/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
@@ -129,16 +129,16 @@ class WaitVirtualServerReadyOnBlade(LoadBalancerParent, task.Task):
         while attempts >= 0:
             try:
                 attempts = attempts - 1
-                vip = self.axapi_client.slb.virtual_server.get(loadbalancer.id)
+                self.axapi_client.slb.virtual_server.get(loadbalancer.id)
                 break
-            except exceptions.ReadTimeout as e:
+            except exceptions.ReadTimeout:
                 # Don't retry for ReadTimout, since acos-client already already have
                 # tries and timeout for axapi request. And it will take very long to
                 # response this error.
                 if attempts < 0:
                     # Don't raise, LB creation is success just not sync. to vBlade yet
                     break
-            except Exception as e:
+            except Exception:
                 if attempts < 0:
                     # Don't raise, LB creation is success just not sync. to vBlade yet
                     break

--- a/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
@@ -17,7 +17,7 @@ from oslo_config import cfg
 from oslo_log import log as logging
 from requests import exceptions
 from taskflow import task
-
+import time
 
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator_for_revert
@@ -118,3 +118,26 @@ class UpdateVirtualServerTask(LoadBalancerParent, task.Task):
         except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception("Failed to update load balancer: %s", loadbalancer.id)
             raise e
+
+
+class WaitVirtualServerReadyOnBlade(LoadBalancerParent, task.Task):
+    """Task to wait vBlade get virtual-server configuration from vMaster"""
+
+    @axapi_client_decorator
+    def execute(self, loadbalancer, vthunder):
+        attempts = CONF.a10_controller_worker.amp_vcs_retries
+        while attempts >= 0:
+            try:
+                attempts = attempts - 1
+                vip = self.axapi_client.slb.virtual_server.get(loadbalancer.id)
+                break
+            except exceptions.ReadTimeout as e:
+                # Don't retry for ReadTimout, since acos-client already already have
+                # tries and timeout for axapi request. And it will take very long to
+                # response this error.
+                if attempts < 0:
+                    raise e
+            except Exception as e:
+                if attempts < 0:
+                    raise e
+                time.sleep(CONF.a10_controller_worker.amp_vcs_wait_sec)

--- a/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
@@ -136,8 +136,10 @@ class WaitVirtualServerReadyOnBlade(LoadBalancerParent, task.Task):
                 # tries and timeout for axapi request. And it will take very long to
                 # response this error.
                 if attempts < 0:
-                    raise e
+                    # Don't raise, LB creation is success just not sync. to vBlade yet
+                    break
             except Exception as e:
                 if attempts < 0:
-                    raise e
+                    # Don't raise, LB creation is success just not sync. to vBlade yet
+                    break
                 time.sleep(CONF.a10_controller_worker.amp_vcs_wait_sec)


### PR DESCRIPTION
## Description
If Bug Fix:
- Required: Severity Level High
- Required: Issue Description
In Active-Standby mode, when create 2 or more LB without wait, first virtual-server lost.
This is because 2'nd LB creation will reload vMaster, but vcs configuration sync. is not finished. So, when vMaster is reloading the vBlade didn't have the virtual-server configuration and become vMaster. So, the virtual-server is lost.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2348

## Technical Approach
 - Add new task WaitVirtualServerReadyOnBlade() to make sure LB is on vBlade. So, the VCS sync. is ready and no more reload on vBlade.

## Config Changes
<pre>
<b>[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
#default_axapi_timeout = 600

[a10_controller_worker]
amp_image_owner_id = 99c9c2304f114685a32db30769c8a7e2
amp_secgroup_list = 2d0a3480-7f08-4184-b96f-c39bb444dd38
amp_flavor_id = 69995a83-c47a-427f-bf70-e9d9752aa915
amp_boot_network_list = 7f8ddd7f-c5c3-463a-b1c3-596f988480a4
#amp_boot_network_list = 7f8ddd7f-c5c3-463a-b1c3-596f988480a4, 61305531-6e3a-44b4-8e67-05e93363dddc, a66685db-31ee-46c6-928a-ac034d87dc63, ec33a88d-3290-4ad6-95cc-226fcd2a4458
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 150
amp_active_wait_sec = 10
amp_busy_wait_sec = 0
amp_image_id = 0a845873-bd91-4f8c-ad58-cf5d5afde09c
loadbalancer_topology = ACTIVE_STANDBY
</b>
</pre>

## Test Cases
commands:
```
openstack loadbalancer create --vip-subnet-id tp91 --name vip1
openstack loadbalancer create --vip-subnet-id tp92 --name vip2
openstack loadbalancer create --vip-subnet-id tp90 --name vip3
openstack loadbalancer create --vip-subnet-id tp-private --name vip4

```

## Manual Testing



result:
```
!
slb virtual-server 0bb83d1f-7f81-4c4b-be2f-0b7f59ef0dca 192.168.92.193
!
slb virtual-server 97787c8a-f42f-4c03-8c5a-f4ea9460444b 172.16.1.129
!
slb virtual-server b9bb652a-53cb-47f0-b999-8a2d4f8e3e91 192.168.90.195
!
slb virtual-server e10180b4-83e6-4c2d-8e7c-0e1a86991a95 192.168.91.149
!

```
