### PR TITLE
[a10-octavia v2.0] Feature/vcs negotiate state

### DIFF
--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -106,7 +106,7 @@ DELETE_FLOW = 'delete'
 UPDATE_FLOW = 'update'
 
 # ACOS versions
-ACOS_5_2_1_P2 = "5.2.1-p2"
+ACOS_5_2_1_P2 = "5.2.1-P2"
 
 # ============================
 # Taskflow flow and task names

--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -105,6 +105,9 @@ CREATE_FLOW = 'create'
 DELETE_FLOW = 'delete'
 UPDATE_FLOW = 'update'
 
+# ACOS versions
+ACOS_5_2_1_P2 = "5.2.1-p2"
+
 # ============================
 # Taskflow flow and task names
 # ============================

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -123,16 +123,6 @@ class LoadBalancerFlows(object):
         lb_create_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
 
-        # For first LB, vcs just setup and need sync. config and reload vBlade severial times.
-        if not vthunder and topology == constants.TOPOLOGY_ACTIVE_STANDBY:
-            lb_create_flow.add(a10_database_tasks.GetBackupVThunderByLoadBalancer(
-                name="get-blade-thunder-for-checking",
-                requires=constants.LOADBALANCER,
-                provides=a10constants.BACKUP_VTHUNDER))
-            lb_create_flow.add(virtual_server_tasks.WaitVirtualServerReadyOnBlade(
-                requires=(constants.LOADBALANCER),
-                rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
-
         return lb_create_flow
 
     def _create_single_topology(self):

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -334,10 +334,6 @@ class VThunderFlows(object):
             requires=(a10constants.VTHUNDER, a10constants.SET_ID),
             rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
         vrrp_subflow.add(self._get_vrrp_status_subflow(sf_name))
-        # Wait for aVCS sync
-        vrrp_subflow.add(vthunder_tasks.VCSSyncWait(
-            name=sf_name + '-' + a10constants.VCS_SYNC_WAIT + '-for-thunder',
-            requires=a10constants.VTHUNDER))
 
         return vrrp_subflow
 


### PR DESCRIPTION
## Description
- Features story: https://a10networks.atlassian.net/browse/STACK-2322
- design document: https://teams.microsoft.com/l/file/8ACCF57A-2CEF-4E5E-A767-93EDC0ED77DD?tenantId=91d27ab9-8c5e-41d4-82e8-3d1bf81fcb2f&fileType=docx&objectUrl=https%3A%2F%2Fa10networks.sharepoint.com%2Fsites%2FOpenstack%2FShared%20Documents%2FDevelopment%2FResearch%20%26%20Design%2Fa10-octavia%20v2.0%20-%20Victoria%20Support%2FvThunder%20VCS%20issues%20Enhancement%2F%5BDD%5D%20vThunder%20VCS%20issues%20Enhancement.docx&baseUrl=https%3A%2F%2Fa10networks.sharepoint.com%2Fsites%2FOpenstack&serviceName=teams&threadId=19:0f1acbb173d74758b05ee8bacb000d68@thread.tacv2&groupId=37bbf3ad-c05a-4e67-b0cc-12bcd1479beb

acos-client side changes: https://github.com/a10networks/acos-client/pull/351

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2322
https://a10networks.atlassian.net/browse/STACK-2471
https://a10networks.atlassian.net/browse/STACK-2472
https://a10networks.atlassian.net/browse/STACK-2609

## Technical Approach
In ACOS 5.2.1-p2, ACOS provide VCS handshaking status information in vcs summary. Therefore, a10-octavia can use this to check if VCS handshaking is ready. And following a10-octavia operations on vThunders will not be overwrite or removed by VCS reload or configuration merging. 

 
```shell
aXAPI:  GET /axapi/v3/vcs/vcs-summary/oper 
```
```json
{ 
  "vcs-summary": { 
    "oper" : { 
      "vcs-handshake-completed-list": [ 
        { 
          "vcs-handshake-completed-id":2, 
          "vcs-handshake-completed":1 
        } 
      ], 
    }, 
  } 
} 
```

## Config Changes
<pre>
<b>[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
#default_axapi_timeout = 600
l2dsr_support = True
slb_no_snat_support = True

[a10_controller_worker]
amp_image_owner_id = 99c9c2304f114685a32db30769c8a7e2
amp_secgroup_list = 2d0a3480-7f08-4184-b96f-c39bb444dd38
amp_flavor_id = 69995a83-c47a-427f-bf70-e9d9752aa915
amp_boot_network_list = 7f8ddd7f-c5c3-463a-b1c3-596f988480a4
#amp_boot_network_list = 7f8ddd7f-c5c3-463a-b1c3-596f988480a4, 61305531-6e3a-44b4-8e67-05e93363dddc, a66685db-31ee-46c6-928a-ac034d87dc63, ec33a88d-3290-4ad6-95cc-226fcd2a4458
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 150
amp_active_wait_sec = 10
amp_busy_wait_sec = 0
loadbalancer_topology = ACTIVE_STANDBY

# ACOS 5.2.1-p2 build 112
amp_image_id = 2624c20e-7f0a-4c82-abe6-334797aa29e1
</b>
</pre>


## Test Cases
- create 2 LB with different subnet, and check ACOS side after finished
```
openstack loadbalancer create --vip-subnet-id tp91 --name vip1
openstack loadbalancer create --vip-subnet-id tp92 --name vip2

```

## Manual Testing

```
stack@openstack-4:~/source/a10-octavia/vThunder$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address    | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| 1cdc1d6d-ddcf-4943-a742-ebe41778bd04 | vip1 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.179 | ACTIVE              | a10      |
| f244c6ee-fa84-4c73-812d-283a7b5944ed | vip2 | 99c9c2304f114685a32db30769c8a7e2 | 192.168.91.65  | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
```

```
vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 744 bytes
!Configuration last updated at 10:03:03 IST Thu Jul 8 2021
!Configuration last saved at 10:03:07 IST Thu Jul 8 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 192.168.91.59
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.28.68
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.28.68
  health-check octavia_health_monitor
!
slb virtual-server 1cdc1d6d-ddcf-4943-a742-ebe41778bd04 192.168.91.179
!
slb virtual-server f244c6ee-fa84-4c73-812d-283a7b5944ed 192.168.91.65
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
```

```
vThunder-Standby-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 744 bytes
!Configuration last updated at 10:03:03 IST Thu Jul 8 2021
!Configuration last saved at 09:56:45 IST Thu Jul 8 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 192.168.91.59
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.28.68
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.28.68
  health-check octavia_health_monitor
!
slb virtual-server 1cdc1d6d-ddcf-4943-a742-ebe41778bd04 192.168.91.179
!
slb virtual-server f244c6ee-fa84-4c73-812d-283a7b5944ed 192.168.91.65
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
```
