### PR TITLE
updated the code for vthunder flows

### DIFF
--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -358,7 +358,9 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                  constants.BUILD_TYPE_PRIORITY:
                  constants.LB_CREATE_NORMAL_PRIORITY,
                  constants.FLAVOR: flavor,
-                 constants.AMPS_DATA: []}
+                 constants.AMPS_DATA: [],
+                 a10constants.VTHUNDER_CONFIG: None,
+                 a10constants.USE_DEVICE_FLAVOR: None}
 
         topology = CONF.a10_controller_worker.loadbalancer_topology
 
@@ -366,10 +368,9 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             constants.TOPOLOGY: topology
         }
 
-        vthunder_conf = CONF.hardware_thunder.devices.get(lb.project_id, None)
-        device_dict = CONF.hardware_thunder.devices
-
         if self._is_rack_flow(lb.project_id, flavor=flavor):
+            vthunder_conf = CONF.hardware_thunder.devices.get(lb.project_id, None)
+            device_dict = CONF.hardware_thunder.devices
             create_lb_flow = self._lb_flows.get_create_rack_vthunder_load_balancer_flow(
                 vthunder_conf=vthunder_conf, device_dict=device_dict,
                 topology=topology, listeners=lb.listeners)
@@ -485,11 +486,10 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         member_parent_proj = utils.get_parent_project(
             member.project_id)
 
-        vthunder_conf = CONF.hardware_thunder.devices.get(load_balancer.project_id, None)
-
         if (member.project_id in parent_project_list or
                 (member_parent_proj and member_parent_proj in parent_project_list)
                 or self._is_rack_flow(member.project_id, loadbalancer=load_balancer)):
+            vthunder_conf = CONF.hardware_thunder.devices.get(load_balancer.project_id, None)
             create_member_tf = self._taskflow_load(
                 self._member_flows.get_rack_vthunder_create_member_flow(),
                 store={
@@ -510,7 +510,9 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                                                           constants.LOADBALANCER:
                                                           load_balancer,
                                                           a10constants.COMPUTE_BUSY: busy,
-                                                          constants.POOL: pool})
+                                                          constants.POOL: pool,
+                                                          a10constants.VTHUNDER_CONFIG: None,
+                                                          a10constants.USE_DEVICE_FLAVOR: None})
             self._register_flow_notify_handler(create_member_tf, member.project_id, True, busy)
 
         with tf_logging.DynamicLoggingListener(create_member_tf,

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -218,9 +218,6 @@ class LoadBalancerFlows(object):
         delete_LB_flow.add(a10_database_tasks.MarkVThunderStatusInDB(
             requires=a10constants.VTHUNDER,
             inject={"status": constants.PENDING_DELETE}))
-        delete_LB_flow.add(vthunder_tasks.SetupDeviceNetworkMap(
-            requires=a10constants.VTHUNDER,
-            provides=a10constants.VTHUNDER))
         delete_LB_flow.add(compute_tasks.NovaServerGroupDelete(
             requires=constants.SERVER_GROUP_ID))
         delete_LB_flow.add(database_tasks.MarkLBAmphoraeHealthBusy(


### PR DESCRIPTION
## Description
- Severity Level: Low
- Issue Description: [vthunder]: Failed to create lb and member on latest code

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2392

## Technical Approach
- Change the position of vthunder_conf and device_dict variable.
- Added dependencies as None for vthunder flow
- Removed SetupDeviceNetworkMap task from delete lb for vthunder.

## Manual Testing
1) Create lb, listener, pool and member
```
openstack loadbalancer create --name v1 --vip-subnet-id private-a-subnet
openstack loadbalancer listener create --name l1 v1 --protocol tcp --protocol-port 80
openstack loadbalancer pool create --name p1 --protocol tcp --lb-algorithm LEAST_CONNECTIONS --listener l1
openstack loadbalancer member create --address 10.0.0.199 --subnet-id private-a-subnet --protocol-port 80 --name m1 p1

stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 3d728d92-ac84-44c0-a407-e1c07b748286 | v1   | 9b9275cbbca6430993aba4759606fe4d | 10.0.0.69   | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer listener list
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| id                                   | default_pool_id                      | name | project_id                       | protocol | protocol_port | admin_state_up |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| 29ca4f43-e6b7-4847-8e26-027cfa8a7ebd | 822ec4d0-e2e6-46df-9778-018a2425f3ab | l1   | 9b9275cbbca6430993aba4759606fe4d | TCP      |            80 | True           |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer pool list
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| id                                   | name | project_id                       | provisioning_status | protocol | lb_algorithm      | admin_state_up |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| 822ec4d0-e2e6-46df-9778-018a2425f3ab | p1   | 9b9275cbbca6430993aba4759606fe4d | ACTIVE              | TCP      | LEAST_CONNECTIONS | True           |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer member list p1
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address    | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| f5df4fdd-f430-4f21-9f9a-662295178b69 | m1   | 9b9275cbbca6430993aba4759606fe4d | ACTIVE              | 10.0.0.199 |            80 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+

vthunder
!
vrrp-a vrid 0
  floating-ip 10.0.0.120
!
vrrp-a vrid 1
  device-context 1
    blade-parameters
      priority 150
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.129
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server 9b927_10_0_0_199 10.0.0.199
  port 80 tcp
!
slb server octavia_health_manager_controller 10.64.3.129
  health-check octavia_health_monitor
!
slb service-group 822ec4d0-e2e6-46df-9778-018a2425f3ab tcp
  method least-connection
  member 9b927_10_0_0_199 80
!
slb virtual-server 3d728d92-ac84-44c0-a407-e1c07b748286 10.0.0.69
  port 80 tcp
    name 29ca4f43-e6b7-4847-8e26-027cfa8a7ebd
    conn-limit 6400000
    extended-stats
!
```

2) Delete the lb
```
stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer delete v1 --cascade
stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer list

stack@adeeb:~/adeeb/a10-octavia$
```
