### PR TITLE
[STACK-2375] optimize LB creation/deletion time

### DIFF
--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -1068,6 +1068,8 @@ class VCSSyncWait(VThunderBaseTask):
                             msg="vBlade not found in vcs-summary")
                     raise acos_errors.AxapiJsonFormatError(
                         msg="vMaster not found in vcs-summary")
+                if vmaster_ready is True and vblade_ready is True:
+                    break
             except req_exceptions.ReadTimeout as e:
                 # Don't retry for ReadTimout, since acos-client already already have
                 # tries and timeout for axapi request. And it will take very long to


### PR DESCRIPTION
## Description
optimize LB creation time


## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2375

## Technical Approach
- task VCSSyncWait didn't exit the while loop when vMaster/vBlade are present.

## Config Changes

<pre>
<b>[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
#default_axapi_timeout = 600
l2dsr_support = True
slb_no_snat_support = True

[a10_controller_worker]
amp_image_owner_id = 99c9c2304f114685a32db30769c8a7e2
amp_secgroup_list = 2d0a3480-7f08-4184-b96f-c39bb444dd38
amp_flavor_id = 69995a83-c47a-427f-bf70-e9d9752aa915
#amp_boot_network_list = 7f8ddd7f-c5c3-463a-b1c3-596f988480a4
amp_boot_network_list = 7f8ddd7f-c5c3-463a-b1c3-596f988480a4, 61305531-6e3a-44b4-8e67-05e93363dddc, a66685db-31ee-46c6-928a-ac034d87dc63, ec33a88d-3290-4ad6-95cc-226fcd2a4458
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 150
amp_active_wait_sec = 10
#amp_vcs_retries = 59
#amp_vcs_wait_sec = 10
amp_busy_wait_sec = 0
amp_image_id = 0a845873-bd91-4f8c-ad58-cf5d5afde09c
#loadbalancer_topology = SINGLE
loadbalancer_topology = ACTIVE_STANDBY

[a10_health_manager]
udp_server_ip_address = 10.64.28.68
bind_port = 5550
bind_ip = 10.64.28.68
heartbeat_interval = 5
heartbeat_key = insecure
heartbeat_timeout = 90
health_check_interval = 3
failover_timeout = 600
health_check_timeout = 3
health_check_max_retries = 5

[a10_house_keeping]
load_balancer_expiry_age = 3600
amphorae_expiry_age = 3600
#use_periodic_write_memory = 'enable'
#write_mem_interval = 300

[a10_global]
network_type = "flat"
#network_type = "vlan"
#vrid=7
vrid_floating_ip = "dhcp"
</b>
</pre>

## Test Cases
- create multiple LB and delete them
- trace journal log and find tasks that takes more time. and try to reduce it.

## Manual Testing
```
openstack loadbalancer create --vip-subnet-id tp91 --name vip1
openstack loadbalancer create --vip-subnet-id tp91 --name vip2
openstack loadbalancer create --vip-subnet-id tp91 --name vip3
openstack loadbalancer delete vip3
openstack loadbalancer delete vip2
openstack loadbalancer delete vip1
```
