### PR TITLE
[STACK-2513] NatPoolCreate revert flow only delete pools it created

### DIFF
--- a/a10_octavia/controller/worker/tasks/nat_pool_tasks.py
+++ b/a10_octavia/controller/worker/tasks/nat_pool_tasks.py
@@ -32,7 +32,6 @@ class NatPoolCreate(task.Task):
 
     @axapi_client_decorator
     def execute(self, loadbalancer, vthunder, flavor_data=None):
-        self._added_pool_list = []
         device_pool = None
         if flavor_data:
             natpool_flavor_list = flavor_data.get('nat_pool_list')


### PR DESCRIPTION
## Description
Severity Level: Low
Issue Description:
NAT pool deleted unexpected when snat flavor use same pool name with different ip range in different flavor.

**Notice: this bug priority is low, because even pool is deleted. It will still be created when creating listener with the pool**

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2513

## Technical Approach
- In NatPoolCreate revert flavor, only delete NAT pool which created in execute().

## Config Changes
<pre>
<b>N/A</b>
</pre>


## Test Cases
- same as QA

## Manual Testing
```
openstack loadbalancer flavorprofile create --name fp_snat --provider a10 --flavor-data '{"nat-pool":{"pool-name":"pool1", "start-address":"192.168.90.201", "end-address":"192.168.90.210", "netmask":"/24" }}'
openstack loadbalancer flavor create --name f_snat --flavorprofile fp_snat
openstack loadbalancer flavorprofile create --name fp_snat1 --provider a10 --flavor-data '{"nat-pool":{"pool-name":"pool1", "start-address":"192.168.90.211", "end-address":"192.168.90.220", "netmask":"/24" }}'
openstack loadbalancer flavor create --name f_snat1 --flavorprofile fp_snat1
openstack loadbalancer create --flavor f_snat --vip-subnet-id tp91 --vip-address 192.168.91.56 --name vip1
openstack loadbalancer create --flavor f_snat1 --vip-subnet-id tp91 --vip-address 192.168.91.57 --name vip2
```

Result:
```
ip nat pool pool1 192.168.90.201 192.168.90.210 netmask /24 gateway 192.168.90.1
!
slb virtual-server 53057b04-20ec-49a3-85d5-d2d74336f578 192.168.91.56
!
```
