### PR TITLE
[STACK-2572] remove AAP for L2DSR via configuration

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -302,7 +302,9 @@ class LoadBalancerFlows(object):
             provides=a10constants.LB_COUNT_FLAVOR))
         delete_LB_flow.add(vthunder_tasks.DeleteL2DSR(
             requires=(constants.SUBNET, constants.AMPHORA,
-                      a10constants.LB_COUNT_FLAVOR, constants.FLAVOR_DATA)))
+                      a10constants.LB_COUNT_FLAVOR,
+                      a10constants.LB_COUNT_SUBNET,
+                      constants.FLAVOR_DATA)))
         delete_LB_flow.add(nat_pool_tasks.NatPoolDelete(
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
                       a10constants.LB_COUNT_FLAVOR, constants.FLAVOR_DATA)))

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -155,8 +155,12 @@ class AllowL2DSR(VThunderBaseTask):
 class DeleteL2DSR(VThunderBaseTask):
     """Task to delete wildcat address in allowed_address_pair for L2DSR"""
 
-    def execute(self, subnet, amphora, lb_count_flavor, flavor_data=None):
-        if not CONF.vthunder.l2dsr_support:
+    def execute(self, subnet, amphora, lb_count_flavor, lb_count_subnet, flavor_data=None):
+        if CONF.vthunder.l2dsr_support:
+            if lb_count_subnet <= 1:
+                for amp in amphora:
+                    self.network_driver.remove_any_source_ip_on_egress(subnet.network_id, amp)
+        else:
             if lb_count_flavor <= 1 and flavor_data:
                 deployment = flavor_data.get('deployment')
                 if deployment and 'dsr_type' in deployment:

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -1017,6 +1017,6 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         mock_task = task.DeleteL2DSR()
         mock_task._network_driver = self.client_mock
         lb_count = 1
-        mock_task.execute(SUBNET, AMPHORAE, lb_count, flavor_data=DEPLOYMENT_FLAVOR)
+        mock_task.execute(SUBNET, AMPHORAE, lb_count, lb_count, flavor_data=DEPLOYMENT_FLAVOR)
         self.client_mock.remove_any_source_ip_on_egress.assert_called_with(
             SUBNET.network_id, AMPHORAE[0])


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description:
We never remove 0.0.0.0/0 from AAP when use configuration to deploy l2dsr.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2572

## Technical Approach
Add logic to remove 0.0.0.0/0 from AAP when L2DSR deploy by configuration.

## Config Changes
<pre>
<b>[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
l2dsr_support = True
slb_no_snat_support = True

[a10_controller_worker]
amp_image_owner_id = 99c9c2304f114685a32db30769c8a7e2
amp_secgroup_list = 2d0a3480-7f08-4184-b96f-c39bb444dd38
amp_flavor_id = 69995a83-c47a-427f-bf70-e9d9752aa915
#amp_boot_network_list = 7f8ddd7f-c5c3-463a-b1c3-596f988480a4
amp_boot_network_list = 7f8ddd7f-c5c3-463a-b1c3-596f988480a4, 61305531-6e3a-44b4-8e67-05e93363dddc, a66685db-31ee-46c6-928a-ac034d87dc63, ec33a88d-3290-4ad6-95cc-226fcd2a4458
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 150
amp_active_wait_sec = 10
amp_busy_wait_sec = 0
amp_image_id = 0a845873-bd91-4f8c-ad58-cf5d5afde09c
loadbalancer_topology = SINGLE
</b>
</pre>


## Test Cases
 - remove latest LB from subnet and check if 0.0.0.0/0 will be removed from AAP
```
openstack loadbalancer create --vip-subnet-id tp91 --name vip1
openstack loadbalancer create --vip-subnet-id tp92 --name vip2
openstack loadbalancer delete vip2
```

## Manual Testing
```

stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| 2d7d148e-e94e-49e0-a890-64b6532600df | vip1 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.6  | ACTIVE              | a10      |
| 3e109a1e-0ad9-46bc-8403-134224765297 | vip2 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.92.91 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack port show 3265998d-f88b-4d9c-b229-e3c94da4669d
+-------------------------+----------------------------------------------------------------------------------------------------------------------------------
--------------------------------------------------+
| Field                   | Value
                                                  |
+-------------------------+----------------------------------------------------------------------------------------------------------------------------------
--------------------------------------------------+
| admin_state_up          | UP
                                                  |
| allowed_address_pairs   | ip_address='0.0.0.0/0', mac_address='fa:16:3e:e7:7d:e6'
                                                  |
|                         | ip_address='192.168.92.22', mac_address='fa:16:3e:e7:7d:e6'
                                                  |
|                         | ip_address='192.168.92.91', mac_address='fa:16:3e:e7:7d:e6'
                                                  |
| binding_host_id         | openstack-4
                                                  |
| binding_profile         |
                                                  |
| binding_vif_details     | bridge_name='br-int', datapath_type='system', ovs_hybrid_plug='False', port_filter='True'
                                                  |
| binding_vif_type        | ovs
                                                  |
| binding_vnic_type       | normal
                                                  |
| created_at              | 2021-06-29T09:57:50Z
                                                  |
| data_plane_status       | None
                                                  |
| description             |
                                                  |
| device_id               | 4b1d5ecd-b76c-4636-a2fd-31d171163747
                                                  |
| device_owner            | compute:nova
                                                  |
| dns_assignment          | None
                                                  |
| dns_domain              | None
                                                  |
| dns_name                | None
                                                  |
| extra_dhcp_opts         |
                                                  |
| fixed_ips               | ip_address='192.168.92.218', subnet_id='65b4be82-364f-4315-bc63-a0779a33d304'
                                                  |
| id                      | 3265998d-f88b-4d9c-b229-e3c94da4669d
                                                  |
| location                | Munch({'project': Munch({'domain_id': 'default', 'id': u'99c9c2304f114685a32db30769c8a7e2', 'name': 'admin', 'domain_name': None}
), 'cloud': '', 'region_name': '', 'zone': None}) |
| mac_address             | fa:16:3e:e7:7d:e6
                                                  |
| name                    |
                                                  |
| network_id              | ec33a88d-3290-4ad6-95cc-226fcd2a4458
                                                  |
| port_security_enabled   | True
                                                  |
| project_id              | 99c9c2304f114685a32db30769c8a7e2
                                                  |
| propagate_uplink_status | None
                                                  |
| qos_policy_id           | None
                                                  |
| resource_request        | None
                                                  |
| revision_number         | 8
                                                  |
| security_group_ids      | 14e03afd-967a-4f1b-8e10-a68661c11338, 2d0a3480-7f08-4184-b96f-c39bb444dd38
                                                  |
| status                  | ACTIVE
                                                  |
| tags                    |
                                                  |
| trunk_details           | None
                                                  |
| updated_at              | 2021-06-29T10:06:01Z
                                                  |
+-------------------------+----------------------------------------------------------------------------------------------------------------------------------
--------------------------------------------------+
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer delete vip2
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack port show 3265998d-f88b-4d9c-b229-e3c94da4669d
+-------------------------+----------------------------------------------------------------------------------------------------------------------------------
--------------------------------------------------+
| Field                   | Value
                                                  |
+-------------------------+----------------------------------------------------------------------------------------------------------------------------------
--------------------------------------------------+
| admin_state_up          | UP
                                                  |
| allowed_address_pairs   |
                                                  |
| binding_host_id         | openstack-4
                                                  |
| binding_profile         |
                                                  |
| binding_vif_details     | bridge_name='br-int', datapath_type='system', ovs_hybrid_plug='False', port_filter='True'
                                                  |
| binding_vif_type        | ovs
                                                  |
| binding_vnic_type       | normal
                                                  |
| created_at              | 2021-06-29T09:57:50Z
                                                  |
| data_plane_status       | None
                                                  |
| description             |
                                                  |
| device_id               | 4b1d5ecd-b76c-4636-a2fd-31d171163747
                                                  |
| device_owner            | compute:nova
                                                  |
| dns_assignment          | None
                                                  |
| dns_domain              | None
                                                  |
| dns_name                | None
                                                  |
| extra_dhcp_opts         |
                                                  |
| fixed_ips               | ip_address='192.168.92.218', subnet_id='65b4be82-364f-4315-bc63-a0779a33d304'
                                                  |
| id                      | 3265998d-f88b-4d9c-b229-e3c94da4669d
                                                  |
| location                | Munch({'project': Munch({'domain_id': 'default', 'id': u'99c9c2304f114685a32db30769c8a7e2', 'name': 'admin', 'domain_name': None}
), 'cloud': '', 'region_name': '', 'zone': None}) |
| mac_address             | fa:16:3e:e7:7d:e6
                                                  |
| name                    |
                                                  |
| network_id              | ec33a88d-3290-4ad6-95cc-226fcd2a4458
                                                  |
| port_security_enabled   | True
                                                  |
| project_id              | 99c9c2304f114685a32db30769c8a7e2
                                                  |
| propagate_uplink_status | None
                                                  |
| qos_policy_id           | None
                                                  |
| resource_request        | None
                                                  |
| revision_number         | 12
                                                  |
| security_group_ids      | 2d0a3480-7f08-4184-b96f-c39bb444dd38
                                                  |
| status                  | ACTIVE
                                                  |
| tags                    |
                                                  |
| trunk_details           | None
                                                  |
| updated_at              | 2021-06-29T10:13:18Z
                                                  |
+-------------------------+----------------------------------------------------------------------------------------------------------------------------------
--------------------------------------------------+
```
