### PR TITLE
[BUG][STACK-2355]: Fixed an issue ValueError: list.remove(x): x not in list while deleting loadbalancer and member

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -217,8 +217,6 @@ class MemberFlows(object):
         delete_member_flow.add(a10_database_tasks.GetFlavorData(
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
             provides=constants.FLAVOR))
-        delete_member_flow.add(database_tasks.DeleteMemberInDB(
-            requires=constants.MEMBER))
         delete_member_flow.add(a10_database_tasks.GetLoadBalancerListByProjectID(
             requires=a10constants.VTHUNDER,
             provides=a10constants.LOADBALANCERS_LIST))
@@ -283,6 +281,8 @@ class MemberFlows(object):
                     a10constants.MEMBER_COUNT_IP,
                     a10constants.MEMBER_COUNT_IP_PORT_PROTOCOL)))
         delete_member_flow.add(self.get_delete_member_vrid_subflow())
+        delete_member_flow.add(database_tasks.DeleteMemberInDB(
+            requires=constants.MEMBER))
         delete_member_flow.add(database_tasks.DecrementMemberQuota(
             requires=constants.MEMBER))
         delete_member_flow.add(database_tasks.MarkPoolActiveInDB(

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -217,6 +217,8 @@ class MemberFlows(object):
         delete_member_flow.add(a10_database_tasks.GetFlavorData(
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
             provides=constants.FLAVOR))
+        delete_member_flow.add(database_tasks.DeleteMemberInDB(
+            requires=constants.MEMBER))
         delete_member_flow.add(a10_database_tasks.GetLoadBalancerListByProjectID(
             requires=a10constants.VTHUNDER,
             provides=a10constants.LOADBALANCERS_LIST))
@@ -281,8 +283,6 @@ class MemberFlows(object):
                     a10constants.MEMBER_COUNT_IP,
                     a10constants.MEMBER_COUNT_IP_PORT_PROTOCOL)))
         delete_member_flow.add(self.get_delete_member_vrid_subflow())
-        delete_member_flow.add(database_tasks.DeleteMemberInDB(
-            requires=constants.MEMBER))
         delete_member_flow.add(database_tasks.DecrementMemberQuota(
             requires=constants.MEMBER))
         delete_member_flow.add(database_tasks.MarkPoolActiveInDB(

--- a/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
+++ b/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
@@ -368,10 +368,10 @@ class A10OctaviaNeutronDriver(aap.AllowedAddressPairsDriver):
     def _remove_allowed_address_pair_from_port(self, port_id, ip_address):
         port = self.neutron_client.show_port(port_id)
         aap_ips = port['port']['allowed_address_pairs']
-        aap_ips.remove({'ip_address': ip_address})
+        updated_aap_ips = [aap_ip for aap_ip in aap_ips if aap_ip['ip_address'] != ip_address]
         aap = {
             'port': {
-                'allowed_address_pairs': aap_ips,
+                'allowed_address_pairs': updated_aap_ips,
             }
         }
         self.neutron_client.update_port(port_id, aap)
@@ -384,4 +384,6 @@ class A10OctaviaNeutronDriver(aap.AllowedAddressPairsDriver):
             interface = self._get_plugged_interface(
                 amphora.compute_id, subnet.network_id,
                 amphora.lb_network_ip)
-            self._remove_allowed_address_pair_from_port(interface.port_id, vrid.vrid_floating_ip)
+            if interface is not None:
+                self._remove_allowed_address_pair_from_port(
+                    interface.port_id, vrid.vrid_floating_ip)


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description: When deleting a loadbalancer or a member, while deletion of vrid FIP associated to it, `_remove_allowed_address_pair_from_port` is getting called in which aap_ips is a list of dictionaries in which each dictionary is having 2 key-value pairs(ip_address and mac_address). Due to these 2 key value pais, the call `aap_ips.remove({'ip_address': ip_address})` is getting failed throwing `ValueError: list.remove(x): x not in list`.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2355

## Technical Approach
- For removing the allowed_address_pair of vrid FIP port in `_remove_allowed_address_pair_from_port`, using `updated_aap_ips = [aap_ip for aap_ip in aap_ips if aap_ip['ip_address'] != ip_address]` instead of `aap_ips.remove({'ip_address': ip_address})`  as the aap_ips is a list of dicts in which each dict holds 2 key-value pairs.
- Added a check `if interface is not None:` before calling `_remove_allowed_address_pair_from_port`, because interface is getting removed before this task if the the interface is not used by any other objects.

## Manual Testing
1. Create a loadbalancer, listener, pool and member
stack@openstack-3:~$ openstack loadbalancer create --name v3 --vip-subnet-id public-13-subnet
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-05-21T12:44:36                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 0fbf996c-5fee-439b-978e-8a908c18be09 |
| listeners           |                                      |
| name                | v3                                   |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 9ef5e94c53c940239a66dbe4a1058eee     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.13.39                           |
| vip_network_id      | 3f286d58-339c-4ca6-a5f7-8723b0e1fd2d |
| vip_port_id         | 7a2234d8-eff2-4e37-ba5e-9a66863bab81 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 0d4f7a95-d013-4a22-9b8e-6a83b22f8297 |
+---------------------+--------------------------------------+
```

stack@openstack-3:~$ openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name l1 v3
```
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-05-21T13:01:49                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 51700b25-22de-448a-98a7-03bbc94256aa |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 0fbf996c-5fee-439b-978e-8a908c18be09 |
| name                        | l1                                   |
| operating_status            | OFFLINE                              |
| project_id                  | 9ef5e94c53c940239a66dbe4a1058eee     |
| protocol                    | HTTP                                 |
| protocol_port               | 80                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
+-----------------------------+--------------------------------------+
```

stack@openstack-3:~$ openstack loadbalancer pool create --name p1 --protocol HTTP --listener l1 --lb-algorithm least_connections

stack@openstack-3:~/neha/a10-octavia$ openstack loadbalancer member create --name m1 --protocol-port 81 --address 10.0.12.10 --subnet-id public-12-subnet p1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.12.10                           |
| admin_state_up      | True                                 |
| created_at          | 2021-05-21T13:01:53                   |
| id                  | bd32f161-920a-4804-b2f6-2c3c8765a084 |
| name                | m1                                   |
| operating_status    | NO_MONITOR                           |
| project_id          | 9ef5e94c53c940239a66dbe4a1058eee     |
| protocol_port       | 81                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | da29e3b4-c885-4834-b4ee-228d7d1bfac1 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+

```

Result on vThunders:
```
vThunder-vMaster[1/2](NOLICENSE)#show running-config
!Current configuration: 601 bytes
!Configuration last updated at 14:10:02 IST Fri May 21 2021
!Configuration last saved at 14:10:06 IST Fri May 21 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.13.97
  floating-ip 10.0.12.37
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.28.67
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server 9ef5e_10_0_12_10 10.0.12.10
  port 81 tcp
!
slb server octavia_health_manager_controller 10.64.28.67
  health-check octavia_health_monitor
!
slb service-group 21e4e57b-41d6-4a8c-869b-487afddae717 tcp
  method least-connection
  member 9ef5e_10_0_12_10 81
!
slb virtual-server 0fbf996c-5fee-439b-978e-8a908c18be09 10.0.13.39
  port 80 http
    name 51700b25-22de-448a-98a7-03bbc94256aa
    extended-stats
    service-group 21e4e57b-41d6-4a8c-869b-487afddae717
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

```
vThunder-vMaster[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e33.88c7  192.168.0.98/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3eca.ce2e  10.0.13.85/24         1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e53.d3f7  10.0.12.55/24         1  DataPort


```

```
vThunder-vBlade[1/1](NOLICENSE)#show running-config
!Current configuration: 601 bytes
!Configuration last updated at 14:10:03 IST Fri May 21 2021
!Configuration last saved at 14:07:40 IST Fri May 21 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.13.97
  floating-ip 10.0.12.37
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.28.67
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server 9ef5e_10_0_12_10 10.0.12.10
  port 81 tcp
!
slb server octavia_health_manager_controller 10.64.28.67
  health-check octavia_health_monitor
!
slb service-group 21e4e57b-41d6-4a8c-869b-487afddae717 tcp
  method least-connection
  member 9ef5e_10_0_12_10 81
!
slb virtual-server 0fbf996c-5fee-439b-978e-8a908c18be09 10.0.13.39
  port 80 http
    name 51700b25-22de-448a-98a7-03bbc94256aa
    extended-stats
    service-group 21e4e57b-41d6-4a8c-869b-487afddae717
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

```
vThunder-vBlade[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3eb1.55c4  192.168.0.80/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3ef1.e9be  10.0.13.40/24         1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e73.aa6d  10.0.12.102/24        1  DataPort
```

2. Delete member
stack@openstack-3:~$ openstack loadbalancer member delete p1 m1

```
vThunder-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 688 bytes
!Configuration last updated at 14:26:23 IST Fri May 21 2021
!Configuration last saved at 14:26:26 IST Fri May 21 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.13.97
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.28.67
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.28.67
  health-check octavia_health_monitor
!
slb service-group 21e4e57b-41d6-4a8c-869b-487afddae717 tcp
  method least-connection
!
slb virtual-server 0fbf996c-5fee-439b-978e-8a908c18be09 10.0.13.39
  port 80 http
    name 51700b25-22de-448a-98a7-03bbc94256aa
    extended-stats
    service-group 21e4e57b-41d6-4a8c-869b-487afddae717
!
!
cloud-services meta-data
  enable
  provider openstack
!
end

```

```
vThunder-vMaster[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3eb1.55c4  192.168.0.80/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3ef1.e9be  10.0.13.40/24         1  DataPort

```

```
vThunder-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 688 bytes
!Configuration last updated at 14:26:23 IST Fri May 21 2021
!Configuration last saved at 14:23:18 IST Fri May 21 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.13.97
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.28.67
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.28.67
  health-check octavia_health_monitor
!
slb service-group 21e4e57b-41d6-4a8c-869b-487afddae717 tcp
  method least-connection
!
slb virtual-server 0fbf996c-5fee-439b-978e-8a908c18be09 10.0.13.39
  port 80 http
    name 51700b25-22de-448a-98a7-03bbc94256aa
    extended-stats
    service-group 21e4e57b-41d6-4a8c-869b-487afddae717
!
!
cloud-services meta-data
  enable
  provider openstack
!
end

```
```
vThunder-vBlade[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e33.88c7  192.168.0.98/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3eca.ce2e  10.0.13.85/24         1  DataPort
```
Here, member, its interface and vrid FIP is removed successfully without getting the issue.

3. Delete pool, listener and loadbalancer.
stack@openstack-3:~$ openstack loadbalancer pool delete p1
stack@openstack-3:~$ openstack loadbalancer listener delete l1
stack@openstack-3:~$ openstack loadbalancer delete v3

stack@openstack-3:~$ journalctl -af -u a10-controller-worker.service

May 21 13:30:29 openstack-3 a10-octavia-worker[13768]: INFO a10_octavia.controller.queue.endpoint [-] Deleting pool '21e4e57b-41d6-4a8c-869b-487afddae717'...
May 21 13:30:31 openstack-3 a10-octavia-worker[13768]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Attempting to connect vThunder device for connection.
May 21 13:30:32 openstack-3 a10-octavia-worker[13768]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.0.80:shared
May 21 13:30:41 openstack-3 a10-octavia-worker[13768]: INFO a10_octavia.controller.queue.endpoint [-] Deleting listener '51700b25-22de-448a-98a7-03bbc94256aa'...
May 21 13:30:43 openstack-3 a10-octavia-worker[13768]: INFO octavia.controller.worker.tasks.database_tasks [-] Mark ACTIVE in DB for load balancer id: 0fbf996c-5fee-439b-978e-8a908c18be09
May 21 13:30:43 openstack-3 a10-octavia-worker[13768]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.0.80:shared
**May 21 13:31:41 openstack-3 a10-octavia-worker[13768]: INFO a10_octavia.controller.queue.endpoint [-] Deleting load balancer '0fbf996c-5fee-439b-978e-8a908c18be09'...
May 21 13:32:18 openstack-3 a10-octavia-worker[13768]: INFO a10_octavia.controller.worker.tasks.a10_network_tasks [-] VRID floating IP: 10.0.13.97 deleted
May 21 13:32:23 openstack-3 a10-octavia-worker[13768]: INFO octavia.network.drivers.neutron.allowed_address_pairs [-] Deleted security group 973f959b-b2be-45c1-bed5-b089f5185918**

LB deleted successfully without getting the issue