### PR TITLE
[STACK-2488] device flavor use device and partition as owner

### DIFF
--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -341,3 +341,10 @@ def get_loadbalancer_flavor(loadbalancer):
                                                      id=flavor.flavor_profile_id)
             flavor_data = json.loads(flavor_profile.flavor_data)
             return flavor_data
+
+
+def get_device_vrid_owner(device_name, partition, hmt):
+    owner = device_name
+    if hmt == 'enable':
+        owner = device_name + '-' + partition
+    return owner

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -390,8 +390,11 @@ class GetVRIDForLoadbalancerResource(BaseDatabaseTask):
         elif use_device_flavor:
             if vthunder is not None:
                 try:
-                    vrid_list = self.vrid_repo.get_vrid_from_thunder_device(
-                        db_apis.get_session(), device_name=vthunder.device_name)
+                    owner = utils.get_device_vrid_owner(
+                        vthunder.device_name, vthunder.partition_name,
+                        vthunder.hierarchical_multitenancy)
+                    vrid_list = self.vrid_repo.get_vrid_from_owner(
+                        db_apis.get_session(), owner=owner)
                     return vrid_list
                 except Exception as e:
                     LOG.exception(
@@ -418,10 +421,11 @@ class UpdateVRIDForLoadbalancerResource(BaseDatabaseTask):
                     LOG.debug("Successfully deleted DB vrid from project %s",
                               lb_resource.project_id)
                 elif use_device_flavor:
-                    self.vrid_repo.delete(db_apis.get_session(),
-                                          owner=vthunder_config.device_name)
-                    LOG.debug("Successfully deleted DB vrid from device %s",
-                              vthunder_config.device_name)
+                    owner = utils.get_device_vrid_owner(
+                        vthunder_config.device_name, vthunder_config.partition_name,
+                        vthunder_config.hierarchical_multitenancy)
+                    self.vrid_repo.delete(db_apis.get_session(), owner=owner)
+                    LOG.debug("Successfully deleted DB vrid from device %s", owner)
 
             except Exception as e:
                 LOG.error(
@@ -454,10 +458,14 @@ class UpdateVRIDForLoadbalancerResource(BaseDatabaseTask):
             else:
                 if use_device_flavor:
                     try:
+                        owner = utils.get_device_vrid_owner(
+                            vthunder_config.device_name,
+                            vthunder_config.partition_name,
+                            vthunder_config.hierarchical_multitenancy)
                         new_vrid = self.vrid_repo.create(
                             db_apis.get_session(),
                             id=vrid.id,
-                            owner=vthunder_config.device_name,
+                            owner=owner,
                             vrid_floating_ip=vrid.vrid_floating_ip,
                             vrid_port_id=vrid.vrid_port_id,
                             vrid=vrid.vrid,
@@ -1062,16 +1070,17 @@ class CountLoadbalancersOnThunderBySubnet(BaseDatabaseTask):
                     db_apis.get_session(),
                     ip_address=vthunder.ip_address)
                 for vthunder_id in vthunder_ids:
-                    vthunder = self.vthunder_repo.get(
+                    vth = self.vthunder_repo.get(
                         db_apis.get_session(),
                         id=vthunder_id)
 
-                    lb = self.loadbalancer_repo.get_lbs_on_thunder_by_subnet(
-                        db_apis.get_session(),
-                        vthunder.loadbalancer_id,
-                        subnet_id=subnet.id)
-                    if lb:
-                        count = count + 1
+                    if vthunder.partition_name == vth.partition_name:
+                        lb = self.loadbalancer_repo.get_lbs_on_thunder_by_subnet(
+                            db_apis.get_session(),
+                            vth.loadbalancer_id,
+                            subnet_id=subnet.id)
+                        if lb:
+                            count = count + 1
                 return count
             except Exception as e:
                 LOG.exception("Failed to get LB count on thunder for subnet %s due to %s ",

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -779,7 +779,10 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
         update_vrid_flag = False
         existing_fips = []
         if use_device_flavor:
-            self._add_vrid_to_list(updated_vrid_list, subnet, vthunder_config.device_name)
+            owner = a10_utils.get_device_vrid_owner(
+                vthunder_config.device_name, vthunder_config.partition_name,
+                vthunder_config.hierarchical_multitenancy)
+            self._add_vrid_to_list(updated_vrid_list, subnet, owner)
         else:
             self._add_vrid_to_list(updated_vrid_list, subnet, lb_resource.project_id)
         for vrid in updated_vrid_list:

--- a/a10_octavia/db/migration/alembic_migrations/versions/1722c3166462_vrid_table_extend_owner_size.py
+++ b/a10_octavia/db/migration/alembic_migrations/versions/1722c3166462_vrid_table_extend_owner_size.py
@@ -1,0 +1,26 @@
+"""vrid_table_extend_owner_size
+
+Revision ID: 1722c3166462
+Revises: 873ee83aef63
+Create Date: 2021-06-25 18:36:26.122495
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1722c3166462'
+down_revision = '873ee83aef63'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('vrid', 'owner',
+            existing_type=sa.String(128), nullable=False)
+
+
+def downgrade():
+    op.alter_column('vrid', 'owner',
+            existing_type=sa.String(36), nullable=False)

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -456,11 +456,11 @@ class VRIDRepository(BaseRepository):
 
         return vrid_obj_list
 
-    def get_vrid_from_thunder_device(self, session, device_name):
+    def get_vrid_from_owner(self, session, owner):
         vrid_obj_list = []
 
         model = session.query(self.model_class).filter(
-            self.model_class.owner == device_name)
+            self.model_class.owner == owner)
         for data in model:
             vrid_obj_list.append(data.to_data_model())
 


### PR DESCRIPTION
## Description
- Severity Level :High
- Issue Description:
For vrid db table, we use device-name as owner. 
But when using device-name and the device configured with HTM and use-parent-partition. Then the device and partition is not 1 to 1 anymore. (the device-name may configured on different partitions)
And for this case, we need more database entry in vrid table for different partition. So, we can't just use device-name as owner.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2488

## Technical Approach
User "device-name + partition_name" as owner in vrid table.

## Config Changes
<pre>
<b>[a10_global]
network_type = vlan
vrid_floating_ip = ".126"
use_parent_partition=True

[a10_controller_worker]
network_driver = a10_octavia_neutron_driver
loadbalancer_topology = SINGLE

[listener]
autosnat = True
conn_limit=20000

[health_monitor]
post_data = "abc=1"

[a10_house_keeping]
#use_periodic_write_memory = 'enable'
write_mem_interval = 300

[hardware_thunder]
devices = [
                    {
                     "project_id": "3d21c71c4e4040599933bda62a76ae2f",
                     "ip_address": "192.168.90.46",
                     "username": "admin",
                     "password": "a10",
                     "vrid_floating_ip" : "dhcp",
                     "device_name": "admin_dev"
                     },
                    {
                     "project_id": "9955a18b75fa4c30bb865d72b5a86a6a",
                     "ip_address": "192.168.90.45",
                     "partition_name":'p7',
                     "username": "admin",
                     "password": "a10",
                     "vrid_floating_ip" : "dhcp",
                     "device_name": "child1_dev"
                     },
                    {
                     "ip_address": "192.168.90.45",
                     "username": "admin",
                     "password": "a10",
                     "vrid_floating_ip" : "dhcp",
                     #"hierarchical_multitenancy": "enable",
                     "device_name": "dev2"
                     },
             ]
</b>
</pre>


## Test Cases
- device-name flavor create Lb on 2 partition (the step is the same as QA)
```
openstack loadbalancer flavorprofile create --name fp_dev2 --provider a10 --flavor-data '{"device-name": "dev2"}'
openstack loadbalancer flavor create --name f_dev2 --flavorprofile fp_dev2 --description "use device dev2" --enable
openstack loadbalancer create --flavor f_dev2 --vip-subnet-id tp91 --name vip1
#enable devic HMT
openstack loadbalancer create --flavor f_dev2 --vip-subnet-id tp91 --name vip2
openstack loadbalancer delete vip2
#disable device HMT
openstack loadbalancer delete vip1
```

- device-name flavor create Lb and member on 2 partition 
1. disable HMT in dev2
2. create LB, listener, pool and member
3. check configuration on thunder
4. enable HMT 
5. create another LB, listener, pool and member
6. SLB objects will be configured in parent partition. **Also vrid FIP will be configured correct for both VIP subnet and member subnt**
7. delete everything
8. check everything will be remove on thunder
```
openstack loadbalancer create --flavor f_dev2 --vip-subnet-id tp91 --name vip1
openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name vport1 vip1
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener vport1 --name sg1
openstack loadbalancer member create --address 192.168.92.238 --subnet-id tp92 --protocol-port 80 --name srv1 sg1
#enable HMT
openstack loadbalancer create --flavor f_dev2 --vip-subnet-id tp91 --name vip2
openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name vport2 vip2
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener vport2 --name sg2
openstack loadbalancer member create --address 192.168.92.237 --subnet-id tp92 --protocol-port 80 --name srv2 sg2
openstack loadbalancer member delete sg2 srv2
openstack loadbalancer delete vip2 --cascade
#disable HMT
openstack loadbalancer member delete sg1 srv1
openstack loadbalancer delete vip1 --cascade
```

## Manual Testing
- device-name flavor create Lb and member on 2 partition 
```
ACOS-Active-vMaster[15/2](config:2)#show running-config  | sec vrid
vrrp-a vrid 0
  floating-ip 192.168.91.19
ACOS-Active-vMaster[15/2](config:2)#show running-config  | sec virtual-server
slb virtual-server b6c9c44b-e9c7-4e4d-aa83-4a28041152e4 192.168.91.33


ACOS-Active-vMaster[15/2][3d21c71c4e4040](config:2)#show running-config
!Current configuration: 70 bytes
!Configuration last updated at 04:14:09 CST Sat Jun 26 2021
!Configuration last saved at 04:14:14 CST Sat Jun 26 2021
!
active-partition 3d21c71c4e4040
!
!
vrrp-a vrid 0
  floating-ip 192.168.91.213
!
slb virtual-server 6ff29653-d274-4004-a31e-662409f4f69a 192.168.91.4
!
end
!Current config commit point for partition 2 is 0 & config mode is classical-mode
ACOS-Active-vMaster[15/2][3d21c71c4e4040](config:2)#
```

DB:
```
mysql> select * from vrid;
+--------------------------------------+---------------------+------+--------------------------------------+------------------+--------------------------------------+
| id                                   | owner               | vrid | vrid_port_id                         | vrid_floating_ip | subnet_id                            |
+--------------------------------------+---------------------+------+--------------------------------------+------------------+--------------------------------------+
| 24a1fd9a-ab24-4822-8fa5-6e884b912a00 | dev2                |    0 | e16fec01-2f19-4537-8f26-a6e7678d12e6 | 192.168.91.19    | f25ce642-f953-4058-8c46-98fdd72fb129 |
| 5a9ba72b-e709-477b-9cd9-de4f036f9440 | dev2-3d21c71c4e4040 |    0 | 4e3cdab2-0e3c-4ea2-ad69-47b7542ca090 | 192.168.91.213   | f25ce642-f953-4058-8c46-98fdd72fb129 |
+--------------------------------------+---------------------+------+--------------------------------------+------------------+--------------------------------------+
2 rows in set (0.00 sec)
```

Delete:
```
ACOS-Active-vMaster[15/2][3d21c71c4e4040](config:2)#show running-config
!Current configuration: 0 bytes
!Configuration last updated at 05:10:19 CST Sat Jun 26 2021
!Configuration last saved at 05:10:29 CST Sat Jun 26 2021
!
active-partition 3d21c71c4e4040
!
!
!
end
!Current config commit point for partition 2 is 0 & config mode is classical-mode
mysql> select * from vrid;
+--------------------------------------+-------+------+--------------------------------------+------------------+--------------------------------------+
| id                                   | owner | vrid | vrid_port_id                         | vrid_floating_ip | subnet_id                            |
+--------------------------------------+-------+------+--------------------------------------+------------------+--------------------------------------+
| 24a1fd9a-ab24-4822-8fa5-6e884b912a00 | dev2  |    0 | e16fec01-2f19-4537-8f26-a6e7678d12e6 | 192.168.91.19    | f25ce642-f953-4058-8c46-98fdd72fb129 |
+--------------------------------------+-------+------+--------------------------------------+------------------+--------------------------------------+
1 row in set (0.00 sec)


ACOS-Active-vMaster[15/2](config:2)#show running-config | sec vrid
ACOS-Active-vMaster[15/2](config:2)#show running-config | sec virtual-server
ACOS-Active-vMaster[15/2](config:2)#
mysql> select * from vrid;
Empty set (0.00 sec)

```


-------------------------------------
- device-name flavor create Lb and member on 2 partition 

```
vrrp-a vrid 0
  floating-ip 192.168.91.128
  floating-ip 192.168.92.148
!
slb server 3d21c_192_168_92_238 192.168.92.238
  port 80 tcp
!
slb service-group 0ba51fb2-f5a7-4001-9d14-2fc948a5a862 tcp
  member 3d21c_192_168_92_238 80
!
slb virtual-server 1b77d569-29d1-4544-a721-e8362f2db896 192.168.91.56
  port 80 http
    name 4e30a497-4c09-4594-94f5-1e6a3977d263
    conn-limit 20000
    extended-stats
    source-nat auto
    service-group 0ba51fb2-f5a7-4001-9d14-2fc948a5a862
!
ACOS-Active-vMaster[15/2][3d21c71c4e4040](config:2)#show running-config
!Current configuration: 0 bytes
!Configuration last updated at 05:34:17 CST Sat Jun 26 2021
!Configuration last saved at 05:34:22 CST Sat Jun 26 2021
!
active-partition 3d21c71c4e4040
!
!
vrrp-a vrid 0
  floating-ip 192.168.91.74
  floating-ip 192.168.92.146
!
slb server 3d21c_192_168_92_238 192.168.92.238
  port 80 tcp
!
slb service-group 1c52b897-bda8-4f18-a741-8a8cc19707a6 tcp
  member 3d21c_192_168_92_238 80
!
slb virtual-server 7deb3356-eea4-4ac6-9f80-29c9649348a6 192.168.91.16
  port 80 http
    name f3078d1c-d691-4ae3-b5d7-6c8b0b55510d
    conn-limit 20000
    extended-stats
    source-nat auto
    service-group 1c52b897-bda8-4f18-a741-8a8cc19707a6
!
end
!Current config commit point for partition 2 is 0 & config mode is classical-mode
```

db:
```
ACOS-Active-vMaster[15/2][3d21c71c4e4040](config:2)#show running-config
!Current configuration: 0 bytes
!Configuration last updated at 05:34:17 CST Sat Jun 26 2021
!Configuration last saved at 05:34:22 CST Sat Jun 26 2021
!
active-partition 3d21c71c4e4040
!
!
vrrp-a vrid 0
  floating-ip 192.168.91.74
  floating-ip 192.168.92.146
!
slb server 3d21c_192_168_92_238 192.168.92.238
  port 80 tcp
!
slb service-group 1c52b897-bda8-4f18-a741-8a8cc19707a6 tcp
  member 3d21c_192_168_92_238 80
!
slb virtual-server 7deb3356-eea4-4ac6-9f80-29c9649348a6 192.168.91.16
  port 80 http
    name f3078d1c-d691-4ae3-b5d7-6c8b0b55510d
    conn-limit 20000
    extended-stats
    source-nat auto
    service-group 1c52b897-bda8-4f18-a741-8a8cc19707a6
!
end
!Current config commit point for partition 2 is 0 & config mode is classical-mode
```

after delete:
```
ACOS-Active-vMaster[15/2](config:2)#show running-config | sec vird
ACOS-Active-vMaster[15/2](config:2)#show running-config | sec virtual-server
ACOS-Active-vMaster[15/2](config:2)#active-partition 3d21c71c4e4040
Current active partition: 3d21c71c4e4040
ACOS-Active-vMaster[15/2][3d21c71c4e4040](config:2)#show run
ACOS-Active-vMaster[15/2][3d21c71c4e4040](config:2)#show running-config
!Current configuration: 0 bytes
!Configuration last updated at 07:41:02 CST Sat Jun 26 2021
!Configuration last saved at 07:41:12 CST Sat Jun 26 2021
!
active-partition 3d21c71c4e4040
!
!
!
end
!Current config commit point for partition 2 is 0 & config mode is classical-mode

mysql> select * from vrid;
Empty set (0.00 sec)


```