### PR TITLE
[BUG][STACK-2372]: [device-flavor] The VRID FIP is mixed for shared and l3v partition after loadbalancer/memebr deletion in l3v partition

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -932,12 +932,12 @@ class DeleteMultipleVRIDPort(BaseNetworkTask):
                         vrids.append(vrid)
                         subnet = self.network_driver.get_subnet(vrid.subnet_id)
                         self.network_driver.deallocate_vrid_fip(vrid, subnet, amphorae)
-                    else:
+                    elif vrid.vrid_floating_ip in existing_fips:
                         vrid_floating_ip_list.append(vrid.vrid_floating_ip)
                 if not vthunder.partition_name or vthunder.partition_name == 'shared':
                     self.axapi_client.vrrpa.update(
                         vrid.vrid, floating_ips=vrid_floating_ip_list)
-                elif vrid.vrid_floating_ip in existing_fips:
+                else:
                     self.axapi_client.vrrpa.update(
                         vrid.vrid, floating_ips=vrid_floating_ip_list, is_partition=True)
                 LOG.info("VRID floating IP: %s deleted", vrid_floating_ip_list)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
@@ -505,6 +505,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         vrid.vrid_port_id = a10constants.MOCK_VRRP_PORT_ID
         vrid.vrid = VRID_VALUE
         mock_network_task.axapi_client = self.client_mock
+        self.client_mock.vrrpa.get.return_value = EXISTING_FIP_SHARED_PARTITION
         result = mock_network_task.execute(VTHUNDER, [vrid], SUBNET_1,
                                            0, 1, MEMBER)
         self.network_driver_mock.deallocate_vrid_fip.assert_called_with(


### PR DESCRIPTION
## Description
- Severity Level: Medium
- Issue Description: When a loadbalancer/member is deleted in L3V partition and a VRID floating IP is also present in shared partition, then the VRID FIP of shared partition is getting mixed into the L3V partition after the deletion.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2372

## Technical Approach
- In `DeleteVRIDPort` and `DeleteMultipleVRIDPort` tasks, fetching existing vrid FIPs from vThunder.
- Checking if the vrid.vrid_floating_ip is already exists on vThunder i.e in `existing_fips[]` before appending it into `vrid_floating_ip_list[]` sothat shared partition FIP will not get mixed into the l3v partition.

## Manual Testing
1. openstack loadbalancer flavorprofile create --name fp_35 --provider a10 --flavor-data '{"device-name": "device1"}'
openstack loadbalancer flavor create --name f_35 --flavorprofile fp_35

2. config:
[hardware_thunder]
devices = [
{
"ip_address":"10.0.0.65",
"username":"admin",
"password":"a10",
"device_name":"device1",
"vrid_floating_ip":".140"
}
]

Create a loadbalancer with flavor f_35
stack@neha:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --flavor f_35 --name lb1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-06-02T11:16:41                  |
| description         |                                      |
| flavor_id           | cccd548c-9895-4c04-b762-1bb89a316d59 |
| id                  | 2ddd6aeb-b039-4931-b0df-99d9662721e0 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 60b9bb1eeddb4bfc8ab3da24e7c4eee5     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.133                          |
| vip_network_id      | 594c81c0-015f-4cc5-97fd-a1226e443d8b |
| vip_port_id         | 7f7781d9-ca99-4f51-a810-3a13d9d6e1b6 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 5841d92a-8f9d-4c8a-8aed-ebd186899a13 |
+---------------------+--------------------------------------+
```

Result on vThunder:

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 287 bytes
!Configuration last updated at 12:16:51 IST Wed Jun 2 2021
!Configuration last saved at 12:16:58 IST Wed Jun 2 2021
!64-bit Advanced Core OS (ACOS) version 4.1.4-GR1-P5, build 81 (Sep-08-2020,09:32)
!
partition 60b9bb1eeddb4b id 1
!
!
interface management
  ip address dhcp
!
interface ethernet 1
!
interface ethernet 2
!
interface ethernet 3
!
interface ethernet 4
!
vrrp-a vrid 0
  floating-ip 10.0.11.140
!
slb virtual-server 2ddd6aeb-b039-4931-b0df-99d9662721e0 10.0.11.133
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

3. change a10-octavia.conf, just configure "hierarchical_multitenancy": "enable" for device ‘device1’
config:
```
[hardware_thunder]
devices = [
                    {
                     "ip_address":"10.0.0.65",
                     "username":"admin",
                     "password":"a10",
                     "device_name":"device1",
                     "hierarchical_multitenancy": "enable",
                     "vrid_floating_ip":".140"
                     }
          ]

```

4. Create one more loadbalancer with flavor f_35
stack@neha:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-12-subnet --flavor f_35 --name lb2
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-06-02T11:19:08                  |
| description         |                                      |
| flavor_id           | cccd548c-9895-4c04-b762-1bb89a316d59 |
| id                  | 7d3ccb16-7aa2-4adf-a805-85977d39dd68 |
| listeners           |                                      |
| name                | lb2                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 60b9bb1eeddb4bfc8ab3da24e7c4eee5     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.12.193                          |
| vip_network_id      | bf4dfee9-6776-4b32-b85b-007845784265 |
| vip_port_id         | 41a14765-9b7d-4756-92fd-91ab39c1ea43 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | ac1f309e-751c-490d-b5ad-98562468659f |
+---------------------+--------------------------------------+
```

Result on vThunder:

```
vThunder(NOLICENSE)#active-partition 60b9bb1eeddb4b
Current active partition: 60b9bb1eeddb4b
vThunder[60b9bb1eeddb4b](NOLICENSE)#show running-config
!Current configuration: 69 bytes
!Configuration last updated at 12:19:10 IST Wed Jun 2 2021
!Configuration last saved at 12:19:19 IST Wed Jun 2 2021
!
active-partition 60b9bb1eeddb4b
!
!
vrrp-a vrid 0
  floating-ip 10.0.12.140
!
slb virtual-server 7d3ccb16-7aa2-4adf-a805-85977d39dd68 10.0.12.193
!
end

```

5. Delete loadbalancer lb2
stack@neha:~$ openstack loadbalancer delete lb2

Result on vThunder:
No mixing of VRID FIP of shared partition

```
vThunder[60b9bb1eeddb4b](NOLICENSE)#show running-config
!Current configuration: 0 bytes
!Configuration last updated at 12:22:06 IST Wed Jun 2 2021
!Configuration last saved at 12:22:08 IST Wed Jun 2 2021
!
active-partition 60b9bb1eeddb4b
!
!
!
end
```

6. Delete loadbalancer lb1:
stack@neha:~$ openstack loadbalancer delete lb1

Result on vThunder:

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 218 bytes
!Configuration last updated at 12:23:57 IST Wed Jun 2 2021
!Configuration last saved at 12:23:59 IST Wed Jun 2 2021
!64-bit Advanced Core OS (ACOS) version 4.1.4-GR1-P5, build 81 (Sep-08-2020,09:32)
!
partition 60b9bb1eeddb4b id 1
!
!
interface management
  ip address dhcp
!
interface ethernet 1
!
interface ethernet 2
!
interface ethernet 3
!
interface ethernet 4
!
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```