### PR TITLE
[STACK-2578] fix create new partition failed for device map

### DIFF
--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -497,8 +497,6 @@ class HandleACOSPartitionChange(VThunderBaseTask):
             except (acos_errors.ACOSException, req_exceptions.ConnectionError) as e:
                 LOG.exception("Failed to create parition on vThunder: %s", str(e))
                 raise e
-        elif partition.get("status") == "Not-Active":
-            raise exceptions.PartitionNotActiveError(partition, vthunder_config.ip_address)
 
         vthunder_config.partition_name = partition_name
         return vthunder_config

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -680,7 +680,7 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         mock_utils.get_axapi_client.return_value = mock_client
         mock_thunder = copy.deepcopy(VTHUNDER)
         mock_thunder.partition_name = "PartitionA"
-        task_function = task.HandleACOSPartitionChange().execute
+        task.HandleACOSPartitionChange().execute
         mock_client.system.partition.create.assert_not_called()
 
     @mock.patch('a10_octavia.common.utils.get_parent_project',
@@ -1013,9 +1013,6 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         self.client_mock.allow_use_any_source_ip_on_egress.assert_not_called()
 
     def test_deletel2dsr_with_deployment_flavor(self):
-        self.conf.config(
-            group=a10constants.A10_VTHUNDER_OPTS,
-            l2dsr_support=True)
         mock_task = task.DeleteL2DSR()
         mock_task._network_driver = self.client_mock
         lb_count = 1

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -680,9 +680,8 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         mock_utils.get_axapi_client.return_value = mock_client
         mock_thunder = copy.deepcopy(VTHUNDER)
         mock_thunder.partition_name = "PartitionA"
-        expected_error = exceptions.PartitionNotActiveError
         task_function = task.HandleACOSPartitionChange().execute
-        self.assertRaises(expected_error, task_function, LB, mock_thunder)
+        mock_client.system.partition.create.assert_not_called()
 
     @mock.patch('a10_octavia.common.utils.get_parent_project',
                 return_value=None)
@@ -1014,6 +1013,9 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         self.client_mock.allow_use_any_source_ip_on_egress.assert_not_called()
 
     def test_deletel2dsr_with_deployment_flavor(self):
+        self.conf.config(
+            group=a10constants.A10_VTHUNDER_OPTS,
+            l2dsr_support=True)
         mock_task = task.DeleteL2DSR()
         mock_task._network_driver = self.client_mock
         lb_count = 1


### PR DESCRIPTION
## Description
- Severity Level High
- Issue Description:
In HandleACOSPartitionChange() it will raise error when partition is not active, but if the partition is not created be a10-octavia will create the partition and active it. Therefore, this check will make a10-octavia create new partition failed.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2578

## Technical Approach
We should not raise error here, a10-octavia will active the partition later.

## Config Changes
<pre>
<b>[hardware_thunder]
devices = [
                    {
                     "ip_address": "192.168.90.46",
                     "username": "admin",
                     "password": "a10",
                     "vrid_floating_ip" : "dhcp",
                     "partition_name": "p11",
                     "device_name": "dev2"
                     },
                    {
                     "ip_address": "192.168.90.46",
                     "username": "admin",
                     "password": "a10",
                     "vrid_floating_ip" : "dhcp",
                     "device_name": "dev3"
                     },
             ]</b>
</pre>

## Test Cases
- in  config file, use a new partition ('p11') in device map and create a LB on it.
- check out acos, see if new partition is created and LB created on it correctly.

```
openstack loadbalancer flavorprofile create --name fp_dev2 --provider a10 --flavor-data '{"device-name": "dev2"}'
openstack loadbalancer flavor create --name f_dev2 --flavorprofile fp_dev2 --description "use device dev2" --enable
openstack loadbalancer create --flavor f_dev2 --vip-subnet-id tp91 --name vip1
```

## Manual Testing

```
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer create --flavor f_dev2 --vip-subnet-id tp91 --name vip1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-07-01T01:40:32                  |
| description         |                                      |
| flavor_id           | 05084690-b8d8-4864-b1ab-017e8add7c07 |
| id                  | 4a8e70ad-d7b2-48c1-897e-d312cfd19fed |
| listeners           |                                      |
| name                | vip1                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 3d21c71c4e4040599933bda62a76ae2f     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.91.113                       |
| vip_network_id      | 5e1b43e5-9f65-40af-a28f-88e63dc6d667 |
| vip_port_id         | 4f201d5b-ccb3-48ea-b686-34e1e2c0fe95 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | f25ce642-f953-4058-8c46-98fdd72fb129 |
+---------------------+--------------------------------------+
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address    | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| 4a8e70ad-d7b2-48c1-897e-d312cfd19fed | vip1 | 3d21c71c4e4040599933bda62a76ae2f | 192.168.91.113 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
```

```
AX1030(config)#show partition
Total Number of active partitions: 4
Partition Name   Id     L3V/SP     Parent L3V           App Type   Admin Count
------------------------------------------------------------------------------
p7               7       L3V       -                    -            0
9955a18b75fa4c   8       L3V       -                    -            0
3d21c71c4e4040   9       L3V       -                    -            0
p11              12      L3V       -                    -            0
AX1030(config)#active-partition p11
Current active partition: p11
AX1030[p11](config)#show running-config
!Current configuration: 72 bytes
!Configuration last updated at 09:55:37 CST Thu Jul 1 2021
!Configuration last saved at 09:55:41 CST Thu Jul 1 2021
!
active-partition p11
!
!
vrrp-a vrid 0
  floating-ip 192.168.91.63
!
slb virtual-server 4a8e70ad-d7b2-48c1-897e-d312cfd19fed 192.168.91.113
!
end
!Current config commit point for partition 12 is 0 & config mode is classical-mode

```