### PR TITLE
[STACK-2601][STACK-2606] remove cannot have project_id attribute in device-name flavor devie limitation

### DIFF
--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -100,10 +100,6 @@ SUPPORTED_NETWORK_TYPE = [FLAT, VLAN]
 SSL_TEMPLATE = "ssl_template"
 
 COMPUTE_BUSY = "compute_busy"
-FLOW_TYPE = 'flow_type'
-CREATE_FLOW = 'create'
-DELETE_FLOW = 'delete'
-UPDATE_FLOW = 'update'
 
 # ============================
 # Taskflow flow and task names

--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -234,13 +234,6 @@ class ProjectDeviceNotFound(acos_errors.ACOSException):
         super(ProjectDeviceNotFound, self).__init__(msg=msg)
 
 
-class DeviceIsProjectDevice(acos_errors.ACOSException):
-    def __init__(self):
-        msg = ('The device already specify project_id in configuration file, '
-               'device-name flavor can not use it.')
-        super(DeviceIsProjectDevice, self).__init__(msg=msg)
-
-
 class FlavorDeviceNotFound(acos_errors.ACOSException):
     def __init__(self, device):
         msg = ('[device-name flavor] Device [{0}] not found in the configuration'

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -582,8 +582,7 @@ class LoadBalancerFlows(object):
             provides=constants.FLAVOR_DATA))
         update_LB_flow.add(vthunder_tasks.GetVthunderConfByFlavor(
             inject={a10constants.VTHUNDER_CONFIG: vthunder_conf,
-                    a10constants.DEVICE_CONFIG_DICT: device_dict,
-                    a10constants.FLOW_TYPE: a10constants.UPDATE_FLOW},
+                    a10constants.DEVICE_CONFIG_DICT: device_dict},
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG,
                       a10constants.DEVICE_CONFIG_DICT, constants.FLAVOR_DATA),
             provides=(a10constants.VTHUNDER_CONFIG, a10constants.USE_DEVICE_FLAVOR)))
@@ -646,8 +645,7 @@ class LoadBalancerFlows(object):
             provides=constants.FLAVOR_DATA))
         lb_create_flow.add(vthunder_tasks.GetVthunderConfByFlavor(
             inject={a10constants.VTHUNDER_CONFIG: vthunder_conf,
-                    a10constants.DEVICE_CONFIG_DICT: device_dict,
-                    a10constants.FLOW_TYPE: a10constants.CREATE_FLOW},
+                    a10constants.DEVICE_CONFIG_DICT: device_dict},
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG,
                       a10constants.DEVICE_CONFIG_DICT, constants.FLAVOR_DATA),
             provides=(a10constants.VTHUNDER_CONFIG, a10constants.USE_DEVICE_FLAVOR)))
@@ -707,8 +705,7 @@ class LoadBalancerFlows(object):
             provides=constants.FLAVOR_DATA))
         delete_LB_flow.add(vthunder_tasks.GetVthunderConfByFlavor(
             inject={a10constants.VTHUNDER_CONFIG: vthunder_conf,
-                    a10constants.DEVICE_CONFIG_DICT: device_dict,
-                    a10constants.FLOW_TYPE: a10constants.DELETE_FLOW},
+                    a10constants.DEVICE_CONFIG_DICT: device_dict},
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG,
                       a10constants.DEVICE_CONFIG_DICT, constants.FLAVOR_DATA),
             provides=(a10constants.VTHUNDER_CONFIG, a10constants.USE_DEVICE_FLAVOR)))

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -333,8 +333,7 @@ class MemberFlows(object):
             provides=constants.FLAVOR))
         delete_member_flow.add(vthunder_tasks.GetVthunderConfByFlavor(
             inject={a10constants.VTHUNDER_CONFIG: vthunder_conf,
-                    a10constants.DEVICE_CONFIG_DICT: device_dict,
-                    a10constants.FLOW_TYPE: a10constants.DELETE_FLOW},
+                    a10constants.DEVICE_CONFIG_DICT: device_dict},
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG,
                       a10constants.DEVICE_CONFIG_DICT),
             rebind={constants.FLAVOR_DATA: constants.FLAVOR},
@@ -668,8 +667,7 @@ class MemberFlows(object):
             provides=constants.FLAVOR))
         update_member_flow.add(vthunder_tasks.GetVthunderConfByFlavor(
             inject={a10constants.VTHUNDER_CONFIG: vthunder_conf,
-                    a10constants.DEVICE_CONFIG_DICT: device_dict,
-                    a10constants.FLOW_TYPE: a10constants.UPDATE_FLOW},
+                    a10constants.DEVICE_CONFIG_DICT: device_dict},
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG,
                       a10constants.DEVICE_CONFIG_DICT),
             rebind={constants.FLAVOR_DATA: constants.FLAVOR},
@@ -723,8 +721,7 @@ class MemberFlows(object):
             provides=constants.FLAVOR))
         create_member_flow.add(vthunder_tasks.GetVthunderConfByFlavor(
             inject={a10constants.VTHUNDER_CONFIG: vthunder_conf,
-                    a10constants.DEVICE_CONFIG_DICT: device_dict,
-                    a10constants.FLOW_TYPE: a10constants.CREATE_FLOW},
+                    a10constants.DEVICE_CONFIG_DICT: device_dict},
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER_CONFIG,
                       a10constants.DEVICE_CONFIG_DICT),
             rebind={constants.FLAVOR_DATA: constants.FLAVOR},

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -1214,8 +1214,7 @@ class VthunderInstanceBusy(VThunderBaseTask):
 
 class GetVthunderConfByFlavor(VThunderBaseTask):
 
-    def execute(self, loadbalancer, vthunder_config, device_config_dict, flavor_data=None,
-                flow_type=None):
+    def execute(self, loadbalancer, vthunder_config, device_config_dict, flavor_data=None):
         if flavor_data is None and vthunder_config is None:
             raise exceptions.ProjectDeviceNotFound()
 
@@ -1225,9 +1224,6 @@ class GetVthunderConfByFlavor(VThunderBaseTask):
                 dev_key = a10constants.DEVICE_KEY_PREFIX + device_flavor
                 if dev_key in device_config_dict:
                     vthunder_config = device_config_dict[dev_key]
-                    if flow_type is None or flow_type == a10constants.CREATE_FLOW:
-                        if vthunder_config.project_id is not None:
-                            raise exceptions.DeviceIsProjectDevice()
                     vthunder_config.project_id = loadbalancer.project_id
                     if vthunder_config.hierarchical_multitenancy == "enable":
                         vthunder_config.partition_name = loadbalancer.project_id[0:14]


### PR DESCRIPTION
## Description
- Required: Severity Level: Critical
- Required: Issue Description
The a10-nlbaas2oct will use device-name flavor and configuration file will have project_id in device-name flavor device. This hit the limitation of a10-octavia:
**STACK-2413: ​The device-name flavor can only specify devices that didn’t specify project_id in configuration file.**

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2601
https://a10networks.atlassian.net/browse/STACK-2606

## Technical Approach
For the limitation in a10-octavia:
- For the Remove the code to raise the error
- Update the RN and move this limitation as a known Issue (as below)
> STACK-2413: ​For device-name flavor with VRID Floating-ip configured; If user create loadbalancer by both project_id and device-name flavor, the loadbalancer creation may failed or VRID Floating-IP may not work properly.

## Config Changes
<pre>
<b>[hardware_thunder]
devices = [
                    {
                     "project_id": "3d21c71c4e4040599933bda62a76ae2f",
                     "ip_address": "192.168.90.46",
                     "username": "admin",
                     "password": "a10",
                     "vrid_floating_ip" : "dhcp",
                     "device_name": "dev2"
                     },
                    {
                     "ip_address": "192.168.90.45",
                     "username": "admin",
                     "password": "a10",
                     "vrid_floating_ip" : "dhcp",
                     "device_name": "dev3"
                     },
             ]
</b>
</pre>


## Test Cases
- create LB, listener, pool and member with device-name flaovr which project_id attribute is also specified in device.
```
openstack loadbalancer create --flavor f_dev2 --vip-subnet-id tp91 --vip-address 192.168.91.56 --name vip1
openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name vport1 vip1
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener vport1 --name sg1
openstack loadbalancer member create --address 192.168.92.238 --subnet-id tp92 --protocol-port 80 --name srv1 sg1
openstack loadbalancer member delete sg1 srv1
openstack loadbalancer pool delete sg1
openstack loadbalancer listener delete vport1
openstack loadbalancer delete vip1
```

## Manual Testing
- create
```
vrrp-a vrid 0
  floating-ip 192.168.91.233
  floating-ip 192.168.92.143
!
slb server 3d21c_192_168_92_238 192.168.92.238
  port 80 tcp
!
slb service-group 0af09d25-607e-4b5e-8cec-a78a920ac351 tcp
  member 3d21c_192_168_92_238 80
!

slb virtual-server 4a2902b4-8ee3-42ec-b772-384d33509e33 192.168.91.108
  port 80 http
    name aaa39318-ca4d-4967-869a-91469032526f
    conn-limit 20000
    extended-stats
    source-nat auto
    service-group 0af09d25-607e-4b5e-8cec-a78a920ac351
!
```
- delete
```
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer member delete sg1 srv1
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer pool delete sg1
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer listener delete vport1
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer delete vip1
stack@ytsai-openstack:~/source/a10-octavia/v1.3$ openstack loadbalancer list

stack@ytsai-openstack:~/source/a10-octavia/v1.3$
```