### PR TITLE
[STACK-2542]: [device flavor]Fix for deleting members when members created with same IP on two devices

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -410,7 +410,8 @@ class MemberFlows(object):
                     constants.POOL: pool}))
         delete_member_thunder_subflow.add(a10_database_tasks.PoolCountforIP(
             name='pool_count_for_ip_' + member_id,
-            requires=constants.MEMBER, provides=a10constants.POOL_COUNT_IP,
+            requires=[constants.MEMBER, a10constants.USE_DEVICE_FLAVOR, a10constants.POOLS],
+            provides=a10constants.POOL_COUNT_IP,
             rebind={constants.MEMBER: member_id}))
 
         # NAT pools database and pools clean up for flavor
@@ -521,10 +522,6 @@ class MemberFlows(object):
                 rebind={a10constants.LB_RESOURCE: pool},
                 provides=a10constants.PARTITION_PROJECT_LIST
             ))
-        delete_member_vrid_subflow.add(
-            a10_network_tasks.GetPoolsOnThunder(
-                requires=[a10constants.VTHUNDER, a10constants.USE_DEVICE_FLAVOR],
-                provides=a10constants.POOLS))
         delete_member_vrid_subflow.add(
             a10_database_tasks.GetSubnetForDeletionInPool(
                 name='get_subnet_for_deletion_in_pool' + pool,

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -270,6 +270,10 @@ class PoolFlows(object):
         delete_pool_flow.add(model_tasks.DeleteModelObject(
             name='delete_model_object_' + pool_name,
             rebind={constants.OBJECT: pool_name}))
+        delete_pool_flow.add(a10_network_tasks.GetPoolsOnThunder(
+            name='get_pools_on_thunder_' + pool_name,
+            requires=[a10constants.VTHUNDER, a10constants.USE_DEVICE_FLAVOR],
+            provides=a10constants.POOLS))
         # Delete pool children
         delete_pool_flow.add(self._get_delete_health_monitor_vthunder_subflow(health_mon, True))
         delete_pool_flow.add(self._get_delete_member_vthunder_subflow(members, store, pool_name))

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -651,7 +651,7 @@ class PoolCountforIP(BaseDatabaseTask):
         try:
             if use_device_flavor:
                 return self.member_repo.get_pool_count_by_ip_on_thunder(
-                    db_apis.get_session(), member.ip_address, member.project_id, pools)
+                    db_apis.get_session(), member.ip_address, pools)
             else:
                 return self.member_repo.get_pool_count_by_ip(
                     db_apis.get_session(), member.ip_address, member.project_id)

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -647,10 +647,14 @@ class CountMembersWithIPPortProtocol(BaseDatabaseTask):
 
 
 class PoolCountforIP(BaseDatabaseTask):
-    def execute(self, member):
+    def execute(self, member, use_device_flavor, pools):
         try:
-            return self.member_repo.get_pool_count_by_ip(
-                db_apis.get_session(), member.ip_address, member.project_id)
+            if use_device_flavor:
+                return self.member_repo.get_pool_count_by_ip_on_thunder(
+                    db_apis.get_session(), member.ip_address, member.project_id, pools)
+            else:
+                return self.member_repo.get_pool_count_by_ip(
+                    db_apis.get_session(), member.ip_address, member.project_id)
         except Exception as e:
             LOG.exception(
                 "Failed to get pool count with same IP address: %s",

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -521,10 +521,9 @@ class MemberRepository(repo.MemberRepository):
                  or_(self.model_class.provisioning_status == consts.PENDING_DELETE,
                      self.model_class.provisioning_status == consts.ACTIVE))).count()
 
-    def get_pool_count_by_ip_on_thunder(self, session, ip_address, project_id, pool_ids):
+    def get_pool_count_by_ip_on_thunder(self, session, ip_address, pool_ids):
         return session.query(self.model_class.pool_id.distinct()).filter(
             self.model_class.pool_id.in_(pool_ids)).filter(
-            self.model_class.project_id == project_id).filter(
             and_(self.model_class.ip_address == ip_address,
                  or_(self.model_class.provisioning_status == consts.PENDING_DELETE,
                      self.model_class.provisioning_status == consts.ACTIVE))).count()

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -521,6 +521,14 @@ class MemberRepository(repo.MemberRepository):
                  or_(self.model_class.provisioning_status == consts.PENDING_DELETE,
                      self.model_class.provisioning_status == consts.ACTIVE))).count()
 
+    def get_pool_count_by_ip_on_thunder(self, session, ip_address, project_id, pool_ids):
+        return session.query(self.model_class.pool_id.distinct()).filter(
+            self.model_class.pool_id.in_(pool_ids)).filter(
+            self.model_class.project_id == project_id).filter(
+            and_(self.model_class.ip_address == ip_address,
+                 or_(self.model_class.provisioning_status == consts.PENDING_DELETE,
+                     self.model_class.provisioning_status == consts.ACTIVE))).count()
+
     def get_pool_count_subnet(self, session, project_ids, subnet_id):
         return session.query(self.model_class.pool_id.distinct()).filter(
             self.model_class.project_id.in_(project_ids)).filter(

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -254,6 +254,7 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         self.assertEqual(2, member_count)
 
     def test_pool_count_accn_ip(self):
+        use_dev_flavor = False
         member_1 = o_data_models.Member(id=uuidutils.generate_uuid(),
                                         project_id=t_constants.MOCK_PROJECT_ID,
                                         ip_address=t_constants.MOCK_IP_ADDRESS,
@@ -261,7 +262,7 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         mock_count_pool = task.PoolCountforIP()
         mock_count_pool.member_repo.get_pool_count_by_ip = mock.Mock()
         mock_count_pool.member_repo.get_pool_count_by_ip.return_value = 2
-        pool_count = mock_count_pool.execute(member_1)
+        pool_count = mock_count_pool.execute(member_1, use_dev_flavor, mock.ANY)
         self.assertEqual(2, pool_count)
 
     def test_get_subnet_for_deletion_with_pool_no_lb(self):


### PR DESCRIPTION
## Description
- Severity Level: Medium
- Issue Description: [device flavor] member is kept on device if use same member on 2 devices

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-2542

## Technical Approach
- In case of device_flavor, get the pool list available on thunder device. then count pool by ip in pool_list.

## Config Changes
<pre>
[hardware_thunder]
devices = [
                    {
                     "ip_address":"10.0.0.55",
                     "username":"admin",
                     "password":"a10",
                     "partition_name":'p1',
                     "device_name":"AX35",
                     "vrid_floating_ip" : "dhcp"
                     },
                     {
                     "ip_address":"10.0.0.50",
                     "username":"admin",
                     "password":"a10",
                     "partition_name":'p1',
                     "device_name":"AX45",
                     "vrid_floating_ip" : "dhcp"
                     }
          ]

</pre>
 
## Manual Testing
- Similar to QA.
1) Create lbs and other objects
```
openstack loadbalancer flavorprofile create --name fp_natpool --provider a10 --flavor-data  '{
"device-name": "AX35",
"nat-pool":{
"pool-name":"pool1",
"start-address":"10.0.11.111",
"end-address":"10.0.11.115",
"netmask":"/24"
}
}'

openstack loadbalancer flavor create --name f_natpool --flavorprofile fp_natpool 

openstack loadbalancer flavorprofile create --name fp_plist --provider a10 --flavor-data  '{"device-name":"AX45",
"virtual-port":{
"name-expressions":[
{
"regex":"vport1",
"json":{
"pool":"pl1"
}
},
{
"regex":"vport3",
"json":{
"pool":"pl3"
}
}
]
},
"nat-pool-list":[
{
"pool-name":"pl1",
"start-address":"10.0.12.121",
"end-address":"10.0.12.123",
"netmask":"/24"
},
{
"pool-name":"pl3",
"start-address":"10.0.11.121",
"end-address":"10.0.11.123",
"netmask":"/24",
"gateway":"10.0.11.1"
}
]
}'

openstack loadbalancer flavor create --name f_plist --flavorprofile fp_plist

openstack loadbalancer create --name 3dsr --flavor f_natpool --vip-subnet-id provider-vlan-13-subnet
openstack loadbalancer listener create --name l3dsr 3dsr --protocol tcp --protocol-port 80
openstack loadbalancer pool create --name p3dsr --protocol tcp --lb-algorithm LEAST_CONNECTIONS --listener l3dsr
openstack loadbalancer member create --address 10.0.11.145 --subnet-id provider-vlan-11-subnet --protocol-port 80 --name mem1 p3dsr

openstack loadbalancer create --name v4 --flavor f_plist --vip-subnet-id provider-vlan-13-subnet
openstack loadbalancer listener create --protocol TCP --protocol-port 80 --name vport3 v4
openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener vport3 --name p4
openstack loadbalancer member create --address 10.0.11.145 --subnet-id provider-vlan-11-subnet --protocol-port 80 --name mem1 p4

Device 1:
vThunder[p1](config)(NOLICENSE)#show running-config
!Current configuration: 55 bytes
!Configuration last updated at 10:31:12 IST Wed Jun 30 2021
!Configuration last saved at 10:32:06 IST Wed Jun 30 2021
!
active-partition p1
!
!
vrrp-a vrid 0
  floating-ip 10.0.13.119
  floating-ip 10.0.11.200
!
ip nat pool pool1 10.0.11.111 10.0.11.115 netmask /24
!
slb server a5b6e_10_0_11_145 10.0.11.145
  port 80 tcp
!
slb service-group 05f9a68e-1641-4d24-a3e9-4d932c2dcf8d tcp
  method least-connection
  member a5b6e_10_0_11_145 80
!
slb virtual-server d7464376-2cad-46ce-9c1f-b0194dbc69f8 10.0.13.113
  port 80 tcp
    name f47734df-b019-48c2-b90c-30220f2317a3
    conn-limit 88889
    extended-stats
    source-nat pool pool1
    source-nat auto
    service-group 05f9a68e-1641-4d24-a3e9-4d932c2dcf8d
    use-rcv-hop-for-resp
!
end
!Current config commit point for partition 1 is 0 & config mode is classical-mode
vThunder[p1](config)(NOLICENSE)#


Device 2:
vThunder[p1](NOLICENSE)#show running-config
!Current configuration: 124 bytes
!Configuration last updated at 10:26:35 IST Wed Jun 30 2021
!Configuration last saved at 10:26:43 IST Wed Jun 30 2021
!
active-partition p1
!
!
vrrp-a vrid 0
  floating-ip 10.0.13.177
  floating-ip 10.0.11.116
!
ip nat pool pl1 10.0.12.121 10.0.12.123 netmask /24
!
ip nat pool pl3 10.0.11.121 10.0.11.123 netmask /24 gateway 10.0.11.1
!
slb server a5b6e_10_0_11_145 10.0.11.145
  port 80 tcp
!
slb service-group 6f9c3b0b-2389-4503-ad3a-c3d798ae10b3 tcp
  member a5b6e_10_0_11_145 80
!
slb virtual-server a1be77f3-ca3d-4979-a115-8a0f9a203af2 10.0.13.137
  port 80 tcp
    name 2281146f-64ed-4ad7-85cf-63878dfb8e67
    conn-limit 88889
    extended-stats
    source-nat pool pl3
    source-nat auto
    service-group 6f9c3b0b-2389-4503-ad3a-c3d798ae10b3
    use-rcv-hop-for-resp
!
end
!Current config commit point for partition 1 is 0 & config mode is classical-mode
vThunder[p1](NOLICENSE)#


stack@adeeb:~$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| d7464376-2cad-46ce-9c1f-b0194dbc69f8 | 3dsr | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.13.113 | ACTIVE              | a10      |
| a1be77f3-ca3d-4979-a115-8a0f9a203af2 | v4   | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.13.137 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
stack@adeeb:~$
```

2) Delete one lb with cascade.
```
stack@adeeb:~$ openstack loadbalancer delete 3dsr --cascade

Jun 30 09:44:16 adeeb a10-octavia-worker[29613]: INFO a10_octavia.controller.queue.endpoint [-] Deleting load balancer 'd7464376-2cad-46ce-9c1f-b0194dbc69f8'...
Jun 30 09:44:23 adeeb a10-octavia-worker[29613]: INFO a10_octavia.controller.worker.tasks.a10_database_tasks [-] Successfully deleted nat pool entry in database.
Jun 30 09:44:27 adeeb a10-octavia-worker[29613]: INFO a10_octavia.controller.worker.tasks.a10_network_tasks [-] VRID floating IP: [u'10.0.13.119'] deleted
Jun 30 09:44:31 adeeb a10-octavia-worker[29613]: INFO a10_octavia.controller.worker.tasks.a10_network_tasks [-] VRID floating IP: 10.0.13.119 deleted
Jun 30 09:44:35 adeeb a10-octavia-worker[29613]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 10.0.0.55:p1

Device 1:
vThunder[p1](NOLICENSE)#show running-config
!Current configuration: 0 bytes
!Configuration last updated at 10:44:34 IST Wed Jun 30 2021
!Configuration last saved at 10:44:40 IST Wed Jun 30 2021
!
active-partition p1
!
!
!
end
!Current config commit point for partition 1 is 0 & config mode is classical-mode
vThunder[p1](NOLICENSE)#

stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| a1be77f3-ca3d-4979-a115-8a0f9a203af2 | v4   | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.13.137 | ACTIVE              | a10      |
+--------------------------------
```

3) Delete another lb with cascade
```
stack@adeeb:~$ openstack loadbalancer delete v4 --cascade

Jun 30 09:47:11 adeeb a10-octavia-worker[29613]: INFO a10_octavia.controller.queue.endpoint [-] Deleting load balancer 'a1be77f3-ca3d-4979-a115-8a0f9a203af2'...
Jun 30 09:47:36 adeeb a10-octavia-worker[29613]: INFO a10_octavia.controller.worker.tasks.a10_database_tasks [-] Successfully deleted nat pool entry in database.
Jun 30 09:47:45 adeeb a10-octavia-worker[29613]: INFO a10_octavia.controller.worker.tasks.a10_network_tasks [-] VRID floating IP: [u'10.0.13.177'] deleted
Jun 30 09:47:54 adeeb a10-octavia-worker[29613]: INFO a10_octavia.controller.worker.tasks.a10_network_tasks [-] VRID floating IP: 10.0.13.177 deleted
Jun 30 09:48:01 adeeb a10-octavia-worker[29613]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 10.0.0.50:p1

Device 2:
vThunder[p1](NOLICENSE)#show running-config
!Current configuration: 0 bytes
!Configuration last updated at 10:47:58 IST Wed Jun 30 2021
!Configuration last saved at 10:26:43 IST Wed Jun 30 2021
!
active-partition p1
!
!
!
end
!Current config commit point for partition 1 is 0 & config mode is classical-mode
vThunder[p1](NOLICENSE)#

stack@adeeb:~/adeeb/a10-octavia$ openstack loadbalancer list

stack@adeeb:~/adeeb/a10-octavia$
```