### PR TITLE
[BUG][STACK-2368][vthunder: vrid floating ip][negative] vrid floating ip is deleted unexpectedly

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -220,8 +220,6 @@ class MemberFlows(object):
         delete_member_flow.add(a10_database_tasks.GetFlavorData(
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
             provides=constants.FLAVOR))
-        delete_member_flow.add(database_tasks.DeleteMemberInDB(
-            requires=constants.MEMBER))
         delete_member_flow.add(a10_database_tasks.GetLoadBalancerListByProjectID(
             requires=a10constants.VTHUNDER,
             provides=a10constants.LOADBALANCERS_LIST))
@@ -286,6 +284,8 @@ class MemberFlows(object):
                     a10constants.MEMBER_COUNT_IP,
                     a10constants.MEMBER_COUNT_IP_PORT_PROTOCOL)))
         delete_member_flow.add(self.get_delete_member_vrid_subflow())
+        delete_member_flow.add(database_tasks.DeleteMemberInDB(
+            requires=constants.MEMBER))
         delete_member_flow.add(database_tasks.DecrementMemberQuota(
             requires=constants.MEMBER))
         delete_member_flow.add(database_tasks.MarkPoolActiveInDB(

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -366,7 +366,8 @@ class LoadBalancerRepository(repo.LoadBalancerRepository):
             and_(self.model_class.project_id.in_(project_ids),
                  base_models.Vip.subnet_id == subnet_id,
                  or_(self.model_class.provisioning_status == consts.PENDING_DELETE,
-                     self.model_class.provisioning_status == consts.ACTIVE))).count()
+                     self.model_class.provisioning_status == consts.ACTIVE,
+                     self.model_class.provisioning_status == consts.PENDING_UPDATE))).count()
 
     def get_lb_count_by_flavor(self, session, project_ids, flavor_id):
         return session.query(self.model_class).filter(


### PR DESCRIPTION
## Description
- Severity Level: Medium

- Issue Description: When we delete a member using the same subnet as a Loadbalancer, its associated floating ip is also getting removed with the member though LB is using the floating ip.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2368

## Technical Approach

- Modified a DB method **get_lb_by_subnet()** to consider LBs in **PENDING_UPDATE** state as well so that the Loadbalancer in current execution also get considered as it enters into PENDING_UPDATE state during taking LB count by subnet 
- Shifted a task **DeleteMemberInDB** after **get_delete_member_vrid_subflow()** so that during calculating member_count_by subnet member stays in PENDING_DELETE state 

## Manual Testing
Step 1: Create a Loadbalancer 

```
stack@openstack-2:~$ openstack loadbalancer create --name v1 --vip-subnet-id public-11-subnet
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| db5422ea-65ea-4c7a-b4d8-652a99d18274 | v1   | 6b1e0c27d80f4e5892a5c735726c657a | 172.24.11.214 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+

```
Step 2: Create a Listener

```
stack@openstack-2:~$ openstack loadbalancer listener create --name l1 v1 --protocol http --protocol-port 80
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| id                                   | default_pool_id                      | name | project_id                       | protocol | protocol_port | admin_state_up |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| c1bae902-a085-496e-9edc-de6f6b091a7b | 1d5b45b1-8051-4e2a-b9f8-3417d431da07 | l1   | 6b1e0c27d80f4e5892a5c735726c657a | HTTP     |            80 | True           |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
```

Step 3: Create a pool
```
stack@openstack-2:~$ openstack loadbalancer pool create --name p1 --protocol http --lb-algorithm LEAST_CONNECTIONS --listener l1
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| id                                   | name | project_id                       | provisioning_status | protocol | lb_algorithm      | admin_state_up |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| 1d5b45b1-8051-4e2a-b9f8-3417d431da07 | p1   | 6b1e0c27d80f4e5892a5c735726c657a | ACTIVE              | HTTP     | LEAST_CONNECTIONS | True           |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+

```
step4: Create a member with same subnet as Load balancer

```
stack@openstack-2:~$ openstack loadbalancer member create --address 172.24.12.66 --subnet-id public-11-subnet --protocol-port 80 --name m1 p1

+--------------------------------------+------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address      | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
| 93965543-350f-4e84-8561-494ecccf3822 | m1   | 6b1e0c27d80f4e5892a5c735726c657a | ACTIVE              | 172.24.12.66 |            80 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
stack@openstack-2:~$

```

Vthunder Configurations:
```

vThunder-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 602 bytes
!Configuration last updated at 06:18:24 IST Thu May 27 2021
!Configuration last saved at 06:21:21 IST Thu May 27 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 172.24.11.239
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 192.168.0.66
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server 6b1e0_172_24_12_66 172.24.12.66
  port 80 tcp
!
slb server octavia_health_manager_controller 192.168.0.66
  health-check octavia_health_monitor
!
slb service-group 1d5b45b1-8051-4e2a-b9f8-3417d431da07 tcp
  method least-connection
  member 6b1e0_172_24_12_66 80
!
slb virtual-server db5422ea-65ea-4c7a-b4d8-652a99d18274 172.24.11.214
  port 80 http
    name c1bae902-a085-496e-9edc-de6f6b091a7b
    extended-stats
    service-group 1d5b45b1-8051-4e2a-b9f8-3417d431da07
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
```



```
vThunder-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 602 bytes
!Configuration last updated at 06:18:25 IST Thu May 27 2021
!Configuration last saved at 06:09:03 IST Thu May 27 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 172.24.11.239
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 192.168.0.66
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server 6b1e0_172_24_12_66 172.24.12.66
  port 80 tcp
!
slb server octavia_health_manager_controller 192.168.0.66
  health-check octavia_health_monitor
!
slb service-group 1d5b45b1-8051-4e2a-b9f8-3417d431da07 tcp
  method least-connection
  member 6b1e0_172_24_12_66 80
!
slb virtual-server db5422ea-65ea-4c7a-b4d8-652a99d18274 172.24.11.214
  port 80 http
    name c1bae902-a085-496e-9edc-de6f6b091a7b
    extended-stats
    service-group 1d5b45b1-8051-4e2a-b9f8-3417d431da07
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
```


Step 5: Delete a Member:

`stack@openstack-2:~$ openstack loadbalancer member delete p1 m1`


**Result:**

Deleted member successfully  without impacting LB side floating ip

```
stack@openstack-2:~$ openstack loadbalancer member list p1

stack@openstack-2:~$
```

vthunder configuration:

```
vThunder-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 689 bytes
!Configuration last updated at 06:35:03 IST Thu May 27 2021
!Configuration last saved at 06:36:27 IST Thu May 27 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 172.24.11.239
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 192.168.0.66
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 192.168.0.66
  health-check octavia_health_monitor
!
slb service-group 1d5b45b1-8051-4e2a-b9f8-3417d431da07 tcp
  method least-connection
!
slb virtual-server db5422ea-65ea-4c7a-b4d8-652a99d18274 172.24.11.214
  port 80 http
    name c1bae902-a085-496e-9edc-de6f6b091a7b
    extended-stats
    service-group 1d5b45b1-8051-4e2a-b9f8-3417d431da07
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
```

```
vThunder-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 689 bytes
!Configuration last updated at 06:35:03 IST Thu May 27 2021
!Configuration last saved at 06:09:03 IST Thu May 27 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 172.24.11.239
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 192.168.0.66
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 192.168.0.66
  health-check octavia_health_monitor
!
slb service-group 1d5b45b1-8051-4e2a-b9f8-3417d431da07 tcp
  method least-connection
!
slb virtual-server db5422ea-65ea-4c7a-b4d8-652a99d18274 172.24.11.214
  port 80 http
    name c1bae902-a085-496e-9edc-de6f6b091a7b
    extended-stats
    service-group 1d5b45b1-8051-4e2a-b9f8-3417d431da07
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
```

