### PR TITLE
[STACK-2486] fix device flavor can not use global floating-ip config

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -759,8 +759,11 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
         vrid_value = CONF.a10_global.vrid
         prev_vrid_value = vrid_list[0].vrid if vrid_list else None
         updated_vrid_list = copy.copy(vrid_list)
-        if use_device_flavor and vthunder_config.vrid_floating_ip:
-            conf_floating_ip = vthunder_config.vrid_floating_ip
+        if use_device_flavor:
+            if vthunder_config.vrid_floating_ip:
+                conf_floating_ip = vthunder_config.vrid_floating_ip
+            else:
+                conf_floating_ip = CONF.a10_global.vrid_floating_ip
         else:
             conf_floating_ip = a10_utils.get_vrid_floating_ip_for_project(
                 lb_resource.project_id)


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description:
when using device-name flavor, global vrid-floating-ip can't be applied.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2486

## Technical Approach
When device didn't specify FIP, use global FIP config.

## Config Changes
<pre>
<b>[a10_global]
network_type = vlan
vrid_floating_ip = ".126"
#use_parent_partition=True

[a10_controller_worker]
network_driver = a10_octavia_neutron_driver
loadbalancer_topology = SINGLE

[listener]
autosnat = True
conn_limit=20000

[health_monitor]
post_data = "abc=1"

[a10_house_keeping]
#use_periodic_write_memory = 'enable'
write_mem_interval = 300

[hardware_thunder]
devices = [
                    {
                     "project_id": "3d21c71c4e4040599933bda62a76ae2f",
                     "ip_address": "192.168.90.45",
                     "username": "admin",
                     "password": "a10",
                     "vrid_floating_ip" : "dhcp",
                     "device_name": "admin"
                     },
                    {
                     "ip_address": "192.168.90.46",
                     "username": "admin",
                     "password": "a10",
                     #"hierarchical_multitenancy": "enable",
                     "device_name": "dev2",
                     "interface_vlan_map": {
                         "device_1": {
                             "mgmt_ip_address": "192.168.90.46",
                             "ethernet_interfaces": [{
                                 "interface_num": 4,
                                 "vlan_map": [
                                     {"vlan_id": 3, "ve_ip": "192.168.190.61"},
                                     {"vlan_id": 4, "ve_ip": "172.16.1.61"},
                                     {"vlan_id": 5, "ve_ip": "192.168.91.61"},
                                 ]},
                             ]
                          }
                        }
                     },
             ]
</b>
</pre>


## Test Cases
- Same as QA
```
openstack loadbalancer flavorprofile create --name fp_dev2 --provider a10 --flavor-data '{"device-name": "dev2"}'
openstack loadbalancer flavor create --name f_dev2 --flavorprofile fp_dev2 --description "use device dev2" --enable

openstack loadbalancer create --flavor f_dev2 --vip-subnet-id tp91 --vip-address 192.168.91.56 --name vip1
```

## Manual Testing
```
vrrp-a vrid 0
  floating-ip 192.168.91.126
!
slb virtual-server 1dbac9bd-486a-44f5-8045-7a4621700f7f 192.168.91.56
!

```
