### PR TITLE
[STACK-2530][STACK-2533] parameter missing in some flow

### DIFF
--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -684,8 +684,11 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         ctx_flags = [False]
         try:
             if self._is_rack_flow(member.project_id, loadbalancer=load_balancer):
+                vthunder_conf = CONF.hardware_thunder.devices.get(load_balancer.project_id, None)
+                device_dict = CONF.hardware_thunder.devices
                 update_member_tf = self._taskflow_load(
-                    self._member_flows.get_rack_vthunder_update_member_flow(),
+                    self._member_flows.get_rack_vthunder_update_member_flow(
+                        vthunder_conf=vthunder_conf, device_dict=device_dict),
                     store={constants.MEMBER: member,
                            constants.LISTENERS: listeners,
                            constants.LOADBALANCER: load_balancer,
@@ -791,6 +794,10 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         ctx_flags = [False]
         try:
             if self._is_rack_flow(pool.project_id, loadbalancer=load_balancer):
+                vthunder_conf = CONF.hardware_thunder.devices.get(load_balancer.project_id, None)
+                device_dict = CONF.hardware_thunder.devices
+                store.update([(a10constants.VTHUNDER_CONFIG, vthunder_conf),
+                              (a10constants.DEVICE_CONFIG_DICT, device_dict)])
                 delete_pool_tf = self._taskflow_load(
                     self._pool_flows.get_delete_pool_rack_flow(
                         members, health_monitor, store), store=store)

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -315,6 +315,17 @@ class PoolFlows(object):
         delete_pool_flow.add(vthunder_tasks.SetupDeviceNetworkMap(
             requires=a10constants.VTHUNDER,
             provides=a10constants.VTHUNDER))
+
+        # Device Flavor
+        delete_pool_flow.add(a10_database_tasks.GetFlavorData(
+            rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
+            provides=constants.FLAVOR))
+        delete_pool_flow.add(vthunder_tasks.GetVthunderConfByFlavor(
+            requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG,
+                      a10constants.DEVICE_CONFIG_DICT),
+            rebind={constants.FLAVOR_DATA: constants.FLAVOR},
+            provides=(a10constants.VTHUNDER_CONFIG, a10constants.USE_DEVICE_FLAVOR)))
+
         # Delete pool children
         delete_pool_flow.add(self._get_delete_health_monitor_vthunder_subflow(health_mon))
         delete_pool_flow.add(self._get_delete_member_vthunder_subflow(members, store))


### PR DESCRIPTION
## Description
- Severity Level: Critical
- Required: Issue Description
In taskflow flows some parameter is missing and cause openstack command not work.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2530
https://a10networks.atlassian.net/browse/STACK-2533

## Technical Approach
provide the parameters properly.

## Config Changes

<pre>
<b>[a10_global]
network_type = vlan
vrid=7
vrid_floating_ip = ".126"
#use_parent_partition=True

[a10_controller_worker]
network_driver = a10_octavia_neutron_driver
loadbalancer_topology = SINGLE

[listener]
autosnat = True
conn_limit=20000

[health_monitor]
post_data = "abc=1"

[a10_house_keeping]
#use_periodic_write_memory = 'enable'
write_mem_interval = 300

[hardware_thunder]
devices = [
                    {
                     "project_id": "a3ad21c71c4e4040599933bda62a76ae2f",
                     #"project_id": "3d21c71c4e4040599933bda62a76ae2f",
                     "ip_address": "192.168.90.45",
                     "username": "admin",
                     "password": "a10",
                     "device_name": "admin"
                     },
                    {
                     "ip_address": "192.168.90.46",
                     "username": "admin",
                     "password": "a10",
                     #"hierarchical_multitenancy": "enable",
                     "device_name": "dev2",
                     "interface_vlan_map": {
                         "device_1": {
                             "mgmt_ip_address": "192.168.90.46",
                             "ethernet_interfaces": [{
                                 "interface_num": 4,
                                 "vlan_map": [
                                     {"vlan_id": 3, "ve_ip": "192.168.190.61"},
                                     {"vlan_id": 4, "ve_ip": "172.16.1.61"},
                                     {"vlan_id": 5, "ve_ip": "192.168.91.61"},
                                 ]},
                             ]
                          }
                        }
                     },
             ]

</b>
</pre>


## Test Cases
- same as QA
1. create lb, listener, pool and member
2. set member
3. delete pool

```
openstack loadbalancer flavorprofile create --name fp_dev2 --provider a10 --flavor-data '{"device-name": "dev2"}'
openstack loadbalancer flavor create --name f_dev2 --flavorprofile fp_dev2 --description "use device dev2" --enable
openstack loadbalancer create --flavor f_dev2 --vip-subnet-id tp91 --vip-address 192.168.91.56 --name vip1
openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name vport1 vip1
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener vport1 --name sg1
openstack loadbalancer member create --address 192.168.92.238 --subnet-id tp92 --protocol-port 80 --name srv1 sg1
openstack loadbalancer member set sg1 srv1
openstack loadbalancer pool delete sg1
```

## Manual Testing

Result:
```
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer member set sg1 srv1
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| adb560b9-4db0-4cfc-acad-c89c92a6c312 | vip1 | 3d21c71c4e4040599933bda62a76ae2f | 192.168.91.56 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer pool delete sg1
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| adb560b9-4db0-4cfc-acad-c89c92a6c312 | vip1 | 3d21c71c4e4040599933bda62a76ae2f | 192.168.91.56 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer pool list

stack@ytsai-openstack:~/source/a10-octavia/v1.3$

```
