### PR TITLE
[STACK-2517] check rack/vthunder via config file only

### DIFF
--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -1240,14 +1240,6 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             return True
         if key in CONF.hardware_thunder.devices:
             return True
-        if flavor:
-            if flavor.get('device-name', None) is not None:
-                return True
-        if loadbalancer:
-            flavor_data = utils.get_loadbalancer_flavor(loadbalancer)
-            if flavor_data is not None:
-                if flavor_data.get('device-name', None) is not None:
-                    return True
         return False
 
     def _vthunder_busy_check(self, key, is_reload_thread, flags, store=None):


### PR DESCRIPTION
## Description
- Severity Level: Low
- Issue Description:
When device flavor is used, we will treat it as rack flow even there is not devices in configuration file.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2517

## Technical Approach
rack/vthunder flow should decided according to the configuration file only. Even with device-name flavor.

## Config Changes
<pre>
<b>[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
#default_axapi_timeout = 600
l2dsr_support = True
slb_no_snat_support = True

[a10_controller_worker]
amp_image_owner_id = 99c9c2304f114685a32db30769c8a7e2
amp_secgroup_list = 2d0a3480-7f08-4184-b96f-c39bb444dd38
amp_flavor_id = 69995a83-c47a-427f-bf70-e9d9752aa915
#amp_boot_network_list = 7f8ddd7f-c5c3-463a-b1c3-596f988480a4
amp_boot_network_list = 7f8ddd7f-c5c3-463a-b1c3-596f988480a4, 61305531-6e3a-44b4-8e67-05e93363dddc, a66685db-31ee-46c6-928a-ac034d87dc63, ec33a88d-3290-4ad6-95cc-226fcd2a4458
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 150
amp_active_wait_sec = 10
#amp_vcs_retries = 59
#amp_vcs_wait_sec = 10
amp_busy_wait_sec = 0
amp_image_id = 0a845873-bd91-4f8c-ad58-cf5d5afde09c
loadbalancer_topology = SINGLE
#loadbalancer_topology = ACTIVE_STANDBY

[a10_health_manager]
udp_server_ip_address = 10.64.28.68
bind_port = 5550
bind_ip = 10.64.28.68
heartbeat_interval = 5
heartbeat_key = insecure
heartbeat_timeout = 90
health_check_interval = 3
failover_timeout = 600
health_check_timeout = 3
health_check_max_retries = 5

[a10_global]
network_type = "flat"
#network_type = "vlan"
#vrid=7
vrid_floating_ip = "dhcp"
</b>
</pre>


## Test Cases
 - use device flavor on vThunder flow
 - make sure loadbalancer create/delete/set is fine with the flavor 
```
openstack loadbalancer flavorprofile create --name fp_dev2 --provider a10 --flavor-data '{"device-name": "dev2"}'
openstack loadbalancer flavor create --name f_dev2 --flavorprofile fp_dev2 --description "use device dev2" --enable
openstack loadbalancer create --flavor f_dev2 --vip-subnet-id tp91 --vip-address 192.168.91.56 --name vip1
openstack loadbalancer set --description 'test' vip1
openstack loadbalancer delete vip1
```

## Manual Testing
```
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer create --flavor f_dev2 --vip-subnet-id tp91 --vip-address 192.168.91.56 --name vip1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-06-22T02:34:47                  |
| description         |                                      |
| flavor_id           | abbc517c-77d3-4392-b195-b64085726237 |
| id                  | 8e0526e9-e054-48b0-b01c-d7a3a4e3c611 |
| listeners           |                                      |
| name                | vip1                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 99c9c2304f114685a32db30769c8a7e2     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.91.56                        |
| vip_network_id      | 61305531-6e3a-44b4-8e67-05e93363dddc |
| vip_port_id         | f4d11538-f161-405a-821c-26f3c0fc0e89 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 3ea80a1c-5785-4252-b751-c84d614ccb0c |
+---------------------+--------------------------------------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| 8e0526e9-e054-48b0-b01c-d7a3a4e3c611 | vip1 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.56 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer set
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| 8e0526e9-e054-48b0-b01c-d7a3a4e3c611 | vip1 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.56 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer delete vip1
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer list

stack@openstack-4:~/source/a10-octavia/vThunder$
```
