### PR TITLE
[STACK-2519]: Fix for deleting vip ports and security groups in case of fixed_subnets

### DIFF
--- a/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
+++ b/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
@@ -190,6 +190,9 @@ class A10OctaviaNeutronDriver(aap.AllowedAddressPairsDriver):
         vip_port_id = loadbalancer.vip.port_id
         fixed_subnets = CONF.a10_controller_worker.amp_boot_network_list[:]
         subnet = self.get_subnet(loadbalancer.vip.subnet_id)
+        if subnet.network_id in fixed_subnets and lb_count_subnet != 0:
+                    lb_count_subnet = lb_count_subnet + 1
+
         if self.sec_grp_enabled:
             sec_grp = self._get_lb_security_group(loadbalancer.id)
             if sec_grp:
@@ -201,23 +204,22 @@ class A10OctaviaNeutronDriver(aap.AllowedAddressPairsDriver):
                 ports.extend(self._get_instance_ports_by_subnet(
                     amphora.compute_id, loadbalancer.vip.subnet_id))
 
-        if subnet.network_id not in fixed_subnets:
-            for port in ports:
-                port = port.get('port', port)
-                """If lb_count_subnet is greater then 1 then
-                vNIC port is in use by other lbs. Only delete VIP port.
-                In-case of deleting lb(ERROR state),
-                vthunder returned value from database is "None" then
-                lb_count_subnet is equal to 0, in this case delete only vip port."""
-                if lb_count_subnet != 1:
-                    if sec_grp:
-                        self._remove_security_group(port, sec_grp['id'])
-                    if port['id'] == vip_port_id:
-                        self._cleanup_port(vip_port_id, port)
-                else:  # This is the only lb using vNIC ports
+        for port in ports:
+            port = port.get('port', port)
+            """If lb_count_subnet is greater then 1 then
+            vNIC port is in use by other lbs. Only delete VIP port.
+            In-case of deleting lb(ERROR state),
+            vthunder returned value from database is "None" then
+            lb_count_subnet is equal to 0, in this case delete only vip port."""
+            if lb_count_subnet != 1:
+                if sec_grp:
+                    self._remove_security_group(port, sec_grp['id'])
+                if port['id'] == vip_port_id:
                     self._cleanup_port(vip_port_id, port)
+            else:  # This is the only lb using vNIC ports
+                self._cleanup_port(vip_port_id, port)
 
-        if subnet.network_id not in fixed_subnets and sec_grp:
+        if sec_grp:
             self._delete_vip_security_group(sec_grp['id'])
 
         for amphora in filter(

--- a/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
+++ b/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
@@ -191,7 +191,7 @@ class A10OctaviaNeutronDriver(aap.AllowedAddressPairsDriver):
         fixed_subnets = CONF.a10_controller_worker.amp_boot_network_list[:]
         subnet = self.get_subnet(loadbalancer.vip.subnet_id)
         if subnet.network_id in fixed_subnets and lb_count_subnet != 0:
-                    lb_count_subnet = lb_count_subnet + 1
+            lb_count_subnet = lb_count_subnet + 1
 
         if self.sec_grp_enabled:
             sec_grp = self._get_lb_security_group(loadbalancer.id)


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description:  [vThunder] Cleanup VIP port and security group for loadbalancers on fixed_subnets when deletion

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-2519

## Technical Approach
- While using fixed_networks, increase the lb_count_subnet so that only vip port get deleted.

## Manual Testing
1) When multiple network is in amp_network_list.
amp_boot_network_list = 01402810-aa7b-4a9d-a201-7b1df5f4bce3, 36dc5caf-cec1-4e34-befa-d6eafef39938, 2ee882b9-64f1-453c-9c61-b51a0e83ea7a
a) Create multiple lbs.
```
openstack loadbalancer create --name vs1 --vip-subnet-id private-a-subnet
openstack loadbalancer create --name vs2 --vip-subnet-id private-a-subnet
openstack loadbalancer create --name vs3 --vip-subnet-id private-b-subnet
openstack loadbalancer create --name vs4 --vip-subnet-id private-b-subnet

stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| f9ad8155-bcc4-4f01-a2f4-dd623178c15a | vs1  | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.0.153  | ACTIVE              | a10      |
| 6bbe0568-1f8e-407c-969e-eb05ad5a0d9b | vs2  | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.0.191  | ACTIVE              | a10      |
| 088426c4-22ce-4166-9e30-72848d4b6d05 | vs3  | a5b6eb74f8184fc19e77e1693fdfa8e2 | 11.0.0.96   | ACTIVE              | a10      |
| edbc79f9-d36c-43e9-a7f0-2a37e6608c62 | vs4  | a5b6eb74f8184fc19e77e1693fdfa8e2 | 11.0.0.137  | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+

stack@adeeb:~/adeeb/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------+----------------+-----------------+
| ID                                   | Name                                         | Status | Networks                                                                     | Image          | Flavor          |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------+----------------+-----------------+
| 59e5aca4-20f1-4337-a165-0c5302073108 | amphora-3a06c142-bdb2-4cce-8cf6-858e4430f9e3 | ACTIVE | lb-mgmt-net=192.168.0.110; private-net-a=10.0.0.19; private-net-b=11.0.0.135 | vThunder.qcow2 | vThunder_flavor |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------+----------------+-----------------+

stack@adeeb:~/adeeb/a10-octavia$ openstack security group list|grep lb
| 1b4fcfd0-d47d-4cd3-8cf6-abe54410a55a | lb-f9ad8155-bcc4-4f01-a2f4-dd623178c15a |                        | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
| 2068fe76-d07c-4c94-a00d-91db6e1c82ad | lb-edbc79f9-d36c-43e9-a7f0-2a37e6608c62 |                        | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
| 486898c4-bff4-4dca-82b7-f03f424ffa87 | lb-health-mgr-sec-grp                   | lb-health-mgr-sec-grp  | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
| 82833a48-a81b-4f37-a041-02ca4aae3b04 | lb-mgmt-sec-grp                         | lb-mgmt-sec-grp        | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
| a1b62e95-536c-4bdf-9ff3-541c1ba834c8 | lb-088426c4-22ce-4166-9e30-72848d4b6d05 |                        | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
| a77257c4-92e4-4855-b5c1-eddf9a34da83 | lb-6bbe0568-1f8e-407c-969e-eb05ad5a0d9b |                        | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |

stack@adeeb:~/adeeb/a10-octavia$ openstack port list | grep octavia
| 1e9f8d3f-74fc-4b7a-883d-d096a41a5d85 | octavia-health-manager-standalone-listen-port         | fa:16:3e:20:04:fa | ip_address='192.168.0.198', subnet_id='ee66e62e-c971-4635-88d0-34216ed94a88'                        | ACTIVE |
| 588bf4d4-cf9a-47d5-8069-094603b149b5 | octavia-lb-088426c4-22ce-4166-9e30-72848d4b6d05       | fa:16:3e:a3:59:a6 | ip_address='11.0.0.96', subnet_id='5a3129a7-42b2-4f98-9fcf-1aa4fb238c25'                            | DOWN   |
| 74c65b98-58c6-4baa-8ebd-33a01b6a1fe0 | octavia-vrid-fip-991ca4b3-9c44-4d03-8f83-e460d37fabf5 | fa:16:3e:2f:60:2c | ip_address='10.0.0.120', subnet_id='2676dc58-d1df-46c5-bc8a-fab5426684d5'                           | DOWN   |
| 7ef2ea24-761d-4839-ab23-b1bddba5dbf6 | octavia-lb-6bbe0568-1f8e-407c-969e-eb05ad5a0d9b       | fa:16:3e:43:5d:7d | ip_address='10.0.0.191', subnet_id='2676dc58-d1df-46c5-bc8a-fab5426684d5'                           | DOWN   |
| cb65c74e-db84-4057-84b1-09c22b90e63b | octavia-lb-edbc79f9-d36c-43e9-a7f0-2a37e6608c62       | fa:16:3e:84:4b:8a | ip_address='11.0.0.137', subnet_id='5a3129a7-42b2-4f98-9fcf-1aa4fb238c25'                           | DOWN   |
| cd4cddec-f198-4ebd-82f3-741adbaca066 | octavia-lb-f9ad8155-bcc4-4f01-a2f4-dd623178c15a       | fa:16:3e:3e:1d:2e | ip_address='10.0.0.153', subnet_id='2676dc58-d1df-46c5-bc8a-fab5426684d5'                           | DOWN   |
| d6f9bab4-cbd4-4650-91db-1f43de3e4902 | octavia-vrid-fip-1e30d168-acec-43cd-aa42-e1c6f8ab248c | fa:16:3e:07:05:ba | ip_address='11.0.0.120', subnet_id='5a3129a7-42b2-4f98-9fcf-1aa4fb238c25'                           | DOWN   |

vthunder:
!
vrrp-a vrid 0
  floating-ip 10.0.0.120
  floating-ip 11.0.0.120
!
slb virtual-server 088426c4-22ce-4166-9e30-72848d4b6d05 11.0.0.96
!
slb virtual-server 6bbe0568-1f8e-407c-969e-eb05ad5a0d9b 10.0.0.191
!
slb virtual-server edbc79f9-d36c-43e9-a7f0-2a37e6608c62 11.0.0.137
!
slb virtual-server f9ad8155-bcc4-4f01-a2f4-dd623178c15a 10.0.0.153
!

vThunder(NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e06.2867  192.168.0.110/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3eb2.53c0  10.0.0.19/24          1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e50.b00e  11.0.0.135/24         1  DataPort

Global Throughput:608 bits/sec (76 bytes/sec)
Throughput:608 bits/sec (76 bytes/sec)
```

 b) Delete lbs ==> Interface will not be removed from vthunder; only vip ports and security groups will deleted.
```
**openstack loadbalancer delete vs4**
stack@adeeb:~$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| f9ad8155-bcc4-4f01-a2f4-dd623178c15a | vs1  | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.0.153  | ACTIVE              | a10      |
| 6bbe0568-1f8e-407c-969e-eb05ad5a0d9b | vs2  | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.0.191  | ACTIVE              | a10      |
| 088426c4-22ce-4166-9e30-72848d4b6d05 | vs3  | a5b6eb74f8184fc19e77e1693fdfa8e2 | 11.0.0.96   | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
stack@adeeb:~$ openstack server list
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------+----------------+-----------------+
| ID                                   | Name                                         | Status | Networks                                                                     | Image          | Flavor          |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------+----------------+-----------------+
| 59e5aca4-20f1-4337-a165-0c5302073108 | amphora-3a06c142-bdb2-4cce-8cf6-858e4430f9e3 | ACTIVE | lb-mgmt-net=192.168.0.110; private-net-a=10.0.0.19; private-net-b=11.0.0.135 | vThunder.qcow2 | vThunder_flavor |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------+----------------+-----------------+
stack@adeeb:~$ openstack port list | grep octavia
| 1e9f8d3f-74fc-4b7a-883d-d096a41a5d85 | octavia-health-manager-standalone-listen-port         | fa:16:3e:20:04:fa | ip_address='192.168.0.198', subnet_id='ee66e62e-c971-4635-88d0-34216ed94a88'                        | ACTIVE |
| 588bf4d4-cf9a-47d5-8069-094603b149b5 | octavia-lb-088426c4-22ce-4166-9e30-72848d4b6d05       | fa:16:3e:a3:59:a6 | ip_address='11.0.0.96', subnet_id='5a3129a7-42b2-4f98-9fcf-1aa4fb238c25'                            | DOWN   |
| 74c65b98-58c6-4baa-8ebd-33a01b6a1fe0 | octavia-vrid-fip-991ca4b3-9c44-4d03-8f83-e460d37fabf5 | fa:16:3e:2f:60:2c | ip_address='10.0.0.120', subnet_id='2676dc58-d1df-46c5-bc8a-fab5426684d5'                           | DOWN   |
| 7ef2ea24-761d-4839-ab23-b1bddba5dbf6 | octavia-lb-6bbe0568-1f8e-407c-969e-eb05ad5a0d9b       | fa:16:3e:43:5d:7d | ip_address='10.0.0.191', subnet_id='2676dc58-d1df-46c5-bc8a-fab5426684d5'                           | DOWN   |
| cd4cddec-f198-4ebd-82f3-741adbaca066 | octavia-lb-f9ad8155-bcc4-4f01-a2f4-dd623178c15a       | fa:16:3e:3e:1d:2e | ip_address='10.0.0.153', subnet_id='2676dc58-d1df-46c5-bc8a-fab5426684d5'                           | DOWN   |
| d6f9bab4-cbd4-4650-91db-1f43de3e4902 | octavia-vrid-fip-1e30d168-acec-43cd-aa42-e1c6f8ab248c | fa:16:3e:07:05:ba | ip_address='11.0.0.120', subnet_id='5a3129a7-42b2-4f98-9fcf-1aa4fb238c25'                           | DOWN   |

stack@adeeb:~$ openstack security group list |grep lb
| 1b4fcfd0-d47d-4cd3-8cf6-abe54410a55a | lb-f9ad8155-bcc4-4f01-a2f4-dd623178c15a |                        | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
| 486898c4-bff4-4dca-82b7-f03f424ffa87 | lb-health-mgr-sec-grp                   | lb-health-mgr-sec-grp  | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
| 82833a48-a81b-4f37-a041-02ca4aae3b04 | lb-mgmt-sec-grp                         | lb-mgmt-sec-grp        | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
| a1b62e95-536c-4bdf-9ff3-541c1ba834c8 | lb-088426c4-22ce-4166-9e30-72848d4b6d05 |                        | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
| a77257c4-92e4-4855-b5c1-eddf9a34da83 | lb-6bbe0568-1f8e-407c-969e-eb05ad5a0d9b |                        | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
stack@adeeb:~$
vthunder:
!
vrrp-a vrid 0
  floating-ip 10.0.0.120
  floating-ip 11.0.0.120
!
slb virtual-server 088426c4-22ce-4166-9e30-72848d4b6d05 11.0.0.96
!
slb virtual-server 6bbe0568-1f8e-407c-969e-eb05ad5a0d9b 10.0.0.191
!
slb virtual-server f9ad8155-bcc4-4f01-a2f4-dd623178c15a 10.0.0.153
!

vThunder(NOLICENSE)#show interface brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e06.2867  192.168.0.110/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3eb2.53c0  10.0.0.19/24          1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e50.b00e  11.0.0.135/24         1  DataPort

Global Throughput:664 bits/sec (83 bytes/sec)
Throughput:664 bits/sec (83 bytes/sec)

### Delete another lb###

stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer delete vs3
stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| f9ad8155-bcc4-4f01-a2f4-dd623178c15a | vs1  | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.0.153  | ACTIVE              | a10      |
| 6bbe0568-1f8e-407c-969e-eb05ad5a0d9b | vs2  | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.0.191  | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
stack@adeeb:~/adeeb/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------+----------------+-----------------+
| ID                                   | Name                                         | Status | Networks                                                                     | Image          | Flavor          |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------+----------------+-----------------+
| 59e5aca4-20f1-4337-a165-0c5302073108 | amphora-3a06c142-bdb2-4cce-8cf6-858e4430f9e3 | ACTIVE | lb-mgmt-net=192.168.0.110; private-net-a=10.0.0.19; private-net-b=11.0.0.135 | vThunder.qcow2 | vThunder_flavor |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------+----------------+-----------------+
stack@adeeb:~/adeeb/a10-octavia$ openstack port list | grep octavia
| 1e9f8d3f-74fc-4b7a-883d-d096a41a5d85 | octavia-health-manager-standalone-listen-port         | fa:16:3e:20:04:fa | ip_address='192.168.0.198', subnet_id='ee66e62e-c971-4635-88d0-34216ed94a88'                        | ACTIVE |
| 74c65b98-58c6-4baa-8ebd-33a01b6a1fe0 | octavia-vrid-fip-991ca4b3-9c44-4d03-8f83-e460d37fabf5 | fa:16:3e:2f:60:2c | ip_address='10.0.0.120', subnet_id='2676dc58-d1df-46c5-bc8a-fab5426684d5'                           | DOWN   |
| 7ef2ea24-761d-4839-ab23-b1bddba5dbf6 | octavia-lb-6bbe0568-1f8e-407c-969e-eb05ad5a0d9b       | fa:16:3e:43:5d:7d | ip_address='10.0.0.191', subnet_id='2676dc58-d1df-46c5-bc8a-fab5426684d5'                           | DOWN   |
| cd4cddec-f198-4ebd-82f3-741adbaca066 | octavia-lb-f9ad8155-bcc4-4f01-a2f4-dd623178c15a       | fa:16:3e:3e:1d:2e | ip_address='10.0.0.153', subnet_id='2676dc58-d1df-46c5-bc8a-fab5426684d5'                           | DOWN   |

stack@adeeb:~/adeeb/a10-octavia$ openstack security group list |grep lb
| 1b4fcfd0-d47d-4cd3-8cf6-abe54410a55a | lb-f9ad8155-bcc4-4f01-a2f4-dd623178c15a |                        | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
| 486898c4-bff4-4dca-82b7-f03f424ffa87 | lb-health-mgr-sec-grp                   | lb-health-mgr-sec-grp  | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
| 82833a48-a81b-4f37-a041-02ca4aae3b04 | lb-mgmt-sec-grp                         | lb-mgmt-sec-grp        | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
| a77257c4-92e4-4855-b5c1-eddf9a34da83 | lb-6bbe0568-1f8e-407c-969e-eb05ad5a0d9b |                        | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
stack@adeeb:~/adeeb/a10-octavia$
vthunder
!
vrrp-a vrid 0
  floating-ip 10.0.0.120
!
slb virtual-server 6bbe0568-1f8e-407c-969e-eb05ad5a0d9b 10.0.0.191
!
slb virtual-server f9ad8155-bcc4-4f01-a2f4-dd623178c15a 10.0.0.153
!

vThunder(NOLICENSE)#show interface brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e06.2867  192.168.0.110/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3eb2.53c0  10.0.0.19/24          1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e50.b00e  11.0.0.135/24         1  DataPort

Global Throughput:64 bits/sec (8 bytes/sec)
Throughput:64 bits/sec (8 bytes/sec)

####Delete another lb###

stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer delete vs2
stack@adeeb:~/adeeb/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------+----------------+-----------------+
| ID                                   | Name                                         | Status | Networks                                                                     | Image          | Flavor          |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------+----------------+-----------------+
| 59e5aca4-20f1-4337-a165-0c5302073108 | amphora-3a06c142-bdb2-4cce-8cf6-858e4430f9e3 | ACTIVE | lb-mgmt-net=192.168.0.110; private-net-a=10.0.0.19; private-net-b=11.0.0.135 | vThunder.qcow2 | vThunder_flavor |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------+----------------+-----------------+
stack@adeeb:~/adeeb/a10-octavia$ openstack port list | grep octavia
| 1e9f8d3f-74fc-4b7a-883d-d096a41a5d85 | octavia-health-manager-standalone-listen-port         | fa:16:3e:20:04:fa | ip_address='192.168.0.198', subnet_id='ee66e62e-c971-4635-88d0-34216ed94a88'                        | ACTIVE |
| 74c65b98-58c6-4baa-8ebd-33a01b6a1fe0 | octavia-vrid-fip-991ca4b3-9c44-4d03-8f83-e460d37fabf5 | fa:16:3e:2f:60:2c | ip_address='10.0.0.120', subnet_id='2676dc58-d1df-46c5-bc8a-fab5426684d5'                           | DOWN   |
| cd4cddec-f198-4ebd-82f3-741adbaca066 | octavia-lb-f9ad8155-bcc4-4f01-a2f4-dd623178c15a       | fa:16:3e:3e:1d:2e | ip_address='10.0.0.153', subnet_id='2676dc58-d1df-46c5-bc8a-fab5426684d5'                           | DOWN   |

stack@adeeb:~/adeeb/a10-octavia$ openstack security group list |grep lb
| 1b4fcfd0-d47d-4cd3-8cf6-abe54410a55a | lb-f9ad8155-bcc4-4f01-a2f4-dd623178c15a |                        | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
| 486898c4-bff4-4dca-82b7-f03f424ffa87 | lb-health-mgr-sec-grp                   | lb-health-mgr-sec-grp  | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
| 82833a48-a81b-4f37-a041-02ca4aae3b04 | lb-mgmt-sec-grp                         | lb-mgmt-sec-grp        | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
stack@adeeb:~/adeeb/a10-octavia$

###Delete last lb###
stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer list

stack@adeeb:~/adeeb/a10-octavia$ openstack server list

stack@adeeb:~/adeeb/a10-octavia$ openstack port list | grep octavia
| 1e9f8d3f-74fc-4b7a-883d-d096a41a5d85 | octavia-health-manager-standalone-listen-port | fa:16:3e:20:04:fa | ip_address='192.168.0.198', subnet_id='ee66e62e-c971-4635-88d0-34216ed94a88'                        | ACTIVE |

stack@adeeb:~/adeeb/a10-octavia$ openstack security group list |grep lb
| 486898c4-bff4-4dca-82b7-f03f424ffa87 | lb-health-mgr-sec-grp | lb-health-mgr-sec-grp  | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
| 82833a48-a81b-4f37-a041-02ca4aae3b04 | lb-mgmt-sec-grp       | lb-mgmt-sec-grp        | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
stack@adeeb:~/adeeb/a10-octavia$

```
2) Deleting lb which is in error state
```
stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| e836e4dd-a9b9-4c49-918d-0d28167fc9d8 | fp1  | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.0.82   | ACTIVE              | a10      |
| cab25d74-afc3-406c-9aef-0a74ddf1b1f2 | fp2  | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.0.47   | ERROR               | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+

stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer delete fp2

stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| e836e4dd-a9b9-4c49-918d-0d28167fc9d8 | fp1  | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.0.82   | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
stack@adeeb:~/adeeb/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------+----------------+-----------------+
| ID                                   | Name                                         | Status | Networks                                                                     | Image          | Flavor          |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------+----------------+-----------------+
| 2c371e6d-095c-434c-9d3e-24d723dac359 | amphora-47561e34-8ee9-4852-8427-e53707e6bcef | ACTIVE | lb-mgmt-net=192.168.0.170; private-net-a=10.0.0.93; private-net-b=11.0.0.136 | vThunder.qcow2 | vThunder_flavor |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------+----------------+-----------------+

stack@adeeb:~/adeeb/a10-octavia$ openstack security group list |grep lb
| 486898c4-bff4-4dca-82b7-f03f424ffa87 | lb-health-mgr-sec-grp                   | lb-health-mgr-sec-grp  | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
| 82833a48-a81b-4f37-a041-02ca4aae3b04 | lb-mgmt-sec-grp                         | lb-mgmt-sec-grp        | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |
| e13daac2-ee58-43ab-801b-e82446a332a1 | lb-e836e4dd-a9b9-4c49-918d-0d28167fc9d8 |                        | a5b6eb74f8184fc19e77e1693fdfa8e2 | []   |

stack@adeeb:~/adeeb/a10-octavia$ openstack port list | grep octavia
| 11c5f46c-aa1c-4a33-a0fe-f9c07a5b4499 | octavia-vrid-fip-6bdcb267-ea44-4f82-8723-972d242b7b57 | fa:16:3e:47:08:25 | ip_address='10.0.0.120', subnet_id='2676dc58-d1df-46c5-bc8a-fab5426684d5'                           | DOWN   |
| 1e9f8d3f-74fc-4b7a-883d-d096a41a5d85 | octavia-health-manager-standalone-listen-port         | fa:16:3e:20:04:fa | ip_address='192.168.0.198', subnet_id='ee66e62e-c971-4635-88d0-34216ed94a88'                        | ACTIVE |
| 51106dc4-06eb-4103-9ea6-3676698144ef | octavia-lb-e836e4dd-a9b9-4c49-918d-0d28167fc9d8       | fa:16:3e:3d:99:18 | ip_address='10.0.0.82', subnet_id='2676dc58-d1df-46c5-bc8a-fab5426684d5'                            | DOWN   |
stack@adeeb:~/adeeb/a10-octavia$
```

