### PR TITLE
[BUG][STACK-2370][STACk-2362][STACK-2362]:  Interface ve isn't configured when create lb in shared and parent partition.

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -211,7 +211,7 @@ class GetBackupVThunderByLoadBalancer(BaseDatabaseTask):
             db_apis.get_session(), loadbalancer_id)
 
         # VCS vMaster/vBlade may switched
-        if vthunder is not None:
+        if vthunder is not None and backup_vthunder:
             if backup_vthunder.ip_address == vthunder.ip_address:
                 backup_vthunder = self.vthunder_repo.get_vthunder_from_lb(
                     db_apis.get_session(), loadbalancer_id)

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -449,8 +449,13 @@ class SetupDeviceNetworkMap(VThunderBaseTask):
 
     @axapi_client_decorator
     def execute(self, vthunder):
-        if vthunder and vthunder.project_id in CONF.hardware_thunder.devices:
-            vthunder_conf = CONF.hardware_thunder.devices[vthunder.project_id]
+        if not vthunder:
+            return
+        device_name = ''.join([a10constants.DEVICE_KEY_PREFIX,
+                               vthunder.device_name]) if vthunder.device_name else ''
+        vthunder_conf = CONF.hardware_thunder.devices.get(
+            vthunder.project_id) or CONF.hardware_thunder.devices.get(device_name)
+        if vthunder_conf:
             device_network_map = vthunder_conf.device_network_map
 
             # Case when device network map is not provided/length is 0


### PR DESCRIPTION
## Description
- Required: Medium
- Required: Interfaces are not getting configured when LB are created in shared and parent partion.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2370
https://a10networks.atlassian.net/browse/STACK-2362
https://a10networks.atlassian.net/browse/STACK-2363

## Technical Approach
1. Update "SetupDeviceNetworkMap" task to accept device configuration using device name.

## Manual Testing
- Created lb2 for rack device in shared partition, check the equivalent vthunder configurations.
  **master device:**
![image](https://user-images.githubusercontent.com/66299493/120206635-13788a00-c249-11eb-91f9-93628d513a05.png)
 
 blade device
![image](https://user-images.githubusercontent.com/66299493/120206714-29864a80-c249-11eb-8d0c-aff74da4a611.png)

2. Delete LB lb2 from shared partition.
![image](https://user-images.githubusercontent.com/66299493/120207070-96014980-c249-11eb-9b0d-8220d90eb57f.png)

3. Creating LB  lb2 with HMT and UPP settings on.
   master device:
![image](https://user-images.githubusercontent.com/66299493/120208223-d8775600-c24a-11eb-8003-34b8b136e7a4.png)
 
4. Delete lb2, created with HMT and up settings on.
![image](https://user-images.githubusercontent.com/66299493/120208425-14122000-c24b-11eb-959b-8fea22f90c9f.png)
