### PR TITLE
[STACK-2628] Added return when server name is not found

### DIFF
--- a/a10_octavia/controller/worker/tasks/server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/server_tasks.py
@@ -125,6 +125,7 @@ class MemberDelete(task.Task):
             LOG.debug("Successfully dissociated member %s from pool %s", member.id, pool.id)
         except acos_errors.NotFound:
             LOG.debug("Unable to find member %s in pool %s", member.id, pool.id)
+            return
         except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception("Failed to dissociate member %s from pool %s",
                           member.id, pool.id)


### PR DESCRIPTION
## Description
Severity Level: Critical

If the server name cannot be found, the flow enters the except block which logs an debug message. However, this results in the `server_name` variable not being defined later in the flow. This does not affect other tasks as the log is the last operation to occur.

## Jira Ticket
[STACK-2628](https://a10networks.atlassian.net/browse/STACK-2628)

## Technical Approach
Added return after location of server name has failed.

## Config Changes
N/A

## Test Cases
N/A

## Manual Testing

### Create slb tree including member
```
openstack loadbalancer create --vip-subnet-id public-subnet --name lb1
openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name l1 lb1
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener l1 --name pool1
openstack loadbalancer member create --subnet-id private-subnet --name mem1 pool1
```

#### Modify the member name in the db
```
mysql> use octavia;
mysql> UPDATE member SET ip_address = '1.1.1.1';
```

### Perform a delete
```
openstack loadbalancer member delete pool1 m2
```

