### PR TITLE
[BUG][STACK-2393]: [device flavor][Degrade] get AttributeError: 'NoneType' object has no attribute 'hierarchical_multitenancy when try to create lb no matter there's hirerachical_multitenancy enabled or not

### DIFF
--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -358,9 +358,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                  constants.BUILD_TYPE_PRIORITY:
                  constants.LB_CREATE_NORMAL_PRIORITY,
                  constants.FLAVOR: flavor,
-                 constants.AMPS_DATA: [],
-                 a10constants.VTHUNDER_CONFIG: None,
-                 a10constants.USE_DEVICE_FLAVOR: None}
+                 constants.AMPS_DATA: []}
 
         topology = CONF.a10_controller_worker.loadbalancer_topology
 
@@ -379,6 +377,10 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             busy = self._vthunder_busy_check(lb.project_id, True, store)
             create_lb_flow = self._lb_flows.get_create_load_balancer_flow(
                 load_balancer_id, topology=topology, listeners=lb.listeners)
+            store.update([
+                (a10constants.COMPUTE_BUSY, busy),
+                (a10constants.VTHUNDER_CONFIG, None),
+                (a10constants.USE_DEVICE_FLAVOR, False)])
             create_lb_tf = self._taskflow_load(create_lb_flow, store=store)
             self._register_flow_notify_handler(create_lb_tf, lb.project_id, True, busy)
 


### PR DESCRIPTION
## Description
- Severity Level: Critical
- Issue Description: When creating loadbalancer on a hardware thunder using device-flavor with or without hirerachical_multitenancy enabled, then getting an error "get AttributeError: 'NoneType' object has no attribute 'hierarchical_multitenancy"

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2393

## Technical Approach
- Removed `a10constants.VTHUNDER_CONFIG: None` and `a10constants.USE_DEVICE_FLAVOR: None` from the store in `create_load_balancer()` for rack flows sothat the vthunder_config passed to `CheckExistingProjectToThunderMappedEntries()` will not go as None by default. It will be passed same as that of returned from `GetVthunderConfByFlavor()`
- Added parameters `a10constants.COMPUTE_BUSY`, `a10constants.VTHUNDER_CONFIG` and `a10constants.USE_DEVICE_FLAVOR` with their required default values to the store of `create_load_balancer()` for vthunder_flows

## Manual Testing
Config:
```
[hardware_thunder]
devices = [
                    {
                     "ip_address":"10.0.0.65",
                     "username":"admin",
                     "password":"a10",
                     "device_name":"device1",
                     "hierarchical_multitenancy": "enable",
                     "vrid_floating_ip":"dhcp"
                     },
                     {
                      "ip_address":"10.0.0.71",
                      "username":"admin",
                      "password":"a10",
                      "device_name":"device2",
                      #"hierarchical_multitenancy": "enable",
                      "vrid_floating_ip":"dhcp"
                     }
          ]
```

1. openstack loadbalancer flavorprofile create --name fp_35 --provider a10 --flavor-data '{"device-name": "device1"}'
openstack loadbalancer flavor create --name f_35 --flavorprofile fp_35

2. openstack loadbalancer flavorprofile create --name fp_45 --provider a10 --flavor-data '{"device-name": "device2"}'
openstack loadbalancer flavor create --name f_45 --flavorprofile fp_45

3. Create a loadbalancer on device2 using device-flavor with HMT disabled 

stack@neha:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-12-subnet --flavor f_45 --name lb1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-06-04T11:53:32                  |
| description         |                                      |
| flavor_id           | 970d6b5b-d048-4b69-a485-abb00c267ddc |
| id                  | 5936cb50-1d52-416f-9f01-65a63e47a220 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 60b9bb1eeddb4bfc8ab3da24e7c4eee5     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.12.136                          |
| vip_network_id      | bf4dfee9-6776-4b32-b85b-007845784265 |
| vip_port_id         | f3412ba7-9b0d-4fb2-adf5-fda237a49eb9 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | ac1f309e-751c-490d-b5ad-98562468659f |
+---------------------+--------------------------------------+
```


vThunder(NOLICENSE)#show running-config
!Current configuration: 318 bytes
!Configuration last updated at 12:54:34 IST Fri Jun 4 2021
!Configuration last saved at 12:54:37 IST Fri Jun 4 2021
!64-bit Advanced Core OS (ACOS) version 4.1.4-GR1-P5, build 81 (Sep-08-2020,09:32)
!
interface management
  ip address dhcp
!
interface ethernet 1
!
interface ethernet 2
!
interface ethernet 3
!
interface ethernet 4
!
**vrrp-a vrid 0
  floating-ip 10.0.12.131
!
slb virtual-server 5936cb50-1d52-416f-9f01-65a63e47a220 10.0.12.136**
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode


4. Create a loadbalancer on device1 using device-flavor with HMT enabled 
stack@neha:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --flavor f_35 --name lb2
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-06-04T12:00:28                  |
| description         |                                      |
| flavor_id           | cccd548c-9895-4c04-b762-1bb89a316d59 |
| id                  | cd74c071-2323-4ef3-829a-96ba801e2e9a |
| listeners           |                                      |
| name                | lb2                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 60b9bb1eeddb4bfc8ab3da24e7c4eee5     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.118                          |
| vip_network_id      | 594c81c0-015f-4cc5-97fd-a1226e443d8b |
| vip_port_id         | 7d1e7570-ea9d-49aa-8e81-9fdd499746b5 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 5841d92a-8f9d-4c8a-8aed-ebd186899a13 |
+---------------------+--------------------------------------+
```

```
vThunder[60b9bb1eeddb4b](NOLICENSE)#show running-config
!Current configuration: 69 bytes
!Configuration last updated at 13:00:41 IST Fri Jun 4 2021
!Configuration last saved at 13:00:51 IST Fri Jun 4 2021
!
active-partition 60b9bb1eeddb4b
!
!
**vrrp-a vrid 0
  floating-ip 10.0.11.200
!
slb virtual-server cd74c071-2323-4ef3-829a-96ba801e2e9a 10.0.11.118**
!
end
!Current config commit point for partition 1 is 0 & config mode is classical-mode

```
