### PR TITLE
[STACK-2354] Active-Standby Mode Test

### DIFF
--- a/a10_octavia/controller/worker/tasks/utils.py
+++ b/a10_octavia/controller/worker/tasks/utils.py
@@ -20,8 +20,6 @@ from oslo_config import cfg
 
 from a10_octavia.common.data_models import Certificate
 
-from acos_client.v30 import responses as acos_resp
-from requests import exceptions as req_exceptions
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
@@ -129,7 +127,3 @@ def attribute_search(lb_resource, attr_name):
     elif hasattr(lb_resource, 'load_balancer'):
         return attribute_search(lb_resource.load_balancer, attr_name)
     return None
-
-
-def thunder_busy_exceptions():
-    return (acos_resp.axapi_retry_exceptions(), req_exceptions.ReadTimeout)

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -15,6 +15,7 @@
 
 import acos_client
 from acos_client import errors as acos_errors
+
 import datetime
 try:
     import http.client as http_client
@@ -40,7 +41,6 @@ from a10_octavia.controller.worker.tasks.decorators import activate_partition
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator_for_revert
 from a10_octavia.controller.worker.tasks.decorators import device_context_switch_decorator
-from a10_octavia.controller.worker.tasks import utils as a10_task_utils
 from a10_octavia.db import repositories as a10_repo
 
 
@@ -78,7 +78,8 @@ class VThunderComputeConnectivityWait(VThunderBaseTask):
                         attempts = attempts - 1
                         axapi_client.system.information()
                         break
-                    except a10_task_utils.thunder_busy_exceptions():
+                    except (acos_errors.ACOSSystemIsBusy, acos_errors.ACOSSystemNotReady,
+                            req_exceptions.ConnectionError, req_exceptions.ReadTimeout):
                         # acos-client already wait default_axapi_timeout for these exceptions.
                         axapi_timeout = CONF.vthunder.default_axapi_timeout
                         attempt_wait = CONF.a10_controller_worker.amp_active_wait_sec
@@ -356,7 +357,8 @@ class ConfigureaVCSBackup(VThunderBaseTask):
                     attempts = 0
                     LOG.debug("Configured the backup vThunder for aVCS: %s", vthunder.id)
                     break
-                except a10_task_utils.thunder_busy_exceptions() as e:
+                except (acos_errors.ACOSSystemIsBusy, acos_errors.ACOSSystemNotReady,
+                        req_exceptions.ConnectionError, req_exceptions.ReadTimeout) as e:
                     # acos-client already wait default_axapi_timeout for these exceptions.
                     axapi_timeout = CONF.vthunder.default_axapi_timeout
                     attempt_wait = CONF.a10_controller_worker.amp_vcs_wait_sec
@@ -1149,7 +1151,8 @@ class VCSSyncWait(VThunderBaseTask):
                         msg="vMaster not found in vcs-summary")
                 if vmaster_ready is True and vblade_ready is True:
                     break
-            except a10_task_utils.thunder_busy_exceptions() as e:
+            except (acos_errors.ACOSSystemIsBusy, acos_errors.ACOSSystemNotReady,
+                    req_exceptions.ConnectionError, req_exceptions.ReadTimeout) as e:
                 # acos-client already wait default_axapi_timeout for these exceptions.
                 axapi_timeout = CONF.vthunder.default_axapi_timeout
                 attempt_wait = CONF.a10_controller_worker.amp_vcs_wait_sec
@@ -1187,7 +1190,8 @@ class GetMasterVThunder(VThunderBaseTask):
                         raise acos_errors.AxapiJsonFormatError(
                             msg="vMaster not found in vcs-summary")
                     return vthunder
-                except a10_task_utils.thunder_busy_exceptions() as e:
+                except (acos_errors.ACOSSystemIsBusy, acos_errors.ACOSSystemNotReady,
+                        req_exceptions.ConnectionError, req_exceptions.ReadTimeout) as e:
                     # acos-client already wait default_axapi_timeout for these exceptions.
                     axapi_timeout = CONF.vthunder.default_axapi_timeout
                     attempt_wait = CONF.a10_controller_worker.amp_vcs_wait_sec


### PR DESCRIPTION
## Description
Verify vThunder flow basic functionalities for ACTIVE_STANDBY mode

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2354

## Technical Approach
- In Python3 it is expected to provide the name of exception in except block which inherits directly or indirectly from your base class Exception. So when we do specify exceptions by clubbing into a method it treats it as a method of the object and not the class that inherits from the Exception.
 
- To resolve this removed call for **thunder_busy_exceptions()** and raised those exceptions specified in **thunder_busy_exceptions()** directly in **except** block

## Test Cases
- Create/update/Delete a LB, Listener, Pool, Member, HM, L7Policy and L7rule

## Manual Testing

**Create a LB**

```
stack@sana:~$ openstack loadbalancer create --vip-subnet-id vip_subnet --name lb1

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-07-15T08:27:49                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | fe5d4ccf-844c-44cb-967b-209ab8b66e10 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.12.242                       |
| vip_network_id      | 144533bf-db26-440f-a0ca-8ba072769e4a |
| vip_port_id         | 08f70f72-dac6-4692-84f9-95555c92b16a |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
+---------------------+--------------------------------------+

stack@sana:~$

```
```
stack@sana:~$ openstack server list

+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------+----------------+-----------------+
| ID                                   | Name                                         | Status | Networks                                             | Image          | Flavor          |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------+----------------+-----------------+
| 152ad26c-fbeb-46fd-96da-be3f7a9dab4d | amphora-9d334a2c-9636-4897-9527-82c4b9fdbc9e | ACTIVE | lb-mgmt-net=192.168.0.10; vip_network=192.168.12.186 | vThunder.qcow2 | vThunder_flavor |
| 7b6697d1-8611-429d-a25b-d64ec1722452 | amphora-93127849-3b9d-4381-bc8a-646dbda57601 | ACTIVE | lb-mgmt-net=192.168.0.194; vip_network=192.168.12.65 | vThunder.qcow2 | vThunder_flavor |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------+----------------+-----------------+

stack@sana:~$

```
**Create a Listener** 

```
stack@sana:~$ openstack loadbalancer listener create --protocol HTTP --protocol-port 91 lb1 --name l1

+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-07-15T08:39:46                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | d857766f-3b64-4cef-9b74-580d6934216e |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | fe5d4ccf-844c-44cb-967b-209ab8b66e10 |
| name                        | l1                                   |
| operating_status            | OFFLINE                              |
| project_id                  | e1fe759747844dd1871092efe9079a26     |
| protocol                    | HTTP                                 |
| protocol_port               | 91                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
| allowed_cidrs               | None                                 |
| tls_ciphers                 | None                                 |
| tls_versions                | None                                 |
| alpn_protocols              | None                                 |
+-----------------------------+--------------------------------------+

stack@sana:~$
```

**Create a pool**

```
stack@sana:~$ openstack loadbalancer pool create --listener l1  --protocol HTTP --lb-algorithm ROUND_ROBIN --name pool1

+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-07-15T08:41:04                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | 01899fac-6a5e-42ca-9356-8a4a8753b28a |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | d857766f-3b64-4cef-9b74-580d6934216e |
| loadbalancers        | fe5d4ccf-844c-44cb-967b-209ab8b66e10 |
| members              |                                      |
| name                 | pool1                                |
| operating_status     | OFFLINE                              |
| project_id           | e1fe759747844dd1871092efe9079a26     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+

stack@sana:~$

```
**Create a member**

```
stack@sana:~$ openstack loadbalancer member create --subnet-id vip_subnet --protocol-port 83 --address 10.0.0.29 pool1 --name m1

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.0.29                            |
| admin_state_up      | True                                 |
| created_at          | 2021-07-15T08:42:31                  |
| id                  | 850687d2-3605-49a1-80ea-4214d2c82070 |
| name                | m1                                   |
| operating_status    | NO_MONITOR                           |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| protocol_port       | 83                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+

stack@sana:~$
```

**Create a Health monitor**

```
stack@sana:~$ openstack loadbalancer healthmonitor create --delay 10 --timeout 3 --max-retries 3 --type HTTP --name hm1 pool1

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| project_id          | e1fe759747844dd1871092efe9079a26     |
| name                | hm1                                  |
| admin_state_up      | True                                 |
| pools               | 01899fac-6a5e-42ca-9356-8a4a8753b28a |
| created_at          | 2021-07-15T08:43:16                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| delay               | 10                                   |
| expected_codes      | 200                                  |
| max_retries         | 3                                    |
| http_method         | GET                                  |
| timeout             | 3                                    |
| max_retries_down    | 3                                    |
| url_path            | /                                    |
| type                | HTTP                                 |
| id                  | ae49fedc-e198-402e-95b1-552e1d60b7e1 |
| operating_status    | OFFLINE                              |
| http_version        | None                                 |
| domain_name         | None                                 |
+---------------------+--------------------------------------+

stack@sana:~$

```
**Create a L7policy** 

```
stack@sana:~$ openstack loadbalancer l7policy create --action REJECT l1 --name policy

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| listener_id         | d857766f-3b64-4cef-9b74-580d6934216e |
| description         |                                      |
| admin_state_up      | True                                 |
| rules               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| created_at          | 2021-07-15T08:43:35                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| redirect_pool_id    | None                                 |
| redirect_url        | None                                 |
| redirect_prefix     | None                                 |
| action              | REJECT                               |
| position            | 1                                    |
| id                  | fae38be0-5cea-4db9-ac36-e578b01d4818 |
| operating_status    | OFFLINE                              |
| name                | policy                               |
| redirect_http_code  | None                                 |
+---------------------+--------------------------------------+

stack@sana:~$
```

**Create a L7Rule:**

```
stack@sana:~$ openstack loadbalancer l7rule create --type FILE_TYPE --compare-type REGEX --value 'abc' policy

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| created_at          | 2021-07-15T08:45:30                  |
| compare_type        | REGEX                                |
| provisioning_status | PENDING_CREATE                       |
| invert              | False                                |
| admin_state_up      | True                                 |
| updated_at          | None                                 |
| value               | abc                                  |
| key                 | None                                 |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| type                | FILE_TYPE                            |
| id                  | 40462ed5-7a9a-426e-bf7d-901029db41fd |
| operating_status    | OFFLINE                              |
+---------------------+--------------------------------------+

stack@sana:~$

```
**vThunder Configuration:**

**vMaster Configuraation:**

```
vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 601 bytes
!Configuration last updated at 09:45:32 IST Thu Jul 15 2021
!Configuration last saved at 09:45:35 IST Thu Jul 15 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.28.69
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
health monitor ae49fedc-e198-402e-95b1-552e1d60b7e1
  override-port 91
  interval 10 timeout 3
  method http port 91 expect response-code 200 url GET /
!
slb server e1fe7_10_0_0_29 10.0.0.29
  port 83 tcp
!
slb server octavia_health_manager_controller 10.64.28.69
  health-check octavia_health_monitor
!
slb service-group 01899fac-6a5e-42ca-9356-8a4a8753b28a tcp
  health-check ae49fedc-e198-402e-95b1-552e1d60b7e1
  member e1fe7_10_0_0_29 83
!
slb virtual-server fe5d4ccf-844c-44cb-967b-209ab8b66e10 192.168.12.242
  port 91 http
    name d857766f-3b64-4cef-9b74-580d6934216e
    extended-stats
    aflex fae38be0-5cea-4db9-ac36-e578b01d4818
    service-group 01899fac-6a5e-42ca-9356-8a4a8753b28a
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder-Active-vMaster[1/1](NOLICENSE)#
vThunder-Active-vMaster[1/1](NOLICENSE)#show aflex fae38be0-5cea-4db9-ac36-e578b01d4818
Name:                    fae38be0-5cea-4db9-ac36-e578b01d4818
Syntax:                  Check
Virtual port:            Bind
                         fe5d4ccf-844c-44cb-967b-209ab8b66e10: 91
Statistics:
    Event HTTP_REQUEST         execute 0 times (0 failures, 0 aborts)
Content:
 when HTTP_REQUEST {

        if { ([HTTP::uri] matches_regex "abc") } {

        HTTP::close

        }

        }
vThunder-Active-vMaster[1/1](NOLICENSE)#

```

**vBlade Configuration:**

```
vThunder-Standby-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 601 bytes
!Configuration last updated at 09:45:32 IST Thu Jul 15 2021
!Configuration last saved at 09:36:46 IST Thu Jul 15 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.28.69
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
health monitor ae49fedc-e198-402e-95b1-552e1d60b7e1
  override-port 91
  interval 10 timeout 3
  method http port 91 expect response-code 200 url GET /
!
slb server e1fe7_10_0_0_29 10.0.0.29
  port 83 tcp
!
slb server octavia_health_manager_controller 10.64.28.69
  health-check octavia_health_monitor
!
slb service-group 01899fac-6a5e-42ca-9356-8a4a8753b28a tcp
  health-check ae49fedc-e198-402e-95b1-552e1d60b7e1
  member e1fe7_10_0_0_29 83
!
slb virtual-server fe5d4ccf-844c-44cb-967b-209ab8b66e10 192.168.12.242
  port 91 http
    name d857766f-3b64-4cef-9b74-580d6934216e
    extended-stats
    aflex fae38be0-5cea-4db9-ac36-e578b01d4818
    service-group 01899fac-6a5e-42ca-9356-8a4a8753b28a
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder-Standby-vBlade[1/2](NOLICENSE)#
vThunder-Standby-vBlade[1/2](NOLICENSE)#show aflex fae38be0-5cea-4db9-ac36-e578b01d4818
Name:                    fae38be0-5cea-4db9-ac36-e578b01d4818
Syntax:                  Check
Virtual port:            Bind
                         fe5d4ccf-844c-44cb-967b-209ab8b66e10: 91
Statistics:
    Event HTTP_REQUEST         execute 0 times (0 failures, 0 aborts)
Content:
 when HTTP_REQUEST {

        if { ([HTTP::uri] matches_regex "abc") } {

        HTTP::close

        }

        }
vThunder-Standby-vBlade[1/2](NOLICENSE)#

```


**Update Operation:**

```
stack@sana:~$ openstack loadbalancer set --description "First LB" lb1

stack@sana:~$ openstack loadbalancer listener set --connection-limit 5000 l1

stack@sana:~$ openstack loadbalancer pool set --lb-algorithm LEAST_CONNECTIONS pool1

stack@sana:~$ openstack loadbalancer member set pool1 m1

stack@sana:~$ openstack loadbalancer healthmonitor set --delay 20 hm1

stack@sana:~$ openstack loadbalancer l7policy set --action REDIRECT_TO_URL --redirect-url http://www.google.com policy

stack@sana:~$ openstack loadbalancer l7rule set --compare-type EQUAL_TO policy 40462ed5-7a9a-426e-bf7d-901029db41fd

```
**vThunder Configuration:**

**vMaster Configuration:**

```
vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 601 bytes
!Configuration last updated at 10:00:14 IST Thu Jul 15 2021
!Configuration last saved at 10:00:18 IST Thu Jul 15 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.28.69
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
health monitor ae49fedc-e198-402e-95b1-552e1d60b7e1
  override-port 91
  interval 20 timeout 3
  method http port 91 expect response-code 200 url GET /
!
slb server e1fe7_10_0_0_29 10.0.0.29
  port 83 tcp
!
slb server octavia_health_manager_controller 10.64.28.69
  health-check octavia_health_monitor
!
slb service-group 01899fac-6a5e-42ca-9356-8a4a8753b28a tcp
  method least-connection
  health-check ae49fedc-e198-402e-95b1-552e1d60b7e1
  member e1fe7_10_0_0_29 83
!
slb virtual-server fe5d4ccf-844c-44cb-967b-209ab8b66e10 192.168.12.242
  description "First LB"
  port 91 http
    name d857766f-3b64-4cef-9b74-580d6934216e
    conn-limit 5000
    extended-stats
    aflex fae38be0-5cea-4db9-ac36-e578b01d4818
    service-group 01899fac-6a5e-42ca-9356-8a4a8753b28a
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder-Active-vMaster[1/1](NOLICENSE)#sho
vThunder-Active-vMaster[1/1](NOLICENSE)#show aflex fae38be0-5cea-4db9-ac36-e578b01d4818
Name:                    fae38be0-5cea-4db9-ac36-e578b01d4818
Syntax:                  Check
Virtual port:            Bind
                         fe5d4ccf-844c-44cb-967b-209ab8b66e10: 91
Statistics:
    Event HTTP_REQUEST         execute 0 times (0 failures, 0 aborts)
Content:
 when HTTP_REQUEST {

        if { ([HTTP::uri] ends_with "abc") } {

        HTTP::redirect http://www.google.com

        }

        }
vThunder-Active-vMaster[1/1](NOLICENSE)#
```

**vBlade Configuration:**

```
vThunder-Standby-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 601 bytes
!Configuration last updated at 10:00:14 IST Thu Jul 15 2021
!Configuration last saved at 09:36:46 IST Thu Jul 15 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.28.69
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
health monitor ae49fedc-e198-402e-95b1-552e1d60b7e1
  override-port 91
  interval 20 timeout 3
  method http port 91 expect response-code 200 url GET /
!
slb server e1fe7_10_0_0_29 10.0.0.29
  port 83 tcp
!
slb server octavia_health_manager_controller 10.64.28.69
  health-check octavia_health_monitor
!
slb service-group 01899fac-6a5e-42ca-9356-8a4a8753b28a tcp
  method least-connection
  health-check ae49fedc-e198-402e-95b1-552e1d60b7e1
  member e1fe7_10_0_0_29 83
!
slb virtual-server fe5d4ccf-844c-44cb-967b-209ab8b66e10 192.168.12.242
  description "First LB"
  port 91 http
    name d857766f-3b64-4cef-9b74-580d6934216e
    conn-limit 5000
    extended-stats
    aflex fae38be0-5cea-4db9-ac36-e578b01d4818
    service-group 01899fac-6a5e-42ca-9356-8a4a8753b28a
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder-Standby-vBlade[1/2](NOLICENSE)#
vThunder-Standby-vBlade[1/2](NOLICENSE)#
vThunder-Standby-vBlade[1/2](NOLICENSE#)
vThunder-Standby-vBlade[1/2](NOLICENSE)#show aflex fae38be0-5cea-4db9-ac36-e578b01d4818
Name:                    fae38be0-5cea-4db9-ac36-e578b01d4818
Syntax:                  Check
Virtual port:            Bind
                         fe5d4ccf-844c-44cb-967b-209ab8b66e10: 91
Statistics:
    Event HTTP_REQUEST         execute 0 times (0 failures, 0 aborts)
Content:
 when HTTP_REQUEST {

        if { ([HTTP::uri] ends_with "abc") } {

        HTTP::redirect http://www.google.com

        }

        }
vThunder-Standby-vBlade[1/2](NOLICENSE)#
```

**Delete Operation:**

```

stack@sana:~$ openstack loadbalancer l7rule delete policy 40462ed5-7a9a-426e-bf7d-901029db41fd

stack@sana:~$ openstack loadbalancer l7policy delete policy

stack@sana:~$ openstack loadbalancer healthmonitor delete hm1

stack@sana:~$ openstack loadbalancer member delete pool1 m1

stack@sana:~$ openstack loadbalancer pool delete pool1

stack@sana:~$ openstack loadbalancer listener delete l1
```

**Vthunder Configuration:**

**vMaster Configuration:**

```
vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 698 bytes
!Configuration last updated at 10:10:35 IST Thu Jul 15 2021
!Configuration last saved at 10:10:40 IST Thu Jul 15 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.28.69
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.28.69
  health-check octavia_health_monitor
!
slb virtual-server fe5d4ccf-844c-44cb-967b-209ab8b66e10 192.168.12.242
  description "First LB"
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder-Active-vMaster[1/1](NOLICENSE)#
vThunder-Active-vMaster[1/1](NOLICENSE)#show aflex
Max aFlex file size: 32K
Name                                             Syntax   Virtual port
-----------------------------------------------------------------------
host_switching                                   Check    No
http_payload_replace                             Check    No
logging_clients                                  Check    No
redirect1                                        Check    No
redirect2                                        Check    No
redirect_rewrite                                 Check    No
Total aFlex number: 6
vThunder-Active-vMaster[1/1](NOLICENSE)#
```


**vBlade Configuration:**

```
vThunder-Standby-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 698 bytes
!Configuration last updated at 10:10:35 IST Thu Jul 15 2021
!Configuration last saved at 09:36:46 IST Thu Jul 15 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.28.69
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.28.69
  health-check octavia_health_monitor
!
slb virtual-server fe5d4ccf-844c-44cb-967b-209ab8b66e10 192.168.12.242
  description "First LB"
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder-Standby-vBlade[1/2](NOLICENSE)#
vThunder-Standby-vBlade[1/2](NOLICENSE)#show aflex
Max aFlex file size: 32K
Name                                             Syntax   Virtual port
-----------------------------------------------------------------------
host_switching                                   Check    No
http_payload_replace                             Check    No
logging_clients                                  Check    No
redirect1                                        Check    No
redirect2                                        Check    No
redirect_rewrite                                 Check    No
Total aFlex number: 6
vThunder-Standby-vBlade[1/2](NOLICENSE)#
```


**Delete a LB**

```
stack@sana:~$ openstack loadbalancer delete lb1

stack@sana:~$ openstack server list

stack@sana:~$
```

