### PR TITLE
[STACK-2575]: Refined vrid table to use vthunder's ip+partition as owner.

### DIFF
--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -341,10 +341,3 @@ def get_loadbalancer_flavor(loadbalancer):
                                                      id=flavor.flavor_profile_id)
             flavor_data = json.loads(flavor_profile.flavor_data)
             return flavor_data
-
-
-def get_device_vrid_owner(device_name, partition, hmt):
-    owner = device_name
-    if hmt == 'enable':
-        owner = device_name + '-' + partition
-    return owner

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -825,8 +825,7 @@ class LoadBalancerFlows(object):
             a10_database_tasks.GetVRIDForLoadbalancerResource(
                 requires=[
                     a10constants.PARTITION_PROJECT_LIST,
-                    a10constants.VTHUNDER,
-                    a10constants.USE_DEVICE_FLAVOR],
+                    a10constants.VTHUNDER],
                 provides=a10constants.VRID_LIST))
         handle_vrid_for_lb_subflow.add(vthunder_tasks.ConfigureVRID(
             requires=a10constants.VTHUNDER))
@@ -845,8 +844,7 @@ class LoadBalancerFlows(object):
             a10_database_tasks.UpdateVRIDForLoadbalancerResource(
                 requires=[
                     a10constants.VRID_LIST,
-                    a10constants.VTHUNDER_CONFIG,
-                    a10constants.USE_DEVICE_FLAVOR],
+                    a10constants.VTHUNDER],
                 rebind={
                     a10constants.LB_RESOURCE: constants.LOADBALANCER}))
         return handle_vrid_for_lb_subflow
@@ -873,8 +871,7 @@ class LoadBalancerFlows(object):
             a10_database_tasks.GetVRIDForLoadbalancerResource(
                 requires=[
                     a10constants.PARTITION_PROJECT_LIST,
-                    a10constants.VTHUNDER,
-                    a10constants.USE_DEVICE_FLAVOR],
+                    a10constants.VTHUNDER],
                 provides=a10constants.VRID_LIST))
         delete_lb_vrid_subflow.add(
             a10_network_tasks.DeleteVRIDPort(
@@ -909,8 +906,7 @@ class LoadBalancerFlows(object):
             a10_database_tasks.GetVRIDForLoadbalancerResource(
                 requires=[
                     a10constants.PARTITION_PROJECT_LIST,
-                    a10constants.VTHUNDER,
-                    a10constants.USE_DEVICE_FLAVOR],
+                    a10constants.VTHUNDER],
                 provides=a10constants.VRID_LIST))
         delete_lb_vrid_subflow.add(
             a10_network_tasks.DeleteVRIDPort(

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -490,8 +490,7 @@ class MemberFlows(object):
             a10_database_tasks.GetVRIDForLoadbalancerResource(
                 requires=[
                     a10constants.PARTITION_PROJECT_LIST,
-                    a10constants.VTHUNDER,
-                    a10constants.USE_DEVICE_FLAVOR],
+                    a10constants.VTHUNDER],
                 provides=a10constants.VRID_LIST))
         delete_member_vrid_subflow.add(
             a10_network_tasks.DeleteVRIDPort(
@@ -539,8 +538,7 @@ class MemberFlows(object):
                 name='get_vrid_for_loadbalancer_resource' + pool,
                 requires=[
                     a10constants.PARTITION_PROJECT_LIST,
-                    a10constants.VTHUNDER,
-                    a10constants.USE_DEVICE_FLAVOR],
+                    a10constants.VTHUNDER],
                 provides=a10constants.VRID_LIST))
         delete_member_vrid_subflow.add(
             a10_network_tasks.DeleteMultipleVRIDPort(
@@ -573,8 +571,7 @@ class MemberFlows(object):
             a10_database_tasks.GetVRIDForLoadbalancerResource(
                 requires=[
                     a10constants.PARTITION_PROJECT_LIST,
-                    a10constants.VTHUNDER,
-                    a10constants.USE_DEVICE_FLAVOR],
+                    a10constants.VTHUNDER],
                 provides=a10constants.VRID_LIST))
         handle_vrid_for_member_subflow.add(
             a10_network_tasks.HandleVRIDFloatingIP(
@@ -591,8 +588,7 @@ class MemberFlows(object):
             a10_database_tasks.UpdateVRIDForLoadbalancerResource(
                 requires=[
                     a10constants.VRID_LIST,
-                    a10constants.VTHUNDER_CONFIG,
-                    a10constants.USE_DEVICE_FLAVOR],
+                    a10constants.VTHUNDER],
                 rebind={
                     a10constants.LB_RESOURCE: constants.MEMBER}))
 

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -349,7 +349,8 @@ class GetVRIDForLoadbalancerResource(BaseDatabaseTask):
         if partition_project_list:
             try:
                 vrid_list = self.vrid_repo.get_vrid_from_owner(
-                    db_apis.get_session(), owner=owner)
+                    db_apis.get_session(), owner=owner,
+                    project_ids=partition_project_list)
                 return vrid_list
             except Exception as e:
                 LOG.exception(

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -343,34 +343,20 @@ class CreateSpareVThunderEntry(BaseDatabaseTask):
 
 class GetVRIDForLoadbalancerResource(BaseDatabaseTask):
 
-    def execute(self, partition_project_list, vthunder, use_device_flavor):
+    def execute(self, partition_project_list, vthunder):
         vrid_list = []
-        if partition_project_list and not use_device_flavor:
+        owner = vthunder.ip_address + "_" + vthunder.partition_name
+        if partition_project_list:
             try:
-                vrid_list = self.vrid_repo.get_vrid_from_project_ids(
-                    db_apis.get_session(), project_ids=partition_project_list)
+                vrid_list = self.vrid_repo.get_vrid_from_owner(
+                    db_apis.get_session(), owner=owner)
                 return vrid_list
             except Exception as e:
                 LOG.exception(
-                    "Failed to get VRID list for given project list  %s due to %s",
-                    partition_project_list,
+                    "Failed to get VRID list for given owner  %s due to %s",
+                    owner,
                     str(e))
                 raise e
-        elif use_device_flavor:
-            if vthunder is not None:
-                try:
-                    owner = utils.get_device_vrid_owner(
-                        vthunder.device_name, vthunder.partition_name,
-                        vthunder.hierarchical_multitenancy)
-                    vrid_list = self.vrid_repo.get_vrid_from_owner(
-                        db_apis.get_session(), owner=owner)
-                    return vrid_list
-                except Exception as e:
-                    LOG.exception(
-                        "Failed to get VRID list for given device  %s due to %s",
-                        vthunder.device_name,
-                        str(e))
-                    raise e
         return vrid_list
 
 
@@ -380,26 +366,19 @@ class UpdateVRIDForLoadbalancerResource(BaseDatabaseTask):
         self.vrid_created = []
         super(UpdateVRIDForLoadbalancerResource, self).__init__(*arg, **kwargs)
 
-    def execute(self, lb_resource, vrid_list, vthunder_config, use_device_flavor):
+    def execute(self, lb_resource, vrid_list, vthunder):
+        owner = vthunder.ip_address + "_" + vthunder.partition_name
         if not vrid_list:
             # delete all vrids from DB for the lB resource's project.
             try:
-                if not use_device_flavor:
-                    self.vrid_repo.delete(db_apis.get_session(),
-                                          owner=lb_resource.project_id)
-                    LOG.debug("Successfully deleted DB vrid from project %s",
-                              lb_resource.project_id)
-                elif use_device_flavor:
-                    owner = utils.get_device_vrid_owner(
-                        vthunder_config.device_name, vthunder_config.partition_name,
-                        vthunder_config.hierarchical_multitenancy)
-                    self.vrid_repo.delete(db_apis.get_session(), owner=owner)
-                    LOG.debug("Successfully deleted DB vrid from device %s", owner)
+                self.vrid_repo.delete(db_apis.get_session(),
+                                      owner=owner)
+                LOG.debug("Successfully deleted DB vrid from owner %s", owner)
 
             except Exception as e:
                 LOG.error(
-                    "Failed to delete VRID data for project %s due to %s",
-                    lb_resource.project_id,
+                    "Failed to delete VRID data for owner %s due to %s",
+                    owner,
                     str(e))
                 raise e
             return
@@ -425,44 +404,22 @@ class UpdateVRIDForLoadbalancerResource(BaseDatabaseTask):
                     raise e
 
             else:
-                if use_device_flavor:
-                    try:
-                        owner = utils.get_device_vrid_owner(
-                            vthunder_config.device_name,
-                            vthunder_config.partition_name,
-                            vthunder_config.hierarchical_multitenancy)
-                        new_vrid = self.vrid_repo.create(
-                            db_apis.get_session(),
-                            id=vrid.id,
-                            owner=owner,
-                            vrid_floating_ip=vrid.vrid_floating_ip,
-                            vrid_port_id=vrid.vrid_port_id,
-                            vrid=vrid.vrid,
-                            subnet_id=vrid.subnet_id)
-                        self.vrid_created.append(new_vrid)
-                    except Exception as e:
-                        LOG.error(
-                            "Failed to create VRID data for VRID FIP %s due to %s",
-                            vrid.vrid_floating_ip,
-                            str(e))
-                        raise e
-                else:
-                    try:
-                        new_vrid = self.vrid_repo.create(
-                            db_apis.get_session(),
-                            id=vrid.id,
-                            owner=vrid.owner,
-                            vrid_floating_ip=vrid.vrid_floating_ip,
-                            vrid_port_id=vrid.vrid_port_id,
-                            vrid=vrid.vrid,
-                            subnet_id=vrid.subnet_id)
-                        self.vrid_created.append(new_vrid)
-                    except Exception as e:
-                        LOG.error(
-                            "Failed to create VRID data for VRID FIP %s due to %s",
-                            vrid.vrid_floating_ip,
-                            str(e))
-                        raise e
+                try:
+                    new_vrid = self.vrid_repo.create(
+                        db_apis.get_session(),
+                        id=vrid.id,
+                        owner=owner,
+                        vrid_floating_ip=vrid.vrid_floating_ip,
+                        vrid_port_id=vrid.vrid_port_id,
+                        vrid=vrid.vrid,
+                        subnet_id=vrid.subnet_id)
+                    self.vrid_created.append(new_vrid)
+                except Exception as e:
+                    LOG.error(
+                        "Failed to create VRID data for VRID FIP %s due to %s",
+                        vrid.vrid_floating_ip,
+                        str(e))
+                    raise e
 
     def revert(self, *args, **kwargs):
         for vrid in self.vrid_created:

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -778,13 +778,8 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
         vrid_floating_ips = []
         update_vrid_flag = False
         existing_fips = []
-        if use_device_flavor:
-            owner = a10_utils.get_device_vrid_owner(
-                vthunder_config.device_name, vthunder_config.partition_name,
-                vthunder_config.hierarchical_multitenancy)
-            self._add_vrid_to_list(updated_vrid_list, subnet, owner)
-        else:
-            self._add_vrid_to_list(updated_vrid_list, subnet, lb_resource.project_id)
+        owner = vthunder.ip_address + "_" + vthunder.partition_name
+        self._add_vrid_to_list(updated_vrid_list, subnet, owner)
         for vrid in updated_vrid_list:
             try:
                 vrid_summary = self.axapi_client.vrrpa.get(vrid.vrid)
@@ -1057,6 +1052,8 @@ class GetMembersOnThunder(BaseNetworkTask):
             try:
                 member_list = []
                 members = []
+                if vthunder.partition_name != 'shared':
+                    self.axapi_client.system.partition.active(vthunder.partition_name)
                 member_list = self.axapi_client.slb.server.get_all()
                 if member_list:
                     for member in range(len(member_list['server-list'])):

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -1052,8 +1052,6 @@ class GetMembersOnThunder(BaseNetworkTask):
             try:
                 member_list = []
                 members = []
-                if vthunder.partition_name != 'shared':
-                    self.axapi_client.system.partition.active(vthunder.partition_name)
                 member_list = self.axapi_client.slb.server.get_all()
                 if member_list:
                     for member in range(len(member_list['server-list'])):

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -461,20 +461,12 @@ class VRIDRepository(BaseRepository):
 
     # A project can have multiple VRIDs, so need to convert each vrid object through
     # "to_data_model"
-    def get_vrid_from_project_ids(self, session, project_ids):
-        vrid_obj_list = []
-        model = session.query(self.model_class).filter(
-            self.model_class.owner.in_(project_ids))
-        for data in model:
-            vrid_obj_list.append(data.to_data_model())
-
-        return vrid_obj_list
-
-    def get_vrid_from_owner(self, session, owner):
+    def get_vrid_from_owner(self, session, owner, project_ids):
         vrid_obj_list = []
 
         model = session.query(self.model_class).filter(
-            self.model_class.owner == owner)
+            or_(self.model_class.owner == owner,
+                self.model_class.owner.in_(project_ids)))
         for data in model:
             vrid_obj_list.append(data.to_data_model())
 

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -131,8 +131,8 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
 
         mock_vrid_entry.vrid_repo = mock.Mock()
         mock_vrid_entry.vthunder_repo = mock.Mock()
-        mock_vrid_entry.vrid_repo.get_vrid_from_project_ids.return_value = VRID
-        vrid = mock_vrid_entry.execute([a10constants.MOCK_PROJECT_ID], thunder, False)
+        mock_vrid_entry.vrid_repo.get_vrid_from_owner.return_value = VRID
+        vrid = mock_vrid_entry.execute([a10constants.MOCK_PROJECT_ID], thunder)
         self.assertEqual(VRID, vrid)
 
     def test_get_vrid_for_project(self):
@@ -153,8 +153,8 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
 
         mock_vrid_entry.vrid_repo = mock.Mock()
         mock_vrid_entry.vthunder_repo = mock.Mock()
-        mock_vrid_entry.vrid_repo.get_vrid_from_project_ids.return_value = VRID
-        vrid = mock_vrid_entry.execute(MEMBER_1, thunder, False)
+        mock_vrid_entry.vrid_repo.get_vrid_from_owner.return_value = VRID
+        vrid = mock_vrid_entry.execute(MEMBER_1, thunder)
         mock_vrid_entry.vthunder_repo.get_partition_for_project.assert_not_called()
         self.assertEqual(VRID, vrid)
 
@@ -170,10 +170,10 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
 
         mock_vrid_entry = task.UpdateVRIDForLoadbalancerResource()
         mock_vrid_entry.vrid_repo = mock.Mock()
-        mock_vrid_entry.execute(MEMBER_1, [], thunder, False)
+        mock_vrid_entry.execute(MEMBER_1, [], thunder)
         mock_vrid_entry.vrid_repo.delete.assert_called_once_with(
             mock.ANY,
-            owner=a10constants.MOCK_PROJECT_ID
+            owner=thunder.ip_address + "_" + thunder.partition_name
         )
 
     def test_update_vrid_for_project_member_with_port_and_with_vrid(self):
@@ -181,7 +181,7 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         mock_vrid_entry = task.UpdateVRIDForLoadbalancerResource()
         mock_vrid_entry.vrid_repo = mock.Mock()
         mock_vrid_entry.vrid_repo.exists.return_value = True
-        mock_vrid_entry.execute(MEMBER_1, [VRID], thunder, False)
+        mock_vrid_entry.execute(MEMBER_1, [VRID], thunder)
         mock_vrid_entry.vrid_repo.update.assert_called_once_with(
             mock.ANY,
             VRID.id,
@@ -196,10 +196,10 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         mock_vrid_entry = task.UpdateVRIDForLoadbalancerResource()
         mock_vrid_entry.vrid_repo = mock.Mock()
         mock_vrid_entry.vrid_repo.exists.return_value = False
-        mock_vrid_entry.execute(MEMBER_1, [VRID], thunder, False)
+        mock_vrid_entry.execute(MEMBER_1, [VRID], thunder)
         mock_vrid_entry.vrid_repo.create.assert_called_once_with(
             mock.ANY,
-            owner=MEMBER_1.project_id,
+            owner=thunder.ip_address + "_" + thunder.partition_name,
             id=VRID.id,
             vrid=VRID.vrid,
             vrid_floating_ip=VRID.vrid_floating_ip,

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
@@ -124,6 +124,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
             self, mock_patched_ip, mock_floating_ip):
         member = copy.deepcopy(MEMBER)
         member.subnet_id = SUBNET_1.id
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.ip_address = '10.0.0.1'
         subnet = copy.deepcopy(SUBNET_1)
         subnet.cidr = a10constants.MOCK_SUBNET_CIDR
         vthunder_config = copy.deepcopy(HW_THUNDER)
@@ -136,7 +138,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         self.network_driver_mock.allocate_vrid_fip.return_value = port
         self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
                          vrid=VRID_VALUE)
-        mock_network_task.execute(VTHUNDER, member, [], subnet, vthunder_config)
+        mock_network_task.execute(vthunder, member, [], subnet, vthunder_config)
         self.network_driver_mock.allocate_vrid_fip.assert_called_with(
             mock.ANY, None, mock.ANY,
             fixed_ip=a10constants.MOCK_VRID_FLOATING_IP_1)
@@ -150,6 +152,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
             self, mock_patched_ip):
         member = copy.deepcopy(MEMBER)
         member.subnet_id = SUBNET_1.id
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.ip_address = '10.0.0.1'
         subnet = copy.deepcopy(SUBNET_1)
         subnet.cidr = a10constants.MOCK_SUBNET_CIDR
         vthunder_config = copy.deepcopy(HW_THUNDER2)
@@ -162,7 +166,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         self.client_mock.vrrpa.get.return_value = EXISTING_FIP_SHARED_PARTITION
         self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
                          vrid=VRID_VALUE)
-        mock_network_task.execute(VTHUNDER, member, [], subnet,
+        mock_network_task.execute(vthunder, member, [], subnet,
                                   vthunder_config, use_device_flavor=True)
         mock_network_task.axapi_client.get_vrid_floating_ip_for_project.assert_not_called()
         self.client_mock.vrrpa.update.assert_called_with(
@@ -185,6 +189,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         port.fixed_ips.append(MockIP(a10constants.MOCK_VRID_FLOATING_IP_1))
         vthunder = copy.deepcopy(VTHUNDER)
         vthunder.partition_name = 'partition_1'
+        vthunder.ip_address = '10.0.0.1'
         mock_network_task = a10_network_tasks.HandleVRIDFloatingIP()
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
@@ -210,6 +215,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
             self, get_floating_ip, check_subnet):
         member = copy.deepcopy(MEMBER)
         member.subnet_id = SUBNET_1.id
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.ip_address = '10.0.0.1'
         subnet = copy.deepcopy(SUBNET_1)
         subnet.cidr = a10constants.MOCK_SUBNET_CIDR
         vthunder_config = copy.deepcopy(HW_THUNDER)
@@ -222,7 +229,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         self.client_mock.vrrpa.get.return_value = EXISTING_FIP_SHARED_PARTITION
         self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
                          vrid=VRID_VALUE)
-        mock_network_task.execute(VTHUNDER, member, [VRID_1], subnet, vthunder_config)
+        mock_network_task.execute(vthunder, member, [VRID_1], subnet, vthunder_config)
         self.network_driver_mock.allocate_vrid_fip.assert_called_with(
             mock.ANY, None, None, fixed_ip=None)
         self.client_mock.vrrpa.update.assert_called_with(
@@ -246,6 +253,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         port.fixed_ips.append(MockIP(a10constants.MOCK_VRID_FLOATING_IP_1))
         vthunder = copy.deepcopy(VTHUNDER)
         vthunder.partition_name = 'partition_1'
+        vthunder.ip_address = '10.0.0.1'
         mock_network_task = a10_network_tasks.HandleVRIDFloatingIP()
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
@@ -287,6 +295,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         vrid = copy.deepcopy(VRID_1)
         vrid.vrid_floating_ip = a10constants.MOCK_VRID_FLOATING_IP_1
         vrid.vrid = VRID_VALUE
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.ip_address = '10.0.0.1'
         member = copy.deepcopy(MEMBER)
         member.subnet_id = a10constants.MOCK_SUBNET_ID
         subnet = copy.deepcopy(SUBNET_1)
@@ -298,7 +308,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
         self.client_mock.vrrpa.get.return_value = EXISTING_FIP_SHARED_PARTITION
-        mock_network_task.execute(VTHUNDER, member, [vrid], subnet, vthunder_config)
+        mock_network_task.execute(vthunder, member, [vrid], subnet, vthunder_config)
         self.network_driver_mock.allocate_vrid_fip.assert_not_called()
         self.client_mock.vrrpa.update.assert_not_called()
 
@@ -310,6 +320,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
     def test_HandleVRIDFloatingIP_replace_floating_ip_in_shared_partition_with_static_ip(
             self, mock_utils, mock_patched_ip, get_floating_ip):
         vrid = copy.deepcopy(VRID_1)
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.ip_address = '10.0.0.1'
         vrid.vrid_floating_ip = a10constants.MOCK_VRID_FLOATING_IP_1
         vrid.vrid = VRID_VALUE
         vrid.vrid_port_id = a10constants.MOCK_VRRP_PORT_ID
@@ -327,7 +339,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         self.client_mock.vrrpa.get.return_value = EXISTING_FIP_SHARED_PARTITION
         self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
                          vrid=VRID_VALUE)
-        mock_network_task.execute(VTHUNDER, member, [vrid], subnet, vthunder_config)
+        mock_network_task.execute(vthunder, member, [vrid], subnet, vthunder_config)
         self.network_driver_mock.allocate_vrid_fip.assert_called_with(
             vrid, subnet.network_id, mock.ANY,
             fixed_ip=a10constants.MOCK_VRID_FLOATING_IP_2)
@@ -356,6 +368,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         vthunder_config = copy.deepcopy(HW_THUNDER)
         port.fixed_ips.append(MockIP(a10constants.MOCK_VRID_FLOATING_IP_2))
         vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.ip_address = '10.0.0.1'
         vthunder.partition_name = 'partition_1'
         mock_network_task = a10_network_tasks.HandleVRIDFloatingIP()
         mock_network_task.axapi_client = self.client_mock
@@ -380,6 +393,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
     def test_HandleVRIDFloatingIP_noop_given_same_subnet_with_conf_fip_set_to_dhcp(
             self, get_floating_ip):
         vrid = copy.deepcopy(VRID_1)
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.ip_address = '10.0.0.1'
         vrid.vrid_floating_ip = a10constants.MOCK_VRID_FLOATING_IP_1
         vrid.vrid = VRID_VALUE
         vrid.vrid_port_id = a10constants.MOCK_VRRP_PORT_ID
@@ -392,7 +407,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
         self.client_mock.vrrpa.get.return_value = EXISTING_FIP_SHARED_PARTITION
-        fip_port = mock_network_task.execute(VTHUNDER, member, [vrid], subnet, vthunder_config)
+        fip_port = mock_network_task.execute(vthunder, member, [vrid], subnet, vthunder_config)
         self.network_driver_mock.allocate_vrid_fip.assert_not_called()
         self.network_driver_mock.delete_port.assert_not_called()
         self.assertEqual(fip_port, [vrid])
@@ -407,6 +422,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
     def test_HandleVRIDFloatingIP_replace_floating_ip_diff_subnet_in_shared_part_conf_fip_set_dhcp(
             self, mock_utils, get_floating_ip, check_subnet):
         vrid = copy.deepcopy(VRID_1)
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.ip_address = '10.0.0.1'
         vrid.vrid_floating_ip = a10constants.MOCK_VRID_FLOATING_IP_1
         vrid.vrid = VRID_VALUE
         vrid.vrid_port_id = a10constants.MOCK_VRRP_PORT_ID
@@ -425,7 +442,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         self.client_mock.vrrpa.get.return_value = EXISTING_FIP_SHARED_PARTITION
         self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
                          vrid=VRID_VALUE)
-        mock_network_task.execute(VTHUNDER, member, [vrid], subnet, vthunder_config)
+        mock_network_task.execute(vthunder, member, [vrid], subnet, vthunder_config)
         self.network_driver_mock.allocate_vrid_fip.assert_called_with(
             vrid, subnet.network_id, mock.ANY, fixed_ip=None)
         self.client_mock.vrrpa.update.assert_called_with(
@@ -454,6 +471,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         port.fixed_ips.append(MockIP(a10constants.MOCK_VRID_FLOATING_IP_1))
         vthunder = copy.deepcopy(VTHUNDER)
         vthunder.partition_name = 'partition_1'
+        vthunder.ip_address = '10.0.0.1'
         mock_network_task = a10_network_tasks.HandleVRIDFloatingIP()
         mock_network_task.axapi_client = self.client_mock
         self.network_driver_mock.get_subnet.return_value = subnet
@@ -477,6 +495,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
             self, get_floating_ip, mock_utils):
         member = copy.deepcopy(MEMBER)
         member.subnet_id = a10constants.MOCK_SUBNET_ID
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.ip_address = '10.0.0.1'
         subnet = copy.deepcopy(SUBNET_1)
         subnet.cidr = a10constants.MOCK_SUBNET_CIDR
         port = copy.deepcopy(PORT)
@@ -490,7 +510,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         self.client_mock.vrrpa.get.return_value = EXISTING_FIP_SHARED_PARTITION
         self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
                          vrid=VRID_VALUE)
-        mock_network_task.execute(VTHUNDER, member, [VRID_1], subnet, vthunder_config)
+        mock_network_task.execute(vthunder, member, [VRID_1], subnet, vthunder_config)
         self.network_driver_mock.allocate_vrid_fip.assert_called_with(
             mock.ANY, subnet.network_id, mock.ANY,
             fixed_ip=a10constants.MOCK_VRID_FULL_FLOATING_IP)


### PR DESCRIPTION
## Description
Used vthunder's ip_address and partition_name as ip_partition as a owner in vrid table for handling correct vrid FIP creation and deletion cases among different partitions on same and different vthunders

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2575

## Technical Approach
- Stored vthunder.ip_address + "_"+ vthunder.partition_name as owner in vrid table for all cases(device_flavor as well as non device_flavor cases)
- Modified `GetMembersOnThunder()` task to get members on currently active partition on a thunder device. 

## Manual Testing
openstack loadbalancer flavorprofile create --name fp_35 --provider a10 --flavor-data '{"device-name": "device1"}'
openstack loadbalancer flavor create --name f_35 --flavorprofile fp_35

openstack loadbalancer flavorprofile create --name fp_45 --provider a10 --flavor-data '{"device-name": "device2"}'
openstack loadbalancer flavor create --name f_45 --flavorprofile fp_45

**Creation cases:**

1. Create a loadbalancer, listener, pool and member on device1 on shared and l3v partition.

On shared partition:
stack@neha:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --flavor f_35 --name lb1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-07-01T10:12:17                  |
| description         |                                      |
| flavor_id           | 44ad00f1-b7d8-49de-9e54-03ceb3f444ce |
| id                  | 63e63e4b-406e-4ee8-ab30-f02842954794 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e53e09a471d3415ab56dd29d3298d526     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.177                          |
| vip_network_id      | eab8b60f-1e06-420f-8ca5-1557d36f132a |
| vip_port_id         | 42f90cb8-573b-4bb2-bf15-8390b5fa7b5c |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | c9fb06a8-9736-49a7-9fcd-1475ba0c04f2 |
+---------------------+--------------------------------------+
```

stack@neha:~$ openstack loadbalancer listener create --protocol TCP --protocol-port 82 --name l1 lb1
```
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-07-01T10:13:36                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 67130bd7-fae8-4355-9354-5e10b0a8fcd8 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 63e63e4b-406e-4ee8-ab30-f02842954794 |
| name                        | l1                                   |
| operating_status            | OFFLINE                              |
| project_id                  | e53e09a471d3415ab56dd29d3298d526     |
| protocol                    | TCP                                  |
| protocol_port               | 82                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
+-----------------------------+--------------------------------------+
```

stack@neha:~$ openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener l1 --name p1
```
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-07-01T10:13:51                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | 95f94c1f-7fce-42ed-a18e-bcd175bc90cf |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | 67130bd7-fae8-4355-9354-5e10b0a8fcd8 |
| loadbalancers        | 63e63e4b-406e-4ee8-ab30-f02842954794 |
| members              |                                      |
| name                 | p1                                   |
| operating_status     | OFFLINE                              |
| project_id           | e53e09a471d3415ab56dd29d3298d526     |
| protocol             | TCP                                  |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
+----------------------+--------------------------------------+
```

stack@neha:~$ openstack loadbalancer member create --address 10.0.12.11 --subnet-id provider-vlan-12-subnet --protocol-port 93 --name mem1 p1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.12.11                           |
| admin_state_up      | True                                 |
| created_at          | 2021-07-01T10:14:21                  |
| id                  | 00fb4a0e-a3ca-4cb3-bd1f-440e949c5a42 |
| name                | mem1                                 |
| operating_status    | NO_MONITOR                           |
| project_id          | e53e09a471d3415ab56dd29d3298d526     |
| protocol_port       | 93                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 9c5cbcec-c8a0-4a30-bc56-7879a064a2b2 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
```

Result on device1:

vThunder(NOLICENSE)#show running-config
!Current configuration: 280 bytes
!Configuration last updated at 11:14:28 IST Thu Jul 1 2021
!Configuration last saved at 11:15:16 IST Thu Jul 1 2021
!64-bit Advanced Core OS (ACOS) version 4.1.4-GR1-P5, build 81 (Sep-08-2020,09:32)
!
partition e53e09a471d341 id 1
!
partition 60d60d76206843 id 2
!
partition 56443ed3346a4d id 3
!
!
interface management
  ip address dhcp
!
interface ethernet 1
!
interface ethernet 2
!
interface ethernet 3
!
interface ethernet 4
!
vrrp-a vrid 0
  floating-ip 10.0.11.174
  floating-ip 10.0.12.171
!
slb server e53e0_10_0_12_11 10.0.12.11
  port 93 tcp
!
slb service-group 95f94c1f-7fce-42ed-a18e-bcd175bc90cf tcp
  member e53e0_10_0_12_11 93
!
slb virtual-server 63e63e4b-406e-4ee8-ab30-f02842954794 10.0.11.177
  port 82 tcp
    name 67130bd7-fae8-4355-9354-5e10b0a8fcd8
    extended-stats
    service-group 95f94c1f-7fce-42ed-a18e-bcd175bc90cf
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode


On partition p1:
stack@neha:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --flavor f_35 --name lb2
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-07-01T10:19:48                  |
| description         |                                      |
| flavor_id           | 44ad00f1-b7d8-49de-9e54-03ceb3f444ce |
| id                  | 64457dbe-8be8-4c89-b4bb-c41816d5b277 |
| listeners           |                                      |
| name                | lb2                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e53e09a471d3415ab56dd29d3298d526     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.127                          |
| vip_network_id      | eab8b60f-1e06-420f-8ca5-1557d36f132a |
| vip_port_id         | 1b6d83e1-7cd7-4723-90ca-9bae519396b2 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | c9fb06a8-9736-49a7-9fcd-1475ba0c04f2 |
+---------------------+--------------------------------------+
```

stack@neha:~$ openstack loadbalancer listener create --protocol TCP --protocol-port 83 --name l2 lb2
```
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-07-01T10:23:44                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | b2241f04-086b-4177-94aa-d161595737ba |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 64457dbe-8be8-4c89-b4bb-c41816d5b277 |
| name                        | l2                                   |
| operating_status            | OFFLINE                              |
| project_id                  | e53e09a471d3415ab56dd29d3298d526     |
| protocol                    | TCP                                  |
| protocol_port               | 83                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
+-----------------------------+--------------------------------------+
```

stack@neha:~$ openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener l2 --name p2
```
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-07-01T10:23:57                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | 33b2e38f-0c2f-4df3-a7be-90054885252a |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | b2241f04-086b-4177-94aa-d161595737ba |
| loadbalancers        | 64457dbe-8be8-4c89-b4bb-c41816d5b277 |
| members              |                                      |
| name                 | p2                                   |
| operating_status     | OFFLINE                              |
| project_id           | e53e09a471d3415ab56dd29d3298d526     |
| protocol             | TCP                                  |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
+----------------------+--------------------------------------+
```

stack@neha:~$ openstack loadbalancer member create --address 10.0.12.12 --subnet-id provider-vlan-12-subnet --protocol-port 92 --name mem2 p2
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.12.12                           |
| admin_state_up      | True                                 |
| created_at          | 2021-07-01T10:24:24                  |
| id                  | 8cb4f997-56f7-43da-b9b6-862a9bae5583 |
| name                | mem2                                 |
| operating_status    | NO_MONITOR                           |
| project_id          | e53e09a471d3415ab56dd29d3298d526     |
| protocol_port       | 92                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 9c5cbcec-c8a0-4a30-bc56-7879a064a2b2 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
```

Result on device1:

vThunder[p1](NOLICENSE)#show running-config
!Current configuration: 0 bytes
!Configuration last updated at 11:24:31 IST Thu Jul 1 2021
!Configuration last saved at 11:24:39 IST Thu Jul 1 2021
!
active-partition p1
!
!
vrrp-a vrid 0
  floating-ip 10.0.11.101
  floating-ip 10.0.12.137
!
slb server e53e0_10_0_12_12 10.0.12.12
  port 92 tcp
!
slb service-group 33b2e38f-0c2f-4df3-a7be-90054885252a tcp
  member e53e0_10_0_12_12 92
!
slb virtual-server 64457dbe-8be8-4c89-b4bb-c41816d5b277 10.0.11.127
  port 83 tcp
    name b2241f04-086b-4177-94aa-d161595737ba
    extended-stats
    service-group 33b2e38f-0c2f-4df3-a7be-90054885252a
!
end
!Current config commit point for partition 4 is 0 & config mode is classical-mode


2.  Create a loadbalancer, listener, pool and member on device2 on shared and l3v partition.

On shared partition:
stack@neha:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --flavor f_45 --name lb3
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-07-01T10:25:30                  |
| description         |                                      |
| flavor_id           | 04603832-9b16-4a05-be91-95684064c6f0 |
| id                  | b7e85768-5381-421f-8341-a8126043cf76 |
| listeners           |                                      |
| name                | lb3                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e53e09a471d3415ab56dd29d3298d526     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.103                          |
| vip_network_id      | eab8b60f-1e06-420f-8ca5-1557d36f132a |
| vip_port_id         | a6c43157-8c6a-49b1-a386-4cef576baae5 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | c9fb06a8-9736-49a7-9fcd-1475ba0c04f2 |
+---------------------+--------------------------------------+
```

stack@neha:~$ openstack loadbalancer listener create --protocol TCP --protocol-port 93 --name l3 lb3
```
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-07-01T10:27:36                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | b5ea7515-e36b-4e63-980b-fb76c93e4db4 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | b7e85768-5381-421f-8341-a8126043cf76 |
| name                        | l3                                   |
| operating_status            | OFFLINE                              |
| project_id                  | e53e09a471d3415ab56dd29d3298d526     |
| protocol                    | TCP                                  |
| protocol_port               | 93                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
+-----------------------------+--------------------------------------+
```

stack@neha:~$ openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener l3 --name p3
```
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-07-01T10:27:49                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | e601b1f1-c4bb-4f50-9ce7-d76849809b60 |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | b5ea7515-e36b-4e63-980b-fb76c93e4db4 |
| loadbalancers        | b7e85768-5381-421f-8341-a8126043cf76 |
| members              |                                      |
| name                 | p3                                   |
| operating_status     | OFFLINE                              |
| project_id           | e53e09a471d3415ab56dd29d3298d526     |
| protocol             | TCP                                  |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
+----------------------+--------------------------------------+
```

stack@neha:~$ openstack loadbalancer member create --address 10.0.12.21 --subnet-id provider-vlan-12-subnet --protocol-port 96 --name mem3 p3
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.12.21                           |
| admin_state_up      | True                                 |
| created_at          | 2021-07-01T10:28:25                  |
| id                  | 7c86ba37-ad41-41cf-9e11-77f209456797 |
| name                | mem3                                 |
| operating_status    | NO_MONITOR                           |
| project_id          | e53e09a471d3415ab56dd29d3298d526     |
| protocol_port       | 96                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 9c5cbcec-c8a0-4a30-bc56-7879a064a2b2 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
```

Result on device2:

vThunder(NOLICENSE)#show running-config
!Current configuration: 218 bytes
!Configuration last updated at 11:28:41 IST Thu Jul 1 2021
!Configuration last saved at 11:26:37 IST Thu Jul 1 2021
!64-bit Advanced Core OS (ACOS) version 4.1.4-GR1-P5, build 81 (Sep-08-2020,09:32)
!
partition e53e09a471d341 id 1
!
!
interface management
  ip address dhcp
!
interface ethernet 1
!
interface ethernet 2
!
interface ethernet 3
!
interface ethernet 4
!
vrrp-a vrid 0
  floating-ip 10.0.11.134
  floating-ip 10.0.12.165
!
slb server e53e0_10_0_12_21 10.0.12.21
  port 96 tcp
!
slb service-group e601b1f1-c4bb-4f50-9ce7-d76849809b60 tcp
  member e53e0_10_0_12_21 96
!
slb virtual-server b7e85768-5381-421f-8341-a8126043cf76 10.0.11.103
  port 93 tcp
    name b5ea7515-e36b-4e63-980b-fb76c93e4db4
    extended-stats
    service-group e601b1f1-c4bb-4f50-9ce7-d76849809b60
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode


On partition p2:
stack@neha:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --flavor f_45 --name lb4
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-07-01T10:41:59                  |
| description         |                                      |
| flavor_id           | 04603832-9b16-4a05-be91-95684064c6f0 |
| id                  | 7c025c16-7c95-445c-816f-2bc24c046e86 |
| listeners           |                                      |
| name                | lb4                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e53e09a471d3415ab56dd29d3298d526     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.122                          |
| vip_network_id      | eab8b60f-1e06-420f-8ca5-1557d36f132a |
| vip_port_id         | 2339201f-8c36-4f81-aec6-0edb8a315068 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | c9fb06a8-9736-49a7-9fcd-1475ba0c04f2 |
+---------------------+--------------------------------------+
```

stack@neha:~$ openstack loadbalancer listener create --protocol TCP --protocol-port 94 --name l4 lb4
```
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-07-01T10:42:29                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 558746bd-e139-4ea5-9abf-4952457572bc |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 7c025c16-7c95-445c-816f-2bc24c046e86 |
| name                        | l4                                   |
| operating_status            | OFFLINE                              |
| project_id                  | e53e09a471d3415ab56dd29d3298d526     |
| protocol                    | TCP                                  |
| protocol_port               | 94                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
+-----------------------------+--------------------------------------+
```

stack@neha:~$ openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener l4 --name p4
```
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-07-01T10:42:42                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | 0bae418c-64ea-4f11-8a85-6334d7a504ac |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | 558746bd-e139-4ea5-9abf-4952457572bc |
| loadbalancers        | 7c025c16-7c95-445c-816f-2bc24c046e86 |
| members              |                                      |
| name                 | p4                                   |
| operating_status     | OFFLINE                              |
| project_id           | e53e09a471d3415ab56dd29d3298d526     |
| protocol             | TCP                                  |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
+----------------------+--------------------------------------+
```

stack@neha:~$ openstack loadbalancer member create --address 10.0.12.22 --subnet-id provider-vlan-12-subnet --protocol-port 96 --name mem4 p4
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.12.22                           |
| admin_state_up      | True                                 |
| created_at          | 2021-07-01T10:43:03                  |
| id                  | dbc20ba3-a76a-4de0-98c4-1161ef57cc1d |
| name                | mem4                                 |
| operating_status    | NO_MONITOR                           |
| project_id          | e53e09a471d3415ab56dd29d3298d526     |
| protocol_port       | 96                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 9c5cbcec-c8a0-4a30-bc56-7879a064a2b2 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
```

Result on device2:

vThunder[p2](NOLICENSE)#show running-config
!Current configuration: 0 bytes
!Configuration last updated at 11:43:09 IST Thu Jul 1 2021
!Configuration last saved at 11:43:15 IST Thu Jul 1 2021
!
active-partition p2
!
!
vrrp-a vrid 0
  floating-ip 10.0.11.180
  floating-ip 10.0.12.118
!
slb server e53e0_10_0_12_22 10.0.12.22
  port 96 tcp
!
slb service-group 0bae418c-64ea-4f11-8a85-6334d7a504ac tcp
  member e53e0_10_0_12_22 96
!
slb virtual-server 7c025c16-7c95-445c-816f-2bc24c046e86 10.0.11.122
  port 94 tcp
    name 558746bd-e139-4ea5-9abf-4952457572bc
    extended-stats
    service-group 0bae418c-64ea-4f11-8a85-6334d7a504ac
!
end
!Current config commit point for partition 2 is 0 & config mode is classical-mode


**Deletion cases:**

stack@neha:~$ **openstack loadbalancer member delete p4 mem4**

vThunder[p2](NOLICENSE)#show running-config
!Current configuration: 60 bytes
!Configuration last updated at 11:44:49 IST Thu Jul 1 2021
!Configuration last saved at 11:44:24 IST Thu Jul 1 2021
!
active-partition p2
!
!
vrrp-a vrid 0
  floating-ip 10.0.11.180
!
slb service-group 0bae418c-64ea-4f11-8a85-6334d7a504ac tcp
!
slb virtual-server 7c025c16-7c95-445c-816f-2bc24c046e86 10.0.11.122
  port 94 tcp
    name 558746bd-e139-4ea5-9abf-4952457572bc
    extended-stats
    service-group 0bae418c-64ea-4f11-8a85-6334d7a504ac
!
end
!Current config commit point for partition 2 is 0 & config mode is classical-mode


stack@neha:~$ **openstack loadbalancer delete lb4 --cascade**

vThunder[p2](NOLICENSE)#show running-config
!Current configuration: 0 bytes
!Configuration last updated at 11:45:45 IST Thu Jul 1 2021
!Configuration last saved at 11:44:54 IST Thu Jul 1 2021
!
active-partition p2
!
!
!
end
!Current config commit point for partition 2 is 0 & config mode is classical-mode
vThunder[p2](NOLICENSE)#


stack@neha:~$ **openstack loadbalancer member delete p3 mem3**

vThunder(NOLICENSE)#show running-config
!Current configuration: 297 bytes
!Configuration last updated at 11:46:34 IST Thu Jul 1 2021
!Configuration last saved at 11:46:40 IST Thu Jul 1 2021
!64-bit Advanced Core OS (ACOS) version 4.1.4-GR1-P5, build 81 (Sep-08-2020,09:32)
!
partition e53e09a471d341 id 1
!
partition p2 id 2
!
!
interface management
  ip address dhcp
!
interface ethernet 1
!
interface ethernet 2
!
interface ethernet 3
!
interface ethernet 4
!
vrrp-a vrid 0
  floating-ip 10.0.11.134
!
slb service-group e601b1f1-c4bb-4f50-9ce7-d76849809b60 tcp
!
slb virtual-server b7e85768-5381-421f-8341-a8126043cf76 10.0.11.103
  port 93 tcp
    name b5ea7515-e36b-4e63-980b-fb76c93e4db4
    extended-stats
    service-group e601b1f1-c4bb-4f50-9ce7-d76849809b60
!
!
cloud-services meta-data
  enable
  provider openstack
!


stack@neha:~$ **openstack loadbalancer member delete p2 mem2**

vThunder[p1](NOLICENSE)#show running-config
!Current configuration: 60 bytes
!Configuration last updated at 11:47:46 IST Thu Jul 1 2021
!Configuration last saved at 11:48:35 IST Thu Jul 1 2021
!
active-partition p1
!
!
vrrp-a vrid 0
  floating-ip 10.0.11.101
!
slb service-group 33b2e38f-0c2f-4df3-a7be-90054885252a tcp
!
slb virtual-server 64457dbe-8be8-4c89-b4bb-c41816d5b277 10.0.11.127
  port 83 tcp
    name b2241f04-086b-4177-94aa-d161595737ba
    extended-stats
    service-group 33b2e38f-0c2f-4df3-a7be-90054885252a
!
end
!Current config commit point for partition 4 is 0 & config mode is classical-mode


stack@neha:~$ **openstack loadbalancer delete lb2 --cascade**

vThunder[p1](NOLICENSE)#show running-config
!Current configuration: 0 bytes
!Configuration last updated at 11:49:41 IST Thu Jul 1 2021
!Configuration last saved at 11:48:35 IST Thu Jul 1 2021
!
active-partition p1
!
!
!
end
!Current config commit point for partition 4 is 0 & config mode is classical-mode
vThunder[p1](NOLICENSE)#

stack@neha:~$ **openstack loadbalancer delete lb3 --cascade**

vThunder(NOLICENSE)#show running-config
!Current configuration: 237 bytes
!Configuration last updated at 11:50:20 IST Thu Jul 1 2021
!Configuration last saved at 11:50:24 IST Thu Jul 1 2021
!64-bit Advanced Core OS (ACOS) version 4.1.4-GR1-P5, build 81 (Sep-08-2020,09:32)
!
partition e53e09a471d341 id 1
!
partition p2 id 2
!
!
interface management
  ip address dhcp
!
interface ethernet 1
!
interface ethernet 2
!
interface ethernet 3
!
interface ethernet 4
!
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode


stack@neha:~$ **openstack loadbalancer delete lb1 --cascade**

vThunder(NOLICENSE)#show running-config
!Current configuration: 299 bytes
!Configuration last updated at 11:51:17 IST Thu Jul 1 2021
!Configuration last saved at 11:22:57 IST Thu Jul 1 2021
!64-bit Advanced Core OS (ACOS) version 4.1.4-GR1-P5, build 81 (Sep-08-2020,09:32)
!
partition e53e09a471d341 id 1
!
partition 60d60d76206843 id 2
!
partition 56443ed3346a4d id 3
!
partition p1 id 4
!
!
interface management
  ip address dhcp
!
interface ethernet 1
!
interface ethernet 2
!
interface ethernet 3
!
interface ethernet 4
!
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode


Also tested simple testcases on vthunder flows as we don't use partitioning there. They are working as expected.