### PR TITLE
[STACK_2524]: [vthunder]Fix missing dependency issue for member set command

### DIFF
--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -690,18 +690,16 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                            constants.UPDATE_DICT: member_updates})
             else:
                 busy = self._vthunder_busy_check(member.project_id, False, ctx_flags, None)
-                update_member_tf = self._taskflow_load(self._member_flows.
-                                                       get_update_member_flow(topology=topology),
-                                                       store={constants.MEMBER: member,
-                                                              constants.LISTENERS:
-                                                              listeners,
-                                                              constants.LOADBALANCER:
-                                                              load_balancer,
-                                                              a10constants.COMPUTE_BUSY: busy,
-                                                              constants.POOL:
-                                                              pool,
-                                                              constants.UPDATE_DICT:
-                                                              member_updates})
+                update_member_tf = self._taskflow_load(
+                    self._member_flows.get_update_member_flow(topology=topology),
+                    store={constants.MEMBER: member,
+                           constants.LISTENERS: listeners,
+                           constants.LOADBALANCER: load_balancer,
+                           a10constants.COMPUTE_BUSY: busy,
+                           constants.POOL: pool,
+                           constants.UPDATE_DICT: member_updates,
+                           a10constants.VTHUNDER_CONFIG: None,
+                           a10constants.USE_DEVICE_FLAVOR: False})
                 self._register_flow_notify_handler(update_member_tf, member.project_id, False,
                                                    busy, ctx_flags)
 


### PR DESCRIPTION
## Description
- Severity Level : Medium
- Description: [vthunder] failed to set member and get error: MissingDependencies: 'execute' method on 'a10_octavia.controller.worker.tasks.a10_database_tasks.

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-2524

## Technical Approach
- Added _a10constants.VTHUNDER_CONFIG_ and _a10constants.USE_DEVICE_FLAVOR_  in store for _get_update_member_flow_ in controller worker.

## Manual Testing
- Similar to QA.
1) Create lb and other objects then set the member.
```
openstack loadbalancer create --name vs3 --vip-subnet-id private-a-subnet
openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name l1 vs1
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener l1 --name p1
openstack loadbalancer member create --address 10.0.0.90 --subnet-id private-a-subnet --protocol-port 80 --name m1 p1

stack@adeeb:~$ openstack loadbalancer member set p1 m1
logs:
Jun 23 10:42:49 adeeb a10-octavia-worker[21739]: INFO a10_octavia.controller.queue.endpoint [-] Updating member 'e25d4262-31c6-4f75-9f10-e4995a57a573'...
Jun 23 10:43:00 adeeb a10-octavia-worker[21739]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.0.69:shared

stack@adeeb:~$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 1f94e4f7-02f2-4f1e-b827-3b4994206ae6 | vs3  | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.0.66   | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
stack@adeeb:~$ openstack loadbalancer listener list
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| id                                   | default_pool_id                      | name | project_id                       | protocol | protocol_port | admin_state_up |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| 3da03b51-460c-4441-b547-a3daa397b23c | 25ccf2ad-44a9-4c3e-a7c8-0223b1e062e8 | l1   | a5b6eb74f8184fc19e77e1693fdfa8e2 | HTTP     |            80 | True           |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
stack@adeeb:~$ openstack loadbalancer pool list
+--------------------------------------+------+----------------------------------+---------------------+----------+--------------+----------------+
| id                                   | name | project_id                       | provisioning_status | protocol | lb_algorithm | admin_state_up |
+--------------------------------------+------+----------------------------------+---------------------+----------+--------------+----------------+
| 25ccf2ad-44a9-4c3e-a7c8-0223b1e062e8 | p1   | a5b6eb74f8184fc19e77e1693fdfa8e2 | ACTIVE              | HTTP     | ROUND_ROBIN  | True           |
+--------------------------------------+------+----------------------------------+---------------------+----------+--------------+----------------+
stack@adeeb:~$ openstack loadbalancer member list p1
+--------------------------------------+------+----------------------------------+---------------------+-----------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address   | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+-----------+---------------+------------------+--------+
| e25d4262-31c6-4f75-9f10-e4995a57a573 | m1   | a5b6eb74f8184fc19e77e1693fdfa8e2 | ACTIVE              | 10.0.0.90 |            80 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+-----------+---------------+------------------+--------+
stack@adeeb:~$

vthunder:
!
vrrp-a vrid 0
  floating-ip 10.0.0.120
!
slb server a5b6e_10_0_0_90 10.0.0.90
  port 80 tcp
!
slb service-group 25ccf2ad-44a9-4c3e-a7c8-0223b1e062e8 tcp
  member a5b6e_10_0_0_90 80
!
slb virtual-server 1f94e4f7-02f2-4f1e-b827-3b4994206ae6 10.0.0.66
  port 80 http
    name 3da03b51-460c-4441-b547-a3daa397b23c
    conn-limit 6400000
    extended-stats
    service-group 25ccf2ad-44a9-4c3e-a7c8-0223b1e062e8
!
```
