### PR TITLE
[BUG][STACK-2384]: [device flavor] Should not block VRID floating ip between different vthunder partitions

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -759,11 +759,18 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
 
         vrid_value = CONF.a10_global.vrid
         prev_vrid_value = vrid_list[0].vrid if vrid_list else None
+        parent_vrid_fip_flag = False
         if use_device_flavor and vthunder_config.vrid_floating_ip:
             conf_floating_ip = vthunder_config.vrid_floating_ip
         else:
             conf_floating_ip = a10_utils.get_vrid_floating_ip_for_project(
                 lb_resource.project_id)
+
+        if vthunder_config:
+            hierarchical_mt = vthunder_config.hierarchical_multitenancy
+            use_parent_partition = CONF.a10_global.use_parent_partition
+            if hierarchical_mt == 'enable' and use_parent_partition:
+                parent_vrid_fip_flag = True
 
         if not conf_floating_ip:
             for vrid in vrid_list:
@@ -813,7 +820,7 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
         if (prev_vrid_value is not None) and (prev_vrid_value != vrid_value):
             self._remove_device_vrid_fip(vthunder.partition_name, prev_vrid_value)
             self._update_device_vrid_fip(vthunder.partition_name, vrid_floating_ips, vrid_value)
-        elif update_vrid_flag:
+        elif update_vrid_flag or parent_vrid_fip_flag:
             self._update_device_vrid_fip(vthunder.partition_name, vrid_floating_ips, vrid_value)
 
         return vrid_list


### PR DESCRIPTION
## Description
- Severity Level: Medium
- Issue Description: When a loadbalancer is created for a child project of admin with use_parent_partition=True and vrid FIP of the LB's subnet is already present there on the same parent partition(admin partition) on a different vthunder, then the VRID FIP is not getting created on the parent partition(admin partition) of the vthunder on which the LB is being created.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2384

## Technical Approach
- Setting a flag **parent_vrid_fip_flag** as True if `hierarchical_multitenancy == 'enable' and use_parent_partition=True` in case of hardware thunders.
- If VRID FIP of the LB which is being created on parent partition is already present on parent partition on another vthunder, then `_replace_vrid_port()` will not get called as the vrid_floating_ip is already present on the parent partition. Due to this, `update_vrid_flag` flag is not set to True and `_update_device_vrid_fip()` is not getting called to update the LB's VRID FIP on the parent partition. So added a check with `parent_vrid_fip_flag` flag along with `update_vrid_flag` flag for updating device's vrid fip.

## Manual Testing
1. openstack loadbalancer flavorprofile create --name fp_35 --provider a10 --flavor-data '{"device-name": "device1"}'
    openstack loadbalancer flavor create --name f_35 --flavorprofile fp_35

2. openstack loadbalancer flavorprofile create --name fp_45 --provider a10 --flavor-data '{"device-name": "device2"}'
    openstack loadbalancer flavor create --name f_45 --flavorprofile fp_45

3. Config file:
```
[a10_global]
network_type = 'flat'
vrid_floating_ip = ".126"
use_shared_for_template_lookup = True
use_parent_partition= True

[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"

[a10_controller_worker]
network_driver = a10_octavia_neutron_driver

[a10_health_manager]
udp_server_ip_address = 10.64.3.126
bind_port = 5550
bind_ip = 10.64.3.126
heartbeat_interval = 5
heartbeat_key = insecure
heartbeat_timeout = 90
health_check_interval = 3
failover_timeout = 600
health_check_timeout = 3
health_check_max_retries = 5

[a10_house_keeping]
load_balancer_expiry_age = 3600
amphorae_expiry_age = 3600

[hardware_thunder]
devices = [
                    {
                     "project_id":"60b9bb1eeddb4bfc8ab3da24e7c4eee5",
                     "ip_address":"10.0.0.65",
                     "username":"admin",
                     "password":"a10",
                     "device_name":"device1",
                     "hierarchical_multitenancy": "enable",
                     "vrid_floating_ip":"dhcp"
                     },
                     {
                      "project_id":"3badaaf7c5ed4223982cda53151bd472",
                      "ip_address":"10.0.0.71",
                      "username":"admin",
                      "password":"a10",
                      "device_name":"device2",
                      "hierarchical_multitenancy": "enable",
                      "vrid_floating_ip":"dhcp"
                     }
          ]
```

4. stack@neha:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --flavor f_35 --name lb2
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-06-07T12:49:28                  |
| description         |                                      |
| flavor_id           | cccd548c-9895-4c04-b762-1bb89a316d59 |
| id                  | 79b2f9b1-0fbb-454f-bd51-8e610846f2af |
| listeners           |                                      |
| name                | lb2                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 60b9bb1eeddb4bfc8ab3da24e7c4eee5     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.165                          |
| vip_network_id      | 594c81c0-015f-4cc5-97fd-a1226e443d8b |
| vip_port_id         | 096d1f7b-525e-4c09-9683-18c4f0dc56c3 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 5841d92a-8f9d-4c8a-8aed-ebd186899a13 |
+---------------------+--------------------------------------+
```

Result on device1:

vThunder[60b9bb1eeddb4b](NOLICENSE)#show running-config
!Current configuration: 69 bytes
!Configuration last updated at 13:49:30 IST Mon Jun 7 2021
!Configuration last saved at 13:49:42 IST Mon Jun 7 2021
!
active-partition 60b9bb1eeddb4b
!
!
vrrp-a vrid 0
  floating-ip 10.0.11.146
!
slb virtual-server 79b2f9b1-0fbb-454f-bd51-8e610846f2af 10.0.11.165
!
end
!Current config commit point for partition 1 is 0 & config mode is classical-mode

5. stack@neha:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-13-subnet --flavor f_45 --name lb3
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-06-07T12:52:05                  |
| description         |                                      |
| flavor_id           | 970d6b5b-d048-4b69-a485-abb00c267ddc |
| id                  | 32abedeb-25d9-4294-9d73-be90e1e602e6 |
| listeners           |                                      |
| name                | lb3                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 60b9bb1eeddb4bfc8ab3da24e7c4eee5     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.13.199                          |
| vip_network_id      | 36c6fbe8-27cf-4f69-b1ab-1b90a520bedb |
| vip_port_id         | bc36d194-436f-49fc-a2db-5ca8f04b5a7d |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 0838b8dd-70ca-4986-980b-83de2da19663 |
+---------------------+--------------------------------------+
```

Result on device2:

vThunder[60b9bb1eeddb4b](NOLICENSE)#show running-config
!Current configuration: 69 bytes
!Configuration last updated at 13:52:08 IST Mon Jun 7 2021
!Configuration last saved at 13:52:55 IST Mon Jun 7 2021
!
active-partition 60b9bb1eeddb4b
!
!
vrrp-a vrid 0
  floating-ip 10.0.13.120
!
slb virtual-server 32abedeb-25d9-4294-9d73-be90e1e602e6 10.0.13.199
!
end
!Current config commit point for partition 2 is 0 & config mode is classical-mode

6. stack@neha:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --flavor f_45 --name lb4 --project admin_child1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-06-07T12:54:06                  |
| description         |                                      |
| flavor_id           | 970d6b5b-d048-4b69-a485-abb00c267ddc |
| id                  | 93a4d1ce-c7f9-4203-a811-ed22d6905aa6 |
| listeners           |                                      |
| name                | lb4                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 3badaaf7c5ed4223982cda53151bd472     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.128                          |
| vip_network_id      | 594c81c0-015f-4cc5-97fd-a1226e443d8b |
| vip_port_id         | 7ef8e1f9-fc77-4fb4-b3f4-76759860ee08 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 5841d92a-8f9d-4c8a-8aed-ebd186899a13 |
+---------------------+--------------------------------------+
```

Result on device2:

vThunder[60b9bb1eeddb4b](NOLICENSE)#show running-config
!Current configuration: 138 bytes
!Configuration last updated at 13:54:06 IST Mon Jun 7 2021
!Configuration last saved at 13:54:09 IST Mon Jun 7 2021
!
active-partition 60b9bb1eeddb4b
!
!
**vrrp-a vrid 0
  floating-ip 10.0.13.120
  floating-ip 10.0.11.146
!
slb virtual-server 32abedeb-25d9-4294-9d73-be90e1e602e6 10.0.13.199
!
slb virtual-server 93a4d1ce-c7f9-4203-a811-ed22d6905aa6 10.0.11.128**
!
end
!Current config commit point for partition 2 is 0 & config mode is classical-mode