### PR TITLE
[STACK-2541]: Fix for deleting member side floating ip when configured same subnet members on 2 different devices[device_flavor]

### DIFF
--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -31,6 +31,7 @@ WRITE_MEM_FOR_LOCAL_PARTITION = 'write_memory_for_local_partition'
 MEMBER_LIST = 'member_list'
 SUBNET_LIST = 'subnet_list'
 MEMBERS = 'members'
+POOLS = 'pools'
 
 PARTITION_PROJECT_LIST = 'partition_project_list'
 IFNUM_BACKUP = 'ifnum_backup'

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -521,10 +521,17 @@ class MemberFlows(object):
                 provides=a10constants.PARTITION_PROJECT_LIST
             ))
         delete_member_vrid_subflow.add(
+            a10_network_tasks.GetPoolsOnThunder(
+                requires=[a10constants.VTHUNDER, a10constants.USE_DEVICE_FLAVOR],
+                provides=a10constants.POOLS))
+        delete_member_vrid_subflow.add(
             a10_database_tasks.GetSubnetForDeletionInPool(
                 name='get_subnet_for_deletion_in_pool' + pool,
-                requires=[a10constants.MEMBER_LIST, a10constants.PARTITION_PROJECT_LIST],
                 rebind={a10constants.MEMBER_LIST: pool_members},
+                requires=[
+                    a10constants.PARTITION_PROJECT_LIST,
+                    a10constants.USE_DEVICE_FLAVOR,
+                    a10constants.POOLS],
                 provides=a10constants.SUBNET_LIST))
         delete_member_vrid_subflow.add(
             a10_database_tasks.GetVRIDForLoadbalancerResource(

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -683,7 +683,7 @@ class PoolCountforIP(BaseDatabaseTask):
 
 class GetSubnetForDeletionInPool(BaseDatabaseTask):
 
-    def execute(self, member_list, partition_project_list):
+    def execute(self, member_list, partition_project_list, use_device_flavor, pools):
         """
 
         :param member_list: Receives the list of members, under specific pool.
@@ -697,8 +697,12 @@ class GetSubnetForDeletionInPool(BaseDatabaseTask):
             member_subnet = []
             for member in member_list:
                 if member.subnet_id not in member_subnet:
-                    pool_count_subnet = self.member_repo.get_pool_count_subnet(
-                        db_apis.get_session(), partition_project_list, member.subnet_id)
+                    if use_device_flavor:
+                        pool_count_subnet = self.member_repo.get_pool_count_subnet_on_thunder(
+                            db_apis.get_session(), pools, member.subnet_id)
+                    else:
+                        pool_count_subnet = self.member_repo.get_pool_count_subnet(
+                            db_apis.get_session(), partition_project_list, member.subnet_id)
                     lb_count_subnet = self.loadbalancer_repo.get_lb_count_by_subnet(
                         db_apis.get_session(), partition_project_list, member.subnet_id)
                     if pool_count_subnet <= 1 and lb_count_subnet == 0:

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -1065,3 +1065,25 @@ class GetMembersOnThunder(BaseNetworkTask):
                 raise e
         else:
             return
+
+
+class GetPoolsOnThunder(BaseNetworkTask):
+
+    @axapi_client_decorator
+    def execute(self, vthunder, use_device_flavor):
+        if vthunder and use_device_flavor:
+            try:
+                server_group_list = []
+                server_groups = []
+                server_group_list = self.axapi_client.slb.service_group.all()
+                if server_group_list:
+                    for server_group in range(len(server_group_list['service-group-list'])):
+                        server_groups.append(
+                            server_group_list['service-group-list'][server_group]['name'])
+                return server_groups
+            except Exception as e:
+                LOG.exception("Failed to get pools on the vthunder due to %s ",
+                              str(e))
+                raise e
+        else:
+            return

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -514,6 +514,13 @@ class MemberRepository(repo.MemberRepository):
                  or_(self.model_class.provisioning_status == consts.PENDING_DELETE,
                      self.model_class.provisioning_status == consts.ACTIVE))).count()
 
+    def get_pool_count_subnet_on_thunder(self, session, pool_ids, subnet_id):
+        return session.query(self.model_class.pool_id.distinct()).filter(
+            self.model_class.pool_id.in_(pool_ids)).filter(
+            and_(self.model_class.subnet_id == subnet_id,
+                 or_(self.model_class.provisioning_status == consts.PENDING_DELETE,
+                     self.model_class.provisioning_status == consts.ACTIVE))).count()
+
     def get_members_on_thunder_by_subnet(self, session, ip_address, subnet_id):
         model = session.query(self.model_class).filter(
             and_(self.model_class.ip_address == ip_address,

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -355,23 +355,25 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         self.assertEqual(2, pool_count)
 
     def test_get_subnet_for_deletion_with_pool_no_lb(self):
+        use_dev_flavor = False
         mock_subnets = task.GetSubnetForDeletionInPool()
         mock_subnets.member_repo.get_pool_count_subnet = mock.Mock()
         mock_subnets.member_repo.get_pool_count_subnet.return_value = 1
         mock_subnets.loadbalancer_repo.get_lb_count_by_subnet = mock.Mock()
         mock_subnets.loadbalancer_repo.get_lb_count_by_subnet.return_value = 0
         subnet_list = mock_subnets.execute(
-            [MEMBER_1, MEMBER_2], [a10constants.MOCK_PROJECT_ID])
+            [MEMBER_1, MEMBER_2], [a10constants.MOCK_PROJECT_ID], use_dev_flavor, mock.ANY)
         self.assertEqual(['mock-subnet-1', 'mock-subnet-2'], subnet_list)
 
     def test_get_subnet_for_deletion_with_multiple_pool_lb(self):
+        use_dev_flavor = False
         mock_subnets = task.GetSubnetForDeletionInPool()
         mock_subnets.member_repo.get_pool_count_subnet = mock.Mock()
         mock_subnets.member_repo.get_pool_count_subnet.return_value = 2
         mock_subnets.loadbalancer_repo.get_lb_count_by_subnet = mock.Mock()
         mock_subnets.loadbalancer_repo.get_lb_count_by_subnet.return_value = 2
         subnet_list = mock_subnets.execute(
-            [MEMBER_1, MEMBER_2], [a10constants.MOCK_PROJECT_ID])
+            [MEMBER_1, MEMBER_2], [a10constants.MOCK_PROJECT_ID], use_dev_flavor, mock.ANY)
         self.assertEqual([], subnet_list)
 
     def test_get_child_projects_for_partition(self):


### PR DESCRIPTION
## Description
- Severity Level: Medium
- Issue Description: [device flavor] member side floating ip will be leftover if configured same subnet members on 2 different devices

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-2541

## Technical Approach
- In case of device_flavor, get the pool list available on thunder device. then count the pool which has given subnet.

## Config Changes
<pre>
<b>
[hardware_thunder]
devices = [
                    {
                     "ip_address":"10.0.0.55",
                     "username":"admin",
                     "password":"a10",
                     "partition_name":'p1',
                     "device_name":"AX35",
                     "vrid_floating_ip" : "dhcp"
                     },
                     {
                     "ip_address":"10.0.0.50",
                     "username":"admin",
                     "password":"a10",
                     "partition_name":'p1',
                     "device_name":"AX45",
                     "vrid_floating_ip" : "dhcp"
                     }
          ]
</b>
</pre>
 
## Manual Testing
Similar to QA.
1) Create lbs and other objects
```
openstack loadbalancer flavorprofile create --name fp_natpool --provider a10 --flavor-data  '{
"device-name": "AX35",
"nat-pool":{
"pool-name":"pool1",
"start-address":"10.0.11.111",
"end-address":"10.0.11.115",
"netmask":"/24"
}
}'
openstack loadbalancer flavor create --name f_natpool --flavorprofile fp_natpool 

openstack loadbalancer flavorprofile create --name fp_plist --provider a10 --flavor-data  '{"device-name":"AX45",
"virtual-port":{
"name-expressions":[
{
"regex":"vport1",
"json":{
"pool":"pl1"
}
},
{
"regex":"vport3",
"json":{
"pool":"pl3"
}
}
]
},
"nat-pool-list":[
{
"pool-name":"pl1",
"start-address":"10.0.12.121",
"end-address":"10.0.12.123",
"netmask":"/24"
},
{
"pool-name":"pl3",
"start-address":"10.0.11.121",
"end-address":"10.0.11.123",
"netmask":"/24",
"gateway":"10.0.11.1"
}
]
}'
openstack loadbalancer flavor create --name f_plist --flavorprofile fp_plist

openstack loadbalancer create --name 3dsr --flavor f_natpool --vip-subnet-id provider-vlan-13-subnet
openstack loadbalancer listener create --name l3dsr 3dsr --protocol tcp --protocol-port 80
openstack loadbalancer pool create --name p3dsr --protocol tcp --lb-algorithm LEAST_CONNECTIONS --listener l3dsr
openstack loadbalancer member create --address 10.0.11.135 --subnet-id provider-vlan-11-subnet --protocol-port 80 --name mem1 p3dsr

openstack loadbalancer create --name v4 --flavor f_plist --vip-subnet-id provider-vlan-13-subnet
openstack loadbalancer listener create --protocol TCP --protocol-port 80 --name vport3 v4
openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener vport3 --name p4
openstack loadbalancer member create --address 10.0.11.145 --subnet-id provider-vlan-11-subnet --protocol-port 80 --name mem1 p4

**Device 1:**
vThunder[p1](NOLICENSE)#show running-config
!Current configuration: 55 bytes
!Configuration last updated at 16:47:13 IST Tue Jun 29 2021
!Configuration last saved at 16:47:17 IST Tue Jun 29 2021
!
active-partition p1
!
!
vrrp-a vrid 0
  floating-ip 10.0.13.173
  floating-ip 10.0.11.147
!
ip nat pool pool1 10.0.11.111 10.0.11.115 netmask /24
!
slb server a5b6e_10_0_11_135 10.0.11.135
  port 80 tcp
!
slb service-group 68b216a6-c74c-4534-8b06-2eb7cf824056 tcp
  method least-connection
  member a5b6e_10_0_11_135 80
!
slb virtual-server 8a598b53-ee16-44f5-8bbb-bd49cc7b9ae0 10.0.13.108
  port 80 tcp
    name f3e564a4-4028-4015-bacf-c0b3619cfd63
    conn-limit 88889
    extended-stats
    source-nat pool pool1
    source-nat auto
    service-group 68b216a6-c74c-4534-8b06-2eb7cf824056
    use-rcv-hop-for-resp
!
end
!Current config commit point for partition 1 is 0 & config mode is classical-mode
vThunder[p1](NOLICENSE)#

**Device 2:**
vThunder[p1](NOLICENSE)#show running-config
!Current configuration: 124 bytes
!Configuration last updated at 16:48:35 IST Tue Jun 29 2021
!Configuration last saved at 12:57:14 IST Tue Jun 29 2021
!
active-partition p1
!
!
vrrp-a vrid 0
  floating-ip 10.0.13.198
  floating-ip 10.0.11.187
!
ip nat pool pl1 10.0.12.121 10.0.12.123 netmask /24
!
ip nat pool pl3 10.0.11.121 10.0.11.123 netmask /24 gateway 10.0.11.1
!
slb server a5b6e_10_0_11_145 10.0.11.145
  port 80 tcp
!
slb service-group da3ab92c-3fde-48ae-ab47-8871bd8e1cb7 tcp
  member a5b6e_10_0_11_145 80
!
slb virtual-server 9f510699-1927-4eff-abbf-3357457f8200 10.0.13.110
  port 80 tcp
    name ff3f7ac2-cef3-4a17-b8da-179c02ef3481
    conn-limit 88889
    extended-stats
    source-nat pool pl3
    source-nat auto
    service-group da3ab92c-3fde-48ae-ab47-8871bd8e1cb7
    use-rcv-hop-for-resp
!
end
!Current config commit point for partition 1 is 0 & config mode is classical-mode
vThunder[p1](NOLICENSE)#
```

2) Delete one lb with cascade
```
stack@adeeb:~$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 8a598b53-ee16-44f5-8bbb-bd49cc7b9ae0 | 3dsr | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.13.108 | ACTIVE              | a10      |
| 9f510699-1927-4eff-abbf-3357457f8200 | v4   | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.13.110 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+

stack@adeeb:~$ openstack loadbalancer delete 3dsr --cascade

logs:
Jun 29 16:06:05 adeeb a10-octavia-worker[9934]: INFO a10_octavia.controller.queue.endpoint [-] Deleting load balancer '8a598b53-ee16-44f5-8bbb-bd49cc7b9ae0'...
Jun 29 16:06:14 adeeb a10-octavia-worker[9934]: INFO a10_octavia.controller.worker.tasks.a10_database_tasks [-] Successfully deleted nat pool entry in database.
Jun 29 16:06:18 adeeb a10-octavia-worker[9934]: INFO a10_octavia.controller.worker.tasks.a10_network_tasks [-] VRID floating IP: [u'10.0.13.173'] deleted
Jun 29 16:06:21 adeeb a10-octavia-worker[9934]: INFO a10_octavia.controller.worker.tasks.a10_network_tasks [-] VRID floating IP: 10.0.13.173 deleted
Jun 29 16:06:24 adeeb a10-octavia-worker[9934]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 10.0.0.55:p1

Device 1:
vThunder[p1](NOLICENSE)#show running-config
!Current configuration: 0 bytes
!Configuration last updated at 17:06:23 IST Tue Jun 29 2021
!Configuration last saved at 16:47:17 IST Tue Jun 29 2021
!
active-partition p1
!
!
!
end
!Current config commit point for partition 1 is 0 & config mode is classical-mode
vThunder[p1](NOLICENSE)#

stack@adeeb:~$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 9f510699-1927-4eff-abbf-3357457f8200 | v4   | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.13.110 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+

```
3) Delete another lb with cascade
```
stack@adeeb:~$ openstack loadbalancer delete v4 --cascade
logs:
Jun 29 16:07:21 adeeb a10-octavia-worker[9934]: INFO a10_octavia.controller.queue.endpoint [-] Deleting load balancer '9f510699-1927-4eff-abbf-3357457f8200'...
Jun 29 16:07:26 adeeb a10-octavia-worker[9934]: INFO a10_octavia.controller.worker.tasks.a10_database_tasks [-] Successfully deleted nat pool entry in database.
Jun 29 16:07:29 adeeb a10-octavia-worker[9934]: INFO a10_octavia.controller.worker.tasks.a10_network_tasks [-] VRID floating IP: [u'10.0.13.198'] deleted
Jun 29 16:07:33 adeeb a10-octavia-worker[9934]: INFO a10_octavia.controller.worker.tasks.a10_network_tasks [-] VRID floating IP: 10.0.13.198 deleted
Jun 29 16:07:36 adeeb a10-octavia-worker[9934]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 10.0.0.50:p1

**Device 2:**
vThunder[p1](NOLICENSE)#show running-config
!Current configuration: 0 bytes
!Configuration last updated at 17:07:35 IST Tue Jun 29 2021
!Configuration last saved at 17:07:43 IST Tue Jun 29 2021
!
active-partition p1
!
!
!
end
!Current config commit point for partition 1 is 0 & config mode is classical-mode
vThunder[p1](NOLICENSE)#

stack@adeeb:~$ openstack loadbalancer list

stack@adeeb:~$
```

