### PR TITLE
[BUG][STACK-2378]: [vthunder] LB is in PENDING_DELETE for 30+ minutes even when the amp_busy_wait_sec=100

### DIFF
--- a/a10_octavia/controller/worker/tasks/decorators.py
+++ b/a10_octavia/controller/worker/tasks/decorators.py
@@ -50,10 +50,11 @@ def axapi_client_decorator(func):
             self.axapi_client = None
         result = func(self, *args, **kwargs)
 
-        try:
-            self.axapi_client.session.close()
-        except Exception as e:
-            LOG.debug("Failed to close the vThunder session: %s", str(e))
+        if vthunder:
+            try:
+                self.axapi_client.session.close()
+            except Exception as e:
+                LOG.debug("Failed to close the vThunder session: %s", str(e))
 
         return result
 


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description: When a loadbalancer goes into ERROR state while its creation and then if we try to delete it, then the loadbalancer remains in PENDING_DELETE state for a long time instead of simply deleting it.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2378

## Technical Approach
- As vthunder will be None in the case where LB goes into ERROR state, so returning None from GetMasterVThunder task if vthunder is None at GetMasterVThunder task else returning the master vthunder.
- If vthunder is None, then returning from VCSSyncWait task without executing it further.

## Manual Testing
1. Create a loadbalancer and wait till it is ACTIVE and vThunder is ready

stack@neha:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name lb1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-06-01T06:22:20                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | d7a73f44-c5cf-4625-bd30-89d34b1300bf |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 60b9bb1eeddb4bfc8ab3da24e7c4eee5     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.111                          |
| vip_network_id      | 594c81c0-015f-4cc5-97fd-a1226e443d8b |
| vip_port_id         | 3e964c31-6656-4219-8362-0e51756a5ed8 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 5841d92a-8f9d-4c8a-8aed-ebd186899a13 |
+---------------------+--------------------------------------+
```

stack@neha:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| d7a73f44-c5cf-4625-bd30-89d34b1300bf | lb1  | 60b9bb1eeddb4bfc8ab3da24e7c4eee5 | 10.0.11.111 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```

2.  openstack loadbalancer flavorprofile create --name fp_natpool_1 --provider a10 --flavor-data '{"nat-pool":{"pool-name":"test","start-address":"1.1.1.2","end-address":"1.1.1.10","netmask":"/24"}}'

3. openstack loadbalancer flavor create --name f_natpool_1 --flavorprofile fp_natpool_1

4. Create a loadbalancer with flavor f_natpool_1

stack@neha:~$ openstack loadbalancer create --name vf1 --vip-subnet-id provider-vlan-11-subnet --flavor f_natpool_1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-06-01T07:06:11                  |
| description         |                                      |
| flavor_id           | 93495cb9-5de3-44f8-8314-0034ec58c828 |
| id                  | b0f3aa9e-ca43-4759-b3f5-b246617c4d02 |
| listeners           |                                      |
| name                | vf1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 60b9bb1eeddb4bfc8ab3da24e7c4eee5     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.145                          |
| vip_network_id      | 594c81c0-015f-4cc5-97fd-a1226e443d8b |
| vip_port_id         | 52da6aeb-5389-4308-8376-2aa43d7f91f4 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 5841d92a-8f9d-4c8a-8aed-ebd186899a13 |
+---------------------+--------------------------------------+
```
stack@neha:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| d7a73f44-c5cf-4625-bd30-89d34b1300bf | lb1  | 60b9bb1eeddb4bfc8ab3da24e7c4eee5 | 10.0.11.111 | ACTIVE              | a10      |
| b0f3aa9e-ca43-4759-b3f5-b246617c4d02 | vf1  | 60b9bb1eeddb4bfc8ab3da24e7c4eee5 | 10.0.11.145 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```

5. stack@neha:~$ openstack loadbalancer listener create --name lf1 vf1 --protocol tcp --protocol-port 80
```
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-06-01T07:07:50                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | bc92dd0a-c0cf-44d2-be1c-4996d5fb3800 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | b0f3aa9e-ca43-4759-b3f5-b246617c4d02 |
| name                        | lf1                                  |
| operating_status            | OFFLINE                              |
| project_id                  | 60b9bb1eeddb4bfc8ab3da24e7c4eee5     |
| protocol                    | TCP                                  |
| protocol_port               | 80                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
+-----------------------------+--------------------------------------+
```

6. stack@neha:~$ openstack loadbalancer pool create --name pf1 --protocol tcp --lb-algorithm LEAST_CONNECTIONS --listener lf1
```
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-06-01T07:08:24                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | fb426947-5401-4589-a7ab-498d10895771 |
| lb_algorithm         | LEAST_CONNECTIONS                    |
| listeners            | bc92dd0a-c0cf-44d2-be1c-4996d5fb3800 |
| loadbalancers        | b0f3aa9e-ca43-4759-b3f5-b246617c4d02 |
| members              |                                      |
| name                 | pf1                                  |
| operating_status     | OFFLINE                              |
| project_id           | 60b9bb1eeddb4bfc8ab3da24e7c4eee5     |
| protocol             | TCP                                  |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
+----------------------+--------------------------------------+
```

7. stack@neha:~$ openstack loadbalancer member create --address 10.0.12.20 --subnet-id provider-vlan-12-subnet --protocol-port 80 --name m1 pf1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.12.20                           |
| admin_state_up      | True                                 |
| created_at          | 2021-06-01T07:09:14                  |
| id                  | f75fedb7-ae7c-4c68-821d-b686b53f1e83 |
| name                | m1                                   |
| operating_status    | NO_MONITOR                           |
| project_id          | 60b9bb1eeddb4bfc8ab3da24e7c4eee5     |
| protocol_port       | 80                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | ac1f309e-751c-490d-b5ad-98562468659f |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
```

stack@neha:~$ openstack loadbalancer member list pf1
```
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address    | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| f75fedb7-ae7c-4c68-821d-b686b53f1e83 | m1   | 60b9bb1eeddb4bfc8ab3da24e7c4eee5 | ACTIVE              | 10.0.12.20 |            80 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+

```

8. openstack loadbalancer flavorprofile create --name fp1 --provider a10 --flavor-data '{"nat-pool":{"pool-name":"pool1","start-address":"172.24.11.251","end-address":"172.24.11.252","netmask":"/24"},"nat-pool-list":[{"pool-name":"pool1","start-address":"172.24.11.251","end-address":"172.24.11.252","netmask":"/24"},{"pool-name":"pool2","start-address":"172.24.11.253","end-address":"172.24.11.253","netmask":"/24","gateway":"172.24.11.254","ip-rr":1,"port-overload":1,"vrid":15}],"virtual-port":{"name-expressions":[{"regex":"lt2","json":{"pool":"pool2"}}]}}'

9. openstack loadbalancer flavor create --name f1 --flavorprofile fp1

10. Create a loadbalancer with flavor f1
stack@neha:~$ openstack loadbalancer create --name vf_1 --vip-subnet-id provider-vlan-11-subnet --flavor f1

Below error occurs for this which is expected to be here and the LB goes into ERROR state
ERROR oslo_messaging.rpc.server ACOSException: 654377167 Total number of regular NAT IPs exceeded.

stack@neha:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| d7a73f44-c5cf-4625-bd30-89d34b1300bf | lb1  | 60b9bb1eeddb4bfc8ab3da24e7c4eee5 | 10.0.11.111 | ACTIVE              | a10      |
| b0f3aa9e-ca43-4759-b3f5-b246617c4d02 | vf1  | 60b9bb1eeddb4bfc8ab3da24e7c4eee5 | 10.0.11.145 | ACTIVE              | a10      |
| fa84f4ed-fa5d-4a0d-9b72-ff7ec31b9430 | v_f1 | 60b9bb1eeddb4bfc8ab3da24e7c4eee5 | 10.0.11.184 | ERROR               | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```

11. Delete the loadbalancer v_f1
stack@neha:~$ openstack loadbalancer delete v_f1

**The loadbalancer v_f1 is DELETED SUCCESSFULLY**

stack@neha:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| d7a73f44-c5cf-4625-bd30-89d34b1300bf | lb1  | 60b9bb1eeddb4bfc8ab3da24e7c4eee5 | 10.0.11.111 | ACTIVE              | a10      |
| b0f3aa9e-ca43-4759-b3f5-b246617c4d02 | vf1  | 60b9bb1eeddb4bfc8ab3da24e7c4eee5 | 10.0.11.145 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```