### PR TITLE
[STACK-2339] Removal of AAP locks lb in error state during delete

### DIFF
--- a/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
+++ b/a10_octavia/network/drivers/neutron/a10_octavia_neutron.py
@@ -430,7 +430,14 @@ class A10OctaviaNeutronDriver(aap.AllowedAddressPairsDriver):
             self._remove_allowed_address_pair_from_port(interface.port_id, '0.0.0.0/0')
 
     def _remove_allowed_address_pair_from_port(self, port_id, ip_address):
-        port = self.neutron_client.show_port(port_id)
+        try:
+            port = self.neutron_client.show_port(port_id)
+        except neutron_client_exceptions.PortNotFoundClient:
+            LOG.warning("Can't deallocate AAP from instance port {0} because it "
+                        "cannot be found in neutron. "
+                        "Continuing cleanup.".format(port_id))
+            return
+
         aap_ips = port['port']['allowed_address_pairs']
         if isinstance(ip_address, list):
             updated_aap_ips = aap_ips


### PR DESCRIPTION
## Description
Severity Level: Low

Deletion of instance port would result in inability to delete loadbalancer.

## Jira Ticket
[STACK-2339](https://a10networks.atlassian.net/browse/STACK-2339)

## Technical Approach
- Added exception handler around show port 

## Config Changes
N/A


## Test Cases
N/A

## Manual Testing

Example Config

```
[a10_global]
vrid_floating_ip = ".9" <---- Required

[vthunder]
default_vthunder_username = admin
default_vthunder_password = a10
default_axapi_version = 30

[a10_controller_worker]
....
loadbalancer_topology = ACTIVE_STANDBY   <--- Required

```

### 1. Create a loadbalancer in any network
`openstack loadbalancer create --name lb1 --vip-subnet-id private-subnet`

### 2. Place a breakpoint using `rpdb`
Add breakpoint to line 433 of the a10_octavia_neutron network driver

### 3. Restart service
```sudo systemctl restart a10-c*```

### 4. Execute lb delete
`openstack loadbalancer delete lb1`

### 5. Delete port
When the breakpoint is hit, use rpdb to print the `port_id` variable contents. Use the output to execute the following

`openstack port delete <port_id>`

### 6. Continue past the breakpoint
At this point the warning will be logged and the loadbalancer successfully deleted.

