### PR TITLE
[STACK-2399] Fix set Loadbalancer error

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -546,10 +546,6 @@ class LoadBalancerFlows(object):
                       constants.FLAVOR_DATA)))
         update_LB_flow.add(database_tasks.UpdateLoadbalancerInDB(
             requires=[constants.LOADBALANCER, constants.UPDATE_DICT]))
-        if CONF.a10_global.network_type == 'vlan':
-            update_LB_flow.add(vthunder_tasks.TagInterfaceForLB(
-                requires=[constants.LOADBALANCER,
-                          a10constants.VTHUNDER]))
         update_LB_flow.add(database_tasks.MarkLBActiveInDB(
             requires=constants.LOADBALANCER))
         update_LB_flow.add(vthunder_tasks.WriteMemory(
@@ -806,6 +802,8 @@ class LoadBalancerFlows(object):
             a10_database_tasks.GetVRIDForLoadbalancerResource(
                 requires=a10constants.PARTITION_PROJECT_LIST,
                 provides=a10constants.VRID_LIST))
+        handle_vrid_for_lb_subflow.add(vthunder_tasks.ConfigureVRID(
+            requires=a10constants.VTHUNDER))
         handle_vrid_for_lb_subflow.add(
             a10_network_tasks.HandleVRIDFloatingIP(
                 requires=[

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -562,6 +562,63 @@ class LoadBalancerFlows(object):
             requires=a10constants.VTHUNDER))
         return update_LB_flow
 
+    def get_update_rack_load_balancer_flow(self, vthunder_conf, device_dict, topology):
+        """Flow to update load balancer."""
+
+        update_LB_flow = linear_flow.Flow(constants.UPDATE_LOADBALANCER_FLOW)
+        update_LB_flow.add(lifecycle_tasks.LoadBalancerToErrorOnRevertTask(
+            requires=constants.LOADBALANCER))
+
+        # device-name flavor support
+        update_LB_flow.add(a10_database_tasks.GetFlavorData(
+            rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
+            provides=constants.FLAVOR_DATA))
+        update_LB_flow.add(vthunder_tasks.GetVthunderConfByFlavor(
+            inject={a10constants.VTHUNDER_CONFIG: vthunder_conf,
+                    a10constants.DEVICE_CONFIG_DICT: device_dict},
+            requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG,
+                      a10constants.DEVICE_CONFIG_DICT, constants.FLAVOR_DATA),
+            provides=(a10constants.VTHUNDER_CONFIG, a10constants.USE_DEVICE_FLAVOR)))
+
+        update_LB_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
+            requires=constants.LOADBALANCER,
+            provides=a10constants.VTHUNDER))
+        if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+            update_LB_flow.add(vthunder_tasks.GetMasterVThunder(
+                name=a10constants.GET_MASTER_VTHUNDER,
+                requires=a10constants.VTHUNDER,
+                provides=a10constants.VTHUNDER))
+        update_LB_flow.add(a10_database_tasks.MarkVThunderStatusInDB(
+            requires=a10constants.VTHUNDER,
+            inject={"status": constants.PENDING_UPDATE}))
+        update_LB_flow.add(vthunder_tasks.SetupDeviceNetworkMap(
+            requires=a10constants.VTHUNDER,
+            provides=a10constants.VTHUNDER))
+        update_LB_flow.add(network_tasks.ApplyQos(
+            requires=(constants.LOADBALANCER, constants.UPDATE_DICT)))
+        update_LB_flow.add(self.handle_vrid_for_loadbalancer_subflow())
+
+        update_LB_flow.add(virtual_server_tasks.UpdateVirtualServerTask(
+            requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
+                      constants.FLAVOR_DATA)))
+        update_LB_flow.add(database_tasks.UpdateLoadbalancerInDB(
+            requires=[constants.LOADBALANCER, constants.UPDATE_DICT]))
+        if CONF.a10_global.network_type == 'vlan':
+            update_LB_flow.add(vthunder_tasks.TagInterfaceForLB(
+                requires=[constants.LOADBALANCER,
+                          a10constants.VTHUNDER]))
+        update_LB_flow.add(database_tasks.MarkLBActiveInDB(
+            requires=constants.LOADBALANCER))
+        update_LB_flow.add(vthunder_tasks.WriteMemory(
+            requires=a10constants.VTHUNDER))
+        update_LB_flow.add(a10_database_tasks.MarkVThunderStatusInDB(
+            name="pending_update_to_active",
+            requires=a10constants.VTHUNDER,
+            inject={"status": constants.ACTIVE}))
+        update_LB_flow.add(a10_database_tasks.SetThunderUpdatedAt(
+            requires=a10constants.VTHUNDER))
+        return update_LB_flow
+
     def get_create_rack_vthunder_load_balancer_flow(
             self, vthunder_conf, device_dict, topology, listeners=None):
         """Flow to create rack load balancer"""

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -708,7 +708,7 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
         has_vrid = True
         try:
             self.axapi_client.vrrpa.get(vrid)
-        except acos_errors.NotFound as e:
+        except acos_errors.NotFound:
             has_vrid = False
 
         try:

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -704,20 +704,6 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
                           str(vrid_value))
             raise e
 
-    def _create_vrid(self, vrid):
-        has_vrid = True
-        try:
-            self.axapi_client.vrrpa.get(vrid)
-        except acos_errors.NotFound:
-            has_vrid = False
-
-        try:
-            if not has_vrid:
-                self.axapi_client.system.action.configureVRID(vrid)
-        except Exception as e:
-            LOG.exception("Failed to create vrid d: %s", vrid, str(e))
-            raise e
-
     def _update_device_vrid_fip(self, partition_name, vrid_floating_ip_list, vrid_value):
         try:
             is_partition = (partition_name is not None and partition_name != 'shared')
@@ -831,7 +817,6 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
             if vrid_subnet.id == subnet.id or vrid.vrid_floating_ip in existing_fips:
                 vrid_floating_ips.append(vrid.vrid_floating_ip)
 
-        self._create_vrid(vrid_value)
         if (prev_vrid_value is not None) and (prev_vrid_value != vrid_value):
             self._remove_device_vrid_fip(vthunder.partition_name, prev_vrid_value)
             self._update_device_vrid_fip(vthunder.partition_name, vrid_floating_ips, vrid_value)

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -440,9 +440,11 @@ class SetupDeviceNetworkMap(VThunderBaseTask):
             return
         device_name = ''.join([a10constants.DEVICE_KEY_PREFIX,
                                vthunder.device_name]) if vthunder.device_name else ''
-        vthunder_conf = (CONF.hardware_thunder.devices.get(device_name) or
-                         CONF.hardware_thunder.devices.get(vthunder.project_id))
-        if vthunder_conf:
+        vthunder_conf = None
+        if isinstance(CONF.hardware_thunder.devices, dict):
+            vthunder_conf = (CONF.hardware_thunder.devices.get(device_name) or
+                             CONF.hardware_thunder.devices.get(vthunder.project_id))
+        if vthunder_conf is not None:
             device_network_map = vthunder_conf.device_network_map
 
             # Case when device network map is not provided/length is 0

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -269,9 +269,11 @@ class ConfigureVRID(VThunderBaseTask):
     """Task to configure vThunder VRID"""
 
     @axapi_client_decorator
-    def execute(self, vthunder, vrid=1):
+    def execute(self, vthunder):
         try:
-            self.axapi_client.system.action.configureVRID(vrid)
+            vrid = CONF.a10_global.vrid
+            if not self.axapi_client.vrrpa.exists(vrid):
+                self.axapi_client.system.action.configureVRID(vrid)
             LOG.debug("Configured the master vThunder for VRID")
         except (acos_errors.ACOSException, req_exceptions.ConnectionError) as e:
             LOG.exception("Failed to configure VRID on vthunder: %s", str(e))


### PR DESCRIPTION
If Bug Fix:
Severity Level: Critical
Issue Description: openstack loadbalancer set will failed, since loadbalancer_update flow missing parameters in store for HandleVRIDFloatingIP task.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2399

## Technical Approach
- Provide proper a10constants.VTHUNDER_CONFIG and a10constants.USE_DEVICE_FLAVOR for vthunder update flow.
- create vrid if it is not exist on thunder.

## Config Changes
<pre>
<b>[a10_global]
network_type = vlan
vrid=7
vrid_floating_ip = ".126"
#use_parent_partition=True

[a10_controller_worker]
network_driver = a10_octavia_neutron_driver
loadbalancer_topology = SINGLE

[listener]
autosnat = True
conn_limit=20000

[health_monitor]
post_data = "abc=1"

[a10_house_keeping]
#use_periodic_write_memory = 'enable'
write_mem_interval = 300

[hardware_thunder]
devices = [
                    {
                     "project_id": "3d21c71c4e4040599933bda62a76ae2f",
                     "ip_address": "192.168.90.46",
                     "username": "admin",
                     "password": "a10",
                     "device_name": "admin"
                     },
                    {
                     "ip_address": "192.168.90.46",
                     "username": "admin",
                     "password": "a10",
                     #"hierarchical_multitenancy": "enable",
                     "device_name": "dev2",
                     "interface_vlan_map": {
                         "device_1": {
                             "mgmt_ip_address": "192.168.90.46",
                             "ethernet_interfaces": [{
                                 "interface_num": 4,
                                 "vlan_map": [
                                     {"vlan_id": 3, "ve_ip": "192.168.190.61"},
                                     {"vlan_id": 4, "ve_ip": "172.16.1.61"},
                                     {"vlan_id": 5, "ve_ip": "192.168.91.61"},
                                 ]},
                             ]
                          }
                        }
                     },
             ]
</b>
</pre>

## Test Cases
1. Same steps as QA 
2. test vThunder loadbalancer update flow 

## Manual Testing
1. Same steps as QA 
```
vrrp-a vrid 7
  floating-ip 192.168.91.126
!
slb virtual-server 22d9c34d-844a-4ce3-92a3-49d07162f3fc 192.168.91.161
!
```

2. test vThunder loadbalancer update flow 
```
stack@openstack-4:~/source/a10-octavia/vthunder2$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address    | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| dd9c4214-5534-4444-8a28-3e6ca35be2be | vip1 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.247 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
stack@openstack-4:~/source/a10-octavia/vthunder2$ openstack loadbalancer set --description 'test' vip1
stack@openstack-4:~/source/a10-octavia/vthunder2$ openstack loadbalancer show vip1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-06-08T12:38:33                  |
| description         | test                                 |
| flavor_id           | None                                 |
| id                  | dd9c4214-5534-4444-8a28-3e6ca35be2be |
| listeners           |                                      |
| name                | vip1                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 99c9c2304f114685a32db30769c8a7e2     |
| provider            | a10                                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-06-08T13:05:16                  |
| vip_address         | 192.168.91.247                       |
| vip_network_id      | 61305531-6e3a-44b4-8e67-05e93363dddc |
| vip_port_id         | 889983ae-7da4-4419-b6bc-f290e23507d9 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 3ea80a1c-5785-4252-b751-c84d614ccb0c |
+---------------------+--------------------------------------+

```