### PR TITLE
[BUG][vthunder: active-standby][STACK-2278]: the vrid 1 is used instead of vrid 0

### DIFF
--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -373,13 +373,6 @@ class VThunderFlows(object):
 
     def _configure_vrrp_subflow(self, sf_name):
         configure_vrrp_subflow = linear_flow.Flow(sf_name)
-        # VRID Configuration
-        configure_vrrp_subflow.add(vthunder_tasks.ConfigureVRID(
-            name=sf_name + '-' + a10constants.CONFIGURE_VRID_FOR_MASTER_VTHUNDER,
-            requires=(a10constants.VTHUNDER)))
-        configure_vrrp_subflow.add(vthunder_tasks.ConfigureVRID(
-            name=sf_name + '-' + a10constants.CONFIGURE_VRID_FOR_BACKUP_VTHUNDER,
-            rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
         # Configure aVCS
         configure_vrrp_subflow.add(vthunder_tasks.ConfigureaVCSMaster(
             name=sf_name + '-' + a10constants.CONFIGURE_AVCS_SYNC_FOR_MASTER,


### PR DESCRIPTION
Severity Level: High
Issue Description: Blade-params priority getting set in vrid 1, we could use vrid 0 for setting blade-param priority. 

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2278

## Technical Approach
Observations:
-  Default blade-param priority i.e, 150 does not get reflected on vthunder VRID 0.
-  While setting FIP the blade-param priority automatically set with default values, we can observe this in response to VRID FIP operations.
Changes:
- Removed the  config blade param priority in VRID 1 code from vthunder flow.

Need to check the reason the default blade-param priority not showing up in VRID 0.

## Manual Testing
- Create LB lb1 for vthunder flow, inspect call for VRID FIP operation
> stack@rahul:~/rahul/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 281ccaf6-078d-4498-bb25-36813eb3bbb4 | l1   | 56becc092e8e40b1882fa96a04d6bca8 | 10.0.11.109 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
stack@rahul:~/rahul/a10-octavia$ 

Response of VRID FIP update operation:

> {
     "vrid": {
         "blade-parameters": {
             "priority": 150,
             "uuid": "62fbd5a6-c838-11eb-bc81-fa163e4c8ce4",
             "a10-url": "/axapi/v3/vrrp-a/vrid/0/blade-parameters"
         },
         "uuid": "62fbc2be-c838-11eb-bc81-fa163e4c8ce4",
         "vrid-val": 0,
         "preempt-mode": {
             "threshold": 0,
             "disable": 0
         },
         "floating-ip": {
             "ip-address-cfg": [
                 {
                     "ip-address": "10.0.11.186"
                 }
             ]
         },
         "a10-url": "/axapi/v3/vrrp-a/vrid/0"
     }
 }

vThunder results:
> vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config vrrp-a 
!Section configuration: 98 bytes        
!
vrrp-a common 
  device-id 1 
  set-id 1 
  enable 
!
vrrp-a vrid 0 
  floating-ip 10.0.11.186 
!
