### PR TITLE
[STACK-2382]: Updated the revert flow so that interface didn't removed from vthunder

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -465,7 +465,7 @@ class AllocateVIP(BaseNetworkTask):
         vip = result
         LOG.warning("Deallocating vip %s", vip.ip_address)
         try:
-            self.network_driver.deallocate_vip(vip, lb_count_subnet)
+            self.network_driver.deallocate_vip(loadbalancer, lb_count_subnet)
         except Exception as e:
             LOG.error("Failed to deallocate VIP.  Resources may still "
                       "be in use from vip: %(vip)s due to error: %(except)s",

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -368,7 +368,7 @@ class PlugVIP(BaseNetworkTask):
                     amphora.vrrp_port_id = amp_data.vrrp_port_id
                     amphora.ha_port_id = amp_data.ha_port_id
 
-            self.network_driver.unplug_vip(loadbalancer, loadbalancer.vip)
+            self.network_driver.unplug_vip_revert(loadbalancer, loadbalancer.vip)
         except Exception as e:
             LOG.error("Failed to unplug VIP.  Resources may still "
                       "be in use from vip: %(vip)s due to error: %(except)s",
@@ -465,7 +465,7 @@ class AllocateVIP(BaseNetworkTask):
         vip = result
         LOG.warning("Deallocating vip %s", vip.ip_address)
         try:
-            self.network_driver.deallocate_vip(loadbalancer, lb_count_subnet)
+            self.network_driver.deallocate_vip(vip, lb_count_subnet)
         except Exception as e:
             LOG.error("Failed to deallocate VIP.  Resources may still "
                       "be in use from vip: %(vip)s due to error: %(except)s",

--- a/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
+++ b/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
@@ -410,7 +410,7 @@ class A10OctaviaNeutronDriver(aap.AllowedAddressPairsDriver):
             return
         try:
             self._remove_allowed_address_pair_from_port(interface.port_id, vip.ip_address)
-        except Exception as e:
+        except Exception:
             message = _('Error unplugging VIP. Could not clear '
                         'allowed address pairs from port '
                         '{port_id}.').format(port_id=vip.port_id)


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description: [vthunder][negative] same nat pool name in flavor, when create lb will get error: Exception during message handling: Exists: 1
Here Interface from vthunder gets removed.

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-2382

## Technical Approach
- Revert flow of PlugVIP task was detaching the interface from amphorae.
  PlugVIP==>revert==>unplug_vip==>unplug_aap_port==>unplug_network.
 So, Copied the _unplug_aap_port_ method from Octavia into A10 neutron driver and removed the code which was detaching the port from instance. Earlier all entries were removed from port's AAP, added __remove_allowed_address_pair_from_port_ for removing specific VIP address.

## Manual Testing
1) Create flavor profile, flavor and loadbalancer.
```
openstack loadbalancer flavorprofile create --name fp_natpool_1 --provider a10 --flavor-data '{"nat-pool":{"pool-name":"test","start-address":"1.1.1.2","end-address":"1.1.1.4","netmask":"/24"}}'
openstack loadbalancer flavorprofile create --name fp_natpool_1 --provider a10 --flavor-data '{"nat-pool":{"pool-name":"test","start-address":"1.1.1.5","end-address":"1.1.1.6","netmask":"/24"}}'
openstack loadbalancer flavor create --name f_natpool_1 --flavorprofile 5e3789a1-82de-4b0b-a948-fd06598ac782
openstack loadbalancer flavor create --name f_natpool_2 --flavorprofile ed227e69-0b89-411c-b8e0-6db6113e8321
openstack loadbalancer create --name v1 --vip-subnet-id private-a-subnet
openstack loadbalancer create --name fp1 --vip-subnet-id private-a-subnet --flavor f_natpool_1
```

2) vthunder
```
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.0.120
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
ip nat pool test 1.1.1.2 1.1.1.4 netmask /24
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.129
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.129
  health-check octavia_health_monitor
!
slb virtual-server 57a9fd21-cbb6-452d-ae32-ad4966302bf0 10.0.0.141
!
slb virtual-server ca02d8af-9caa-4884-a197-4d7b924aaf40 10.0.0.215
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder-vMaster[1/1](NOLICENSE)#
vThunder-vMaster[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e71.bf26  192.168.0.85/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3eac.0253  10.0.0.164/24         1  DataPort

Global Throughput:10416 bits/sec (1302 bytes/sec)
Throughput:10416 bits/sec (1302 bytes/sec)
vThunder-vMaster[1/1](NOLICENSE)#
```

3)Create lb with same natpool name in flavor==> will giving exception Exists.
openstack loadbalancer create --name fp2 --vip-subnet-id private-a-subnet --flavor f_natpool_2

4)After getting Exception in logs
```
stack@adeeb:~$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 57a9fd21-cbb6-452d-ae32-ad4966302bf0 | v1   | 5cf9ea6499494d1f8bab607b227f4e84 | 10.0.0.141  | ACTIVE              | a10      |
| ca02d8af-9caa-4884-a197-4d7b924aaf40 | fp1  | 5cf9ea6499494d1f8bab607b227f4e84 | 10.0.0.215  | ACTIVE              | a10      |
| 7bc9a189-874c-4937-86e7-3c5695e0633f | fp2  | 5cf9ea6499494d1f8bab607b227f4e84 | 10.0.0.113  | ERROR               | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+

```
5)Interface is not removed from vthunder
```
vThunder-vMaster[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e71.bf26  192.168.0.85/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3eac.0253  10.0.0.164/24         1  DataPort

Global Throughput:10536 bits/sec (1317 bytes/sec)
Throughput:10536 bits/sec (1317 bytes/sec)
vThunder-vMaster[1/1](NOLICENSE)#
```

![image](https://user-images.githubusercontent.com/76765492/120313126-3497b400-c2f7-11eb-903c-47ea865803d2.png)

**Another Test case**
1) Create 2 lbs with different subnets.
```
openstack loadbalancer create --name fp1 --vip-subnet-id private-a-subnet --flavor f_natpool_1
openstack loadbalancer create --name fp2 --vip-subnet-id private-b-subnet --flavor f_natpool_1

stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 38d6df5b-6d03-44c3-bb84-9b780bee7cd8 | fp1  | 5cf9ea6499494d1f8bab607b227f4e84 | 10.0.0.46   | ACTIVE              | a10      |
| 15f6f3a1-d4eb-4339-a429-862cc09dc524 | fp2  | 5cf9ea6499494d1f8bab607b227f4e84 | 11.0.0.190  | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
stack@adeeb:~/adeeb/a10-octavia$

vThunder-vMaster[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ea8.aa4c  192.168.0.86/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3e9b.34f8  10.0.0.123/24         1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e3e.1dc5  11.0.0.213/24         1  DataPort

Global Throughput:19536 bits/sec (2442 bytes/sec)
Throughput:19536 bits/sec (2442 bytes/sec)
vThunder-vMaster[1/2](NOLICENSE)#

vThunder-vBlade[1/1](NOLICENSE)#show interfaces  brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3eed.b195  192.168.0.145/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3ef3.0dea  10.0.0.94/24          1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e6d.a5ba  11.0.0.101/24         1  DataPort

Global Throughput:20472 bits/sec (2559 bytes/sec)
Throughput:20472 bits/sec (2559 bytes/sec) 
```

2) Delete 1 lb and interface is detached from vthunder.
```
openstack loadbalancer delete fp2

stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 38d6df5b-6d03-44c3-bb84-9b780bee7cd8 | fp1  | 5cf9ea6499494d1f8bab607b227f4e84 | 10.0.0.46   | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
stack@adeeb:~/adeeb/a10-octavia$

vThunder-vMaster[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ea8.aa4c  192.168.0.86/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3e9b.34f8  10.0.0.123/24         1  DataPort

Global Throughput:9752 bits/sec (1219 bytes/sec)
Throughput:9752 bits/sec (1219 bytes/sec)
vThunder-vMaster[1/2](NOLICENSE)#

vThunder-vBlade[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3eed.b195  192.168.0.145/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3ef3.0dea  10.0.0.94/24          1  DataPort

Global Throughput:10384 bits/sec (1298 bytes/sec)
Throughput:10384 bits/sec (1298 bytes/sec)
vThunder-vBlade[1/1](NOLICENSE)#
```

