### PR TITLE
[STACK-2385]: Added L2DSR Support

### DIFF
--- a/a10_octavia/api/drivers/driver.py
+++ b/a10_octavia/api/drivers/driver.py
@@ -291,6 +291,10 @@ class A10ProviderDriver(driver_base.ProviderDriver):
                         raise Exception('end-address is required for nat-pool-list flavor')
                     if 'netmask' not in nat:
                         raise Exception('netmask is required for nat-pool-list flavor')
+            if 'deployment' in flavor_dict:
+                deployment = flavor_dict['deployment']
+                if 'dsr_type' not in deployment:
+                    raise Exception('dsr_type is required for deployment flavor')
 
         except js_exceptions.ValidationError as e:
             error_object = ''

--- a/a10_octavia/api/drivers/driver.py
+++ b/a10_octavia/api/drivers/driver.py
@@ -293,10 +293,9 @@ class A10ProviderDriver(driver_base.ProviderDriver):
                         raise Exception('netmask is required for nat-pool-list flavor')
             if 'deployment' in flavor_dict:
                 deployment = flavor_dict['deployment']
-                if ('dsr_type' not in deployment or
+                if ('dsr_type' in deployment and
                         deployment['dsr_type'] not in ['l2dsr_transparent']):
-                    raise Exception('dsr_type is required for deployment flavor and'
-                                    ' l2dsr_transparent is required value for dsr_type')
+                    raise Exception('l2dsr_transparent is required value for dsr_type')
 
         except js_exceptions.ValidationError as e:
             error_object = ''

--- a/a10_octavia/api/drivers/driver.py
+++ b/a10_octavia/api/drivers/driver.py
@@ -295,8 +295,8 @@ class A10ProviderDriver(driver_base.ProviderDriver):
                 deployment = flavor_dict['deployment']
                 if ('dsr_type' not in deployment or
                         deployment['dsr_type'] not in ['l2dsr_transparent']):
-                        raise Exception('dsr_type is required for deployment flavor and'
-                                        ' l2dsr_transparent is required value for dsr_type')
+                    raise Exception('dsr_type is required for deployment flavor and'
+                                    ' l2dsr_transparent is required value for dsr_type')
 
         except js_exceptions.ValidationError as e:
             error_object = ''

--- a/a10_octavia/api/drivers/driver.py
+++ b/a10_octavia/api/drivers/driver.py
@@ -293,12 +293,10 @@ class A10ProviderDriver(driver_base.ProviderDriver):
                         raise Exception('netmask is required for nat-pool-list flavor')
             if 'deployment' in flavor_dict:
                 deployment = flavor_dict['deployment']
-                if 'dsr_type' not in deployment:
-                    raise Exception('dsr_type is required for deployment flavor')
-                else:
-                    dsr_type = deployment['dsr_type']
-                    if dsr_type not in ['l2dsr_transparent']:
-                        raise Exception('l2dsr_transparent is required value for dsr_type')
+                if ('dsr_type' not in deployment or
+                        deployment['dsr_type'] not in ['l2dsr_transparent']):
+                        raise Exception('dsr_type is required for deployment flavor and'
+                                        ' l2dsr_transparent is required value for dsr_type')
 
         except js_exceptions.ValidationError as e:
             error_object = ''

--- a/a10_octavia/api/drivers/driver.py
+++ b/a10_octavia/api/drivers/driver.py
@@ -295,6 +295,10 @@ class A10ProviderDriver(driver_base.ProviderDriver):
                 deployment = flavor_dict['deployment']
                 if 'dsr_type' not in deployment:
                     raise Exception('dsr_type is required for deployment flavor')
+                else:
+                    dsr_type = deployment['dsr_type']
+                    if dsr_type not in ['l2dsr_transparent']:
+                        raise Exception('l2dsr_transparent is required value for dsr_type')
 
         except js_exceptions.ValidationError as e:
             error_object = ''

--- a/a10_octavia/api/drivers/flavor_schema.py
+++ b/a10_octavia/api/drivers/flavor_schema.py
@@ -190,6 +190,8 @@ SUPPORTED_FLAVOR_SCHEMA = {
             "properties": {
                 "dsr_type": {
                     "type": "string",
+                    "description": "Specify deployment DSR type[l2dsr_transparent]"
+                                   " for the loadbalancer"
                 }
             }
         }

--- a/a10_octavia/api/drivers/flavor_schema.py
+++ b/a10_octavia/api/drivers/flavor_schema.py
@@ -183,6 +183,15 @@ SUPPORTED_FLAVOR_SCHEMA = {
         "device-name": {
             "type": "string",
             "description": "Specify vthunder device name that used for this loadbalancer"
+        },
+        "deployment": {
+            "type": "object",
+            "description": "Specify deployment strategy that used for this loadbalancer",
+            "properties": {
+                "dsr_type": {
+                    "type": "string",
+                }
+            }
         }
     }
 }

--- a/a10_octavia/api/drivers/flavor_schema.py
+++ b/a10_octavia/api/drivers/flavor_schema.py
@@ -186,7 +186,7 @@ SUPPORTED_FLAVOR_SCHEMA = {
         },
         "deployment": {
             "type": "object",
-            "description": "Specify deployment strategy that used for this loadbalancer",
+            "description": "Specify deployment strategy for the loadbalancer",
             "properties": {
                 "dsr_type": {
                     "type": "string",

--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -63,9 +63,6 @@ A10_VTHUNDER_OPTS = [
     cfg.IntOpt('default_axapi_timeout',
                default=300,
                help=_('VThunder axapi timeout')),
-    cfg.BoolOpt('l2dsr_support', default=False,
-                help=_('For vThunder VIP port, ingres/egress allows any address with VIP '
-                       'interface MAC address to pass.')),
     cfg.BoolOpt('slb_no_snat_support', default=False,
                 help=_('Allow Loadbalancer use any source address to access backend server.')),
 ]

--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -63,6 +63,9 @@ A10_VTHUNDER_OPTS = [
     cfg.IntOpt('default_axapi_timeout',
                default=300,
                help=_('VThunder axapi timeout')),
+    cfg.BoolOpt('l2dsr_support', default=False,
+                help=_('For vThunder VIP port, ingres/egress allows any address with VIP '
+                       'interface MAC address to pass.')),
     cfg.BoolOpt('slb_no_snat_support', default=False,
                 help=_('Allow Loadbalancer use any source address to access backend server.')),
 ]

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -106,6 +106,8 @@ class LoadBalancerFlows(object):
         lb_create_flow.add(a10_database_tasks.GetFlavorData(
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
             provides=constants.FLAVOR_DATA))
+        lb_create_flow.add(vthunder_tasks.AllowL2DSR(
+            requires=(constants.SUBNET, constants.AMPHORA, constants.FLAVOR_DATA)))
         lb_create_flow.add(nat_pool_tasks.NatPoolCreate(
             requires=(constants.LOADBALANCER,
                       a10constants.VTHUNDER, constants.FLAVOR_DATA)))
@@ -294,6 +296,9 @@ class LoadBalancerFlows(object):
         delete_LB_flow.add(a10_database_tasks.CountLoadbalancersWithFlavor(
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
             provides=a10constants.LB_COUNT_FLAVOR))
+        delete_LB_flow.add(vthunder_tasks.DeleteL2DSR(
+            requires=(constants.SUBNET, constants.AMPHORA,
+                      a10constants.LB_COUNT_FLAVOR, constants.FLAVOR_DATA)))
         delete_LB_flow.add(nat_pool_tasks.NatPoolDelete(
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
                       a10constants.LB_COUNT_FLAVOR, constants.FLAVOR_DATA)))

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -106,8 +106,12 @@ class LoadBalancerFlows(object):
         lb_create_flow.add(a10_database_tasks.GetFlavorData(
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
             provides=constants.FLAVOR_DATA))
+        lb_create_flow.add(a10_database_tasks.CountLoadbalancersWithFlavor(
+            requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
+            provides=a10constants.LB_COUNT_FLAVOR))
         lb_create_flow.add(vthunder_tasks.AllowL2DSR(
-            requires=(constants.SUBNET, constants.AMPHORA, constants.FLAVOR_DATA)))
+            requires=(constants.SUBNET, constants.AMPHORA,
+                      a10constants.LB_COUNT_FLAVOR, constants.FLAVOR_DATA)))
         lb_create_flow.add(nat_pool_tasks.NatPoolCreate(
             requires=(constants.LOADBALANCER,
                       a10constants.VTHUNDER, constants.FLAVOR_DATA)))

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -190,13 +190,6 @@ class VThunderFlows(object):
             name=sf_name + '-' + constants.RELOAD_AMPHORA,
             requires=constants.AMPHORA_ID,
             provides=constants.AMPHORA))
-        create_amp_for_lb_subflow.add(a10_network_tasks.GetLBResourceSubnet(
-            name=sf_name + '-' + a10constants.GET_LB_RESOURCE,
-            rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
-            provides=constants.SUBNET))
-        create_amp_for_lb_subflow.add(vthunder_tasks.AllowL2DSR(
-            name=sf_name + '-' + a10constants.ALLOW_L2DSR,
-            requires=(constants.SUBNET, constants.AMPHORA)))
         if role == constants.ROLE_MASTER:
             create_amp_for_lb_subflow.add(database_tasks.MarkAmphoraMasterInDB(
                 name=sf_name + '-' + constants.MARK_AMP_MASTER_INDB,
@@ -293,9 +286,6 @@ class VThunderFlows(object):
             name=sf_name + '-' + constants.RELOAD_AMPHORA,
             requires=constants.AMPHORA_ID,
             provides=constants.AMPHORA))
-        vthunder_for_amphora_subflow.add(vthunder_tasks.AllowL2DSR(
-            name=sf_name + '-' + a10constants.ALLOW_L2DSR,
-            requires=(constants.SUBNET, constants.AMPHORA)))
         if role == constants.ROLE_MASTER:
             vthunder_for_amphora_subflow.add(database_tasks.MarkAmphoraMasterInDB(
                 name=sf_name + '-' + constants.MARK_AMP_MASTER_INDB,

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -129,9 +129,24 @@ class AmphoraePostVIPPlug(VThunderBaseTask):
 class AllowL2DSR(VThunderBaseTask):
     """Task to add wildcat address in allowed_address_pair for L2DSR"""
 
-    def execute(self, subnet, amphora):
-        if CONF.vthunder.l2dsr_support:
-            self.network_driver.allow_use_any_source_ip_on_egress(subnet.network_id, amphora)
+    def execute(self, subnet, amphora, flavor_data=None):
+        if flavor_data:
+            deployment = flavor_data.get('deployment')
+            if deployment and deployment['dsr_type'] == "l2dsr_transparent":
+                for amp in amphora:
+                    self.network_driver.allow_use_any_source_ip_on_egress(subnet.network_id, amp)
+
+
+class DeleteL2DSR(VThunderBaseTask):
+    """Task to delete wildcat address in allowed_address_pair for L2DSR"""
+
+    def execute(self, subnet, amphora, lb_count_flavor, flavor_data=None):
+        if lb_count_flavor <= 1:
+            if flavor_data:
+                deployment = flavor_data.get('deployment')
+                if deployment and deployment['dsr_type'] == "l2dsr_transparent":
+                    for amp in amphora:
+                        self.network_driver.remove_any_source_ip_on_egress(subnet.network_id, amp)
 
 
 class AllowLoadbalancerForwardWithAnySource(VThunderBaseTask):

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -129,22 +129,35 @@ class AmphoraePostVIPPlug(VThunderBaseTask):
 class AllowL2DSR(VThunderBaseTask):
     """Task to add wildcat address in allowed_address_pair for L2DSR"""
 
-    def execute(self, subnet, amphora, flavor_data=None):
+    def execute(self, subnet, amphora, lb_count_flavor, flavor_data=None):
         if flavor_data:
             deployment = flavor_data.get('deployment')
-            if deployment and deployment['dsr_type'] == "l2dsr_transparent":
-                for amp in amphora:
-                    self.network_driver.allow_use_any_source_ip_on_egress(subnet.network_id, amp)
+            if deployment and 'dsr_type' in deployment:
+                if deployment['dsr_type'] == "l2dsr_transparent":
+                    for amp in amphora:
+                        self.network_driver.allow_use_any_source_ip_on_egress(
+                            subnet.network_id, amp)
+
+    def revert(self, subnet, amphora, lb_count_flavor, flavor_data=None):
+        if lb_count_flavor > 1:
+            return
+
+        if flavor_data:
+            deployment = flavor_data.get('deployment')
+            if deployment and 'dsr_type' in deployment:
+                if deployment['dsr_type'] == "l2dsr_transparent":
+                    for amp in amphora:
+                        self.network_driver.remove_any_source_ip_on_egress(subnet.network_id, amp)
 
 
 class DeleteL2DSR(VThunderBaseTask):
     """Task to delete wildcat address in allowed_address_pair for L2DSR"""
 
     def execute(self, subnet, amphora, lb_count_flavor, flavor_data=None):
-        if lb_count_flavor <= 1:
-            if flavor_data:
-                deployment = flavor_data.get('deployment')
-                if deployment and deployment['dsr_type'] == "l2dsr_transparent":
+        if lb_count_flavor <= 1 and flavor_data:
+            deployment = flavor_data.get('deployment')
+            if deployment and 'dsr_type' in deployment:
+                if deployment['dsr_type'] == "l2dsr_transparent":
                     for amp in amphora:
                         self.network_driver.remove_any_source_ip_on_egress(subnet.network_id, amp)
 

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -138,7 +138,7 @@ class AllowL2DSR(VThunderBaseTask):
                         self.network_driver.allow_use_any_source_ip_on_egress(
                             subnet.network_id, amp)
 
-    def revert(self, subnet, amphora, lb_count_flavor, flavor_data=None):
+    def revert(self, subnet, amphora, lb_count_flavor, flavor_data=None, *args, **kwargs):
         if lb_count_flavor > 1:
             return
 

--- a/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
+++ b/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
@@ -404,6 +404,12 @@ class A10OctaviaNeutronDriver(aap.AllowedAddressPairsDriver):
         else:
             self._add_allowed_address_pair_to_port(interface.port_id, '0.0.0.0/0')
 
+    def remove_any_source_ip_on_egress(self, network_id, amphora):
+        interface = self._get_plugged_interface(
+            amphora.compute_id, network_id, amphora.lb_network_ip)
+        if interface is not None:
+            self._remove_allowed_address_pair_from_port(interface.port_id, '0.0.0.0/0')
+
     def _remove_allowed_address_pair_from_port(self, port_id, ip_address):
         port = self.neutron_client.show_port(port_id)
         aap_ips = port['port']['allowed_address_pairs']

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -183,6 +183,8 @@ VIP = o_data_models.Vip(ip_address="1.1.1.1")
 AMPHORAE = [o_data_models.Amphora(id=a10constants.MOCK_AMPHORA_ID)]
 LB = o_data_models.LoadBalancer(
     id=a10constants.MOCK_LOAD_BALANCER_ID, vip=VIP, amphorae=AMPHORAE)
+DEPLOYMENT_FLAVOR = {'deployment': {"dsr_type": "l2dsr_transparent"}}
+SUBNET = n_data_models.Subnet()
 
 
 class TestVThunderTasks(base.BaseTaskTestCase):
@@ -841,3 +843,26 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         conf, use_dev_flavor = mock_task.execute(mock_LB, FLAVOR_DEV2, DEV_CONF_DICT, None)
         self.assertEqual(use_dev_flavor, False)
         self.assertEqual(conf, FLAVOR_DEV2)
+
+    def test_allowl2dsr_with_deployment_flavor(self):
+        mock_task = task.AllowL2DSR()
+        mock_task._network_driver = self.client_mock
+        lb_count = 1
+        mock_task.execute(SUBNET, AMPHORAE, lb_count, flavor_data=DEPLOYMENT_FLAVOR)
+        self.client_mock.allow_use_any_source_ip_on_egress.assert_called_with(
+            SUBNET.network_id, AMPHORAE[0])
+
+    def test_allowl2dsr_without_deployment_flavor(self):
+        mock_task = task.AllowL2DSR()
+        mock_task._network_driver = self.client_mock
+        lb_count = 1
+        mock_task.execute(SUBNET, AMPHORAE, lb_count, flavor_data=DEV_FLAVOR)
+        self.client_mock.allow_use_any_source_ip_on_egress.assert_not_called()
+
+    def test_deletel2dsr_with_deployment_flavor(self):
+        mock_task = task.DeleteL2DSR()
+        mock_task._network_driver = self.client_mock
+        lb_count = 1
+        mock_task.execute(SUBNET, AMPHORAE, lb_count, flavor_data=DEPLOYMENT_FLAVOR)
+        self.client_mock.remove_any_source_ip_on_egress.assert_called_with(
+            SUBNET.network_id, AMPHORAE[0])


### PR DESCRIPTION
## Description
Added L2DSR flavor support.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2387
https://a10networks.atlassian.net/browse/STACK-2388
https://a10networks.atlassian.net/browse/STACK-2389

## Technical Approach
- Added deployment schema in flavor_schema.py and added schema validation for deployment flavor in driver.py
- Added _AllowL2DSR_ task in create loadbalancer flow.
- Updated _AllowL2DSR_ api; when loadbalancer is created with deployment flavor and value of dsr_type is l2dsr_transparent then it will call  _allow_use_any_source_ip_on_egress_ for adding 0.0.0.0/0 in AAP for each amphora.
- Created _remove_any_source_ip_on_egress_ for removing 0.0.0.0/0 from interface's AAp.
- Created _DeleteL2DSR_; when last loadbalancer with deployement flavor will be removed then it call _remove_any_source_ip_on_egress_.


## Config Changes
<pre>
[listener]
no_dest_nat=True
conn_limit=6400000
use_rsv_hop_for_resp=False
</pre>

## Manual Testing
1)Create flavorprofile and flavorprofile related validation results
```
stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer provider capability list a10
+---------------------------------+----------------------------------------------------------------------------------------------------+
| name                            | description                                                                                        |
+---------------------------------+----------------------------------------------------------------------------------------------------+
| server.name-expressions         | Specify name expression to match members and axapi that will apply to the server                   |
| nat-pool-list                   | Specify axapi of nat pools for loadbalancer                                                        |
| health-monitor.name-expressions | Specify name expression to match healthmonitor and axapi that will apply to the health monitor     |
| device-name                     | Specify vthunder device name that used for this loadbalancer                                       |
| deployment                      | Specify deployment strategy for the loadbalancer                                                   |
| virtual-server.name-expressions | Specify name expression to match loadbalancers and axapi that will apply to the slb virtual-server |
| deployment.dsr_type             | Specify deployment DSR type[l2dsr_transparent] for the loadbalancer                                |
| virtual-port.name-expressions   | Specify name expression to match listeners and axapi that will apply to the vport                  |
| service-group.name-expressions  | Specify name expression to match pools and axapi that will apply to the service-group              |
| server                          | Specify axapi that will apply to the server                                                        |
| service-group                   | Specify axapi that will apply to the service-group                                                 |
| virtual-port                    | Specify axapi that will apply to the vport                                                         |
| nat-pool                        | Specify axapi of default nat pool for loadbalancer                                                 |
| virtual-server                  | Specify axapi that will apply to the slb virtual-server                                            |
| health-monitor                  | Specify axapi that will apply to the health monitor                                                |
+---------------------------------+----------------------------------------------------------------------------------------------------+
stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer flavorprofile create --name fp1 --provider a10 --flavor-data '{"deployment": {"dsr_type":"l2dsr_transparent1"}}'
Provider 'a10' reports error: Failed to validate the flavor metadata due to: l2dsr_transparent is required value for dsr_type (HTTP 500) (Request-ID: req-60c07669-edac-4038-b6f8-0155b557aa2c)

stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer flavorprofile create --name fp1 --provider a10 --flavor-data '{"deployment": {"dsr_type":"l2dsr_transparent"}}'
+---------------+--------------------------------------------------+
| Field         | Value                                            |
+---------------+--------------------------------------------------+
| id            | abfdc896-4618-4d6b-b420-22ed95c08a01             |
| name          | fp1                                              |
| provider_name | a10                                              |
| flavor_data   | {"deployment": {"dsr_type":"l2dsr_transparent"}} |
+---------------+--------------------------------------------------+
```

2)Created loadbalancer with flavor.
```
openstack loadbalancer flavor create --name f1 --flavorprofile fp1 –enable
openstack loadbalancer create --name vs1 --vip-subnet-id private-a-subnet --flavor f1
openstack loadbalancer listener create --name l1 vs1 --protocol tcp --protocol-port 80
openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener l1 --name p1
openstack loadbalancer member create --address 10.0.0.82 --subnet-id private-a-subnet --protocol-port 80 --name mem1 p1

vthunder
!
vrrp-a vrid 0
  floating-ip 10.0.0.120
!
slb server 9b927_10_0_0_82 10.0.0.82
  port 80 tcp
!
slb service-group bc466caa-38f0-4409-a958-c536297e1d9a tcp
  member 9b927_10_0_0_82 80
!
slb virtual-server 72ae7262-868e-4664-9489-1b9011fc6c09 10.0.0.118
  port 80 tcp
    name d1518dcc-e85a-4f55-9862-65168fffa83d
    conn-limit 6400000
    extended-stats
    service-group bc466caa-38f0-4409-a958-c536297e1d9a
    no-dest-nat
!
```
Added 0.0.0./0 in AAP
![image](https://user-images.githubusercontent.com/76765492/121337143-db083880-c939-11eb-99c7-15325cae7fc2.png)

3)Traffic testing
Server
```
root@server1:~# ip addr show
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet 10.0.0.118/32 scope global lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
2: ens2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc pfifo_fast state UP group default qlen 1000
    link/ether fa:16:3e:6f:fd:00 brd ff:ff:ff:ff:ff:ff
    inet 192.168.0.103/24 brd 192.168.0.255 scope global ens2
       valid_lft forever preferred_lft forever
    inet6 fe80::f816:3eff:fe6f:fd00/64 scope link
       valid_lft forever preferred_lft forever
3: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether fa:16:3e:80:8c:a9 brd ff:ff:ff:ff:ff:ff
    inet 10.0.0.82/24 brd 10.0.0.255 scope global ens3
       valid_lft forever preferred_lft forever
    inet6 fe80::f816:3eff:fe80:8ca9/64 scope link
       valid_lft forever preferred_lft forever

root@server1:~# ip route
10.0.0.0/24 dev ens3  proto kernel  scope link  src 10.0.0.82
192.168.0.0/24 dev ens2  proto kernel  scope link  src 192.168.0.103
root@server1:~#
```

Client:
```
root@server1:~# ip add show
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
2: ens2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc pfifo_fast state UP group default qlen 1000
    link/ether fa:16:3e:ab:d7:56 brd ff:ff:ff:ff:ff:ff
    inet 192.168.0.67/24 brd 192.168.0.255 scope global ens2
       valid_lft forever preferred_lft forever
    inet6 fe80::f816:3eff:feab:d756/64 scope link
       valid_lft forever preferred_lft forever
3: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether fa:16:3e:4c:9b:c0 brd ff:ff:ff:ff:ff:ff
    inet 10.0.0.119/24 brd 10.0.0.255 scope global ens3
       valid_lft forever preferred_lft forever
    inet6 fe80::f816:3eff:fe4c:9bc0/64 scope link
       valid_lft forever preferred_lft forever

root@server1:~# ip route
10.0.0.0/24 dev ens3  proto kernel  scope link  src 10.0.0.119
192.168.0.0/24 dev ens2  proto kernel  scope link  src 192.168.0.67

root@server1:~# curl 10.0.0.118:80 -v
* Rebuilt URL to: 10.0.0.118:80/
*   Trying 10.0.0.118...
* Connected to 10.0.0.118 (10.0.0.118) port 80 (#0)
> GET / HTTP/1.1
> Host: 10.0.0.118
> User-Agent: curl/7.47.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Wed, 09 Jun 2021 10:19:12 GMT
< Server: Apache/2.4.18 (Ubuntu)
< Last-Modified: Mon, 06 Apr 2020 06:44:02 GMT
< ETag: "45-5a29997b96fdb"
< Accept-Ranges: bytes
< Content-Length: 69
< Vary: Accept-Encoding
< Content-Type: text/html
<
----------------------
Page from server1

----------------------
```

4)Remove loadbalancer with deployment flavor
```
stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer  list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 72ae7262-868e-4664-9489-1b9011fc6c09 | vs1  | 9b9275cbbca6430993aba4759606fe4d | 10.0.0.118  | ACTIVE              | a10      |
| bec6ed8c-00b2-4174-9307-4ba5bceb1d25 | vs2  | 9b9275cbbca6430993aba4759606fe4d | 10.0.0.67   | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
stack@adeeb:~/adeeb/a10-octavia$
vs1==>lb with flavor
vs2==>lb without flavor

stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer delete vs1 --cascade
stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer  list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| bec6ed8c-00b2-4174-9307-4ba5bceb1d25 | vs2  | 9b9275cbbca6430993aba4759606fe4d | 10.0.0.67   | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
stack@adeeb:~/adeeb/a10-octavia$

```

Removed 0.0.0.0/0 from AAP
![image](https://user-images.githubusercontent.com/76765492/121340489-515a6a00-c93d-11eb-9b66-591a42f167be.png)



