### PR TITLE
[STACK-2321] VRID Floating IP Traffic Issue

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -766,6 +766,7 @@ class LoadBalancerFlows(object):
                     constants.SUBNET,
                     a10constants.LB_COUNT_SUBNET,
                     a10constants.MEMBER_COUNT],
+                rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
                 provides=(
                     a10constants.VRID,
                     a10constants.DELETE_VRID)))
@@ -795,6 +796,7 @@ class LoadBalancerFlows(object):
                     constants.SUBNET,
                     a10constants.LB_COUNT_SUBNET,
                     a10constants.MEMBER_COUNT],
+                rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
                 provides=(
                     a10constants.VRID,
                     a10constants.DELETE_VRID)))

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -529,8 +529,7 @@ class MemberFlows(object):
                 requires=[
                     a10constants.VTHUNDER,
                     a10constants.VRID_LIST,
-                    constants.SUBNET,
-                    constants.LOADBALANCER],
+                    constants.SUBNET],
                 rebind={
                     a10constants.LB_RESOURCE: constants.MEMBER},
                 provides=a10constants.VRID_LIST))

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -465,6 +465,7 @@ class MemberFlows(object):
                     constants.SUBNET,
                     a10constants.LB_COUNT_SUBNET,
                     a10constants.MEMBER_COUNT],
+                rebind={a10constants.LB_RESOURCE: constants.MEMBER},
                 provides=(
                     a10constants.VRID,
                     a10constants.DELETE_VRID)))
@@ -499,6 +500,7 @@ class MemberFlows(object):
                     a10constants.VTHUNDER,
                     a10constants.VRID_LIST,
                     a10constants.SUBNET_LIST],
+                rebind={a10constants.LB_RESOURCE: constants.MEMBER},
                 provides=a10constants.VRID_LIST))
         delete_member_vrid_subflow.add(a10_database_tasks.DeleteMultiVRIDEntry(
             name='delete_multi_vrid_entry' + pool,

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -670,8 +670,7 @@ class GetSubnetForDeletionInPool(BaseDatabaseTask):
                     lb_count_subnet = self.loadbalancer_repo.get_lb_count_by_subnet(
                         db_apis.get_session(), partition_project_list, member.subnet_id)
                     if pool_count_subnet <= 1 and lb_count_subnet == 0:
-                        subnet = self.network_driver.get_subnet(member.subnet_id)
-                        subnet_list.append(subnet)
+                        subnet_list.append(member.subnet_id)
                     member_subnet.append(member.subnet_id)
             return subnet_list
         except Exception as e:

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -32,6 +32,7 @@ from octavia.db import repositories as repo
 from a10_octavia.common import a10constants
 from a10_octavia.common import exceptions
 from a10_octavia.common import utils
+from a10_octavia.controller.worker.tasks import utils as a10_task_utils
 from a10_octavia.db import repositories as a10_repo
 
 CONF = cfg.CONF
@@ -711,7 +712,7 @@ class GetFlavorData(BaseDatabaseTask):
             return flavor_data
 
     def execute(self, lb_resource):
-        flavor_id = utils.attribute_search(lb_resource, 'flavor_id')
+        flavor_id = a10_task_utils.attribute_search(lb_resource, 'flavor_id')
         if flavor_id:
             flavor = self.flavor_repo.get(db_apis.get_session(), id=flavor_id)
             if flavor and flavor.flavor_profile_id:

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -695,15 +695,6 @@ class GetChildProjectsOfParentPartition(BaseDatabaseTask):
 
 class GetFlavorData(BaseDatabaseTask):
 
-    def _flavor_search(self, lb_resource):
-        if hasattr(lb_resource, 'flavor_id'):
-            return lb_resource.flavor_id
-        elif hasattr(lb_resource, 'pool'):
-            return self._flavor_search(lb_resource.pool)
-        elif hasattr(lb_resource, 'load_balancer'):
-            return self._flavor_search(lb_resource.load_balancer)
-        return None
-
     def _format_keys(self, flavor_data):
         if type(flavor_data) is list:
             item_list = []
@@ -719,7 +710,7 @@ class GetFlavorData(BaseDatabaseTask):
             return flavor_data
 
     def execute(self, lb_resource):
-        flavor_id = self._flavor_search(lb_resource)
+        flavor_id = utils.attribute_search(lb_resource, 'flavor_id')
         if flavor_id:
             flavor = self.flavor_repo.get(db_apis.get_session(), id=flavor_id)
             if flavor and flavor.flavor_profile_id:

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -670,7 +670,8 @@ class GetSubnetForDeletionInPool(BaseDatabaseTask):
                     lb_count_subnet = self.loadbalancer_repo.get_lb_count_by_subnet(
                         db_apis.get_session(), partition_project_list, member.subnet_id)
                     if pool_count_subnet <= 1 and lb_count_subnet == 0:
-                        subnet_list.append(member.subnet_id)
+                        subnet = self.network_driver.get_subnet(member.subnet_id)
+                        subnet_list.append(subnet)
                     member_subnet.append(member.subnet_id)
             return subnet_list
         except Exception as e:

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -445,6 +445,7 @@ class UpdateVRIDForLoadbalancerResource(BaseDatabaseTask):
                 try:
                     self.vrid_repo.create(
                         db_apis.get_session(),
+                        id=vrid.id,
                         project_id=vrid.project_id,
                         vrid_floating_ip=vrid.vrid_floating_ip,
                         vrid_port_id=vrid.vrid_port_id,

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -685,7 +685,7 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
 
     def _add_vrid_to_list(self, vrid_list, subnet, project_id):
         vrid_value = CONF.a10_global.vrid
-        filtered_vrid_list = list(filter(lambda x: x == subnet.id, vrid_list))
+        filtered_vrid_list = list(filter(lambda x: x.subnet_id == subnet.id, vrid_list))
         if not filtered_vrid_list:
             vrid_list.append(
                 data_models.VRID(
@@ -785,6 +785,7 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
                 new_ip = a10_utils.get_patched_ip_address(
                     conf_floating_ip, subnet.cidr)
                 if new_ip != vrid.vrid_floating_ip:
+                    vrid.vrid_floating_ip = new_ip
                     vrid = self._replace_vrid_port(vrid, subnet, lb_resource, new_ip)
                     update_vrid_flag = True
             vrid_floating_ips.append(vrid.vrid_floating_ip)
@@ -822,10 +823,6 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
             except Exception as e:
                 LOG.error("Failed to update VRID floating IPs %s due to %s",
                           vrid_floating_ip_list, str(e))
-
-
-class HandleRackVRIDFloatingIP(HandleVRIDFloatingIP):
-    pass
 
 
 class DeleteVRIDPort(BaseNetworkTask):

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -743,7 +743,7 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
         return vrid
 
     @axapi_client_decorator
-    def execute(self, vthunder, lb_resource, vrid_list, subnet, loadbalancer=None):
+    def execute(self, vthunder, lb_resource, vrid_list, subnet):
         """
         :param vthunder:
         :param lb_resource: Can accept LB or member

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -12,12 +12,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 #
-from json import load
 import acos_client.errors as acos_errors
-import copy
 from neutronclient.common import exceptions as neutron_exceptions
 from oslo_config import cfg
 from oslo_log import log as logging
+from oslo_utils import uuidutils
 from requests import exceptions as req_exceptions
 import six
 import socket
@@ -34,7 +33,7 @@ from a10_octavia.common import a10constants
 from a10_octavia.common import data_models
 from a10_octavia.common import utils as a10_utils
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
-
+from a10_octavia.controller.worker.tasks import utils as a10_task_utils
 
 LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
@@ -690,6 +689,7 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
         if not filtered_vrid_list:
             vrid_list.append(
                 data_models.VRID(
+                    id=uuidutils.generate_uuid(),
                     vrid=vrid_value,
                     project_id=project_id,
                     vrid_port_id=None,
@@ -729,7 +729,7 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
             self._delete_vrid_port(vrid.vrid_port_id)
 
         try:
-            amphorae = a10_utils.attribute_search(lb_resource, 'amphorae')
+            amphorae = a10_task_utils.attribute_search(lb_resource, 'amphorae')
             fip_obj = self.network_driver.allocate_vrid_fip(vrid,
                 subnet.network_id, amphorae, conf_floating_ip)
             vrid.vrid_port_id = fip_obj.id

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -818,7 +818,7 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
         if vrid_floating_ip_list:
             vrid_value = CONF.a10_global.vrid
             try:
-                self.update_device_vrid_fip(
+                self._update_device_vrid_fip(
                     vthunder, vrid_floating_ip_list, vrid_value)
             except Exception as e:
                 LOG.error("Failed to update VRID floating IPs %s due to %s",
@@ -871,11 +871,12 @@ class DeleteMultipleVRIDPort(BaseNetworkTask):
                 vrids = []
                 vrid_floating_ip_list = []
                 for vrid in vrid_list:
-                    subnet_matched = list(filter(lambda x: x.id == vrid.subnet_id,
+                    subnet_matched = list(filter(lambda x: x == vrid.subnet_id,
                         subnet_list))
                     if subnet_matched:
                         vrids.append(vrid)
-                        self.network_driver.deallocate_vrid_fip(vrid, subnet_matched[0], amphorae)
+                        subnet = self.network_driver.get_subnet(subnet_matched)
+                        self.network_driver.deallocate_vrid_fip(vrid, subnet, amphorae)
                     else:
                         vrid_floating_ip_list.append(vrid.vrid_floating_ip)
                 if not vthunder.partition_name or vthunder.partition_name == 'shared':

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 #
+from json import load
 import acos_client.errors as acos_errors
 import copy
 from neutronclient.common import exceptions as neutron_exceptions
@@ -683,127 +684,130 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
         self.added_fip_ports = []
         super(HandleVRIDFloatingIP, self).__init__(*arg, **kwargs)
 
+    def _add_vrid_to_list(self, vrid_list, subnet, project_id):
+        vrid_value = CONF.a10_global.vrid
+        filtered_vrid_list = list(filter(lambda x: x == subnet.id, vrid_list))
+        if not filtered_vrid_list:
+            vrid_list.append(
+                data_models.VRID(
+                    vrid=vrid_value,
+                    project_id=project_id,
+                    vrid_port_id=None,
+                    vrid_floating_ip=None,
+                    subnet_id=subnet.id))
+        return vrid_list
+
+    def _remove_device_vrid_fip(self, partition_name, vrid_value):
+        try:
+            is_partition = (partition_name != None and partition_name != 'shared')
+            self.axapi_client.vrrpa.update(vrid_value, floating_ips=[], is_partition=is_partition)
+        except (acos_errors.ACOSException, req_exceptions.ConnectionError) as e:
+            LOG.exception("Failed to remove VRRP floating IPs for vrid: %s",
+                str(vrid_value))
+            raise e
+
+    def _update_device_vrid_fip(self, partition_name, vrid_floating_ip_list, vrid_value):
+        try:
+            is_partition = (partition_name != None and partition_name != 'shared')
+            self.axapi_client.vrrpa.update(
+                    vrid_value, floating_ips=vrid_floating_ip_list, is_partition=is_partition)
+        except (acos_errors.ACOSException, req_exceptions.ConnectionError) as e:
+            LOG.exception("Failed to update VRRP floating IP %s for vrid: %s",
+                          vrid_floating_ip_list, str(vrid_value))
+            raise e
+    
+    def _delete_vrid_port(self, vrid_port_id):
+        try:
+            self.network_driver.delete_port(vrid_port_id)
+        except Exception as e:
+            LOG.error("Failed to delete neutron port for VRID port: %s",
+                      vrid_port_id)
+            raise e
+
+    def _replace_vrid_port(self, vrid, subnet, lb_resource, conf_floating_ip=None):
+        if vrid.vrid_port_id:
+            self._delete_vrid_port(vrid.vrid_port_id)
+
+        try:
+            fip_obj = self.network_driver.create_port(
+                subnet.network_id, subnet.id, fixed_ip=conf_floating_ip)
+            self.added_fip_ports.append(fip_obj)
+            vrid.vrid_floating_ip = fip_obj.fixed_ips[0].ip_address
+            vrid.vrid_port_id = fip_obj.id
+
+            loadbalancer = a10_utils.attribute_search(lb_resource, 'loadbalancer')
+
+            self.network_driver.add_vrid_fip_address_pair(
+                loadbalancer, fip_obj, subnet)
+        except Exception as e:
+            msg = "Failed to create neutron port for loadbalancer resource: %s "
+            if conf_floating_ip:
+                msg += "with floating IP {}".format(conf_floating_ip)
+            LOG.error(msg, lb_resource.id)
+            raise e
+        return vrid
+
     @axapi_client_decorator
     def execute(self, vthunder, lb_resource, vrid_list, subnet, loadbalancer=None):
         """
-
         :param vthunder:
         :param lb_resource: Can accept LB or member
         :param vrid_list: VRID object list for LB resource's project.
         :param subnet: subnet of the resource in question, will be helpful if there is no
         VRID object present for the provided subnet then is should create new VRID
         floating IP instead of updating existing(delete + create -> update)
+        
         :return: return the update list of VRID object, If empty the need to remove all VRID
         objects from DB else need update existing ones.
         """
+
+        vrid_value = CONF.a10_global.vrid
+        prev_vrid_value = copy.deepcopy(vrid_list[0].vrid) if vrid_list else None
+        conf_floating_ip = a10_utils.get_vrid_floating_ip_for_project(lb_resource.project_id)
+
+        if not conf_floating_ip:
+            for vrid in vrid_list:
+                self._delete_vrid_port(vrid.vrid_port_id)
+            vrid_value = prev_vrid_value if prev_vrid_value else vrid_value
+            self._remove_device_vrid_fip(vthunder.partition_name, vrid_value)
+            return []
+
         vrid_floating_ips = []
         update_vrid_flag = False
-        vrid_value = CONF.a10_global.vrid
-        conf_floating_ip = a10_utils.get_vrid_floating_ip_for_project(
-            lb_resource.project_id)
-        prev_vrid_value = copy.deepcopy(
-            vrid_list[0].vrid) if vrid_list else None
-
-        if conf_floating_ip:
-            for vr in vrid_list:
-                if vr.subnet_id == subnet.id:
-                    break
-            else:
-                vrid_list.append(
-                    data_models.VRID(
-                        vrid=vrid_value,
-                        project_id=lb_resource.project_id,
-                        vrid_port_id=None,
-                        vrid_floating_ip=None,
-                        subnet_id=subnet.id))
+        vrid_list = self._add_vrid_to_list(vrid_list, subnet, lb_resource.project_id)
+        for vrid in vrid_list:
+            subnet = self.network_driver.get_subnet(vrid.subnet_id)
+            vrid.vrid = vrid_value
             if conf_floating_ip.lower() == 'dhcp':
-                for vrid in vrid_list:
-                    subnet = self.network_driver.get_subnet(vrid.subnet_id)
-                    subnet_ip, subnet_mask = a10_utils.get_net_info_from_cidr(
-                        subnet.cidr)
-                    vrid.vrid = vrid_value
-                    if not a10_utils.check_ip_in_subnet_range(
-                            vrid.vrid_floating_ip, subnet_ip, subnet_mask):
-                        try:
-                            # delete existing port associated to vrid in
-                            # question.
-                            if vrid.vrid_port_id:
-                                self.network_driver.delete_port(
-                                    vrid.vrid_port_id)
-                            fip_obj = self.network_driver.create_port(
-                                subnet.network_id, subnet.id)
-                            self.added_fip_ports.append(fip_obj)
-                            vrid.vrid_floating_ip = fip_obj.fixed_ips[0].ip_address
-                            vrid.vrid_port_id = fip_obj.id
-                            update_vrid_flag = True
-                        except Exception as e:
-                            LOG.error(
-                                "Failed to create neutron port for lb_resource: %s",
-                                lb_resource.id)
-                            raise e
-                    vrid_floating_ips.append(vrid.vrid_floating_ip)
+                subnet_ip, subnet_mask = a10_utils.get_net_info_from_cidr(
+                    subnet.cidr)
+                if not a10_utils.check_ip_in_subnet_range(
+                        vrid.vrid_floating_ip, subnet_ip, subnet_mask):
+                    vrid = self._replace_vrid_port(vrid, subnet, lb_resource)
+                    update_vrid_flag = True        
             else:
-                for vrid in vrid_list:
-                    subnet = self.network_driver.get_subnet(vrid.subnet_id)
-                    conf_floating_ip = a10_utils.get_vrid_floating_ip_for_project(
-                        lb_resource.project_id)
-                    conf_floating_ip = a10_utils.get_patched_ip_address(
-                        conf_floating_ip, subnet.cidr)
-                    vrid.vrid = vrid_value
-                    if conf_floating_ip != vrid.vrid_floating_ip:
-                        try:
-                            # delete existing port associated to vrid in
-                            # question.
-                            if vrid.vrid_port_id:
-                                self.network_driver.delete_port(
-                                    vrid.vrid_port_id)
-                            fip_obj = self.network_driver.create_port(
-                                subnet.network_id, subnet.id, fixed_ip=conf_floating_ip)
-                            self.added_fip_ports.append(fip_obj)
-                            vrid.vrid_floating_ip = fip_obj.fixed_ips[0].ip_address
-                            vrid.vrid_port_id = fip_obj.id
-                            update_vrid_flag = True
-                        except Exception as e:
-                            LOG.error(
-                                "Failed to create neutron port for loadbalancer resource: %s with "
-                                "floating IP %s", lb_resource.id, conf_floating_ip)
-                            raise e
-                    vrid_floating_ips.append(vrid.vrid_floating_ip)
-        else:
-            for vrid in vrid_list:
-                try:
-                    self.network_driver.delete_port(vrid.vrid_port_id)
-                except Exception as e:
-                    LOG.error(
-                        "Failed to delete neutron port for VRID FIP: %s",
-                        vrid.vrid_floating_ip)
-                    raise e
-                update_vrid_flag = True
-            vrid_list = []
+                new_ip = a10_utils.get_patched_ip_address(
+                    conf_floating_ip, subnet.cidr)
+                if new_ip != vrid.vrid_floating_ip:
+                    vrid = self._replace_vrid_port(vrid, subnet, lb_resource, new_ip)
+                    update_vrid_flag = True
+            vrid_floating_ips.append(vrid.vrid_floating_ip)
+
         if (prev_vrid_value is not None) and (prev_vrid_value != vrid_value):
-            self.update_device_vrid_fip(vthunder, [], prev_vrid_value)
-            self.update_device_vrid_fip(
-                vthunder, vrid_floating_ips, vrid_value)
+            self._remove_device_vrid_fip(vthunder.partition_name, prev_vrid_value)
+            self._update_device_vrid_fip(vthunder.partition_name, vrid_floating_ips, vrid_value)
         elif update_vrid_flag:
-            self.update_device_vrid_fip(
-                vthunder, vrid_floating_ips, vrid_value)
+            self._update_device_vrid_fip(vthunder.partition_name, vrid_floating_ips, vrid_value)
+
         if loadbalancer is None:
             loadbalancer = lb_resource
         self.network_driver.add_vrid_fip_address_pair(
             vthunder, loadbalancer, self.added_fip_ports, subnet)
+
         return vrid_list
 
     @axapi_client_decorator
-    def revert(
-            self,
-            result,
-            vthunder,
-            lb_resource,
-            vrid_list,
-            subnet,
-            *args,
-            **kwargs):
-
+    def revert(self, result, vthunder, lb_resource, vrid_list, subnet, *args, **kwargs):
         LOG.warning(
             "Reverting VRRP floating IP delta task for lb_resource %s",
             lb_resource.id)
@@ -828,22 +832,9 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
                 LOG.error("Failed to update VRID floating IPs %s due to %s",
                           vrid_floating_ip_list, str(e))
 
-    def update_device_vrid_fip(
-            self,
-            vthunder,
-            vrid_floating_ip_list,
-            vrid_value):
-        try:
-            if not vthunder.partition_name or vthunder.partition_name == 'shared':
-                self.axapi_client.vrrpa.update(
-                    vrid_value, floating_ips=vrid_floating_ip_list)
-            else:
-                self.axapi_client.vrrpa.update(
-                    vrid_value, floating_ips=vrid_floating_ip_list, is_partition=True)
-        except (acos_errors.ACOSException, req_exceptions.ConnectionError) as e:
-            LOG.exception("Failed to update VRRP floating IP %s for vrid: %s",
-                          vrid_floating_ip_list, str(vrid_value))
-            raise e
+
+class HandleRackVRIDFloatingIP(HandleVRIDFloatingIP):
+    pass
 
 
 class DeleteVRIDPort(BaseNetworkTask):
@@ -914,7 +905,7 @@ class GetSubnetVLANIDParent(object):
         network_id = self.network_driver.get_subnet(subnet_id).network_id
         network = self.network_driver.get_network(network_id)
         if network.provider_network_type != 'vlan':
-            raise
+            raise Exception()
         return network.provider_segmentation_id
 
 

--- a/a10_octavia/controller/worker/tasks/utils.py
+++ b/a10_octavia/controller/worker/tasks/utils.py
@@ -100,6 +100,7 @@ def dash_to_underscore(my_dict):
     else:
         return my_dict
 
+
 def attribute_search(lb_resource, attr_name):
     """This helper method will recursively walk up the slb tree
     starting from the provided lb_resource and find an attribute

--- a/a10_octavia/controller/worker/tasks/utils.py
+++ b/a10_octavia/controller/worker/tasks/utils.py
@@ -99,3 +99,29 @@ def dash_to_underscore(my_dict):
         return item_dict
     else:
         return my_dict
+
+def attribute_search(self, lb_resource, attr_name):
+    """This helper method will recursively walk up the slb tree
+    starting from the provided lb_resource and find an attribute
+    with the provided name. Though objects like pool refrence a
+    listener and loadbalancer, the following discrete
+    search orders are used:
+
+    1: member -> pool -> listener -> loadbalancer
+    2: healthmonitor -> pool -> listener -> loadbalancer
+
+    :param lb_resource: An slb data model
+    :param obj_type: String name of an slb object
+    (ie 'loadbalancer', 'pool')
+
+    :return: Returns the requested attribute value or none
+    """
+    if hasattr(lb_resource, attr_name):
+        return getattr(lb_resource, attr_name)
+    elif hasattr(lb_resource, 'pool'):
+        return attribute_search(lb_resource.pool, attr_name)
+    elif hasattr(lb_resource, 'listener'):
+        return attribute_search(lb_resource.listener, attr_name)
+    elif hasattr(lb_resource, 'load_balancer'):
+        return attribute_search(lb_resource.load_balancer, attr_name)
+    return None

--- a/a10_octavia/controller/worker/tasks/utils.py
+++ b/a10_octavia/controller/worker/tasks/utils.py
@@ -100,7 +100,7 @@ def dash_to_underscore(my_dict):
     else:
         return my_dict
 
-def attribute_search(self, lb_resource, attr_name):
+def attribute_search(lb_resource, attr_name):
     """This helper method will recursively walk up the slb tree
     starting from the provided lb_resource and find an attribute
     with the provided name. Though objects like pool refrence a

--- a/a10_octavia/db/migration/alembic_migrations/versions/9bfc38df2582_updated_vrid_table_to_use_a_uuid_for_.py
+++ b/a10_octavia/db/migration/alembic_migrations/versions/9bfc38df2582_updated_vrid_table_to_use_a_uuid_for_.py
@@ -1,0 +1,35 @@
+"""Updated vrid table to use a uuid for its primary key
+
+Revision ID: 9bfc38df2582
+Revises: cfce01f4010d
+Create Date: 2021-05-17 08:42:42.132368
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = '9bfc38df2582'
+down_revision = 'cfce01f4010d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute('ALTER TABLE vrid DROP PRIMARY KEY')
+    op.alter_column('vrid', 'id',
+        existing_type=mysql.VARCHAR(length=36),
+        type_=sa.String(36))
+    op.execute('ALTER TABLE vrid ADD PRIMARY KEY (id)')
+    op.alter_column('vrid', 'vrid_floating_ip',
+        existing_type=mysql.VARCHAR(length=40),
+        nullable=False)
+
+def downgrade():
+    op.execute('ALTER TABLE vrid DROP PRIMARY KEY')
+    op.alter_column('vrid', 'id', type_=sa.Integer)
+    op.execute('ALTER TABLE vrid ADD PRIMARY KEY (id)')
+    op.alter_column('vrid', 'vrid_floating_ip',
+        existing_type=mysql.VARCHAR(length=40),
+        nullable=True)

--- a/a10_octavia/db/models.py
+++ b/a10_octavia/db/models.py
@@ -60,11 +60,11 @@ class VRID(base_models.BASE):
     __data_model__ = data_models.VRID
     __tablename__ = 'vrid'
 
-    id = sa.Column(sa.Integer, primary_key=True)
+    id = sa.Column(sa.String(36), primary_key=True)
     project_id = sa.Column(sa.String(36), nullable=False)
     vrid = sa.Column(sa.Integer, default=0)
     vrid_port_id = sa.Column(sa.String(36), nullable=False)
-    vrid_floating_ip = sa.Column(sa.String(40))
+    vrid_floating_ip = sa.Column(sa.String(40), nullable=False)
     subnet_id = sa.Column(sa.String(36), nullable=False)
 
 

--- a/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
+++ b/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
@@ -21,7 +21,7 @@ from octavia.common import constants
 from octavia.i18n import _
 from octavia.network import base
 from octavia.network import data_models as n_data_models
-from octavia.network.drivers.neutron import allowed_address_pairs
+from octavia.network.drivers.neutron import allowed_address_pairs as aap
 from octavia.network.drivers.neutron import utils
 
 from a10_octavia.common import a10constants
@@ -32,10 +32,10 @@ LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
 
 
-class A10OctaviaNeutronDriver(allowed_address_pairs.AllowedAddressPairsDriver):
+class A10OctaviaNeutronDriver(aap.AllowedAddressPairsDriver):
 
     def __init__(self):
-        super(allowed_address_pairs.AllowedAddressPairsDriver, self).__init__()
+        super(aap.AllowedAddressPairsDriver, self).__init__()
         self.compute = stevedore_driver.DriverManager(
             namespace='octavia.compute.drivers',
             name=CONF.controller_worker.compute_driver,
@@ -122,18 +122,6 @@ class A10OctaviaNeutronDriver(allowed_address_pairs.AllowedAddressPairsDriver):
             message = "Error deleting subports"
             LOG.exception(message)
 
-    def _add_allowed_address_pair_to_port(self, port_id, ip_address):
-        port = self.neutron_client.show_port(port_id)
-        aap1 = {'ip_address': ip_address}
-        port['port']['allowed_address_pairs'].append(aap1)
-        ip_address_list = port['port']['allowed_address_pairs']
-        aap = {
-            'port': {
-                'allowed_address_pairs': ip_address_list
-            }
-        }
-        self.neutron_client.update_port(port_id, aap)
-
     def _add_security_group_to_port(self, sec_grp_id, port_id):
         port = self.neutron_client.show_port(port_id)
         port['port']['security_groups'].append(sec_grp_id)
@@ -146,17 +134,6 @@ class A10OctaviaNeutronDriver(allowed_address_pairs.AllowedAddressPairsDriver):
             raise base.PortNotFound(str(e))
         except Exception as e:
             raise base.NetworkException(str(e))
-
-    def _remove_allowed_address_pair_to_port(self, port_id, ip_address):
-        port = self.neutron_client.show_port(port_id)
-        ips = port['port']['allowed_address_pairs']
-        ips = [ip for ip in ips if not (ip_address == ip.get('ip_address'))]
-        aap = {
-            'port': {
-                'allowed_address_pairs': ips
-            }
-        }
-        self.neutron_client.update_port(port_id, aap)
 
     def _remove_security_group(self, port, sec_grp_id):
         port['security_groups'].remove(sec_grp_id)
@@ -197,7 +174,6 @@ class A10OctaviaNeutronDriver(allowed_address_pairs.AllowedAddressPairsDriver):
         return filtered_ports
 
     def _get_ports_by_security_group(self, sec_grp_id):
-
         all_ports = self.neutron_client.list_ports()
         filtered_ports = []
         for port in all_ports.get('ports', []):
@@ -337,41 +313,50 @@ class A10OctaviaNeutronDriver(allowed_address_pairs.AllowedAddressPairsDriver):
                 router_external=network.get('router:external')))
         return network_list_datamodel
 
-    # might required for adding security group in vrrp port
-    def update_vip_sg_1(self, load_balancer, vrid):
-        self._add_vip_security_group_to_port(load_balancer.id, vrid.vrid_port_id)
+    def allocate_vrid_fip(self, vrid, network_id, amphorae, fixed_ip=None):
 
+        fixed_ip_json = {}
+        if vrid.subnet_id:
+            fixed_ip_json['subnet_id'] = vrid.subnet_id
+        if fixed_ip:
+            fixed_ip_json['ip_address'] = fixed_ip
 
-    def allocate_vrid_fip(self):
-        pass
+        # Make sure we are backward compatible with older neutron
+        if self._check_extension_enabled(aap.PROJECT_ID_ALIAS):
+            project_id_key = 'project_id'
+        else:
+            project_id_key = 'tenant_id'
 
-    def add_vrid_fip_address_pair(self, load_balancer, vrid_list, subnet):
-        for vrid in vrid_list:
-            for amphora in filter(
-                    lambda amp: amp.status == constants.AMPHORA_ALLOCATED,
-                    load_balancer.amphorae):
-                interface = self._get_plugged_interface(
-                    amphora.compute_id, subnet.network_id, amphora.lb_network_ip)
-                self._add_vip_address_pair(interface.port_id, vrid.fixed_ips[0].ip_address)
+        # It can be assumed that network_id exists
+        port = {'port': {'name': 'octavia-vrid-fip-' + vrid.id,
+                         'network_id': network_id,
+                         'admin_state_up': False,
+                         'device_id': 'vrid-{0}'.format(vrid.id),
+                         'device_owner': aap.OCTAVIA_OWNER,
+                         project_id_key: vrid.project_id}}
+        if fixed_ip_json:
+            port['port']['fixed_ips'] = [fixed_ip_json]
 
-    def _remove_ip_address_pair(self, loadbalancer, subnet, ip_address):
-        if loadbalancer.amphorae:
-            for amphora in filter(lambda amp: amp.status == constants.AMPHORA_ALLOCATED,
-                                  loadbalancer.amphorae):
-                interface = self._get_plugged_interface(amphora.compute_id,
-                                                        subnet.network_id, amphora.lb_network_ip)
-                try:
-                    self._remove_allowed_address_pair_to_port(interface.port_id, ip_address)
-                except neutron_client_exceptions.PortNotFoundClient as e:
-                    raise base.PortNotFound(str(e))
-                except Exception as e:
-                    message = _('Error adding allowed address pair {ip} '
-                                'to port {port_id}.').format(ip=ip_address,
-                                                             port_id=interface.port_id)
-                    LOG.exception(message)
-                    raise base.NetworkException(str(e))
+        try:
+            new_port = self.neutron_client.create_port(port)
+        except Exception as e:
+            message = _('Error creating neutron port on network '
+                        '{network_id}.').format(
+                network_id=network_id)
+            LOG.exception(message)
+            raise base.AllocateVIPException(
+                message,
+                orig_msg=getattr(e, 'message', None),
+                orig_code=getattr(e, 'status_code', None),
+            )
+        new_port = utils.convert_port_dict_to_model(new_port)
 
-    # might required this function
-    def remove_aap(self, vthunder, loadbalancer, subnet, ip_address):
-        if vthunder.compute_id is not None:
-            self._remove_ip_address_pair(loadbalancer, subnet, ip_address)
+        fixed_ip = new_port.fixed_ips[0].ip_address
+        for amphora in filter(
+            lambda amp: amp.status == constants.AMPHORA_ALLOCATED,
+                    amphorae):
+            interface = self._get_plugged_interface(
+                    amphora.compute_id, network_id, amphora.lb_network_ip)
+            self._add_allowed_address_pair_to_port(interface.port_id, fixed_ip)
+
+        return new_port

--- a/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
+++ b/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
@@ -358,9 +358,9 @@ class A10OctaviaNeutronDriver(aap.AllowedAddressPairsDriver):
         fixed_ip = new_port.fixed_ips[0].ip_address
         for amphora in filter(
             lambda amp: amp.status == constants.AMPHORA_ALLOCATED,
-                    amphorae):
+                amphorae):
             interface = self._get_plugged_interface(
-                    amphora.compute_id, network_id, amphora.lb_network_ip)
+                amphora.compute_id, network_id, amphora.lb_network_ip)
             self._add_allowed_address_pair_to_port(interface.port_id, fixed_ip)
 
         return new_port
@@ -380,8 +380,8 @@ class A10OctaviaNeutronDriver(aap.AllowedAddressPairsDriver):
         self.delete_port(vrid.vrid_port_id)
         for amphora in filter(
             lambda amp: amp.status == constants.AMPHORA_ALLOCATED,
-                    amphorae):
+                amphorae):
             interface = self._get_plugged_interface(
-                    amphora.compute_id, subnet.network_id,
-                    amphora.lb_network_ip)
+                amphora.compute_id, subnet.network_id,
+                amphora.lb_network_ip)
             self._remove_allowed_address_pair_from_port(interface.port_id, vrid.vrid_floating_ip)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -288,6 +288,7 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         mock_vrid_entry.vrid_repo.create.assert_called_once_with(
             mock.ANY,
             project_id=MEMBER_1.project_id,
+            id=VRID.id,
             vrid=VRID.vrid,
             vrid_floating_ip=VRID.vrid_floating_ip,
             vrid_port_id=VRID.vrid_port_id,
@@ -382,31 +383,6 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
             assert_called_once_with(mock.ANY, partition_name='mock-partition-name',
                                     ip_address="mock-ip-addr")
 
-    def test_flavor_search_loadbalancer_find_flavor(self):
-        flavor_task = task.GetFlavorData()
-        found_id = flavor_task._flavor_search(LB)
-        self.assertEqual(found_id, a10constants.MOCK_FLAVOR_ID)
-
-    def test_flavor_search_listener_find_flavor(self):
-        flavor_task = task.GetFlavorData()
-        found_id = flavor_task._flavor_search(LB)
-        self.assertEqual(found_id, a10constants.MOCK_FLAVOR_ID)
-
-    def test_flavor_search_pool_find_flavor(self):
-        flavor_task = task.GetFlavorData()
-        found_id = flavor_task._flavor_search(POOL)
-        self.assertEqual(found_id, a10constants.MOCK_FLAVOR_ID)
-
-    def test_flavor_search_member_find_flavor(self):
-        flavor_task = task.GetFlavorData()
-        found_id = flavor_task._flavor_search(MEMBER_1)
-        self.assertEqual(found_id, a10constants.MOCK_FLAVOR_ID)
-
-    def test_flavor_search_health_monitor_find_flavor(self):
-        flavor_task = task.GetFlavorData()
-        found_id = flavor_task._flavor_search(HM)
-        self.assertEqual(found_id, a10constants.MOCK_FLAVOR_ID)
-
     def test_GetFlavorData_format_flavor_keys(self):
         expected = {"virtual_server": {"arp_disable": 1}}
         flavor = {"virtual-server": {"arp-disable": 1}}
@@ -456,9 +432,10 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         formated_flavor = flavor_task._format_keys(flavor)
         self.assertEqual(formated_flavor, expected)
 
-    def test_GetFlavorData_execute_no_flavor_id(self):
+    @mock.patch('a10_octavia.controller.worker.tasks.a10_database_tasks.a10_task_utils')
+    def test_GetFlavorData_execute_no_flavor_id(self, mock_utils):
+        mock_utils.attribute_search.return_value = None
         flavor_task = task.GetFlavorData()
-        flavor_task._flavor_search = mock.Mock(return_value=None)
         ret_val = flavor_task.execute(LB)
         self.assertEqual(ret_val, None)
 


### PR DESCRIPTION
## Description

Severity Level: High

When deploying in ACTIVE_STANDBY mode and using VRID floating IPs, packets were not being forwarded as the vNIC ports did not have the VRID Floating IP added as an allowed address pair. Furthermore, a distinction does not exist between regular ports and vrid fips in the current implementation.

## Jira Ticket
- [STACK-2321](https://a10networks.atlassian.net/browse/STACK-2321)

## Technical Approach
*Assumes that the vrid floating ip has been set in the config file*
- Create a VRID floating IP port in the DOWN state and it's IP as an allowed address pair on the vNIC whenever a loadbalancer is created in a new subnet
- Create a VRID floating IP port in the DOWN state and it's IP as an allowed address pair on the vNIC whenever a member is created in a new subnet
- Refactor HandleVRIDFloatingIP code to reduce iterations, api calls, and make code flow easier to follow


## Config Changes
N/A

## Test Cases
- Old tests were made to pass

## Manual Testing

### Step 1: Create 2 tenant networks & subnets

```
openstack network create private-net-a
openstack network create private-net-b

openstack subnet create --network private-net-a --subnet-range 10.0.0.0/24 private-a-subnet
openstack subnet create --network private-net-b --subnet-range 11.0.0.0/24 private-b-subnet
```

### Step 2: Create Server and Client instances

**Requires pre-existing apache images**
```
openstack image create --disk-format qcow2 --container-format bare --public --file Apache_server1.qcow2 apache_server
openstack flavor create --vcpu 1 --ram 2048 --disk 20 apache_flavor

openstack security group create apache
openstack security group rule create --ingress --protocol tcp --dst-port 80 apache

openstack server create --image apache_server --flavor apache_flavor --security-group apache --network private-net-a client
openstack server create --image apache_server --flavor apache_flavor --security-group apache --network private-net-b server
```


### Step 3: Setup config file

**autosnat is required for smart nat to take effect**

**vrid_floating_ip is required**

Example config
```
[a10_global]
vrid_floating_ip = ".9"

[vthunder]
default_vthunder_username = admin
default_vthunder_password = a10
default_axapi_version = 30

[a10_controller_worker]
amp_image_owner_id = uuid
amp_secgroup_list = uuid
amp_flavor_id = uuid
amp_boot_network_list = uuid
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 100
amp_active_wait_sec = 2
amp_image_id = uuid
loadbalancer_topology = ACTIVE_STANDBY

[a10_health_manager]
udp_server_ip_address = 10.64.3.134
bind_port = 5550
bind_ip = 10.64.3.134
heartbeat_interval = 5
heartbeat_key = insecure
heartbeat_timeout = 90
health_check_interval = 3
failover_timeout = 600
health_check_timeout = 3
health_check_max_retries = 5

[a10_house_keeping]
load_balancer_expiry_age = 3600
amphorae_expiry_age = 3600

[listener]
autosnat=True
```

### Step 4: Create SLB tree
```
openstack loadbalancer create --name vs1 --vip-subnet-id private-subnet-a
openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name l1 vs1
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener l1 --name p1
openstack loadbalancer member create --address 11.0.0.59 --subnet-id private-subnet-b --protocol-port 80 --name mem1 p1
```

In this example the real server named "server" in the steps above has ip of `11.0.0.59`

### Step 5: Confirm VRID IPs exist

#### On ACOS

![image](https://user-images.githubusercontent.com/10890376/118904285-660f8900-b8ce-11eb-9cef-5d5d800d7c47.png)

#### On Openstack

Easiest to confirm via `Project -> Compute -> Instances' then click instance and `Interfaces`
![image](https://user-images.githubusercontent.com/10890376/118904380-a1aa5300-b8ce-11eb-8c31-3a4fa5df178c.png)

*My real example used private and private-2 instead of the network named above*

Then click the port for the connected subnet and confirm on "Allowed Address Pairs" screen for both subnets and both devices.

![image](https://user-images.githubusercontent.com/10890376/118904455-cacae380-b8ce-11eb-9228-90a079172e04.png)

### Step 6: Set the member's VRID floating IP as the default gateway

Original route table:
```
# ip route
default via 11.0.0.1 dev ens2
11.0.0.0/26 dev ens2  proto kernel  scope link  src 11.0.0.59
169.254.169.254 via 11.0.0.2 dev ens2
```

```
ip route del default via 11.0.0.1 dev ens2
ip route add default via 11.0.0.9 dev ens2
```

Updated table

```
# ip route
default via 11.0.0.9 dev ens2
11.0.0.0/26 dev ens2  proto kernel  scope link  src 11.0.0.59
169.254.169.254 via 11.0.0.2 dev ens2
```

### Step 7: Set TCP dump on member
```
tcpdump -A -s 0 'tcp port 80 and (((ip[2:2] - ((ip[0]&0xf)<<2)) - ((tcp[12]&0xf0)>>2)) != 0)'
```

### Step 8: Curl the VIP
```
curl 10.0.0.38:80
```


#### Confirm response received
```
----------------------
Page from server1

----------------------
```


#### Confirm use of vrid floating IP
```
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on ens2, link-type EN10MB (Ethernet), capture size 262144 bytes
01:24:34.709081 IP host-11-0-0-9.openstacklocal.24147 > host-11-0-0-59.openstacklocal.http: Flags [P.], seq 3938716863:3938716936, ack 1406386594, win 3495, options [nop,nop,TS val 23228617 ecr 22319539], length 73: HTTP: GET / HTTP/1.1
E..}.......R... ...;^S.P....S..............
.bp..T..GET / HTTP/1.1
Host: 10.0.0.38
User-Agent: curl/7.47.0
Accept: */*


01:24:34.730351 IP host-11-0-0-59.openstacklocal.http > host-11-0-0-9.openstacklocal.24147: Flags [P.], seq 1:320, ack 73, win 219, options [nop,nop,TS val 22319544 ecr 23228617], length 319: HTTP: HTTP/1.1 200 OK
E..s:.@.@..'...;...     .P^SS..................
.T...bp.HTTP/1.1 200 OK
Date: Thu, 20 May 2021 01:24:34 GMT
Server: Apache/2.4.18 (Ubuntu)
Last-Modified: Mon, 06 Apr 2020 06:44:02 GMT
ETag: "45-5a29997b96fdb"
Accept-Ranges: bytes
Content-Length: 69
Vary: Accept-Encoding
Content-Type: text/html

----------------------
Page from server1

----------------------
```

Response goes to VRID Floating IP of `11.0.0.9` instead of the ACOS port which is `11.0.0.33`


### Step 9: Shutoff the ACTIVE devices
![image](https://user-images.githubusercontent.com/10890376/118905051-dbc82480-b8cf-11eb-9549-883dbd9cee29.png)

Then confirm that traffic still goes through `11.0.0.9` as expected
