### PR TITLE
[STACK-2413] device-flavor only allow devices without project_id

### DIFF
--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -234,6 +234,13 @@ class ProjectDeviceNotFound(acos_errors.ACOSException):
         super(ProjectDeviceNotFound, self).__init__(msg=msg)
 
 
+class DeviceIsProjectDevice(acos_errors.ACOSException):
+    def __init__(self):
+        msg = ('The device already specify project_id in configuration file, '
+               'device-name flavor can not use it.')
+        super(DeviceIsProjectDevice, self).__init__(msg=msg)
+
+
 class FlavorDeviceNotFound(acos_errors.ACOSException):
     def __init__(self, device):
         msg = ('[device-name flavor] Device [{0}] not found in the configuration'

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -408,10 +408,9 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             busy = self._vthunder_busy_check(lb.project_id, True, store)
             create_lb_flow = self._lb_flows.get_create_load_balancer_flow(
                 load_balancer_id, topology=topology, listeners=lb.listeners)
-            store.update([
-                (a10constants.COMPUTE_BUSY, busy),
-                (a10constants.VTHUNDER_CONFIG, None),
-                (a10constants.USE_DEVICE_FLAVOR, False)])
+            store.update([(a10constants.COMPUTE_BUSY, busy),
+                          (a10constants.VTHUNDER_CONFIG, None),
+                          (a10constants.USE_DEVICE_FLAVOR, False)])
             create_lb_tf = self._taskflow_load(create_lb_flow, store=store)
             self._register_flow_notify_handler(create_lb_tf, lb.project_id, True, busy)
 

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -556,18 +556,15 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                     a10constants.USE_DEVICE_FLAVOR: None})
         else:
             busy = self._vthunder_busy_check(member.project_id, True, None)
-            create_member_tf = self._taskflow_load(self._member_flows.
-                                                   get_create_member_flow(
-                                                       topology=topology),
-                                                   store={constants.MEMBER: member,
-                                                          constants.LISTENERS:
-                                                          listeners,
-                                                          constants.LOADBALANCER:
-                                                          load_balancer,
-                                                          a10constants.COMPUTE_BUSY: busy,
-                                                          constants.POOL: pool,
-                                                          a10constants.VTHUNDER_CONFIG: None,
-                                                          a10constants.USE_DEVICE_FLAVOR: None})
+            create_member_tf = self._taskflow_load(
+                self._member_flows.get_create_member_flow(topology=topology),
+                store={constants.MEMBER: member,
+                       constants.LISTENERS: listeners,
+                       constants.LOADBALANCER: load_balancer,
+                       a10constants.COMPUTE_BUSY: busy,
+                       constants.POOL: pool,
+                       a10constants.VTHUNDER_CONFIG: None,
+                       a10constants.USE_DEVICE_FLAVOR: None})
             self._register_flow_notify_handler(create_member_tf, member.project_id, True, busy)
 
         with tf_logging.DynamicLoggingListener(create_member_tf,

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -1177,6 +1177,8 @@ class GetVthunderConfByFlavor(VThunderBaseTask):
                 dev_key = a10constants.DEVICE_KEY_PREFIX + device_flavor
                 if dev_key in device_config_dict:
                     vthunder_config = device_config_dict[dev_key]
+                    if vthunder_config.project_id is not None:
+                        raise exceptions.DeviceIsProjectDevice()
                     vthunder_config.project_id = loadbalancer.project_id
                     if vthunder_config.hierarchical_multitenancy == "enable":
                         vthunder_config.partition_name = loadbalancer.project_id[0:14]

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -163,7 +163,7 @@ INTERFACES = {
     }
 }
 
-FLAVOR_DEV1 = a10_data_models.HardwareThunder(project_id="project-1", device_name="rack_thunder_1",
+FLAVOR_DEV1 = a10_data_models.HardwareThunder(device_name="rack_thunder_1",
                                               undercloud=True, username="abc", password="abc",
                                               ip_address="10.10.10.10", partition_name="shared",
                                               device_name_as_key=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 acos-client>=2.1.0		#
 octavia>=4.1.1,<5.0.0.0rc1	# stein version of octavia
 octavia-lib			#
-keystone>=15.0.1,<16.0.0
+keystone>=16.0.0
 python-barbicanclient>=4.5.2 	# copied from octavia requirements.txt
 python-glanceclient>=2.8.0 	# Apache-2.0
 python-novaclient>=9.1.0 	# Apache-2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 acos-client>=2.1.0		#
 octavia>=4.1.1,<5.0.0.0rc1	# stein version of octavia
 octavia-lib			#
-keystone>=15.0.1
+keystone>=16.0.0
 python-barbicanclient>=4.5.2 	# copied from octavia requirements.txt
 python-glanceclient>=2.8.0 	# Apache-2.0
 python-novaclient>=9.1.0 	# Apache-2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 acos-client>=2.1.0		#
 octavia>=4.1.1,<5.0.0.0rc1	# stein version of octavia
 octavia-lib			#
-keystone>=16.0.0
 python-barbicanclient>=4.5.2 	# copied from octavia requirements.txt
 python-glanceclient>=2.8.0 	# Apache-2.0
 python-novaclient>=9.1.0 	# Apache-2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 acos-client>=2.1.0		#
 octavia>=4.1.1,<5.0.0.0rc1	# stein version of octavia
 octavia-lib			#
-keystone>=16.0.0
+keystone>=15.0.1,<16.0.0
 python-barbicanclient>=4.5.2 	# copied from octavia requirements.txt
 python-glanceclient>=2.8.0 	# Apache-2.0
 python-novaclient>=9.1.0 	# Apache-2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 acos-client>=2.1.0		#
 octavia>=4.1.1,<5.0.0.0rc1	# stein version of octavia
 octavia-lib			#
-keystone>=15.0.1,<16.0.0
+keystone>=15.0.1
 python-barbicanclient>=4.5.2 	# copied from octavia requirements.txt
 python-glanceclient>=2.8.0 	# Apache-2.0
 python-novaclient>=9.1.0 	# Apache-2.0


### PR DESCRIPTION
## Description
Don't allow device-name flavor use devices with project_id in configuration file

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2413

## Technical Approach
Don't allow device-name flavor use devices with project_id in configuration file

## Config Changes
<pre>
<b>[hardware_thunder]
devices = [
                    {
                     "project_id": "3d21c71c4e4040599933bda62a76ae2f",
                     "ip_address": "192.168.90.45",
                     "username": "admin",
                     "password": "a10",
                     "device_name": "admin"
                     },
                    {
                     "project_id": "2aae8b6e8ddd4e2991b6c342824056b0",
                     "ip_address": "192.168.90.46",
                     "username": "admin",
                     "password": "a10",
                     #"hierarchical_multitenancy": "enable",
                     "device_name": "dev2",
                     "interface_vlan_map": {
                         "device_1": {
                             "mgmt_ip_address": "192.168.90.46",
                             "ethernet_interfaces": [{
                                 "interface_num": 4,
                                 "vlan_map": [
                                     {"vlan_id": 3, "ve_ip": "192.168.190.61"},
                                     {"vlan_id": 4, "ve_ip": "172.16.1.61"},
                                     {"vlan_id": 5, "ve_ip": "192.168.91.61"},
                                 ]},
                             ]
                          }
                        }
                     },</b>
</pre>


## Test Cases
```
openstack loadbalancer flavorprofile create --name fp_dev2 --provider a10 --flavor-data '{"device-name": "dev2"}'
openstack loadbalancer flavor create --name f_dev2 --flavorprofile fp_dev2 --description "use device dev2" --enable
openstack loadbalancer create --flavor f_dev2 --vip-subnet-id tp91 --vip-address 192.168.91.56 --name vip1
```

## Manual Testing
```
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer create --flavor f_dev2 --vip-subnet-id tp91 --vip-address 192.168.91.56 --name vip1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-06-15T16:01:20                  |
| description         |                                      |
| flavor_id           | 05084690-b8d8-4864-b1ab-017e8add7c07 |
| id                  | 97fcf043-b032-436f-983d-71b8018c22dc |
| listeners           |                                      |
| name                | vip1                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 3d21c71c4e4040599933bda62a76ae2f     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.91.56                        |
| vip_network_id      | 5e1b43e5-9f65-40af-a28f-88e63dc6d667 |
| vip_port_id         | 6521c3a4-a848-40c1-843f-7168680a9c74 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | f25ce642-f953-4058-8c46-98fdd72fb129 |
+---------------------+--------------------------------------+
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer list

+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| 97fcf043-b032-436f-983d-71b8018c22dc | vip1 | 3d21c71c4e4040599933bda62a76ae2f | 192.168.91.56 | ERROR               | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer delete vip1
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer list
```
- journal log:
```
Jun 16 00:01:21 ytsai-openstack a10-octavia-worker[32521]: ERROR oslo_messaging.rpc.server DeviceIsProjectDevice: 1 The device already specify project_id in configuration file, device-name flavor can not use it.
```