### PR TITLE
[STACK-2639] Added multi-port compatability with migrated neutron-lbaas servers

### DIFF
--- a/a10_octavia/controller/worker/tasks/server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/server_tasks.py
@@ -44,7 +44,6 @@ class MemberCreate(task.Task):
 
     @axapi_client_decorator
     def execute(self, member, vthunder, pool, member_count_ip, flavor=None):
-        server_name = '{}_{}'.format(member.project_id[:5], member.ip_address.replace('.', '_'))
         server_args = utils.meta(member, 'server', {})
         server_args = utils.dash_to_underscore(server_args)
         server_args['conn_limit'] = CONF.server.conn_limit
@@ -75,14 +74,17 @@ class MemberCreate(task.Task):
 
         try:
             try:
+                server_name = _get_server_name(self.axapi_client, member)
+                self.axapi_client.slb.server.update(server_name, member.ip_address, status=status,
+                                                    server_templates=server_temp,
+                                                    **server_args)
+                LOG.debug("Successfully created member: %s", member.id)
+            except acos_errors.NotFound:
+                server_name = '{}_{}'.format(member.project_id[:5], member.ip_address.replace('.', '_'))
                 self.axapi_client.slb.server.create(server_name, member.ip_address, status=status,
                                                     server_templates=server_temp,
                                                     **server_args)
                 LOG.debug("Successfully created member: %s", member.id)
-            except (acos_errors.Exists, acos_errors.AddressSpecifiedIsInUse):
-                self.axapi_client.slb.server.update(server_name, member.ip_address, status=status,
-                                                    server_templates=server_temp,
-                                                    **server_args)
         except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception("Failed to create member: %s", member.id)
             raise e

--- a/a10_octavia/controller/worker/tasks/server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/server_tasks.py
@@ -80,7 +80,8 @@ class MemberCreate(task.Task):
                                                     **server_args)
                 LOG.debug("Successfully created member: %s", member.id)
             except acos_errors.NotFound:
-                server_name = '{}_{}'.format(member.project_id[:5], member.ip_address.replace('.', '_'))
+                server_name = '{}_{}'.format(member.project_id[:5],
+                                             member.ip_address.replace('.', '_'))
                 self.axapi_client.slb.server.create(server_name, member.ip_address, status=status,
                                                     server_templates=server_temp,
                                                     **server_args)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_server_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_server_tasks.py
@@ -73,7 +73,9 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
         member_task.CONF = self.conf
         return member_task
 
-    def test_MemberCreate_execute_create_with_server_template(self):
+    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    def test_MemberCreate_execute_create_with_server_template(self, mock_server_name):
+        mock_server_name.side_effect = acos_errors.NotFound()
         member_port_count_ip = 1
         member_task = self._create_member_task_with_server_template('my_server_template')
         member_task.execute(MEMBER, VTHUNDER, POOL, member_port_count_ip)
@@ -81,7 +83,9 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
         self.assertIn('template-server', kwargs['server_templates'])
         self.assertEqual(kwargs['server_templates']['template-server'], 'my_server_template')
 
-    def test_MemberCreate_execute_create_with_shared_template_log_warning(self):
+    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    def test_MemberCreate_execute_create_with_shared_template_log_warning(self, mock_server_name):
+        mock_server_name.side_effect = acos_errors.NotFound()
         member_port_count_ip = 1
         member_task = self._create_member_task_with_server_template(
             'my_server_template', use_shared=True)
@@ -94,7 +98,9 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
             member_task.execute(MEMBER, VTHUNDER, POOL, member_port_count_ip)
             self.assertEqual(expected_log, cm.output)
 
-    def test_MemberCreate_execute_create_with_flavor(self):
+    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    def test_MemberCreate_execute_create_with_flavor(self, mock_server_name):
+        mock_server_name.side_effect = acos_errors.NotFound()
         mock_create_member = task.MemberCreate()
         member_port_count_ip = 1
         flavor = {"server": {"conn_limit": 65535, "conn_resume": 5000}}
@@ -107,7 +113,9 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
             SERVER_NAME, MEMBER.ip_address, status=mock.ANY,
             server_templates=mock.ANY, **expect_key_args)
 
-    def test_MemberCreate_execute_create_with_regex_overwrite_flavor(self):
+    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    def test_MemberCreate_execute_create_with_regex_overwrite_flavor(self, mock_server_name):
+        mock_server_name.side_effect = acos_errors.NotFound()
         mock_create_member = task.MemberCreate()
         member_port_count_ip = 1
         flavor = {"server": {"conn_limit": 65535}}
@@ -126,7 +134,9 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
             SERVER_NAME, member_obj.ip_address, status=mock.ANY,
             server_templates=mock.ANY, **expect_key_args)
 
-    def test_MemberCreate_execute_create_with_regex_flavor(self):
+    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    def test_MemberCreate_execute_create_with_regex_flavor(self, mock_server_name):
+        mock_server_name.side_effect = acos_errors.NotFound()
         mock_create_member = task.MemberCreate()
         member_port_count_ip = 1
         flavor = {}
@@ -145,7 +155,9 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
             SERVER_NAME, member_obj.ip_address, status=mock.ANY,
             server_templates=mock.ANY, **expect_key_args)
 
-    def test_MemberCreate_execute_create_flavor_override_config(self):
+    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    def test_MemberCreate_execute_create_flavor_override_config(self, mock_server_name):
+        mock_server_name.side_effect = acos_errors.NotFound()
         self.conf.config(group=a10constants.SERVER_CONF_SECTION, conn_resume=300)
         mock_create_member = task.MemberCreate()
         member_port_count_ip = 1
@@ -168,7 +180,9 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
         self.client_mock.slb.server.delete.assert_called_with(
             SERVER_NAME)
 
-    def test_create_member_task(self):
+    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    def test_create_member_task(self, mock_server_name):
+        mock_server_name.side_effect = acos_errors.NotFound()
         mock_create_member = task.MemberCreate()
         member_port_count_ip = 1
         mock_create_member.CONF = self.conf


### PR DESCRIPTION
## Description
Severity: Low

Handling of the backwards compatibility of real server naming only extends towards the update and delete tasks. However, servers can be used by multiple members. Therefore, the backwards compatibility should also occur in the member create.

## Jira Ticket
- [STACK-2639](https://a10networks.atlassian.net/browse/STACK-2639)

## Technical Approach
- Required: Overview of approach taken to solve the problem
- Optional: List of tasks completed w/ links 

## Config Changes
N/A

## Test Cases
- Updated old test cases to reflect changes in update logic
- Renamed revert test to match intent
- Added create test for multi port 

## Manual Testing

### Create Neutron LBaaS objects
```
neutron lbaas-loadbalancer-create --name lb1 provider-vlan-11-subnet

neutron lbaas-listener-create --protocol http --protocol-port 5 --name l1 --loadbalancer lb1

neutron lbaas-pool-create --lb-algorithm ROUND_ROBIN --protocol http --name p1 --listener l1 --session-persistence type=HTTP_COOKIE

neutron lbaas-healthmonitor-create --delay 10 --timeout 5 --max-retries 4 --type HTTP --pool p1

neutron lbaas-member-create --protocol-port 80 --subnet provider-vlan-12-subnet --address 10.0.12.68 --name m1 p1
```

### Perform Migration with a10-nlbaas2oct
a10_nlbaas2oct --config-file a10-nlbaas2oct/a10_nlbaas2oct/a10_nlbaas2oct.conf --all

### Create a listener and pool in Octavia on the same loadbalancer
```
openstack loadbalancer listener create --name l2 lb1--protocol https --protocol-port 443

openstack loadbalancer pool create --name p2 --protocol https --lb-algorithm LEAST_CONNECTIONS --listener l2

openstack loadbalancer member create --address 10.0.12.68  --subnet-id provider-vlan-12-subnet --protocol-port 443 --name m2 p2
```

### Expected results
- The server with IP of 10.0.12.68 will now have ports 80 and 443
- Each pool will have it's own member