### PR TITLE
[STACK-2341] Backwards compatibility for partition name

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -647,13 +647,9 @@ class LoadBalancerFlows(object):
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG,
                       a10constants.DEVICE_CONFIG_DICT, constants.FLAVOR_DATA),
             provides=(a10constants.VTHUNDER_CONFIG, a10constants.USE_DEVICE_FLAVOR)))
-
-        lb_create_flow.add(
-            a10_database_tasks.CheckExistingProjectToThunderMappedEntries(
-                requires=(
-                    constants.LOADBALANCER,
-                    a10constants.VTHUNDER_CONFIG),
-                provides=a10constants.VTHUNDER_CONFIG))
+        lb_create_flow.add(vthunder_tasks.HandleACOSPartitionChange(
+            requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG), 
+            provides=a10constants.VTHUNDER_CONFIG))
         lb_create_flow.add(
             a10_database_tasks.CheckExistingThunderToProjectMappedEntries(
                 requires=(

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -648,7 +648,7 @@ class LoadBalancerFlows(object):
                       a10constants.DEVICE_CONFIG_DICT, constants.FLAVOR_DATA),
             provides=(a10constants.VTHUNDER_CONFIG, a10constants.USE_DEVICE_FLAVOR)))
         lb_create_flow.add(vthunder_tasks.HandleACOSPartitionChange(
-            requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG), 
+            requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG),
             provides=a10constants.VTHUNDER_CONFIG))
         lb_create_flow.add(
             a10_database_tasks.CheckExistingThunderToProjectMappedEntries(

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -383,16 +383,12 @@ class VThunderFlows(object):
         sf_name = prefix + '-' + constants.GET_AMPHORA_FOR_LB_SUBFLOW
 
         amp_for_lb_flow = linear_flow.Flow(sf_name)
-
         amp_for_lb_flow.add(a10_database_tasks.CreateRackVthunderEntry(
             name=sf_name + '-' + 'create_rack_vThunder_entry_in_database',
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG)))
         amp_for_lb_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
-        amp_for_lb_flow.add(vthunder_tasks.HandleACOSPartitionChange(
-            name=sf_name + '-' + a10constants.CHANGE_PARTITION,
-            requires=a10constants.VTHUNDER))
         return amp_for_lb_flow
 
     def _is_vrrp_configured(self, history):

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -113,37 +113,6 @@ class CreateVThunderEntry(BaseDatabaseTask):
                 loadbalancer.id)
 
 
-class CheckExistingProjectToThunderMappedEntries(BaseDatabaseTask):
-    """ Check existing Thunder entry with same project id.
-        If exists, ensure the existing IPAddress:Partition
-        is used to configure, otherwise Raise ConfigValueError
-    """
-
-    def execute(self, loadbalancer, vthunder_config):
-        hierarchical_mt = vthunder_config.hierarchical_multitenancy
-        if hierarchical_mt == 'enable':
-            vthunder_config.partition_name = loadbalancer.project_id[:14]
-            if CONF.a10_global.use_parent_partition:
-                parent_project_id = utils.get_parent_project(
-                    vthunder_config.project_id)
-                if parent_project_id:
-                    if parent_project_id != 'default':
-                        vthunder_config.partition_name = parent_project_id[:14]
-                else:
-                    LOG.error(
-                        "The parent project for project %s does not exist. ",
-                        vthunder_config.project_id)
-                    raise exceptions.ParentProjectNotFound(
-                        vthunder_config.project_id)
-            else:
-                LOG.warning(
-                    "Hierarchical multitenancy is disabled, use_parent_partition "
-                    "configuration will not be applied for loadbalancer: %s",
-                    loadbalancer.id)
-
-        return vthunder_config
-
-
 class CheckExistingThunderToProjectMappedEntries(BaseDatabaseTask):
     """ Check for all existing Thunder entries to ensure
         all belong to different projects, otherwise

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -442,23 +442,58 @@ class ConfirmVRRPStatus(VThunderBaseTask):
 class HandleACOSPartitionChange(VThunderBaseTask):
     """Task to switch to specified partition"""
 
-    def execute(self, vthunder):
-        axapi_client = a10_utils.get_axapi_client(vthunder)
+    def _get_hmt_partition_name(self, loadbalancer):
+        partition_name = loadbalancer.project_id
+        if CONF.a10_global.use_parent_partition:
+            parent_project_id = utils.get_parent_project(loadbalancer.project_id)
+            if parent_project_id:
+                if parent_project_id != 'default':
+                    partition_name = parent_project_id
+            else:
+                LOG.error(
+                    "The parent project for project %s does not exist. ",
+                    loadbalancer.project_id)
+                raise exceptions.ParentProjectNotFound(loadbalancer.project_id)
+        else:
+            LOG.warning(
+                "Hierarchical multitenancy is disabled, use_parent_partition "
+                "configuration will not be applied for loadbalancer: %s",
+                loadbalancer.id)
+        return partition_name
+
+    def execute(self, loadbalancer, vthunder_config):
+        axapi_client = a10_utils.get_axapi_client(vthunder_config)
+
+        partition_name = vthunder_config.partition_name
+        hierarchical_mt = vthunder_config.hierarchical_multitenancy
+        if hierarchical_mt == 'enable':
+            partition_name = self._handle_hmt_partition(loadbalancer)
+
         try:
-            partition = axapi_client.system.partition.get(vthunder.partition_name)
+            partition = axapi_client.system.partition.get(partition_name)
         except acos_errors.NotFound:
             partition = None
 
+        # Check if partition is using old n-lbaas length
         if partition is None:
             try:
-                axapi_client.system.partition.create(vthunder.partition_name)
+                partition = axapi_client.system.partition.get(partition_name[:13])
+            except acos_errors.NotFound:
+                partition = None
+
+        if partition is None:
+            try:
+                axapi_client.system.partition.create(partition_name)
                 axapi_client.system.action.write_memory(partition="shared")
-                LOG.info("Partition %s created", vthunder.partition_name)
+                LOG.info("Partition %s created", partition_name)
             except (acos_errors.ACOSException, req_exceptions.ConnectionError) as e:
                 LOG.exception("Failed to create parition on vThunder: %s", str(e))
                 raise e
         elif partition.get("status") == "Not-Active":
-            raise exceptions.PartitionNotActiveError(partition, vthunder.ip_address)
+            raise exceptions.PartitionNotActiveError(partition, vthunder_config.ip_address)
+
+        vthunder_config.partition_name = partition
+        return vthunder_config
 
 
 class SetupDeviceNetworkMap(VThunderBaseTask):

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -470,13 +470,13 @@ class HandleACOSPartitionChange(VThunderBaseTask):
             partition_name = self._get_hmt_partition_name(loadbalancer)
 
         try:
-            partition = axapi_client.system.partition.get(partition_name[:14])
+            partition = axapi_client.system.partition.get(partition_name)
             partition_name = partition['partition-name']
         except acos_errors.NotFound:
             partition = None
 
         # Check if partition is using old n-lbaas length
-        if partition is None:
+        if partition is None and hierarchical_mt == 'enable':
             try:
                 partition = axapi_client.system.partition.get(partition_name[:13])
                 partition_name = partition['partition-name']

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -445,7 +445,7 @@ class HandleACOSPartitionChange(VThunderBaseTask):
     def _get_hmt_partition_name(self, loadbalancer):
         partition_name = loadbalancer.project_id[:14]
         if CONF.a10_global.use_parent_partition:
-            parent_project_id = utils.get_parent_project(loadbalancer.project_id)
+            parent_project_id = a10_utils.get_parent_project(loadbalancer.project_id)
             if parent_project_id:
                 if parent_project_id != 'default':
                     partition_name = parent_project_id[:14]

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -31,7 +31,6 @@ from octavia.tests.common import constants as t_constants
 
 from a10_octavia.common import config_options
 from a10_octavia.common import data_models
-from a10_octavia.common import exceptions
 from a10_octavia.common import utils
 from a10_octavia.controller.worker.tasks import a10_database_tasks as task
 from a10_octavia.tests.common import a10constants
@@ -113,95 +112,6 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         mock_get_vthunder.vthunder_repo.get_vthunder_from_lb.return_value = None
         vthunder = mock_get_vthunder.execute(LB)
         self.assertEqual(vthunder, None)
-
-    @mock.patch('a10_octavia.common.utils.get_parent_project',
-                return_value=a10constants.MOCK_PARENT_PROJECT_ID)
-    def test_create_rack_vthunder_entry_parent_partition_exists(
-            self, mock_parent_project_id):
-        self.conf.config(
-            group=a10constants.A10_GLOBAL_CONF_SECTION,
-            use_parent_partition=True)
-        mock_lb = copy.deepcopy(LB)
-        mock_lb.project_id = a10constants.MOCK_CHILD_PROJECT_ID
-        mock_vthunder_config = copy.deepcopy(HW_THUNDER)
-        mock_vthunder_config.hierarchical_multitenancy = "enable"
-        mock_create_vthunder = task.CreateRackVthunderEntry()
-        mock_create_vthunder.vthunder_repo = mock.MagicMock()
-        mock_vthunder = copy.deepcopy(VTHUNDER)
-        mock_vthunder.partition_name = a10constants.MOCK_PARENT_PROJECT_ID[:14]
-        mock_create_vthunder.vthunder_repo.create.return_value = mock_vthunder
-        vthunder = mock_create_vthunder.execute(mock_lb, mock_vthunder_config)
-        self.assertEqual(vthunder.partition_name,
-                         a10constants.MOCK_PARENT_PROJECT_ID[:14])
-
-    @mock.patch('a10_octavia.common.utils.get_parent_project',
-                return_value=None)
-    def test_create_rack_vthunder_entry_parent_partition_not_exists(
-            self, mock_parent_project_id):
-        self.conf.config(
-            group=a10constants.A10_GLOBAL_CONF_SECTION,
-            use_parent_partition=True)
-        mock_lb = copy.deepcopy(LB)
-        mock_lb.project_id = a10constants.MOCK_CHILD_PROJECT_ID
-        mock_vthunder_config = copy.deepcopy(HW_THUNDER)
-        mock_vthunder_config.hierarchical_multitenancy = "enable"
-        mock_create_vthunder = task.CheckExistingProjectToThunderMappedEntries()
-        mock_create_vthunder.vthunder_repo = mock.MagicMock()
-        mock_vthunder = copy.deepcopy(VTHUNDER)
-        mock_vthunder.partition_name = a10constants.MOCK_CHILD_PART
-        self.assertRaises(exceptions.ParentProjectNotFound,
-                          mock_create_vthunder.execute, mock_lb,
-                          mock_vthunder_config)
-
-    def test_create_rack_vthunder_entry_parent_partition_no_hmt(self):
-        self.conf.config(group=a10constants.A10_GLOBAL_CONF_SECTION,
-                         use_parent_partition=True)
-        mock_lb = copy.deepcopy(LB)
-        mock_lb.project_id = a10constants.MOCK_CHILD_PROJECT_ID
-        mock_vthunder_config = copy.deepcopy(HW_THUNDER)
-        mock_vthunder_config.hierarchical_multitenancy = "disable"
-        mock_create_vthunder = task.CreateRackVthunderEntry()
-        mock_create_vthunder.vthunder_repo = mock.MagicMock()
-        mock_vthunder = copy.deepcopy(VTHUNDER)
-        mock_vthunder.partition_name = a10constants.MOCK_CHILD_PART
-
-        mock_create_vthunder.vthunder_repo.create.return_value = mock_vthunder
-        vthunder = mock_create_vthunder.execute(mock_lb, mock_vthunder_config)
-        self.assertEqual(vthunder.partition_name, a10constants.MOCK_CHILD_PART)
-
-    def test_create_rack_vthunder_entry_parent_partition_hmt_no_use_parent_partition(
-            self):
-        self.conf.config(
-            group=a10constants.A10_GLOBAL_CONF_SECTION,
-            use_parent_partition=False)
-        mock_lb = copy.deepcopy(LB)
-        mock_lb.project_id = a10constants.MOCK_CHILD_PROJECT_ID
-        mock_vthunder_config = copy.deepcopy(HW_THUNDER)
-        mock_vthunder_config.hierarchical_multitenancy = "enable"
-        mock_create_vthunder = task.CreateRackVthunderEntry()
-        mock_create_vthunder.vthunder_repo = mock.MagicMock()
-        mock_vthunder = copy.deepcopy(VTHUNDER)
-        mock_vthunder.partition_name = a10constants.MOCK_CHILD_PART
-        mock_create_vthunder.vthunder_repo.create.return_value = mock_vthunder
-        vthunder = mock_create_vthunder.execute(mock_lb, mock_vthunder_config)
-        self.assertEqual(vthunder.partition_name, a10constants.MOCK_CHILD_PART)
-
-    def test_create_rack_vthunder_entry_child_partition_exists(self):
-        self.conf.config(
-            group=a10constants.A10_GLOBAL_CONF_SECTION,
-            use_parent_partition=False)
-        mock_lb = copy.deepcopy(LB)
-        mock_lb.project_id = a10constants.MOCK_CHILD_PROJECT_ID
-        mock_vthunder_config = copy.deepcopy(HW_THUNDER)
-        mock_vthunder_config.hierarchical_multitenancy = "enable"
-        mock_create_vthunder = task.CreateRackVthunderEntry()
-        mock_create_vthunder.vthunder_repo = mock.MagicMock()
-        mock_vthunder = copy.deepcopy(VTHUNDER)
-        mock_vthunder.partition_name = a10constants.MOCK_CHILD_PROJECT_ID[:14]
-        mock_create_vthunder.vthunder_repo.create.return_value = mock_vthunder
-        vthunder = mock_create_vthunder.execute(mock_lb, mock_vthunder_config)
-        self.assertEqual(vthunder.partition_name,
-                         a10constants.MOCK_CHILD_PROJECT_ID[:14])
 
     def test_get_vrid_for_project_member_hmt_use_partition(self):
         thunder = copy.deepcopy(HW_THUNDER)


### PR DESCRIPTION
## Description
Added support for objects using l3v partitions which have been migrated from Neutron LBaaS to Octavia

## Jira Ticket
[STACK-2341](https://a10networks.atlassian.net/browse/STACK-2341)

## Technical Approach
- Migrated HMT handling in CheckExistingProjectToThunderMappedEntries task to HandleACOSPartitionChange task
- Executed HandleACOSCPartitionChange task before vthunder repo create to ensure proper partition name usage
- Added extra get request to try with 13 char if 14 char hmt partition is not found

Backwards compatibility is handled by checking if the partition name exists with it being at most 14 char. If it does not exist and HMT is enabled, then a check is done against 13 char.

## Config Changes
N/A

## Test Cases
- Added test that a previously existing hmt partition with 13 chars is used instead of creation for 14 char partition
- Migrated other test cases from a10_database_task test to a10_vthunder_task tests as they were not testing anything
   due to previously altered functionality

## Manual Testing

### Requirements:
- 1 hardware device

### 1. Test HMT backwards compatibility

#### 1a. Create a partition on the hardware device with the first 13 char of project-id

#### 1b. Enable HMT in a10-octavia.conf

#### 1c. Create the loadbalancer in the same project

#### 1d. Ensure that configuration is present in previously created partition

### 2. Test HMT creates new partition

#### 2a. Enable HMT in a10-octavia.conf

#### 2b. Create the loadbalancer in new project

#### 2c. Ensure that configuration is present in the new partition that is 14 char in length