### PR TITLE
[BUG][STACK-2372]: [device flavor] the vrid floating ip is mixed for shared and l3v partitions

### DIFF
--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -485,6 +485,8 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         member_parent_proj = utils.get_parent_project(
             member.project_id)
 
+        vthunder_conf = CONF.hardware_thunder.devices.get(load_balancer.project_id, None)
+
         if (member.project_id in parent_project_list or
                 (member_parent_proj and member_parent_proj in parent_project_list)
                 or self._is_rack_flow(member.project_id, loadbalancer=load_balancer)):
@@ -494,7 +496,9 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                     constants.MEMBER: member,
                     constants.LISTENERS: listeners,
                     constants.LOADBALANCER: load_balancer,
-                    constants.POOL: pool})
+                    constants.POOL: pool,
+                    a10constants.VTHUNDER_CONFIG: vthunder_conf,
+                    a10constants.USE_DEVICE_FLAVOR: None})
         else:
             busy = self._vthunder_busy_check(member.project_id, True, None)
             create_member_tf = self._taskflow_load(self._member_flows.

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -529,7 +529,9 @@ class MemberFlows(object):
                 requires=[
                     a10constants.VTHUNDER,
                     a10constants.VRID_LIST,
-                    constants.SUBNET],
+                    constants.SUBNET,
+                    a10constants.VTHUNDER_CONFIG,
+                    a10constants.USE_DEVICE_FLAVOR],
                 rebind={
                     a10constants.LB_RESOURCE: constants.MEMBER},
                 provides=a10constants.VRID_LIST))

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -779,8 +779,13 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
         existing_fips = []
         vrid_list = self._add_vrid_to_list(vrid_list, subnet, lb_resource.project_id)
         for vrid in vrid_list:
-            vrid_summary = self.axapi_client.vrrpa.get(vrid.vrid)
-            if 'floating-ip' in vrid_summary['vrid']:
+            try:
+                vrid_summary = self.axapi_client.vrrpa.get(vrid.vrid)
+            except Exception as e:
+                vrid_summary = {}
+                LOG.exception("Failed to get existing VRID summary due to: %s", str(e))
+
+            if vrid_summary and 'floating-ip' in vrid_summary['vrid']:
                 vrid_fip = vrid_summary['vrid']['floating-ip']
                 if vthunder.partition_name != 'shared':
                     for i in range(len(vrid_fip['ip-address-part-cfg'])):

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -776,24 +776,36 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
 
         vrid_floating_ips = []
         update_vrid_flag = False
+        existing_fips = []
         vrid_list = self._add_vrid_to_list(vrid_list, subnet, lb_resource.project_id)
         for vrid in vrid_list:
-            subnet = self.network_driver.get_subnet(vrid.subnet_id)
+            vrid_summary = self.axapi_client.vrrpa.get(vrid.vrid)
+            if 'floating-ip' in vrid_summary['vrid']:
+                vrid_fip = vrid_summary['vrid']['floating-ip']
+                if vthunder.partition_name != 'shared':
+                    for i in range(len(vrid_fip['ip-address-part-cfg'])):
+                        existing_fips.append(
+                            vrid_fip['ip-address-part-cfg'][i]['ip-address-partition'])
+                else:
+                    for i in range(len(vrid_fip['ip-address-cfg'])):
+                        existing_fips.append(vrid_fip['ip-address-cfg'][i]['ip-address'])
+            vrid_subnet = self.network_driver.get_subnet(vrid.subnet_id)
             vrid.vrid = vrid_value
             if conf_floating_ip.lower() == 'dhcp':
                 subnet_ip, subnet_mask = a10_utils.get_net_info_from_cidr(
-                    subnet.cidr)
+                    vrid_subnet.cidr)
                 if not a10_utils.check_ip_in_subnet_range(
                         vrid.vrid_floating_ip, subnet_ip, subnet_mask):
-                    vrid = self._replace_vrid_port(vrid, subnet, lb_resource)
+                    vrid = self._replace_vrid_port(vrid, vrid_subnet, lb_resource)
                     update_vrid_flag = True
             else:
                 new_ip = a10_utils.get_patched_ip_address(
-                    conf_floating_ip, subnet.cidr)
+                    conf_floating_ip, vrid_subnet.cidr)
                 if new_ip != vrid.vrid_floating_ip:
-                    vrid = self._replace_vrid_port(vrid, subnet, lb_resource, new_ip)
+                    vrid = self._replace_vrid_port(vrid, vrid_subnet, lb_resource, new_ip)
                     update_vrid_flag = True
-            vrid_floating_ips.append(vrid.vrid_floating_ip)
+            if vrid_subnet.id == subnet.id or vrid.vrid_floating_ip in existing_fips:
+                vrid_floating_ips.append(vrid.vrid_floating_ip)
 
         if (prev_vrid_value is not None) and (prev_vrid_value != vrid_value):
             self._remove_device_vrid_fip(vthunder.partition_name, prev_vrid_value)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
@@ -58,6 +58,27 @@ HW_THUNDER2 = data_models.HardwareThunder(
     ip_address="10.10.10.11",
     partition_name="shared",
     vrid_floating_ip="192.168.8.126")
+EXISTING_FIP_SHARED_PARTITION = {
+    u'vrid': {u'blade-parameters': {
+        u'priority': 150, u'uuid': u'41e54b26-bc4f-11eb-bd71-525400895118',
+        u'a10-url': u'/axapi/v3/vrrp-a/vrid/0/blade-parameters'},
+        u'uuid': u'41e5439c-bc4f-11eb-bd71-525400895118', u'floating-ip': {
+            u'ip-address-cfg': [{
+                u'ip-address': u'192.168.8.140'}, {u'ip-address': u'192.168.9.140'}]},
+            u'vrid-val': 0, u'preempt-mode': {u'threshold': 0, u'disable': 0},
+            u'a10-url': u'/axapi/v3/vrrp-a/vrid/0'}
+}
+EXISTING_FIP_L3V_PARTITION = {
+    u'vrid': {u'blade-parameters': {
+        u'priority': 150, u'uuid': u'41e54b26-bc4f-11eb-bd71-525400895118',
+        u'a10-url': u'/axapi/v3/vrrp-a/vrid/0/blade-parameters'},
+        u'uuid': u'41e5439c-bc4f-11eb-bd71-525400895118', u'floating-ip': {
+            u'ip-address-part-cfg': [{
+                u'ip-address-partition': u'192.168.8.140'},
+                {u'ip-address-partition': u'192.168.9.140'}]},
+            u'vrid-val': 0, u'preempt-mode': {u'threshold': 0, u'disable': 0},
+            u'a10-url': u'/axapi/v3/vrrp-a/vrid/0'}
+}
 
 
 class MockIP(object):
@@ -108,6 +129,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         vthunder_config = copy.deepcopy(HW_THUNDER)
         port = copy.deepcopy(PORT)
         port.fixed_ips.append(MockIP(a10constants.MOCK_VRID_FLOATING_IP_1))
+        self.client_mock.vrrpa.get.return_value = EXISTING_FIP_SHARED_PARTITION
         mock_network_task = a10_network_tasks.HandleVRIDFloatingIP()
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
@@ -137,6 +159,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
         self.network_driver_mock.allocate_vrid_fip.return_value = port
+        self.client_mock.vrrpa.get.return_value = EXISTING_FIP_SHARED_PARTITION
         self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
                          vrid=VRID_VALUE)
         mock_network_task.execute(VTHUNDER, member, [], subnet,
@@ -166,6 +189,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
         self.network_driver_mock.allocate_vrid_fip.return_value = port
+        self.client_mock.vrrpa.get.return_value = EXISTING_FIP_L3V_PARTITION
         self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
                          vrid=VRID_VALUE)
         mock_network_task.execute(vthunder, member, [], subnet, vthunder_config)
@@ -195,6 +219,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
         self.network_driver_mock.allocate_vrid_fip.return_value = port
+        self.client_mock.vrrpa.get.return_value = EXISTING_FIP_SHARED_PARTITION
         self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
                          vrid=VRID_VALUE)
         mock_network_task.execute(VTHUNDER, member, [VRID_1], subnet, vthunder_config)
@@ -225,6 +250,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
         self.network_driver_mock.allocate_vrid_fip.return_value = port
+        self.client_mock.vrrpa.get.return_value = EXISTING_FIP_L3V_PARTITION
         self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
                          vrid=VRID_VALUE)
         mock_network_task.execute(vthunder, member, [VRID_1], subnet, vthunder_config)
@@ -271,6 +297,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         mock_network_task = a10_network_tasks.HandleVRIDFloatingIP()
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
+        self.client_mock.vrrpa.get.return_value = EXISTING_FIP_SHARED_PARTITION
         mock_network_task.execute(VTHUNDER, member, [vrid], subnet, vthunder_config)
         self.network_driver_mock.allocate_vrid_fip.assert_not_called()
         self.client_mock.vrrpa.update.assert_not_called()
@@ -297,6 +324,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
         self.network_driver_mock.allocate_vrid_fip.return_value = port
+        self.client_mock.vrrpa.get.return_value = EXISTING_FIP_SHARED_PARTITION
         self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
                          vrid=VRID_VALUE)
         mock_network_task.execute(VTHUNDER, member, [vrid], subnet, vthunder_config)
@@ -333,6 +361,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
         self.network_driver_mock.allocate_vrid_fip.return_value = port
+        self.client_mock.vrrpa.get.return_value = EXISTING_FIP_L3V_PARTITION
         self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
                          vrid=VRID_VALUE)
         mock_network_task.execute(vthunder, member, [vrid], subnet, vthunder_config)
@@ -362,6 +391,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         mock_network_task = a10_network_tasks.HandleVRIDFloatingIP()
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
+        self.client_mock.vrrpa.get.return_value = EXISTING_FIP_SHARED_PARTITION
         fip_port = mock_network_task.execute(VTHUNDER, member, [vrid], subnet, vthunder_config)
         self.network_driver_mock.allocate_vrid_fip.assert_not_called()
         self.network_driver_mock.delete_port.assert_not_called()
@@ -392,6 +422,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
         self.network_driver_mock.allocate_vrid_fip.return_value = port
+        self.client_mock.vrrpa.get.return_value = EXISTING_FIP_SHARED_PARTITION
         self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
                          vrid=VRID_VALUE)
         mock_network_task.execute(VTHUNDER, member, [vrid], subnet, vthunder_config)
@@ -427,6 +458,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
         self.network_driver_mock.allocate_vrid_fip.return_value = port
+        self.client_mock.vrrpa.get.return_value = EXISTING_FIP_L3V_PARTITION
         self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
                          vrid=VRID_VALUE)
         mock_network_task.execute(vthunder, member, [vrid], subnet, vthunder_config)
@@ -455,6 +487,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
         self.network_driver_mock.allocate_vrid_fip.return_value = port
+        self.client_mock.vrrpa.get.return_value = EXISTING_FIP_SHARED_PARTITION
         self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
                          vrid=VRID_VALUE)
         mock_network_task.execute(VTHUNDER, member, [VRID_1], subnet, vthunder_config)


### PR DESCRIPTION
## Description
- Severity Level: Medium
- Issue Description: When a loadbalancer/member is created in L3V partition and a VRID floating IP is also present in shared partition, then the VRID FIP of shared partition is getting mixed with the current VRID FIP created in L3V partition.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2372

## Technical Approach
- For vrid in vrid_list, appending `vrid.vrid_floating_ip` in vrid_floating_ips[] only when the subnet of the vrid is same as that of lb_resource(newly added vrid fip) or the vrid.vrid_floating_ip is already present on vthunder(previously present vrid fip) sothat correct VRID FIPs will be passed to `_update_device_vrid_fip()` method to create VRID FIPs on vthunder.
- Modified the call of HandleVRIDFloatingIP task in a10_member_flows as per the modified task.

## Test Cases
- Given a vrid floating ip, when it's subnet is same as that of current lb-resource, then it will be added of vrid_floating_ips[]
- Given a vrid floating ip, when it's already present on vThunder, then it will be added of vrid_floating_ips[]

## Manual Testing
1. openstack loadbalancer flavorprofile create --name fp_35 --provider a10 --flavor-data '{"device-name": "device1"}'
    openstack loadbalancer flavor create --name f_35 --flavorprofile fp_35

2. config:
[hardware_thunder]
devices = [
                    {
                     "ip_address":"10.0.0.65",
                     "username":"admin",
                     "password":"a10",
                     "device_name":"device1",
                     "vrid_floating_ip":".140"
                     }
          ]

Create a loadbalancer with flavor f_35
stack@neha:~$ openstack loadbalancer create --flavor f_35 --vip-subnet-id provider-vlan-11-subnet --name lb1                                 
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-05-31T07:31:33                  |
| description         |                                      |
| flavor_id           | cccd548c-9895-4c04-b762-1bb89a316d59 |
| id                  | 06efc613-d5a9-476b-a2df-1d2c53b8182a |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 60b9bb1eeddb4bfc8ab3da24e7c4eee5     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.125                          |
| vip_network_id      | 594c81c0-015f-4cc5-97fd-a1226e443d8b |
| vip_port_id         | 9285d79e-32af-47da-ba0d-c01a6fb8ce98 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 5841d92a-8f9d-4c8a-8aed-ebd186899a13 |
+---------------------+--------------------------------------+

```

Results on vThunder:
```
vThunder(NOLICENSE)#show running-config
!Current configuration: 287 bytes
!Configuration last updated at 08:31:41 IST Mon May 31 2021
!Configuration last saved at 08:31:43 IST Mon May 31 2021
!64-bit Advanced Core OS (ACOS) version 4.1.4-GR1-P5, build 81 (Sep-08-2020,09:32)
!
partition 60b9bb1eeddb4b id 1
!
!
interface management
  ip address dhcp
!
interface ethernet 1
!
interface ethernet 2
!
interface ethernet 3
!
interface ethernet 4
!
vrrp-a vrid 0
  floating-ip 10.0.11.140
!
slb virtual-server 06efc613-d5a9-476b-a2df-1d2c53b8182a 10.0.11.125
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

3. change a10-octavia.conf, just configure "hierarchical_multitenancy": "enable"  for device ‘device1’
config:
```
[hardware_thunder]
devices = [
                    {
                     "ip_address":"10.0.0.65",
                     "username":"admin",
                     "password":"a10",
                     "device_name":"device1",
                     "hierarchical_multitenancy": "enable",
                     "vrid_floating_ip":".140"
                     }
          ]
```

4. Create one more loadbalancer with flavor f_35
stack@neha:~$ openstack loadbalancer create --flavor f_35 --vip-subnet-id provider-vlan-12-subnet --name lb2
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-05-31T07:33:19                  |
| description         |                                      |
| flavor_id           | cccd548c-9895-4c04-b762-1bb89a316d59 |
| id                  | 878ce8fa-c38b-49d3-81a0-46289425364f |
| listeners           |                                      |
| name                | lb2                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 60b9bb1eeddb4bfc8ab3da24e7c4eee5     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.12.181                          |
| vip_network_id      | bf4dfee9-6776-4b32-b85b-007845784265 |
| vip_port_id         | 838e8db3-84c2-4102-95be-5b44fa492055 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | ac1f309e-751c-490d-b5ad-98562468659f |
+---------------------+--------------------------------------+

```

Result on vThunder:
**No mixing of floating IPs in the l3v partition**

```
vThunder[60b9bb1eeddb4b](NOLICENSE)#show running-config
!Current configuration: 69 bytes
!Configuration last updated at 08:33:22 IST Mon May 31 2021
!Configuration last saved at 08:33:29 IST Mon May 31 2021
!
active-partition 60b9bb1eeddb4b
!
!
vrrp-a vrid 0
  floating-ip 10.0.12.140
!
slb virtual-server 878ce8fa-c38b-49d3-81a0-46289425364f 10.0.12.181
!
end
```

4. Create a listener,pool and member

stack@neha:~$ openstack loadbalancer listener create --protocol TCP --protocol-port 8080 --name l1 lb2
```
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-05-31T07:34:11                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 1b4fc746-a264-479e-8c1d-677cc4cfc660 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 878ce8fa-c38b-49d3-81a0-46289425364f |
| name                        | l1                                   |
| operating_status            | OFFLINE                              |
| project_id                  | 60b9bb1eeddb4bfc8ab3da24e7c4eee5     |
| protocol                    | TCP                                  |
| protocol_port               | 8080                                 |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
+-----------------------------+--------------------------------------+
```

stack@neha:~$ openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --name p1 --listener l1
```
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-05-31T07:34:29                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | faa3087c-603b-44d0-be31-cbe0a9cddb18 |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | 1b4fc746-a264-479e-8c1d-677cc4cfc660 |
| loadbalancers        | 878ce8fa-c38b-49d3-81a0-46289425364f |
| members              |                                      |
| name                 | p1                                   |
| operating_status     | OFFLINE                              |
| project_id           | 60b9bb1eeddb4bfc8ab3da24e7c4eee5     |
| protocol             | TCP                                  |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
+----------------------+--------------------------------------+
```


stack@neha:~$ openstack loadbalancer member create --protocol-port 82 --subnet-id provider-vlan-13-subnet --address 10.0.13.1 --name m1 p1   
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.13.1                            |
| admin_state_up      | True                                 |
| created_at          | 2021-05-31T07:34:55                  |
| id                  | 4dc82b8b-c4d4-4155-b29e-7fc7dc802cc0 |
| name                | m1                                   |
| operating_status    | NO_MONITOR                           |
| project_id          | 60b9bb1eeddb4bfc8ab3da24e7c4eee5     |
| protocol_port       | 82                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 0838b8dd-70ca-4986-980b-83de2da19663 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
```

Result on vThunder:
No mixing of floating IPs in the l3v partition

```
vThunder[60b9bb1eeddb4b](NOLICENSE)#show running-config
!Current configuration: 0 bytes
!Configuration last updated at 08:34:56 IST Mon May 31 2021
!Configuration last saved at 08:34:57 IST Mon May 31 2021
!
active-partition 60b9bb1eeddb4b
!
!
vrrp-a vrid 0
  floating-ip 10.0.12.140
  floating-ip 10.0.13.161
!
slb server 60b9b_10_0_13_1 10.0.13.1
  port 82 tcp
!
slb service-group faa3087c-603b-44d0-be31-cbe0a9cddb18 tcp
  member 60b9b_10_0_13_1 82
!
slb virtual-server 878ce8fa-c38b-49d3-81a0-46289425364f 10.0.12.181
  port 8080 tcp
    name 1b4fc746-a264-479e-8c1d-677cc4cfc660
    extended-stats
    service-group faa3087c-603b-44d0-be31-cbe0a9cddb18
!
end
```


