### PR TITLE
[STACK-2349]: Fix for removing VRID floating IP without removing vip-port and security group when a loadbalancer is deleted with having its vip network-id in amp_boot_network_list

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -465,13 +465,9 @@ class CountLoadbalancersInProjectBySubnet(BaseDatabaseTask):
     def execute(self, subnet, partition_project_list):
         if partition_project_list:
             try:
-                count = self.loadbalancer_repo.get_lb_count_by_subnet(
+                return self.loadbalancer_repo.get_lb_count_by_subnet(
                     db_apis.get_session(),
                     project_ids=partition_project_list, subnet_id=subnet.id)
-                fixed_subnets = CONF.a10_controller_worker.amp_boot_network_list[:]
-                if subnet.network_id in fixed_subnets:
-                    count = count + 1
-                return count
             except Exception as e:
                 LOG.exception("Failed to get LB count for subnet %s due to %s ",
                               subnet.id, str(e))

--- a/a10_octavia/tests/unit/network/drivers/neutron/test_a10_neutron_driver.py
+++ b/a10_octavia/tests/unit/network/drivers/neutron/test_a10_neutron_driver.py
@@ -19,6 +19,9 @@ except ImportError:
 
 from neutronclient.common import exceptions as neutron_client_exceptions
 
+from oslo_config import cfg
+from oslo_config import fixture as oslo_fixture
+
 from octavia.common import clients
 from octavia.network import base as network_driver_base
 from octavia.network.drivers.neutron import allowed_address_pairs
@@ -27,7 +30,9 @@ from octavia.tests.common import data_model_helpers as dmh
 from octavia.tests.unit import base
 
 from a10_octavia.common import a10constants
+from a10_octavia.common import config_options
 from a10_octavia.network.drivers.neutron import a10_octavia_neutron
+from a10_octavia.tests.common import a10constants as a10_tconstants
 
 
 class TestA10NeutronDriver(base.TestCase):
@@ -48,6 +53,9 @@ class TestA10NeutronDriver(base.TestCase):
                 self.k_session = mock.patch(
                     'keystoneauth1.session.Session').start()
                 self.driver = a10_octavia_neutron.A10OctaviaNeutronDriver()
+        self.conf = self.useFixture(oslo_fixture.Config(cfg.CONF))
+        self.conf.register_opts(config_options.A10_CONTROLLER_WORKER_OPTS,
+                                group=a10_tconstants.A10_CONTROLLER_WORKER_CONF_SECTION)
 
     def _setup_deallocate_vip_mocks(self):
         self.driver._get_lb_security_group = mock.MagicMock()


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description: When a loadbalancer's vip-subnet's network id is specified there in amp_boot_network_list and we delete that loadbalancer, then VRID floating IP associated with that LB is not getting removed.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2349

## Technical Approach
- Removed the logic of incrementing lb_count when the LB's vip-network is in **amp_boot_network_list** sothat the VRID FIP can get removed in that case.
- Added a check for confirming whether LB's vip-network id is in **amp_boot_network_list** or not and if LB's vip network-id is there in amp_boot_network_list, then vip-port and the security group will not be removed


## Manual Testing
Step1: Create 4 loadbalancers with 4 different subnets, with all the 4 subnets' networks are in amp_boot_network_list in config file.
In my config file, amp_boot_network_list holds total 7 network ids(lb-mgmt network, 4 vip-networks of the 4 LBs and 2 other networks).

```
stack@neha:~$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| b8f01eff-a0c0-479f-bd56-608d83e16f38 | lb1  | 56f90ce7d79546de8b94257f25584892 | 192.168.8.172 | ACTIVE              | a10      |
| 0de8b615-6a89-4d63-a31f-fc8ee40b42c7 | lb2  | 56f90ce7d79546de8b94257f25584892 | 10.0.11.166   | ACTIVE              | a10      |
| c628a9e7-e1d2-4bce-90fe-c5d8ef312aa3 | lb3  | 56f90ce7d79546de8b94257f25584892 | 192.168.9.183 | ACTIVE              | a10      |
| 526cc3f0-950a-4f4e-a38a-cfa2113ed4a4 | lb4  | 56f90ce7d79546de8b94257f25584892 | 10.0.12.110   | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+

```

```
vThunder-vMaster[1/2](NOLICENSE)#show running-config
!Current configuration: 881 bytes
!Configuration last updated at 06:24:50 IST Wed May 26 2021
!Configuration last saved at 06:25:19 IST Wed May 26 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/4
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/5
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/6
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/4
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/5
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/6
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 192.168.8.111
  floating-ip 10.0.11.195
  floating-ip 192.168.9.241
  floating-ip 10.0.12.156
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb virtual-server 0de8b615-6a89-4d63-a31f-fc8ee40b42c7 10.0.11.166
!
slb virtual-server 526cc3f0-950a-4f4e-a38a-cfa2113ed4a4 10.0.12.110
!
slb virtual-server b8f01eff-a0c0-479f-bd56-608d83e16f38 192.168.8.172
!
slb virtual-server c628a9e7-e1d2-4bce-90fe-c5d8ef312aa3 192.168.9.183
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

```
vThunder-vMaster[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e47.353c  192.168.0.197/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e98.c26c  192.168.8.80/24       1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3ebc.ba8f  10.0.11.171/24        1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e1d.6a77  10.0.12.187/24        1  DataPort
4                   Up    Full  10000  none  1    N/A       fa16.3e9c.8535  10.0.13.154/24        1  DataPort
5                   Up    Full  10000  none  1    N/A       fa16.3e82.04e2  10.0.14.109/24        1  DataPort
6                   Up    Full  10000  none  1    N/A       fa16.3ece.fac5  192.168.9.126/24      1  DataPort
```

```
vThunder-vBlade[1/1](NOLICENSE)#show running-config
!Current configuration: 881 bytes
!Configuration last updated at 06:24:50 IST Wed May 26 2021
!Configuration last saved at 06:18:54 IST Wed May 26 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/4
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/5
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/6
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/4
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/5
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/6
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 192.168.8.111
  floating-ip 10.0.11.195
  floating-ip 192.168.9.241
  floating-ip 10.0.12.156
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb virtual-server 0de8b615-6a89-4d63-a31f-fc8ee40b42c7 10.0.11.166
!
slb virtual-server 526cc3f0-950a-4f4e-a38a-cfa2113ed4a4 10.0.12.110
!
slb virtual-server b8f01eff-a0c0-479f-bd56-608d83e16f38 192.168.8.172
!
slb virtual-server c628a9e7-e1d2-4bce-90fe-c5d8ef312aa3 192.168.9.183
!
!
cloud-services meta-data
  enable
  provider openstack
!
end

```

```
vThunder-vBlade[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3eb2.2836  192.168.0.58/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3e3f.d6fb  192.168.8.252/24      1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e66.e894  10.0.11.117/24        1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e96.5a51  10.0.12.106/24        1  DataPort
4                   Up    Full  10000  none  1    N/A       fa16.3e9b.fafd  10.0.13.180/24        1  DataPort
5                   Up    Full  10000  none  1    N/A       fa16.3e74.14b2  10.0.14.197/24        1  DataPort
6                   Up    Full  10000  none  1    N/A       fa16.3e27.5b60  192.168.9.17/24       1  DataPort
```

Step2: Delete lb2 and lb4 whose vip network-id are there in amp_boot_network_list.
stack@neha:~$ **openstack loadbalancer delete lb4**
stack@neha:~$ **openstack loadbalancer delete lb2**

Result:
VRID floating IPs associated with lb4 and lb2 got deleted from vThunders.

```
stack@neha:~$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| b8f01eff-a0c0-479f-bd56-608d83e16f38 | lb1  | 56f90ce7d79546de8b94257f25584892 | 192.168.8.172 | ACTIVE              | a10      |
| c628a9e7-e1d2-4bce-90fe-c5d8ef312aa3 | lb3  | 56f90ce7d79546de8b94257f25584892 | 192.168.9.183 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
```

```
vThunder-vMaster[1/2](NOLICENSE)#show running-config
!Current configuration: 743 bytes
!Configuration last updated at 07:11:06 IST Wed May 26 2021
!Configuration last saved at 07:11:27 IST Wed May 26 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/4
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/5
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/6
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/4
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/5
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/6
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 192.168.8.111
  floating-ip 192.168.9.241
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb virtual-server b8f01eff-a0c0-479f-bd56-608d83e16f38 192.168.8.172
!
slb virtual-server c628a9e7-e1d2-4bce-90fe-c5d8ef312aa3 192.168.9.183
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
```

```
vThunder-vMaster[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e47.353c  192.168.0.197/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e98.c26c  192.168.8.80/24       1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3ebc.ba8f  10.0.11.171/24        1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e1d.6a77  10.0.12.187/24        1  DataPort
4                   Up    Full  10000  none  1    N/A       fa16.3e9c.8535  10.0.13.154/24        1  DataPort
5                   Up    Full  10000  none  1    N/A       fa16.3e82.04e2  10.0.14.109/24        1  DataPort
6                   Up    Full  10000  none  1    N/A       fa16.3ece.fac5  192.168.9.126/24      1  DataPort
```

```
vThunder-vBlade[1/1](NOLICENSE)#show running-config
!Current configuration: 743 bytes
!Configuration last updated at 07:11:06 IST Wed May 26 2021
!Configuration last saved at 06:18:54 IST Wed May 26 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/4
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/5
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/6
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/4
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/5
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/6
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 192.168.8.111
  floating-ip 192.168.9.241
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb virtual-server b8f01eff-a0c0-479f-bd56-608d83e16f38 192.168.8.172
!
slb virtual-server c628a9e7-e1d2-4bce-90fe-c5d8ef312aa3 192.168.9.183
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
```

```
vThunder-vBlade[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3eb2.2836  192.168.0.58/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3e3f.d6fb  192.168.8.252/24      1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e66.e894  10.0.11.117/24        1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e96.5a51  10.0.12.106/24        1  DataPort
4                   Up    Full  10000  none  1    N/A       fa16.3e9b.fafd  10.0.13.180/24        1  DataPort
5                   Up    Full  10000  none  1    N/A       fa16.3e74.14b2  10.0.14.197/24        1  DataPort
6                   Up    Full  10000  none  1    N/A       fa16.3e27.5b60  192.168.9.17/24       1  DataPort
```
