### PR TITLE
[STACK-2580]: [device flavor]failed to delete pool and get MissingDependencies

### DIFF
--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -813,6 +813,8 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                         members, health_monitor, store), store=store)
             else:
                 topology = CONF.a10_controller_worker.loadbalancer_topology
+                store.update({a10constants.USE_DEVICE_FLAVOR: False,
+                              a10constants.POOLS: None})
                 busy = self._vthunder_busy_check(pool.project_id, False, ctx_flags,
                                                  load_balancer, store)
                 delete_pool_tf = self._taskflow_load(

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -114,6 +114,9 @@ class PoolFlows(object):
             requires=[constants.LOADBALANCER, constants.LISTENER, a10constants.VTHUNDER]))
         delete_pool_flow.add(persist_tasks.DeleteSessionPersistence(
             requires=[a10constants.VTHUNDER, constants.POOL]))
+        delete_pool_flow.add(a10_network_tasks.GetPoolsOnThunder(
+            requires=[a10constants.VTHUNDER, a10constants.USE_DEVICE_FLAVOR],
+            provides=a10constants.POOLS))
         # Delete pool children
         delete_pool_flow.add(self._get_delete_health_monitor_vthunder_subflow(health_mon))
         delete_pool_flow.add(self._get_delete_member_vthunder_subflow(members, store))
@@ -329,6 +332,9 @@ class PoolFlows(object):
                       a10constants.DEVICE_CONFIG_DICT),
             rebind={constants.FLAVOR_DATA: constants.FLAVOR},
             provides=(a10constants.VTHUNDER_CONFIG, a10constants.USE_DEVICE_FLAVOR)))
+        delete_pool_flow.add(a10_network_tasks.GetPoolsOnThunder(
+            requires=[a10constants.VTHUNDER, a10constants.USE_DEVICE_FLAVOR],
+            provides=a10constants.POOLS))
 
         # Delete pool children
         delete_pool_flow.add(self._get_delete_health_monitor_vthunder_subflow(health_mon))

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -114,9 +114,6 @@ class PoolFlows(object):
             requires=[constants.LOADBALANCER, constants.LISTENER, a10constants.VTHUNDER]))
         delete_pool_flow.add(persist_tasks.DeleteSessionPersistence(
             requires=[a10constants.VTHUNDER, constants.POOL]))
-        delete_pool_flow.add(a10_network_tasks.GetPoolsOnThunder(
-            requires=[a10constants.VTHUNDER, a10constants.USE_DEVICE_FLAVOR],
-            provides=a10constants.POOLS))
         # Delete pool children
         delete_pool_flow.add(self._get_delete_health_monitor_vthunder_subflow(health_mon))
         delete_pool_flow.add(self._get_delete_member_vthunder_subflow(members, store))


### PR DESCRIPTION
## Description
- Severity Level: Medium
- Issue Description: [device flavor]failed to delete pool and get MissingDependencies

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-2580

## Technical Approach
- Added missing dependency in delete pool flow 
 
## Manual Testing
1) Create lb and other objects
```
openstack loadbalancer flavorprofile create --name fp_natpool --provider a10 --flavor-data  '{
"device-name": "AX35",
"nat-pool":{
"pool-name":"pool1",
"start-address":"10.0.11.111",
"end-address":"10.0.11.115",
"netmask":"/24"
}
}'
openstack loadbalancer flavor create --name f_natpool --flavorprofile fp_natpool
openstack loadbalancer create --name 3dsr --flavor f_natpool --vip-subnet-id provider-vlan-13-subnet
openstack loadbalancer listener create --name l3dsr 3dsr --protocol tcp --protocol-port 80
openstack loadbalancer pool create --name p3dsr --protocol tcp --lb-algorithm LEAST_CONNECTIONS --listener l3dsr
openstack loadbalancer member create --address 10.0.11.145 --subnet-id provider-vlan-11-subnet --protocol-port 80 --name mem1 p3dsr
stack@adeeb:~$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 635467ac-0872-4d8d-ab31-66d4f9cb142e | 3dsr | a5b6eb74f8184fc19e77e1693fdfa8e2 | 10.0.13.187 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
stack@adeeb:~$ openstack loadbalancer listener list
+--------------------------------------+--------------------------------------+-------+----------------------------------+----------+---------------+----------------+
| id                                   | default_pool_id                      | name  | project_id                       | protocol | protocol_port | admin_state_up |
+--------------------------------------+--------------------------------------+-------+----------------------------------+----------+---------------+----------------+
| ad416105-878b-47e2-a935-6e790b323512 | b6286569-afd0-48e1-be86-27390bb52095 | l3dsr | a5b6eb74f8184fc19e77e1693fdfa8e2 | TCP      |            80 | True           |
+--------------------------------------+--------------------------------------+-------+----------------------------------+----------+---------------+----------------+
stack@adeeb:~$ openstack loadbalancer pool list
+--------------------------------------+-------+----------------------------------+---------------------+----------+-------------------+----------------+
| id                                   | name  | project_id                       | provisioning_status | protocol | lb_algorithm      | admin_state_up |
+--------------------------------------+-------+----------------------------------+---------------------+----------+-------------------+----------------+
| b6286569-afd0-48e1-be86-27390bb52095 | p3dsr | a5b6eb74f8184fc19e77e1693fdfa8e2 | ACTIVE              | TCP      | LEAST_CONNECTIONS | True           |
+--------------------------------------+-------+----------------------------------+---------------------+----------+-------------------+----------------+
stack@adeeb:~$ openstack loadbalancer member list p3dsr
+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address     | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| ce173d30-9147-41a6-b30b-788da7a63cf5 | mem1 | a5b6eb74f8184fc19e77e1693fdfa8e2 | ACTIVE              | 10.0.11.145 |            80 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
stack@adeeb:~$
```
2) Delete pool
```
stack@adeeb:~$ openstack loadbalancer pool delete p3dsr
stack@adeeb:~$

Logs:
Jul 01 07:20:48 adeeb a10-octavia-worker[28233]: INFO a10_octavia.controller.queue.endpoint [-] Deleting pool 'b6286569-afd0-48e1-be86-27390bb52095'...
Jul 01 07:21:15 adeeb a10-octavia-worker[28233]: INFO a10_octavia.controller.worker.tasks.a10_database_tasks [-] Successfully deleted nat pool entry in database.
Jul 01 07:21:26 adeeb a10-octavia-worker[28233]: INFO a10_octavia.controller.worker.tasks.a10_network_tasks [-] VRID floating IP: [u'10.0.13.186'] deleted
Jul 01 07:21:30 adeeb a10-octavia-worker[28233]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 10.0.0.55:p1


stack@adeeb:~$ openstack loadbalancer pool list

stack@adeeb:~$
```