### PR TITLE
[]STACK-2527]: Fix for adding 0.0.0.0/0 in interface AAP when a10_config file has l2dsr_support = True 

### DIFF
--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -128,6 +128,10 @@ class AllowL2DSR(VThunderBaseTask):
     """Task to add wildcat address in allowed_address_pair for L2DSR"""
 
     def execute(self, subnet, amphora, lb_count_flavor, flavor_data=None):
+        if CONF.vthunder.l2dsr_support:
+            for amp in amphora:
+                self.network_driver.allow_use_any_source_ip_on_egress(subnet.network_id, amp)
+
         if flavor_data:
             deployment = flavor_data.get('deployment')
             if deployment and 'dsr_type' in deployment:


### PR DESCRIPTION
## Description
- Severity Level - Medium
- Issue Description - [vthunder l2dsr] there's no 0.0.0.0/0 added in aap when create lb with l2dsr_support = True in a10-octavia.conf

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2527

## Technical Approach
- Add code for adding 0.0.0.0/0 in AAP when l2dsr_support = True in a10_config file 

## Config Changes

<pre>
<b>
[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
l2dsr_support = True
</b>
</pre>


## Manual Testing
- Similar to QA
1) Create lb.
```
stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 1f94e4f7-02f2-4f1e-b827-3b4994206ae6 | vs3  | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.0.66   | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
stack@adeeb:~/adeeb/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+----------------------------------------------------+----------------+-----------------+
| ID                                   | Name                                         | Status | Networks                                           | Image          | Flavor          |
+--------------------------------------+----------------------------------------------+--------+----------------------------------------------------+----------------+-----------------+
| 95df7f8f-465b-472b-b479-261c3bbf1c38 | amphora-62f533c5-60f9-4873-976a-91fe29b89159 | ACTIVE | lb-mgmt-net=192.168.0.69; private-net-a=10.0.0.230 | vThunder.qcow2 | vThunder_flavor |
+--------------------------------------+----------------------------------------------+--------+----------------------------------------------------+----------------+-----------------+
```
![image](https://user-images.githubusercontent.com/76765492/123059789-c17deb00-d427-11eb-823c-472343c082db.png)

