### PR TITLE
[STACK-2531]: Fix for not deleting 0.0.0.0/0 from AAP if l2dsr_support= True mentioned in config

### DIFF
--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -156,12 +156,14 @@ class DeleteL2DSR(VThunderBaseTask):
     """Task to delete wildcat address in allowed_address_pair for L2DSR"""
 
     def execute(self, subnet, amphora, lb_count_flavor, flavor_data=None):
-        if lb_count_flavor <= 1 and flavor_data:
-            deployment = flavor_data.get('deployment')
-            if deployment and 'dsr_type' in deployment:
-                if deployment['dsr_type'] == "l2dsr_transparent":
-                    for amp in amphora:
-                        self.network_driver.remove_any_source_ip_on_egress(subnet.network_id, amp)
+        if not CONF.vthunder.l2dsr_support:
+            if lb_count_flavor <= 1 and flavor_data:
+                deployment = flavor_data.get('deployment')
+                if deployment and 'dsr_type' in deployment:
+                    if deployment['dsr_type'] == "l2dsr_transparent":
+                        for amp in amphora:
+                            self.network_driver.remove_any_source_ip_on_egress(
+                                subnet.network_id, amp)
 
 
 class AllowLoadbalancerForwardWithAnySource(VThunderBaseTask):


### PR DESCRIPTION
## Description
- Severity Level: Medium
- Issue Description: [vthunder] 0.0.0.0/0 is delete wronlgy when delete one l2dsr lb created by flavor while another l2dsr is still there which is created by config file

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-2531

## Technical Approach
- Added condition when l2dsr_support mentioned in a10_config file then not to delete 0.0.0.0/0 from AAP

## Config Changes
<pre>
<b>
[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
l2dsr_support = True
</b>
</pre>

## Manual Testing
- Required: List of steps to manually test feature or fix 
Similar to QA
1) Create lbs
```
openstack loadbalancer create --name v1 --vip-subnet-id private-11-subnet ( config file will be attached)
openstack loadbalancer flavorprofile create --name fpdsr --provider a10 --flavor-data '{"deployment": {"dsr_type":"l2dsr_transparent"}}’
openstack loadbalancer flavor create --name fdsr --flavorprofile fpdsr
openstack loadbalancer create --name vdsr --flavor fdsr --vip-subnet-id private-11-subnet
stack@adeeb:~$ openstack loadbalancer  list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| ecc34fd9-d064-4b28-bcea-92ac9532cf7b | v1   | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.11.175 | ACTIVE              | a10      |
| d4301bff-d23a-4b63-bcc9-ede789abf57b | vdsr | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.11.107 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+

```
![image](https://user-images.githubusercontent.com/76765492/123594686-a5a28c80-d80d-11eb-9adf-f3e00719caeb.png)

2) Delete lb.
```
stack@adeeb:~$ openstack loadbalancer delete vdsr
stack@adeeb:~$ openstack loadbalancer  list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| ecc34fd9-d064-4b28-bcea-92ac9532cf7b | v1   | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.11.175 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
stack@adeeb:~$
```
![image](https://user-images.githubusercontent.com/76765492/123594755-ba7f2000-d80d-11eb-8b9b-a140000ae3a4.png)
