### PR TITLE
[BUG][device flavor][STACK-2394]L vrid floating ip should not be assigned if lb is failed to be created.

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -722,11 +722,11 @@ class LoadBalancerFlows(object):
                 provides=constants.LOADBALANCER))
         post_create_lb_flow.add(database_tasks.UpdateLoadbalancerInDB(
             requires=[constants.LOADBALANCER, constants.UPDATE_DICT]))
-        post_create_lb_flow.add(self.handle_vrid_for_loadbalancer_subflow())
         if CONF.a10_global.network_type == 'vlan':
             post_create_lb_flow.add(vthunder_tasks.TagInterfaceForLB(
                 requires=[constants.LOADBALANCER,
                           a10constants.VTHUNDER]))
+        post_create_lb_flow.add(self.handle_vrid_for_loadbalancer_subflow())
         if mark_active:
             post_create_lb_flow.add(database_tasks.MarkLBActiveInDB(
                 name=sf_name + '-' + constants.MARK_LB_ACTIVE_INDB,


### PR DESCRIPTION
## Description
Severity Level: High
Issue Description: Create one lb but it failed due to TagInterface. Then the lb is in ERROR, but floating ip is assigned and configured on thunder, expect the vrid floating ip will be revoked, otherwise the floating ip will be kept there even the error lb deleted

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2394

## Technical Approach
1. Handle VRID flow added after TagInterface flow.
2. Since VRID_LIST is a mutable object, hence the VRID_LIST object is getting updated in handle VRID flow which causes revert flow receiving  updated VRID_LIST.
3. Added revert for updateVRIDDB.
 
## Manual Testing
- Create LB lb-1 with error.
openstack loadbalancer create --name l1 --vip-subnet-id provider-vlan-11-subnet
![image](https://user-images.githubusercontent.com/66299493/121039258-90b67880-c7ce-11eb-8328-c46afe21a890.png)

Check vthunder:
> !Section configuration: 125 bytes       
!
vrrp-a common 
  device-id 2 
  set-id 1 
  enable 
!
vrrp-a vrid 0 
  floating-ip 10.0.12.186 
  floating-ip 10.0.14.186

Check DB:
![image](https://user-images.githubusercontent.com/66299493/121039588-d70bd780-c7ce-11eb-8d8d-5000f1a93b64.png)

2. Delete lb1 which is in error state.
![image](https://user-images.githubusercontent.com/66299493/121039750-fd317780-c7ce-11eb-8ecd-852ab16334bd.png)
