### PR TITLE
[STACK-2382]: On deleting error state loadbalancer, interface will not be removed from vthunder.  

### DIFF
--- a/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
+++ b/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
@@ -204,12 +204,12 @@ class A10OctaviaNeutronDriver(aap.AllowedAddressPairsDriver):
         if subnet.network_id not in fixed_subnets:
             for port in ports:
                 port = port.get('port', port)
-                if lb_count_subnet > 1:  # vNIC port is in use by other lbs. Only delete VIP port.
+                if lb_count_subnet != 1:  # vNIC port is in use by other lbs. Only delete VIP port.
                     if sec_grp:
                         self._remove_security_group(port, sec_grp['id'])
                     if port['id'] == vip_port_id:
                         self._cleanup_port(vip_port_id, port)
-                elif lb_count_subnet <= 1:  # This is the only lb using vNIC ports
+                else:  # This is the only lb using vNIC ports
                     self._cleanup_port(vip_port_id, port)
 
         if subnet.network_id not in fixed_subnets and sec_grp:

--- a/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
+++ b/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
@@ -204,7 +204,12 @@ class A10OctaviaNeutronDriver(aap.AllowedAddressPairsDriver):
         if subnet.network_id not in fixed_subnets:
             for port in ports:
                 port = port.get('port', port)
-                if lb_count_subnet != 1:  # vNIC port is in use by other lbs. Only delete VIP port.
+                """If lb_count_subnet is greater then 1 then
+                vNIC port is in use by other lbs. Only delete VIP port.
+                In-case of deleting lb(ERROR state),
+                vthunder returned value from database is "None" then
+                lb_count_subnet is equal to 0, in this case delete only vip port."""
+                if lb_count_subnet != 1:
                     if sec_grp:
                         self._remove_security_group(port, sec_grp['id'])
                     if port['id'] == vip_port_id:


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description: When deleting lb(which is in ERROR state), it was removing interface from vthunder.

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-2382

## Technical Approach
- On creating lb with same nat pool name flavor, as expected it will go in error state. On reverting, new vthunder entry will be removed from vthunder repo. While deleting the same lb, the vthunder value returned from databases will be none, then lb_count_subnet will be 0, it causes to delete all ports. So changed the conditions for deleting the ports.

## Manual Testing
**1)Interface will not remove in revert flow.** 
a)Create lbs 
```
openstack loadbalancer flavorprofile create --name fp_natpool_1 --provider a10 --flavor-data '{"nat-pool":{"pool-name":"test","start-address":"1.1.1.2","end-address":"1.1.1.4","netmask":"/24"}}'
openstack loadbalancer flavorprofile create --name fp_natpool_2 --provider a10 --flavor-data '{"nat-pool":{"pool-name":"test","start-address":"1.1.1.5","end-address":"1.1.1.6","netmask":"/24"}}'
openstack loadbalancer flavor create --name f_natpool_1 --flavorprofile fp_natpool_1
openstack loadbalancer flavor create --name f_natpool_2 --flavorprofile fp_natpool_2
openstack loadbalancer create --name vs --vip-subnet-id private-a-subne
openstack loadbalancer create --name fp1 --vip-subnet-id private-a-subnet --flavor f_natpool_1

stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| c22a320f-8e85-461a-a230-4a734cee307e | vs   | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.0.43   | ACTIVE              | a10      |
| 26a5d111-3a7d-41fb-b8a9-5df20133eb67 | fp1  | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.0.49   | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+

stack@adeeb:~/adeeb/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------+----------------+-----------------+
| ID                                   | Name                                         | Status | Networks                                            | Image          | Flavor          |
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------+----------------+-----------------+
| a3b3e43c-7255-4d7e-b3ee-349e9e564807 | amphora-5133bf5d-25bb-4821-af3b-a17aa834a4b9 | ACTIVE | lb-mgmt-net=192.168.0.144; private-net-a=10.0.0.108 | vThunder.qcow2 | vThunder_flavor |
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------+----------------+-----------------+

vthunder:
!
vrrp-a vrid 0
  floating-ip 10.0.0.120
!
ip nat pool test 1.1.1.2 1.1.1.4 netmask /24
!
slb virtual-server 26a5d111-3a7d-41fb-b8a9-5df20133eb67 10.0.0.49
!
slb virtual-server c22a320f-8e85-461a-a230-4a734cee307e 10.0.0.43
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e21.88c3  192.168.0.144/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e08.4d03  10.0.0.108/24         1  DataPort

Global Throughput:0 bits/sec (0 bytes/sec)
Throughput:0 bits/sec (0 bytes/sec)
vThunder(NOLICENSE)#

```
b) Create another lb with same natpool name flavor
```
openstack loadbalancer create --name fp2 --vip-subnet-id private-a-subnet --flavor f_natpool_2

Logs
Jun 16 11:51:47 adeeb a10-octavia-worker[19155]: INFO a10_octavia.controller.queue.endpoint [-] Creating load balancer '04393978-17c8-42a3-b779-18aa378b5887'...
Jun 16 11:51:48 adeeb a10-octavia-worker[19155]: INFO a10_octavia.controller.worker.flows.a10_load_balancer_flows [-] TOPOLOGY ===SINGLE
Jun 16 11:51:48 adeeb a10-octavia-worker[19155]: INFO octavia.controller.worker.tasks.database_tasks [-] Created Amphora in DB with id 260201ce-c4e4-4ae4-a788-b94693c3c740
Jun 16 11:51:49 adeeb a10-octavia-worker[19155]: INFO a10_octavia.controller.worker.tasks.a10_database_tasks [-] Successfully created vthunder entry in database.
Jun 16 11:51:49 adeeb a10-octavia-worker[19155]: INFO octavia.network.drivers.neutron.allowed_address_pairs [-] Port 9fb1aa6b-f2e7-4045-9286-48e9d03f54cf already exists. Nothing to be done.
Jun 16 11:51:49 adeeb a10-octavia-worker[19155]: INFO octavia.controller.worker.tasks.database_tasks [-] Mark ALLOCATED in DB for amphora: 260201ce-c4e4-4ae4-a788-b94693c3c740 with compute id a3b3e43c-7255-4d7e-b3ee-349e9e564807 for load balancer: 04393978-17c8-42a3-b779-18aa378b5887
Jun 16 11:51:50 adeeb a10-octavia-worker[19155]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Attempting to connect vThunder device for connection.
Jun 16 11:51:56 adeeb a10-octavia-worker[19155]: INFO octavia.controller.worker.tasks.database_tasks [-] Mark ACTIVE in DB for load balancer id: 04393978-17c8-42a3-b779-18aa378b5887
Jun 16 11:51:56 adeeb a10-octavia-worker[19155]: ERROR a10_octavia.controller.worker.tasks.nat_pool_tasks [-] Nat-pool with name test already exists on partition shared of thunder device 192.168.0.144: Exists: 1

stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| c22a320f-8e85-461a-a230-4a734cee307e | vs   | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.0.43   | ACTIVE              | a10      |
| 26a5d111-3a7d-41fb-b8a9-5df20133eb67 | fp1  | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.0.49   | ACTIVE              | a10      |
| 04393978-17c8-42a3-b779-18aa378b5887 | fp2  | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.0.198  | ERROR               | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
stack@adeeb:~/adeeb/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------+----------------+-----------------+
| ID                                   | Name                                         | Status | Networks                                            | Image          | Flavor          |
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------+----------------+-----------------+
| a3b3e43c-7255-4d7e-b3ee-349e9e564807 | amphora-5133bf5d-25bb-4821-af3b-a17aa834a4b9 | ACTIVE | lb-mgmt-net=192.168.0.144; private-net-a=10.0.0.108 | vThunder.qcow2 | vThunder_flavor |
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------+----------------+-----------------+

vThunder(NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e21.88c3  192.168.0.144/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e08.4d03  10.0.0.108/24         1  DataPort

Global Throughput:0 bits/sec (0 bytes/sec)
Throughput:0 bits/sec (0 bytes/sec)
vThunder(NOLICENSE)#

```
**2)Interface will not remove on deleting the error state lb.**
a) Delete the lb which is in error state.
```
openstack loadbalancer delete fp2

stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| c22a320f-8e85-461a-a230-4a734cee307e | vs   | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.0.43   | ACTIVE              | a10      |
| 26a5d111-3a7d-41fb-b8a9-5df20133eb67 | fp1  | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.0.49   | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
stack@adeeb:~/adeeb/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------+----------------+-----------------+
| ID                                   | Name                                         | Status | Networks                                            | Image          | Flavor          |
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------+----------------+-----------------+
| a3b3e43c-7255-4d7e-b3ee-349e9e564807 | amphora-5133bf5d-25bb-4821-af3b-a17aa834a4b9 | ACTIVE | lb-mgmt-net=192.168.0.144; private-net-a=10.0.0.108 | vThunder.qcow2 | vThunder_flavor |
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------+----------------+-----------------+

stack@adeeb:~/adeeb/a10-octavia$ openstack security group list | grep 04393978-17c8-42a3-b779-18aa378b5887
stack@adeeb:~/adeeb/a10-octavia$ openstack port list | grep 04393978-17c8-42a3-b779-18aa378b5887
stack@adeeb:~/adeeb/a10-octavia$

vthunder:
vThunder(NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e21.88c3  192.168.0.144/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e08.4d03  10.0.0.108/24         1  DataPort

Global Throughput:0 bits/sec (0 bytes/sec)
Throughput:0 bits/sec (0 bytes/sec)
vThunder(NOLICENSE)#

```
**3)Normal Case**
a)Create lbs with different subnets
```
openstack loadbalancer create --name vs2 --vip-subnet-id private-b-subnet

stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| c22a320f-8e85-461a-a230-4a734cee307e | vs   | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.0.43   | ACTIVE              | a10      |
| 26a5d111-3a7d-41fb-b8a9-5df20133eb67 | fp1  | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.0.49   | ACTIVE              | a10      |
| 83f5cd9a-2573-4c43-8569-1ae2e04d2aa1 | vs2  | a5b6eb74f8184fc19e77e1693fdfa8e2 | 11.0.0.86   | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
stack@adeeb:~/adeeb/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------+----------------+-----------------+
| ID                                   | Name                                         | Status | Networks                                                                     | Image          | Flavor          |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------+----------------+-----------------+
| a3b3e43c-7255-4d7e-b3ee-349e9e564807 | amphora-5133bf5d-25bb-4821-af3b-a17aa834a4b9 | ACTIVE | lb-mgmt-net=192.168.0.144; private-net-a=10.0.0.108; private-net-b=11.0.0.60 | vThunder.qcow2 | vThunder_flavor |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------+----------------+-----------------+

vThunder(NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e21.88c3  192.168.0.144/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e08.4d03  10.0.0.108/24         1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e61.0905  11.0.0.60/24          1  DataPort

Global Throughput:0 bits/sec (0 bytes/sec)
Throughput:0 bits/sec (0 bytes/sec)
vThunder(NOLICENSE)#

```
b) Delete loadbalancer vs2.
```
openstack loadbalancer delete vs2

Security group, port and Interface are removed 
stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| c22a320f-8e85-461a-a230-4a734cee307e | vs   | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.0.43   | ACTIVE              | a10      |
| 26a5d111-3a7d-41fb-b8a9-5df20133eb67 | fp1  | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.0.49   | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
stack@adeeb:~/adeeb/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------+----------------+-----------------+
| ID                                   | Name                                         | Status | Networks                                            | Image          | Flavor          |
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------+----------------+-----------------+
| a3b3e43c-7255-4d7e-b3ee-349e9e564807 | amphora-5133bf5d-25bb-4821-af3b-a17aa834a4b9 | ACTIVE | lb-mgmt-net=192.168.0.144; private-net-a=10.0.0.108 | vThunder.qcow2 | vThunder_flavor |
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------+----------------+-----------------+
stack@adeeb:~/adeeb/a10-octavia$ openstack security group list | grep 83f5cd9a-2573-4c43-8569-1ae2e04d2aa1
stack@adeeb:~/adeeb/a10-octavia$ openstack port list | grep 83f5cd9a-2573-4c43-8569-1ae2e04d2aa1
stack@adeeb:~/adeeb/a10-octavia$

vThunder(NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e21.88c3  192.168.0.144/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e08.4d03  10.0.0.108/24         1  DataPort

Global Throughput:392 bits/sec (49 bytes/sec)
Throughput:392 bits/sec (49 bytes/sec)
vThunder(NOLICENSE)#

```
c) Delete remaining lbs
```
stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer delete fp1
stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer delete vs

stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer list

stack@adeeb:~/adeeb/a10-octavia$

stack@adeeb:~/adeeb/a10-octavia$ openstack port list|grep octavia
| 1e9f8d3f-74fc-4b7a-883d-d096a41a5d85 | octavia-health-manager-standalone-listen-port | fa:16:3e:20:04:fa | ip_address='192.168.0.198', subnet_id='ee66e62e-c971-4635-88d0-34216ed94a88'                        | ACTIVE |
stack@adeeb:~/adeeb/a10-octavia$ openstack security group list | grep lb
| 486898c4-bff4-4dca-82b7-f03f424ffa87 | lb-health-mgr-sec-grp | lb-health-mgr-sec-grp  | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
| 82833a48-a81b-4f37-a041-02ca4aae3b04 | lb-mgmt-sec-grp       | lb-mgmt-sec-grp        | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
stack@adeeb:~/adeeb/a10-octavia$ 

```