### PR TITLE
[STACK-2356] get_create_load_balancer_flow get lb failed in revert flow

### DIFF
--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -51,13 +51,15 @@ CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
 
 
-def ctx_cnt_dec(ctx_lock, ctx_map, key, is_reload_thread, flags=None):
+def ctx_cnt_dec(ctx_lock, ctx_map, key, is_reload_thread, flags):
     ctx_lock.acquire()
     LOG.debug('--------------------------ctx_cnt_dec-----------------------------')
     try:
         ctx = ctx_map.get(key)
         if ctx is None:
             raise
+        if flags is not None and flags[0] is False:
+            return
 
         normal_thrd_num, reload_thrd_num = ctx
         LOG.debug('vthunder %s ctx: normal_thrd(%d), reload_thrd(%d)',
@@ -70,7 +72,7 @@ def ctx_cnt_dec(ctx_lock, ctx_map, key, is_reload_thread, flags=None):
             if normal_thrd_num > 0:
                 normal_thrd_num = normal_thrd_num - 1
         if flags is not None:
-            flags[0] = True
+            flags[0] = False
         LOG.debug('vthunder %s ctx: normal_thrd(%d), reload_thrd(%d)',
                   key, normal_thrd_num, reload_thrd_num)
         ctx_map[key] = (normal_thrd_num, reload_thrd_num)
@@ -91,7 +93,7 @@ def flow_notification_handler(state, details, **kwargs):
         ctx_flags = kwargs.get('ctx_flags')
         if ctx_lock is None or ctx_map is None:
             raise
-        ctx_cnt_dec(ctx_lock, ctx_map, key, is_reload_thread, flags=ctx_flags)
+        ctx_cnt_dec(ctx_lock, ctx_map, key, is_reload_thread, ctx_flags)
 
 
 class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
@@ -116,6 +118,8 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         self._exclude_result_logging_tasks = ()
         self.ctx_map = None
         self.ctx_lock = None
+
+        # flag: ctx counter need to decrease when done
         self.ctx_flags = [False]
         super(A10ControllerWorker, self).__init__()
 
@@ -160,21 +164,21 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(health_mon.project_id, False, None)
-        create_hm_tf = self._taskflow_load(
-            self._health_monitor_flows.get_create_health_monitor_flow(topology=topology),
-            store={constants.HEALTH_MON: health_mon,
-                   constants.POOL: pool,
-                   constants.LISTENERS: listeners,
-                   constants.LOADBALANCER: load_balancer,
-                   a10constants.COMPUTE_BUSY: busy,
-                   a10constants.WRITE_MEM_SHARED_PART: True})
-        self._register_flow_notify_handler(create_hm_tf, health_mon.project_id, False, busy)
-        with tf_logging.DynamicLoggingListener(create_hm_tf,
-                                               log=LOG):
-            try:
+        try:
+            create_hm_tf = self._taskflow_load(
+                self._health_monitor_flows.get_create_health_monitor_flow(topology=topology),
+                store={constants.HEALTH_MON: health_mon,
+                       constants.POOL: pool,
+                       constants.LISTENERS: listeners,
+                       constants.LOADBALANCER: load_balancer,
+                       a10constants.COMPUTE_BUSY: busy,
+                       a10constants.WRITE_MEM_SHARED_PART: True})
+            self._register_flow_notify_handler(create_hm_tf, health_mon.project_id, False, busy)
+            with tf_logging.DynamicLoggingListener(create_hm_tf,
+                                                   log=LOG):
                 create_hm_tf.run()
-            finally:
-                self._set_vthunder_available(health_mon.project_id, False)
+        finally:
+            self._set_vthunder_available(health_mon.project_id, False)
 
     def delete_health_monitor(self, health_monitor_id):
         """Deletes a health monitor.
@@ -194,21 +198,21 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(health_mon.project_id, False, None)
-        delete_hm_tf = self._taskflow_load(
-            self._health_monitor_flows.get_delete_health_monitor_flow(topology=topology),
-            store={constants.HEALTH_MON: health_mon,
-                   constants.POOL: pool,
-                   constants.LISTENERS: listeners,
-                   constants.LOADBALANCER: load_balancer,
-                   a10constants.COMPUTE_BUSY: busy,
-                   a10constants.WRITE_MEM_SHARED_PART: True})
-        self._register_flow_notify_handler(delete_hm_tf, health_mon.project_id, False, busy)
-        with tf_logging.DynamicLoggingListener(delete_hm_tf,
-                                               log=LOG):
-            try:
+        try:
+            delete_hm_tf = self._taskflow_load(
+                self._health_monitor_flows.get_delete_health_monitor_flow(topology=topology),
+                store={constants.HEALTH_MON: health_mon,
+                       constants.POOL: pool,
+                       constants.LISTENERS: listeners,
+                       constants.LOADBALANCER: load_balancer,
+                       a10constants.COMPUTE_BUSY: busy,
+                       a10constants.WRITE_MEM_SHARED_PART: True})
+            self._register_flow_notify_handler(delete_hm_tf, health_mon.project_id, False, busy)
+            with tf_logging.DynamicLoggingListener(delete_hm_tf,
+                                                   log=LOG):
                 delete_hm_tf.run()
-            finally:
-                self._set_vthunder_available(health_mon.project_id, False)
+        finally:
+            self._set_vthunder_available(health_mon.project_id, False)
 
     def update_health_monitor(self, health_monitor_id, health_monitor_updates):
         """Updates a health monitor.
@@ -239,22 +243,22 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(health_mon.project_id, False, None)
-        update_hm_tf = self._taskflow_load(
-            self._health_monitor_flows.get_update_health_monitor_flow(topology=topology),
-            store={constants.HEALTH_MON: health_mon,
-                   constants.POOL: pool,
-                   constants.LISTENERS: listeners,
-                   constants.LOADBALANCER: load_balancer,
-                   a10constants.COMPUTE_BUSY: busy,
-                   constants.UPDATE_DICT: health_monitor_updates,
-                   a10constants.WRITE_MEM_SHARED_PART: True})
-        self._register_flow_notify_handler(update_hm_tf, health_mon.project_id, False, busy)
-        with tf_logging.DynamicLoggingListener(update_hm_tf,
-                                               log=LOG):
-            try:
+        try:
+            update_hm_tf = self._taskflow_load(
+                self._health_monitor_flows.get_update_health_monitor_flow(topology=topology),
+                store={constants.HEALTH_MON: health_mon,
+                       constants.POOL: pool,
+                       constants.LISTENERS: listeners,
+                       constants.LOADBALANCER: load_balancer,
+                       a10constants.COMPUTE_BUSY: busy,
+                       constants.UPDATE_DICT: health_monitor_updates,
+                       a10constants.WRITE_MEM_SHARED_PART: True})
+            self._register_flow_notify_handler(update_hm_tf, health_mon.project_id, False, busy)
+            with tf_logging.DynamicLoggingListener(update_hm_tf,
+                                                   log=LOG):
                 update_hm_tf.run()
-            finally:
-                self._set_vthunder_available(health_mon.project_id, False)
+        finally:
+            self._set_vthunder_available(health_mon.project_id, False)
 
     def create_listener(self, listener_id):
         """Function to create listener for A10 provider"""
@@ -272,34 +276,32 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         topology = CONF.a10_controller_worker.loadbalancer_topology
 
-        if (listener.project_id in parent_project_list or
-                (listener_parent_proj and listener_parent_proj in parent_project_list)
-                or self._is_rack_flow(listener.project_id, loadbalancer=load_balancer)):
-            create_listener_tf = self._taskflow_load(self._listener_flows.
-                                                     get_rack_vthunder_create_listener_flow(
-                                                         listener.project_id),
-                                                     store={constants.LOADBALANCER:
-                                                            load_balancer,
-                                                            constants.LISTENER:
-                                                            listener})
-        else:
-            busy = self._vthunder_busy_check(listener.project_id, False, None)
-            create_listener_tf = self._taskflow_load(self._listener_flows.
-                                                     get_create_listener_flow(topology=topology),
-                                                     store={constants.LOADBALANCER:
-                                                            load_balancer,
-                                                            a10constants.COMPUTE_BUSY: busy,
-                                                            constants.LISTENER:
-                                                            listener})
-            self._register_flow_notify_handler(create_listener_tf, listener.project_id,
-                                               False, busy)
+        try:
+            if (listener.project_id in parent_project_list or
+                    (listener_parent_proj and listener_parent_proj in parent_project_list)
+                    or self._is_rack_flow(listener.project_id, loadbalancer=load_balancer)):
+                create_listener_tf = self._taskflow_load(self._listener_flows.
+                                                         get_rack_vthunder_create_listener_flow(
+                                                             listener.project_id),
+                                                         store={constants.LOADBALANCER:
+                                                                load_balancer,
+                                                                constants.LISTENER:
+                                                                listener})
+            else:
+                busy = self._vthunder_busy_check(listener.project_id, False, None)
+                create_listener_tf = self._taskflow_load(
+                    self._listener_flows.get_create_listener_flow(topology=topology),
+                    store={constants.LOADBALANCER: load_balancer,
+                           a10constants.COMPUTE_BUSY: busy,
+                           constants.LISTENER: listener})
+                self._register_flow_notify_handler(create_listener_tf, listener.project_id,
+                                                   False, busy)
 
-        with tf_logging.DynamicLoggingListener(create_listener_tf,
-                                               log=LOG):
-            try:
+            with tf_logging.DynamicLoggingListener(create_listener_tf,
+                                                   log=LOG):
                 create_listener_tf.run()
-            finally:
-                self._set_vthunder_available(listener.project_id, False)
+        finally:
+            self._set_vthunder_available(listener.project_id, False)
 
     def delete_listener(self, listener_id):
         """Function to delete a listener for A10 provider"""
@@ -310,26 +312,26 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         topology = CONF.a10_controller_worker.loadbalancer_topology
 
-        if self._is_rack_flow(listener.project_id, loadbalancer=load_balancer):
-            delete_listener_tf = self._taskflow_load(
-                self._listener_flows.get_delete_rack_listener_flow(),
-                store={constants.LOADBALANCER: load_balancer,
-                       constants.LISTENER: listener})
-        else:
-            busy = self._vthunder_busy_check(listener.project_id, False, None)
-            delete_listener_tf = self._taskflow_load(
-                self._listener_flows.get_delete_listener_flow(topology),
-                store={constants.LOADBALANCER: load_balancer,
-                       a10constants.COMPUTE_BUSY: busy,
-                       constants.LISTENER: listener})
-            self._register_flow_notify_handler(delete_listener_tf, listener.project_id,
-                                               False, busy)
-        with tf_logging.DynamicLoggingListener(delete_listener_tf,
-                                               log=LOG):
-            try:
+        try:
+            if self._is_rack_flow(listener.project_id, loadbalancer=load_balancer):
+                delete_listener_tf = self._taskflow_load(
+                    self._listener_flows.get_delete_rack_listener_flow(),
+                    store={constants.LOADBALANCER: load_balancer,
+                           constants.LISTENER: listener})
+            else:
+                busy = self._vthunder_busy_check(listener.project_id, False, None)
+                delete_listener_tf = self._taskflow_load(
+                    self._listener_flows.get_delete_listener_flow(topology),
+                    store={constants.LOADBALANCER: load_balancer,
+                           a10constants.COMPUTE_BUSY: busy,
+                           constants.LISTENER: listener})
+                self._register_flow_notify_handler(delete_listener_tf, listener.project_id,
+                                                   False, busy)
+            with tf_logging.DynamicLoggingListener(delete_listener_tf,
+                                                   log=LOG):
                 delete_listener_tf.run()
-            finally:
-                self._set_vthunder_available(listener.project_id, False)
+        finally:
+            self._set_vthunder_available(listener.project_id, False)
 
     def update_listener(self, listener_id, listener_updates):
         """Function to Update a listener for A10 provider"""
@@ -352,23 +354,23 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(listener.project_id, False, None)
-        update_listener_tf = self._taskflow_load(self._listener_flows.
-                                                 get_update_listener_flow(topology),
-                                                 store={constants.LISTENER:
-                                                        listener,
-                                                        a10constants.COMPUTE_BUSY: busy,
-                                                        constants.LOADBALANCER:
-                                                            load_balancer,
-                                                        constants.UPDATE_DICT:
-                                                            listener_updates
-                                                        })
-        self._register_flow_notify_handler(update_listener_tf, listener.project_id,
-                                           False, busy)
-        with tf_logging.DynamicLoggingListener(update_listener_tf, log=LOG):
-            try:
+        try:
+            update_listener_tf = self._taskflow_load(self._listener_flows.
+                                                     get_update_listener_flow(topology),
+                                                     store={constants.LISTENER:
+                                                            listener,
+                                                            a10constants.COMPUTE_BUSY: busy,
+                                                            constants.LOADBALANCER:
+                                                                load_balancer,
+                                                            constants.UPDATE_DICT:
+                                                                listener_updates
+                                                            })
+            self._register_flow_notify_handler(update_listener_tf, listener.project_id,
+                                               False, busy)
+            with tf_logging.DynamicLoggingListener(update_listener_tf, log=LOG):
                 update_listener_tf.run()
-            finally:
-                self._set_vthunder_available(listener.project_id, False)
+        finally:
+            self._set_vthunder_available(listener.project_id, False)
 
     @tenacity.retry(
         retry=tenacity.retry_if_exception_type(db_exceptions.NoResultFound),
@@ -397,31 +399,31 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             constants.TOPOLOGY: topology
         }
 
-        if self._is_rack_flow(lb.project_id, flavor=flavor):
-            vthunder_conf = CONF.hardware_thunder.devices.get(lb.project_id, None)
-            device_dict = CONF.hardware_thunder.devices
-            create_lb_flow = self._lb_flows.get_create_rack_vthunder_load_balancer_flow(
-                vthunder_conf=vthunder_conf, device_dict=device_dict,
-                topology=topology, listeners=lb.listeners)
-            create_lb_tf = self._taskflow_load(create_lb_flow, store=store)
-        else:
-            busy = self._vthunder_busy_check(lb.project_id, True, store)
-            create_lb_flow = self._lb_flows.get_create_load_balancer_flow(
-                load_balancer_id, topology, lb.project_id, listeners=lb.listeners)
-            store.update([
-                (a10constants.COMPUTE_BUSY, busy),
-                (a10constants.VTHUNDER_CONFIG, None),
-                (a10constants.USE_DEVICE_FLAVOR, False)])
-            create_lb_tf = self._taskflow_load(create_lb_flow, store=store)
-            self._register_flow_notify_handler(create_lb_tf, lb.project_id, True, busy)
+        try:
+            if self._is_rack_flow(lb.project_id, flavor=flavor):
+                vthunder_conf = CONF.hardware_thunder.devices.get(lb.project_id, None)
+                device_dict = CONF.hardware_thunder.devices
+                create_lb_flow = self._lb_flows.get_create_rack_vthunder_load_balancer_flow(
+                    vthunder_conf=vthunder_conf, device_dict=device_dict,
+                    topology=topology, listeners=lb.listeners)
+                create_lb_tf = self._taskflow_load(create_lb_flow, store=store)
+            else:
+                busy = self._vthunder_busy_check(lb.project_id, True, store)
+                create_lb_flow = self._lb_flows.get_create_load_balancer_flow(
+                    load_balancer_id, topology, lb.project_id, listeners=lb.listeners)
+                store.update([
+                    (a10constants.COMPUTE_BUSY, busy),
+                    (a10constants.VTHUNDER_CONFIG, None),
+                    (a10constants.USE_DEVICE_FLAVOR, False)])
+                create_lb_tf = self._taskflow_load(create_lb_flow, store=store)
+                self._register_flow_notify_handler(create_lb_tf, lb.project_id, True, busy)
 
-        with tf_logging.DynamicLoggingListener(
-                create_lb_tf, log=LOG,
-                hide_inputs_outputs_of=self._exclude_result_logging_tasks):
-            try:
+            with tf_logging.DynamicLoggingListener(
+                    create_lb_tf, log=LOG,
+                    hide_inputs_outputs_of=self._exclude_result_logging_tasks):
                 create_lb_tf.run()
-            finally:
-                self._set_vthunder_available(lb.project_id, True)
+        finally:
+            self._set_vthunder_available(lb.project_id, True)
 
     def delete_load_balancer(self, load_balancer_id, cascade=False):
         """Function to delete load balancer for A10 provider"""
@@ -432,33 +434,33 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                                                             load_balancer_id)
         deleteCompute = False
         busy = self._vthunder_busy_check(lb.project_id, True, None)
-        if vthunder:
-            deleteCompute = self._vthunder_repo.get_delete_compute_flag(db_apis.get_session(),
-                                                                        vthunder.compute_id)
+        try:
+            if vthunder:
+                deleteCompute = self._vthunder_repo.get_delete_compute_flag(db_apis.get_session(),
+                                                                            vthunder.compute_id)
 
-        if cascade:
-            cascade = True
-        if self._is_rack_flow(lb.project_id, loadbalancer=lb):
-            (flow, store) = self._lb_flows.get_delete_rack_vthunder_load_balancer_flow(
-                lb, cascade)
-        else:
-            (flow, store) = self._lb_flows.get_delete_load_balancer_flow(
-                lb, deleteCompute, cascade)
+            if cascade:
+                cascade = True
+            if self._is_rack_flow(lb.project_id, loadbalancer=lb):
+                (flow, store) = self._lb_flows.get_delete_rack_vthunder_load_balancer_flow(
+                    lb, cascade)
+            else:
+                (flow, store) = self._lb_flows.get_delete_load_balancer_flow(
+                    lb, deleteCompute, cascade)
 
-        store.update({constants.LOADBALANCER: lb,
-                      a10constants.COMPUTE_BUSY: busy,
-                      constants.VIP: lb.vip,
-                      constants.SERVER_GROUP_ID: lb.server_group_id})
+            store.update({constants.LOADBALANCER: lb,
+                          a10constants.COMPUTE_BUSY: busy,
+                          constants.VIP: lb.vip,
+                          constants.SERVER_GROUP_ID: lb.server_group_id})
 
-        delete_lb_tf = self._taskflow_load(flow, store=store)
-        self._register_flow_notify_handler(delete_lb_tf, lb.project_id, True, busy)
+            delete_lb_tf = self._taskflow_load(flow, store=store)
+            self._register_flow_notify_handler(delete_lb_tf, lb.project_id, True, busy)
 
-        with tf_logging.DynamicLoggingListener(delete_lb_tf,
-                                               log=LOG):
-            try:
+            with tf_logging.DynamicLoggingListener(delete_lb_tf,
+                                                   log=LOG):
                 delete_lb_tf.run()
-            finally:
-                self._set_vthunder_available(lb.project_id, True)
+        finally:
+            self._set_vthunder_available(lb.project_id, True)
 
     def update_load_balancer(self, load_balancer_id, load_balancer_updates):
         """Function to update load balancer for A10 provider"""
@@ -481,36 +483,36 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         topology = CONF.a10_controller_worker.loadbalancer_topology
 
-        if self._is_rack_flow(lb.project_id, loadbalancer=lb):
-            vthunder_conf = CONF.hardware_thunder.devices.get(lb.project_id, None)
-            device_dict = CONF.hardware_thunder.devices
-            update_lb_tf = self._taskflow_load(
-                self._lb_flows.get_update_rack_load_balancer_flow(vthunder_conf=vthunder_conf,
-                                                                  device_dict=device_dict,
-                                                                  topology=topology),
-                store={constants.LOADBALANCER: lb,
-                       constants.VIP: lb.vip,
-                       constants.LISTENERS: listeners,
-                       constants.UPDATE_DICT: load_balancer_updates})
-        else:
-            busy = self._vthunder_busy_check(lb.project_id, False, None)
-            update_lb_tf = self._taskflow_load(
-                self._lb_flows.get_update_load_balancer_flow(topology=topology),
-                store={constants.LOADBALANCER: lb,
-                       constants.VIP: lb.vip,
-                       a10constants.COMPUTE_BUSY: busy,
-                       constants.LISTENERS: listeners,
-                       constants.UPDATE_DICT: load_balancer_updates,
-                       a10constants.VTHUNDER_CONFIG: None,
-                       a10constants.USE_DEVICE_FLAVOR: False})
-            self._register_flow_notify_handler(update_lb_tf, lb.project_id, False, busy)
+        try:
+            if self._is_rack_flow(lb.project_id, loadbalancer=lb):
+                vthunder_conf = CONF.hardware_thunder.devices.get(lb.project_id, None)
+                device_dict = CONF.hardware_thunder.devices
+                update_lb_tf = self._taskflow_load(
+                    self._lb_flows.get_update_rack_load_balancer_flow(vthunder_conf=vthunder_conf,
+                                                                      device_dict=device_dict,
+                                                                      topology=topology),
+                    store={constants.LOADBALANCER: lb,
+                           constants.VIP: lb.vip,
+                           constants.LISTENERS: listeners,
+                           constants.UPDATE_DICT: load_balancer_updates})
+            else:
+                busy = self._vthunder_busy_check(lb.project_id, False, None)
+                update_lb_tf = self._taskflow_load(
+                    self._lb_flows.get_update_load_balancer_flow(topology=topology),
+                    store={constants.LOADBALANCER: lb,
+                           constants.VIP: lb.vip,
+                           a10constants.COMPUTE_BUSY: busy,
+                           constants.LISTENERS: listeners,
+                           constants.UPDATE_DICT: load_balancer_updates,
+                           a10constants.VTHUNDER_CONFIG: None,
+                           a10constants.USE_DEVICE_FLAVOR: False})
+                self._register_flow_notify_handler(update_lb_tf, lb.project_id, False, busy)
 
-        with tf_logging.DynamicLoggingListener(update_lb_tf,
-                                               log=LOG):
-            try:
+            with tf_logging.DynamicLoggingListener(update_lb_tf,
+                                                   log=LOG):
                 update_lb_tf.run()
-            finally:
-                self._set_vthunder_available(lb.project_id, False)
+        finally:
+            self._set_vthunder_available(lb.project_id, False)
 
     @tenacity.retry(
         retry=tenacity.retry_if_exception_type(db_exceptions.NoResultFound),
@@ -541,41 +543,40 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         member_parent_proj = utils.get_parent_project(
             member.project_id)
 
-        if (member.project_id in parent_project_list or
-                (member_parent_proj and member_parent_proj in parent_project_list)
-                or self._is_rack_flow(member.project_id, loadbalancer=load_balancer)):
-            vthunder_conf = CONF.hardware_thunder.devices.get(load_balancer.project_id, None)
-            create_member_tf = self._taskflow_load(
-                self._member_flows.get_rack_vthunder_create_member_flow(),
-                store={
-                    constants.MEMBER: member,
-                    constants.LISTENERS: listeners,
-                    constants.LOADBALANCER: load_balancer,
-                    constants.POOL: pool,
-                    a10constants.VTHUNDER_CONFIG: vthunder_conf,
-                    a10constants.USE_DEVICE_FLAVOR: None})
-        else:
-            busy = self._vthunder_busy_check(member.project_id, True, None)
-            create_member_tf = self._taskflow_load(self._member_flows.
-                                                   get_create_member_flow(
-                                                       topology=topology),
-                                                   store={constants.MEMBER: member,
-                                                          constants.LISTENERS:
-                                                          listeners,
-                                                          constants.LOADBALANCER:
-                                                          load_balancer,
-                                                          a10constants.COMPUTE_BUSY: busy,
-                                                          constants.POOL: pool,
-                                                          a10constants.VTHUNDER_CONFIG: None,
-                                                          a10constants.USE_DEVICE_FLAVOR: None})
-            self._register_flow_notify_handler(create_member_tf, member.project_id, True, busy)
+        try:
+            if (member.project_id in parent_project_list or
+                    (member_parent_proj and member_parent_proj in parent_project_list)
+                    or self._is_rack_flow(member.project_id, loadbalancer=load_balancer)):
+                vthunder_conf = CONF.hardware_thunder.devices.get(load_balancer.project_id, None)
+                create_member_tf = self._taskflow_load(
+                    self._member_flows.get_rack_vthunder_create_member_flow(),
+                    store={
+                        constants.MEMBER: member,
+                        constants.LISTENERS: listeners,
+                        constants.LOADBALANCER: load_balancer,
+                        constants.POOL: pool,
+                        a10constants.VTHUNDER_CONFIG: vthunder_conf,
+                        a10constants.USE_DEVICE_FLAVOR: None})
+            else:
+                busy = self._vthunder_busy_check(member.project_id, True, None)
+                create_member_tf = self._taskflow_load(
+                    self._member_flows.get_create_member_flow(topology=topology),
+                    store={constants.MEMBER: member,
+                           constants.LISTENERS:
+                           listeners,
+                           constants.LOADBALANCER:
+                           load_balancer,
+                           a10constants.COMPUTE_BUSY: busy,
+                           constants.POOL: pool,
+                           a10constants.VTHUNDER_CONFIG: None,
+                           a10constants.USE_DEVICE_FLAVOR: None})
+                self._register_flow_notify_handler(create_member_tf, member.project_id, True, busy)
 
-        with tf_logging.DynamicLoggingListener(create_member_tf,
-                                               log=LOG):
-            try:
+            with tf_logging.DynamicLoggingListener(create_member_tf,
+                                                   log=LOG):
                 create_member_tf.run()
-            finally:
-                self._set_vthunder_available(member.project_id, True)
+        finally:
+            self._set_vthunder_available(member.project_id, True)
 
     def delete_member(self, member_id):
         """Deletes a pool member.
@@ -591,27 +592,27 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         load_balancer = pool.load_balancer
         topology = CONF.a10_controller_worker.loadbalancer_topology
 
-        if self._is_rack_flow(member.project_id, loadbalancer=load_balancer):
-            delete_member_tf = self._taskflow_load(
-                self._member_flows.get_rack_vthunder_delete_member_flow(),
-                store={constants.MEMBER: member, constants.LISTENERS: listeners,
-                       constants.LOADBALANCER: load_balancer, constants.POOL: pool}
-            )
-        else:
-            busy = self._vthunder_busy_check(member.project_id, True, None)
-            delete_member_tf = self._taskflow_load(
-                self._member_flows.get_delete_member_flow(topology=topology),
-                store={constants.MEMBER: member, constants.LISTENERS: listeners,
-                       constants.LOADBALANCER: load_balancer, a10constants.COMPUTE_BUSY: busy,
-                       constants.POOL: pool}
-            )
-            self._register_flow_notify_handler(delete_member_tf, member.project_id, True, busy)
-        with tf_logging.DynamicLoggingListener(delete_member_tf,
-                                               log=LOG):
-            try:
+        try:
+            if self._is_rack_flow(member.project_id, loadbalancer=load_balancer):
+                delete_member_tf = self._taskflow_load(
+                    self._member_flows.get_rack_vthunder_delete_member_flow(),
+                    store={constants.MEMBER: member, constants.LISTENERS: listeners,
+                           constants.LOADBALANCER: load_balancer, constants.POOL: pool}
+                )
+            else:
+                busy = self._vthunder_busy_check(member.project_id, True, None)
+                delete_member_tf = self._taskflow_load(
+                    self._member_flows.get_delete_member_flow(topology=topology),
+                    store={constants.MEMBER: member, constants.LISTENERS: listeners,
+                           constants.LOADBALANCER: load_balancer, a10constants.COMPUTE_BUSY: busy,
+                           constants.POOL: pool}
+                )
+                self._register_flow_notify_handler(delete_member_tf, member.project_id, True, busy)
+            with tf_logging.DynamicLoggingListener(delete_member_tf,
+                                                   log=LOG):
                 delete_member_tf.run()
-            finally:
-                self._set_vthunder_available(member.project_id, True)
+        finally:
+            self._set_vthunder_available(member.project_id, True)
 
     def batch_update_members(self, old_member_ids, new_member_ids,
                              updated_members):
@@ -646,38 +647,36 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         topology = CONF.a10_controller_worker.loadbalancer_topology
 
-        if self._is_rack_flow(member.project_id, loadbalancer=load_balancer):
-            update_member_tf = self._taskflow_load(self._member_flows.
-                                                   get_rack_vthunder_update_member_flow(),
-                                                   store={constants.MEMBER: member,
-                                                          constants.LISTENERS:
+        try:
+            if self._is_rack_flow(member.project_id, loadbalancer=load_balancer):
+                update_member_tf = self._taskflow_load(
+                    self._member_flows.get_rack_vthunder_update_member_flow(),
+                    store={constants.MEMBER: member,
+                           constants.LISTENERS: listeners,
+                           constants.LOADBALANCER: load_balancer,
+                           constants.POOL: pool,
+                           constants.UPDATE_DICT: member_updates})
+            else:
+                busy = self._vthunder_busy_check(member.project_id, False, None)
+                update_member_tf = self._taskflow_load(self._member_flows.
+                                                       get_update_member_flow(topology=topology),
+                                                       store={constants.MEMBER: member,
+                                                              constants.LISTENERS:
                                                               listeners,
-                                                          constants.LOADBALANCER:
+                                                              constants.LOADBALANCER:
                                                               load_balancer,
-                                                          constants.POOL: pool,
-                                                          constants.UPDATE_DICT: member_updates})
-        else:
-            busy = self._vthunder_busy_check(member.project_id, False, None)
-            update_member_tf = self._taskflow_load(self._member_flows.
-                                                   get_update_member_flow(topology=topology),
-                                                   store={constants.MEMBER: member,
-                                                          constants.LISTENERS:
-                                                          listeners,
-                                                          constants.LOADBALANCER:
-                                                          load_balancer,
-                                                          a10constants.COMPUTE_BUSY: busy,
-                                                          constants.POOL:
-                                                          pool,
-                                                          constants.UPDATE_DICT:
-                                                          member_updates})
-            self._register_flow_notify_handler(update_member_tf, member.project_id, False, busy)
+                                                              a10constants.COMPUTE_BUSY: busy,
+                                                              constants.POOL:
+                                                              pool,
+                                                              constants.UPDATE_DICT:
+                                                              member_updates})
+                self._register_flow_notify_handler(update_member_tf, member.project_id, False, busy)
 
-        with tf_logging.DynamicLoggingListener(update_member_tf,
-                                               log=LOG):
-            try:
+            with tf_logging.DynamicLoggingListener(update_member_tf,
+                                                   log=LOG):
                 update_member_tf.run()
-            finally:
-                self._set_vthunder_available(member.project_id, False)
+        finally:
+            self._set_vthunder_available(member.project_id, False)
 
     @tenacity.retry(
         retry=tenacity.retry_if_exception_type(db_exceptions.NoResultFound),
@@ -708,22 +707,22 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(pool.project_id, False, None)
-        create_pool_tf = self._taskflow_load(self._pool_flows.
-                                             get_create_pool_flow(topology=topology),
-                                             store={constants.POOL: pool,
-                                                    constants.LISTENERS:
-                                                        listeners,
-                                                    constants.LISTENER: default_listener,
-                                                    constants.LOADBALANCER:
-                                                        load_balancer,
-                                                    a10constants.COMPUTE_BUSY: busy})
-        self._register_flow_notify_handler(create_pool_tf, pool.project_id, False, busy)
-        with tf_logging.DynamicLoggingListener(create_pool_tf,
-                                               log=LOG):
-            try:
+        try:
+            create_pool_tf = self._taskflow_load(self._pool_flows.
+                                                 get_create_pool_flow(topology=topology),
+                                                 store={constants.POOL: pool,
+                                                        constants.LISTENERS:
+                                                            listeners,
+                                                        constants.LISTENER: default_listener,
+                                                        constants.LOADBALANCER:
+                                                            load_balancer,
+                                                        a10constants.COMPUTE_BUSY: busy})
+            self._register_flow_notify_handler(create_pool_tf, pool.project_id, False, busy)
+            with tf_logging.DynamicLoggingListener(create_pool_tf,
+                                                   log=LOG):
                 create_pool_tf.run()
-            finally:
-                self._set_vthunder_available(pool.project_id, False)
+        finally:
+            self._set_vthunder_available(pool.project_id, False)
 
     def delete_pool(self, pool_id):
         """Deletes a node pool.
@@ -752,24 +751,24 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                  constants.HEALTH_MON: health_monitor,
                  a10constants.MEMBER_COUNT: mem_count}
 
-        if self._is_rack_flow(pool.project_id, loadbalancer=load_balancer):
-            delete_pool_tf = self._taskflow_load(
-                self._pool_flows.get_delete_pool_rack_flow(
-                    members, health_monitor, store), store=store)
-        else:
-            topology = CONF.a10_controller_worker.loadbalancer_topology
-            busy = self._vthunder_busy_check(pool.project_id, False, store)
-            delete_pool_tf = self._taskflow_load(
-                self._pool_flows.get_delete_pool_flow(
-                    members, health_monitor, store, topology), store=store)
-            self._register_flow_notify_handler(delete_pool_tf, pool.project_id, False, busy)
+        try:
+            if self._is_rack_flow(pool.project_id, loadbalancer=load_balancer):
+                delete_pool_tf = self._taskflow_load(
+                    self._pool_flows.get_delete_pool_rack_flow(
+                        members, health_monitor, store), store=store)
+            else:
+                topology = CONF.a10_controller_worker.loadbalancer_topology
+                busy = self._vthunder_busy_check(pool.project_id, False, store)
+                delete_pool_tf = self._taskflow_load(
+                    self._pool_flows.get_delete_pool_flow(
+                        members, health_monitor, store, topology), store=store)
+                self._register_flow_notify_handler(delete_pool_tf, pool.project_id, False, busy)
 
-        with tf_logging.DynamicLoggingListener(delete_pool_tf,
-                                               log=LOG):
-            try:
+            with tf_logging.DynamicLoggingListener(delete_pool_tf,
+                                                   log=LOG):
                 delete_pool_tf.run()
-            finally:
-                self._set_vthunder_available(pool.project_id, False)
+        finally:
+            self._set_vthunder_available(pool.project_id, False)
 
     def update_pool(self, pool_id, pool_updates):
         """Updates a node pool.
@@ -802,24 +801,24 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(pool.project_id, False, None)
-        update_pool_tf = self._taskflow_load(self._pool_flows.
-                                             get_update_pool_flow(topology),
-                                             store={constants.POOL: pool,
-                                                    constants.LISTENERS:
-                                                        listeners,
-                                                    constants.LISTENER: default_listener,
-                                                    constants.LOADBALANCER:
-                                                        load_balancer,
-                                                    a10constants.COMPUTE_BUSY: busy,
-                                                    constants.UPDATE_DICT:
-                                                        pool_updates})
-        self._register_flow_notify_handler(update_pool_tf, pool.project_id, False, busy)
-        with tf_logging.DynamicLoggingListener(update_pool_tf,
-                                               log=LOG):
-            try:
+        try:
+            update_pool_tf = self._taskflow_load(self._pool_flows.
+                                                 get_update_pool_flow(topology),
+                                                 store={constants.POOL: pool,
+                                                        constants.LISTENERS:
+                                                            listeners,
+                                                        constants.LISTENER: default_listener,
+                                                        constants.LOADBALANCER:
+                                                            load_balancer,
+                                                        a10constants.COMPUTE_BUSY: busy,
+                                                        constants.UPDATE_DICT:
+                                                            pool_updates})
+            self._register_flow_notify_handler(update_pool_tf, pool.project_id, False, busy)
+            with tf_logging.DynamicLoggingListener(update_pool_tf,
+                                                   log=LOG):
                 update_pool_tf.run()
-            finally:
-                self._set_vthunder_available(pool.project_id, False)
+        finally:
+            self._set_vthunder_available(pool.project_id, False)
 
     @tenacity.retry(
         retry=tenacity.retry_if_exception_type(db_exceptions.NoResultFound),
@@ -847,19 +846,19 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(l7policy.project_id, False, None)
-        create_l7policy_tf = self._taskflow_load(
-            self._l7policy_flows.get_create_l7policy_flow(topology=topology),
-            store={constants.L7POLICY: l7policy,
-                   constants.LISTENERS: listeners,
-                   constants.LOADBALANCER: load_balancer,
-                   a10constants.COMPUTE_BUSY: busy})
-        self._register_flow_notify_handler(create_l7policy_tf, l7policy.project_id, False, busy)
-        with tf_logging.DynamicLoggingListener(create_l7policy_tf,
-                                               log=LOG):
-            try:
+        try:
+            create_l7policy_tf = self._taskflow_load(
+                self._l7policy_flows.get_create_l7policy_flow(topology=topology),
+                store={constants.L7POLICY: l7policy,
+                       constants.LISTENERS: listeners,
+                       constants.LOADBALANCER: load_balancer,
+                       a10constants.COMPUTE_BUSY: busy})
+            self._register_flow_notify_handler(create_l7policy_tf, l7policy.project_id, False, busy)
+            with tf_logging.DynamicLoggingListener(create_l7policy_tf,
+                                                   log=LOG):
                 create_l7policy_tf.run()
-            finally:
-                self._set_vthunder_available(l7policy.project_id, False)
+        finally:
+            self._set_vthunder_available(l7policy.project_id, False)
 
     def delete_l7policy(self, l7policy_id):
         """Deletes an L7 policy.
@@ -877,19 +876,19 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(l7policy.project_id, False, None)
-        delete_l7policy_tf = self._taskflow_load(
-            self._l7policy_flows.get_delete_l7policy_flow(topology=topology),
-            store={constants.L7POLICY: l7policy,
-                   constants.LISTENERS: listeners,
-                   constants.LOADBALANCER: load_balancer,
-                   a10constants.COMPUTE_BUSY: busy})
-        self._register_flow_notify_handler(delete_l7policy_tf, l7policy.project_id, False, busy)
-        with tf_logging.DynamicLoggingListener(delete_l7policy_tf,
-                                               log=LOG):
-            try:
+        try:
+            delete_l7policy_tf = self._taskflow_load(
+                self._l7policy_flows.get_delete_l7policy_flow(topology=topology),
+                store={constants.L7POLICY: l7policy,
+                       constants.LISTENERS: listeners,
+                       constants.LOADBALANCER: load_balancer,
+                       a10constants.COMPUTE_BUSY: busy})
+            self._register_flow_notify_handler(delete_l7policy_tf, l7policy.project_id, False, busy)
+            with tf_logging.DynamicLoggingListener(delete_l7policy_tf,
+                                                   log=LOG):
                 delete_l7policy_tf.run()
-            finally:
-                self._set_vthunder_available(l7policy.project_id, False)
+        finally:
+            self._set_vthunder_available(l7policy.project_id, False)
 
     def update_l7policy(self, l7policy_id, l7policy_updates):
         """Updates an L7 policy.
@@ -919,20 +918,20 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(l7policy.project_id, False, None)
-        update_l7policy_tf = self._taskflow_load(
-            self._l7policy_flows.get_update_l7policy_flow(topology=topology),
-            store={constants.L7POLICY: l7policy,
-                   constants.LISTENERS: listeners,
-                   constants.LOADBALANCER: load_balancer,
-                   a10constants.COMPUTE_BUSY: busy,
-                   constants.UPDATE_DICT: l7policy_updates})
-        self._register_flow_notify_handler(update_l7policy_tf, l7policy.project_id, False, busy)
-        with tf_logging.DynamicLoggingListener(update_l7policy_tf,
-                                               log=LOG):
-            try:
+        try:
+            update_l7policy_tf = self._taskflow_load(
+                self._l7policy_flows.get_update_l7policy_flow(topology=topology),
+                store={constants.L7POLICY: l7policy,
+                       constants.LISTENERS: listeners,
+                       constants.LOADBALANCER: load_balancer,
+                       a10constants.COMPUTE_BUSY: busy,
+                       constants.UPDATE_DICT: l7policy_updates})
+            self._register_flow_notify_handler(update_l7policy_tf, l7policy.project_id, False, busy)
+            with tf_logging.DynamicLoggingListener(update_l7policy_tf,
+                                                   log=LOG):
                 update_l7policy_tf.run()
-            finally:
-                self._set_vthunder_available(l7policy.project_id, False)
+        finally:
+            self._set_vthunder_available(l7policy.project_id, False)
 
     @tenacity.retry(
         retry=tenacity.retry_if_exception_type(db_exceptions.NoResultFound),
@@ -961,20 +960,20 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(l7rule.project_id, False, None)
-        create_l7rule_tf = self._taskflow_load(
-            self._l7rule_flows.get_create_l7rule_flow(topology=topology),
-            store={constants.L7RULE: l7rule,
-                   constants.L7POLICY: l7policy,
-                   constants.LISTENERS: listeners,
-                   constants.LOADBALANCER: load_balancer,
-                   a10constants.COMPUTE_BUSY: busy})
-        self._register_flow_notify_handler(create_l7rule_tf, l7rule.project_id, False, busy)
-        with tf_logging.DynamicLoggingListener(create_l7rule_tf,
-                                               log=LOG):
-            try:
+        try:
+            create_l7rule_tf = self._taskflow_load(
+                self._l7rule_flows.get_create_l7rule_flow(topology=topology),
+                store={constants.L7RULE: l7rule,
+                       constants.L7POLICY: l7policy,
+                       constants.LISTENERS: listeners,
+                       constants.LOADBALANCER: load_balancer,
+                       a10constants.COMPUTE_BUSY: busy})
+            self._register_flow_notify_handler(create_l7rule_tf, l7rule.project_id, False, busy)
+            with tf_logging.DynamicLoggingListener(create_l7rule_tf,
+                                                   log=LOG):
                 create_l7rule_tf.run()
-            finally:
-                self._set_vthunder_available(l7rule.project_id, False)
+        finally:
+            self._set_vthunder_available(l7rule.project_id, False)
 
     def delete_l7rule(self, l7rule_id):
         """Deletes an L7 rule.
@@ -992,20 +991,20 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(l7rule.project_id, False, None)
-        delete_l7rule_tf = self._taskflow_load(
-            self._l7rule_flows.get_delete_l7rule_flow(topology=topology),
-            store={constants.L7RULE: l7rule,
-                   constants.L7POLICY: l7policy,
-                   constants.LISTENERS: listeners,
-                   constants.LOADBALANCER: load_balancer,
-                   a10constants.COMPUTE_BUSY: busy})
-        self._register_flow_notify_handler(delete_l7rule_tf, l7rule.project_id, False, busy)
-        with tf_logging.DynamicLoggingListener(delete_l7rule_tf,
-                                               log=LOG):
-            try:
+        try:
+            delete_l7rule_tf = self._taskflow_load(
+                self._l7rule_flows.get_delete_l7rule_flow(topology=topology),
+                store={constants.L7RULE: l7rule,
+                       constants.L7POLICY: l7policy,
+                       constants.LISTENERS: listeners,
+                       constants.LOADBALANCER: load_balancer,
+                       a10constants.COMPUTE_BUSY: busy})
+            self._register_flow_notify_handler(delete_l7rule_tf, l7rule.project_id, False, busy)
+            with tf_logging.DynamicLoggingListener(delete_l7rule_tf,
+                                                   log=LOG):
                 delete_l7rule_tf.run()
-            finally:
-                self._set_vthunder_available(l7rule.project_id, False)
+        finally:
+            self._set_vthunder_available(l7rule.project_id, False)
 
     def update_l7rule(self, l7rule_id, l7rule_updates):
         """Updates an L7 rule.
@@ -1035,21 +1034,21 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         # rack flow _vthunder_busy_check() will always return False
         busy = self._vthunder_busy_check(l7rule.project_id, False, None)
-        update_l7rule_tf = self._taskflow_load(
-            self._l7rule_flows.get_update_l7rule_flow(topology=topology),
-            store={constants.L7RULE: l7rule,
-                   constants.L7POLICY: l7policy,
-                   constants.LISTENERS: listeners,
-                   constants.LOADBALANCER: load_balancer,
-                   a10constants.COMPUTE_BUSY: busy,
-                   constants.UPDATE_DICT: l7rule_updates})
-        self._register_flow_notify_handler(update_l7rule_tf, l7rule.project_id, False, busy)
-        with tf_logging.DynamicLoggingListener(update_l7rule_tf,
-                                               log=LOG):
-            try:
+        try:
+            update_l7rule_tf = self._taskflow_load(
+                self._l7rule_flows.get_update_l7rule_flow(topology=topology),
+                store={constants.L7RULE: l7rule,
+                       constants.L7POLICY: l7policy,
+                       constants.LISTENERS: listeners,
+                       constants.LOADBALANCER: load_balancer,
+                       a10constants.COMPUTE_BUSY: busy,
+                       constants.UPDATE_DICT: l7rule_updates})
+            self._register_flow_notify_handler(update_l7rule_tf, l7rule.project_id, False, busy)
+            with tf_logging.DynamicLoggingListener(update_l7rule_tf,
+                                                   log=LOG):
                 update_l7rule_tf.run()
-            finally:
-                self._set_vthunder_available(l7rule.project_id, False)
+        finally:
+            self._set_vthunder_available(l7rule.project_id, False)
 
     def _switch_roles_for_ha_flow(self, vthunder):
         lock_session = db_apis.get_session(autocommit=False)
@@ -1217,6 +1216,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
     def _vthunder_busy_check(self, key, is_reload_thread, store=None):
         busy = False
+        self.ctx_flags[0] = False
         if self._is_rack_flow(key):
             return busy
 
@@ -1252,20 +1252,19 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             if not busy:
                 LOG.debug('[busy_check] vthunder %s ctx: normal_thrd(%d), reload_thrd(%d)',
                           key, normal_thrd_num, reload_thrd_num)
+                self.ctx_flags[0] = True
                 break
             time.sleep(5)
 
         if store is not None:
             store[a10constants.COMPUTE_BUSY] = busy
 
-        self.ctx_flags[0] = False
         return busy
 
     def _set_vthunder_available(self, key, is_reload_thread):
         if self._is_rack_flow(key):
             return
-        if not self.ctx_flags[0]:
-            ctx_cnt_dec(self.ctx_lock, self.ctx_map, key, is_reload_thread)
+        ctx_cnt_dec(self.ctx_lock, self.ctx_map, key, is_reload_thread, self.ctx_flags)
 
     def _register_flow_notify_handler(self, engine, key, is_reload_thread, instance_busy):
         if self._is_rack_flow(key) or instance_busy:

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -407,7 +407,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         else:
             busy = self._vthunder_busy_check(lb.project_id, True, store)
             create_lb_flow = self._lb_flows.get_create_load_balancer_flow(
-                load_balancer_id, topology=topology, listeners=lb.listeners)
+                load_balancer_id, topology, lb.project_id, listeners=lb.listeners)
             store.update([
                 (a10constants.COMPUTE_BUSY, busy),
                 (a10constants.VTHUNDER_CONFIG, None),

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -52,14 +52,15 @@ LOG = logging.getLogger(__name__)
 
 
 def ctx_cnt_dec(ctx_lock, ctx_map, key, is_reload_thread, flags):
+    if flags is not None and flags[0] is False:
+        return
+
     ctx_lock.acquire()
     LOG.debug('--------------------------ctx_cnt_dec-----------------------------')
     try:
         ctx = ctx_map.get(key)
         if ctx is None:
             raise
-        if flags is not None and flags[0] is False:
-            return
 
         normal_thrd_num, reload_thrd_num = ctx
         LOG.debug('vthunder %s ctx: normal_thrd(%d), reload_thrd(%d)',

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -63,7 +63,8 @@ class LoadBalancerFlows(object):
         self._vthunder_repo = a10repo.VThunderRepository()
         self.loadbalancer_repo = a10repo.LoadBalancerRepository()
 
-    def get_create_load_balancer_flow(self, load_balancer_id, topology, listeners=None):
+    def get_create_load_balancer_flow(self, load_balancer_id, topology, project_id,
+                                      listeners=None):
         """Flow to create a load balancer"""
 
         f_name = constants.CREATE_LOADBALANCER_FLOW
@@ -95,9 +96,8 @@ class LoadBalancerFlows(object):
 
         # IMP: Now creating vThunder config here
         post_amp_prefix = constants.POST_LB_AMP_ASSOCIATION_SUBFLOW
-        lb = self._lb_repo.get(db_apis.get_session(), id=load_balancer_id)
         vthunder = self._vthunder_repo.get_vthunder_by_project_id(db_apis.get_session(),
-                                                                  lb.project_id)
+                                                                  project_id)
 
         lb_create_flow.add(
             self.get_post_lb_vthunder_association_flow(


### PR DESCRIPTION
## Description
Severity Level: High
Issue Description:
As the log, exception raise while getting the LB creation flow. The ctx counters are already increased, but since flow never run. So, flow_notification_handler can't be triggered to reduce the counter. So, counter never decreased.
```
  File "/opt/stack/a10-octavia/a10_octavia/controller/worker/controller_worker.py", line 410, in create_load_balancer
    load_balancer_id, topology=topology, listeners=lb.listeners)
  File "/opt/stack/a10-octavia/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py", line 100, in get_create_load_balancer_flow
    lb.project_id)

```

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2356

## Technical Approach
- fix LB creation raise exception in revert flow issue.
- in control_worker.py, if ctx counter already increased (i.e. _vthunder_busy_check(). we should catch exception to decrease ctx counter when failed.)

## Config Changes
<pre>
<b>N/A</b>
</pre>

## Test Cases
- Test normal LB creation
- Test raise exception in get_create_load_balancer_flow()
- create/delete multiple LB at the same time

## Manual Testing
- Required: List of steps to manually test feature or fix 

```
openstack loadbalancer create --vip-subnet-id tp91 --name vip1
openstack loadbalancer create --vip-subnet-id tp91 --name vip2
openstack loadbalancer create --vip-subnet-id tp91 --name vip3
openstack loadbalancer create --vip-subnet-id tp91 --name vip4
openstack loadbalancer create --vip-subnet-id tp91 --name vip5
openstack loadbalancer create --vip-subnet-id tp91 --name vip6
openstack loadbalancer create --vip-subnet-id tp91 --name vip7

stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address    | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| a300827d-9956-49f8-a450-fd7f59279108 | vip1 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.112 | ACTIVE              | a10      |
| 62d1ffb5-6747-44e7-9505-34ab9e18f9d3 | vip2 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.119 | ACTIVE              | a10      |
| 0353332e-9cd6-4c1e-b987-3a1543e0ac75 | vip3 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.63  | ACTIVE              | a10      |
| b7664e7b-217a-43f6-aaa3-bf52337101bb | vip4 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.223 | ACTIVE              | a10      |
| b60a6d16-0266-4d36-8d5d-f4ebfe4908b0 | vip5 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.81  | ACTIVE              | a10      |
| 01c9cb66-bbc6-44c7-818a-ef4ee7372a97 | vip6 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.17  | ACTIVE              | a10      |
| 6d9cdba1-f1a4-453c-87a1-a8d97c6957b2 | vip7 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.220 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+

stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer delete vip1
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer delete vip2
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer delete vip3
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer delete vip4
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer delete vip5
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer delete vip6
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer delete vip7
stack@openstack-4:~/source/a10-octavia/vThunder$
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer list

stack@openstack-4:~/source/a10-octavia/vThunder$

```

