### PR TITLE
[STACK-2552][STACK-2553][STACK-2563] check topology only on amphora vthunder

### DIFF
--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -99,6 +99,10 @@ SUPPORTED_NETWORK_TYPE = [FLAT, VLAN]
 SSL_TEMPLATE = "ssl_template"
 
 COMPUTE_BUSY = "compute_busy"
+FLOW_TYPE = 'flow_type'
+CREATE_FLOW = 'create'
+DELETE_FLOW = 'delete'
+UPDATE_FLOW = 'update'
 
 # ============================
 # Taskflow flow and task names

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -707,7 +707,8 @@ class LoadBalancerFlows(object):
             provides=constants.FLAVOR_DATA))
         delete_LB_flow.add(vthunder_tasks.GetVthunderConfByFlavor(
             inject={a10constants.VTHUNDER_CONFIG: vthunder_conf,
-                    a10constants.DEVICE_CONFIG_DICT: device_dict},
+                    a10constants.DEVICE_CONFIG_DICT: device_dict,
+                    a10constants.FLOW_TYPE: a10constants.DELETE_FLOW},
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG,
                       a10constants.DEVICE_CONFIG_DICT, constants.FLAVOR_DATA),
             provides=(a10constants.VTHUNDER_CONFIG, a10constants.USE_DEVICE_FLAVOR)))

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -580,7 +580,8 @@ class LoadBalancerFlows(object):
             provides=constants.FLAVOR_DATA))
         update_LB_flow.add(vthunder_tasks.GetVthunderConfByFlavor(
             inject={a10constants.VTHUNDER_CONFIG: vthunder_conf,
-                    a10constants.DEVICE_CONFIG_DICT: device_dict},
+                    a10constants.DEVICE_CONFIG_DICT: device_dict,
+                    a10constants.FLOW_TYPE: a10constants.UPDATE_FLOW},
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG,
                       a10constants.DEVICE_CONFIG_DICT, constants.FLAVOR_DATA),
             provides=(a10constants.VTHUNDER_CONFIG, a10constants.USE_DEVICE_FLAVOR)))
@@ -643,7 +644,8 @@ class LoadBalancerFlows(object):
             provides=constants.FLAVOR_DATA))
         lb_create_flow.add(vthunder_tasks.GetVthunderConfByFlavor(
             inject={a10constants.VTHUNDER_CONFIG: vthunder_conf,
-                    a10constants.DEVICE_CONFIG_DICT: device_dict},
+                    a10constants.DEVICE_CONFIG_DICT: device_dict,
+                    a10constants.FLOW_TYPE: a10constants.CREATE_FLOW},
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG,
                       a10constants.DEVICE_CONFIG_DICT, constants.FLAVOR_DATA),
             provides=(a10constants.VTHUNDER_CONFIG, a10constants.USE_DEVICE_FLAVOR)))

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -333,7 +333,8 @@ class MemberFlows(object):
             provides=constants.FLAVOR))
         delete_member_flow.add(vthunder_tasks.GetVthunderConfByFlavor(
             inject={a10constants.VTHUNDER_CONFIG: vthunder_conf,
-                    a10constants.DEVICE_CONFIG_DICT: device_dict},
+                    a10constants.DEVICE_CONFIG_DICT: device_dict,
+                    a10constants.FLOW_TYPE: a10constants.DELETE_FLOW},
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG,
                       a10constants.DEVICE_CONFIG_DICT),
             rebind={constants.FLAVOR_DATA: constants.FLAVOR},

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -664,7 +664,8 @@ class MemberFlows(object):
             provides=constants.FLAVOR))
         update_member_flow.add(vthunder_tasks.GetVthunderConfByFlavor(
             inject={a10constants.VTHUNDER_CONFIG: vthunder_conf,
-                    a10constants.DEVICE_CONFIG_DICT: device_dict},
+                    a10constants.DEVICE_CONFIG_DICT: device_dict,
+                    a10constants.FLOW_TYPE: a10constants.UPDATE_FLOW},
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG,
                       a10constants.DEVICE_CONFIG_DICT),
             rebind={constants.FLAVOR_DATA: constants.FLAVOR},
@@ -718,7 +719,8 @@ class MemberFlows(object):
             provides=constants.FLAVOR))
         create_member_flow.add(vthunder_tasks.GetVthunderConfByFlavor(
             inject={a10constants.VTHUNDER_CONFIG: vthunder_conf,
-                    a10constants.DEVICE_CONFIG_DICT: device_dict},
+                    a10constants.DEVICE_CONFIG_DICT: device_dict,
+                    a10constants.FLOW_TYPE: a10constants.CREATE_FLOW},
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG,
                       a10constants.DEVICE_CONFIG_DICT),
             rebind={constants.FLAVOR_DATA: constants.FLAVOR},

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -1024,12 +1024,11 @@ class CheckExistingVthunderTopology(BaseDatabaseTask):
             topology)
 
         if vthunder is not None:
-            if topology != (vthunder.topology).encode('utf-8'):
-                LOG.error('Other loadbalancer exists in vthunder with: %s topology',
-                          vthunder.topology)
-                msg = ('vthunder has other loadbalancer with {0} ' +
-                       'topology').format(vthunder.topology)
-                raise octavia_exceptions.InvalidTopology(topology=msg)
+            LOG.error('Other loadbalancer exists in vthunder with: %s topology',
+                      vthunder.topology)
+            msg = ('vthunder has other loadbalancer with {0} ' +
+                   'topology').format(vthunder.topology)
+            raise octavia_exceptions.InvalidTopology(topology=msg)
 
 
 class ValidateComputeForProject(BaseDatabaseTask):

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -1018,9 +1018,10 @@ class CheckExistingVthunderTopology(BaseDatabaseTask):
     """This task only meant to use with vthunder flow[amphora]"""
 
     def execute(self, loadbalancer, topology):
-        vthunder = self.vthunder_repo.get_vthunder_by_project_id(
+        vthunder = self.vthunder_repo.get_vthunder_with_different_topology(
             db_apis.get_session(),
-            loadbalancer.project_id)
+            loadbalancer.project_id,
+            topology)
 
         if vthunder is not None:
             if topology != (vthunder.topology).encode('utf-8'):

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -1171,7 +1171,8 @@ class VthunderInstanceBusy(VThunderBaseTask):
 
 class GetVthunderConfByFlavor(VThunderBaseTask):
 
-    def execute(self, loadbalancer, vthunder_config, device_config_dict, flavor_data=None):
+    def execute(self, loadbalancer, vthunder_config, device_config_dict, flavor_data=None,
+                flow_type=None):
         if flavor_data is None and vthunder_config is None:
             raise exceptions.ProjectDeviceNotFound()
 
@@ -1181,8 +1182,9 @@ class GetVthunderConfByFlavor(VThunderBaseTask):
                 dev_key = a10constants.DEVICE_KEY_PREFIX + device_flavor
                 if dev_key in device_config_dict:
                     vthunder_config = device_config_dict[dev_key]
-                    if vthunder_config.project_id is not None:
-                        raise exceptions.DeviceIsProjectDevice()
+                    if flow_type is None or flow_type != a10constants.DELETE_FLOW:
+                        if vthunder_config.project_id is not None:
+                            raise exceptions.DeviceIsProjectDevice()
                     vthunder_config.project_id = loadbalancer.project_id
                     if vthunder_config.hierarchical_multitenancy == "enable":
                         vthunder_config.partition_name = loadbalancer.project_id[0:14]

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -1182,7 +1182,7 @@ class GetVthunderConfByFlavor(VThunderBaseTask):
                 dev_key = a10constants.DEVICE_KEY_PREFIX + device_flavor
                 if dev_key in device_config_dict:
                     vthunder_config = device_config_dict[dev_key]
-                    if flow_type is None or flow_type != a10constants.DELETE_FLOW:
+                    if flow_type is None or flow_type == a10constants.CREATE_FLOW:
                         if vthunder_config.project_id is not None:
                             raise exceptions.DeviceIsProjectDevice()
                     vthunder_config.project_id = loadbalancer.project_id

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -238,6 +238,21 @@ class VThunderRepository(BaseRepository):
 
         return model.to_data_model()
 
+    def get_vthunder_with_different_topology(self, session, project_id, topology):
+        model = session.query(self.model_class).filter(
+            self.model_class.project_id == project_id).filter(
+            and_(self.model_class.status == "ACTIVE",
+                 or_(self.model_class.role == "STANDALONE",
+                     self.model_class.role == "MASTER"))).filter(
+                self.model_class.compute_id != None).filter(
+                self.model_class.topology != topology).first()
+
+
+        if not model:
+            return None
+
+        return model.to_data_model()
+
     def get_vthunders_by_project_id(self, session, project_id):
         model_list = session.query(self.model_class).filter(
             self.model_class.project_id == project_id).filter(

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -247,7 +247,6 @@ class VThunderRepository(BaseRepository):
                 self.model_class.compute_id != None).filter(
                 self.model_class.topology != topology).first()
 
-
         if not model:
             return None
 


### PR DESCRIPTION
## Description
- Required: Severity Level Low
- Required: Issue Description
-STACK-2552/2553, we raise exception for project_id in device flavor device even in delete/update flow.
- STACK-2563, this should not happen. We only check topology in vThunder flow, but QA's test case should be rack flow. I think QA make some mistake in configuration.


## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2552
https://a10networks.atlassian.net/browse/STACK-2553
https://a10networks.atlassian.net/browse/STACK-2563

## Technical Approach
 - STACK-2552/2553: in delete flow don't raise exception when project_id is in device flavor device.

## Config Changes

<pre>
<b>[hardware_thunder]
devices = [
                    {
                     "project_id": "3d21c71c4e4040599933bda62a76ae2f",
                     "ip_address": "192.168.90.45",
                     "username": "admin",
                     "password": "a10",
                     "vrid_floating_ip" : "dhcp",
                     #"hierarchical_multitenancy": "enable",
                     "device_name": "dev2"
                     },
             ]
</b>
</pre>


## Test Cases
 - STACK-2552: Same as QA
 - STACK-2553: Same as QA

## Manual Testing

- STACK-2552
```
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer create --flavor f_dev2 --vip-subnet-id tp91 --vip-address 192.168.91.56 --name vip1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-06-28T11:07:00                  |
| description         |                                      |
| flavor_id           | 05084690-b8d8-4864-b1ab-017e8add7c07 |
| id                  | ed99efd7-5f42-4375-81db-e3dd633cab18 |
| listeners           |                                      |
| name                | vip1                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 3d21c71c4e4040599933bda62a76ae2f     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.91.56                        |
| vip_network_id      | 5e1b43e5-9f65-40af-a28f-88e63dc6d667 |
| vip_port_id         | 22296ec3-d522-4125-bb04-4b353e440d04 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | f25ce642-f953-4058-8c46-98fdd72fb129 |
+---------------------+--------------------------------------+
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| ed99efd7-5f42-4375-81db-e3dd633cab18 | vip1 | 3d21c71c4e4040599933bda62a76ae2f | 192.168.91.56 | ERROR               | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer delete vip1
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer list


```

- STACK-2553:
```
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer create --flavor f_dev2 --vip-subnet-id tp91 --vip-address 192.168.91.56 --name vip1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-06-28T11:35:31                  |
| description         |                                      |
| flavor_id           | 05084690-b8d8-4864-b1ab-017e8add7c07 |
| id                  | 65326ce2-44c3-45c8-b85f-86fd2dbd39fb |
| listeners           |                                      |
| name                | vip1                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 3d21c71c4e4040599933bda62a76ae2f     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.91.56                        |
| vip_network_id      | 5e1b43e5-9f65-40af-a28f-88e63dc6d667 |
| vip_port_id         | 000a2e1a-9f07-49b2-9302-ba8402426cac |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | f25ce642-f953-4058-8c46-98fdd72fb129 |
+---------------------+--------------------------------------+
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| 65326ce2-44c3-45c8-b85f-86fd2dbd39fb | vip1 | 3d21c71c4e4040599933bda62a76ae2f | 192.168.91.56 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ sudo service a10-controller-worker restart
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer set vip1
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| 65326ce2-44c3-45c8-b85f-86fd2dbd39fb | vip1 | 3d21c71c4e4040599933bda62a76ae2f | 192.168.91.56 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+

```