### PR TITLE
[STACK-2173]: [Vthunder][Enable write memory] Loadbalancer was going in ERROR state while performing write memory.

### DIFF
--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -118,6 +118,12 @@ class AmphoraePostVIPPlug(VThunderBaseTask):
                 LOG.debug("Waiting for 30 seconds to trigger vThunder reload.")
                 time.sleep(30)
                 LOG.debug("Successfully reloaded/rebooted vThunder: %s", vthunder.id)
+                if CONF.a10_house_keeping.use_periodic_write_memory == 'enable':
+                    self.vthunder_repo.update_last_write_mem(
+                        db_apis.get_session(),
+                        vthunder.ip_address,
+                        vthunder.partition_name,
+                        last_write_mem=datetime.datetime.utcnow())
             except (acos_errors.ACOSException, req_exceptions.ConnectionError) as e:
                 LOG.exception("Failed to save configuration and reboot on vThunder "
                               "for amphora id: %s", vthunder.amphora_id)
@@ -195,6 +201,12 @@ class AmphoraePostMemberNetworkPlug(VThunderBaseTask):
                 LOG.debug("Waiting for 30 seconds to trigger vThunder reload/reboot.")
                 time.sleep(30)
                 LOG.debug("Successfully rebooted/reloaded vThunder: %s", vthunder.id)
+                if CONF.a10_house_keeping.use_periodic_write_memory == 'enable':
+                    self.vthunder_repo.update_last_write_mem(
+                        db_apis.get_session(),
+                        vthunder.ip_address,
+                        vthunder.partition_name,
+                        last_write_mem=datetime.datetime.utcnow())
             else:
                 LOG.debug("vThunder reboot/relaod is not required for member addition.")
         except (acos_errors.ACOSException, req_exceptions.ConnectionError) as e:
@@ -1056,6 +1068,12 @@ class AmphoraePostNetworkUnplug(VThunderBaseTask):
                     LOG.debug("Waiting for 30 seconds to trigger vThunder reload/reboot.")
                     time.sleep(30)
                     LOG.debug("Successfully rebooted/reloaded vThunder: %s", vthunder.id)
+                    if CONF.a10_house_keeping.use_periodic_write_memory == 'enable':
+                        self.vthunder_repo.update_last_write_mem(
+                            db_apis.get_session(),
+                            vthunder.ip_address,
+                            vthunder.partition_name,
+                            last_write_mem=datetime.datetime.utcnow())
                 else:
                     LOG.debug("vThunder reboot/relaod is not required for member addition.")
         except (acos_errors.ACOSException, req_exceptions.ConnectionError) as e:

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -113,17 +113,17 @@ class AmphoraePostVIPPlug(VThunderBaseTask):
         if added_ports and amphora_id in added_ports and len(added_ports[amphora_id]) > 0:
             try:
                 self.axapi_client.system.action.write_memory()
-                self.axapi_client.system.action.reload_reboot_for_interface_attachment(
-                    vthunder.acos_version)
-                LOG.debug("Waiting for 30 seconds to trigger vThunder reload.")
-                time.sleep(30)
-                LOG.debug("Successfully reloaded/rebooted vThunder: %s", vthunder.id)
                 if CONF.a10_house_keeping.use_periodic_write_memory == 'enable':
                     self.vthunder_repo.update_last_write_mem(
                         db_apis.get_session(),
                         vthunder.ip_address,
                         vthunder.partition_name,
                         last_write_mem=datetime.datetime.utcnow())
+                self.axapi_client.system.action.reload_reboot_for_interface_attachment(
+                    vthunder.acos_version)
+                LOG.debug("Waiting for 30 seconds to trigger vThunder reload.")
+                time.sleep(30)
+                LOG.debug("Successfully reloaded/rebooted vThunder: %s", vthunder.id)
             except (acos_errors.ACOSException, req_exceptions.ConnectionError) as e:
                 LOG.exception("Failed to save configuration and reboot on vThunder "
                               "for amphora id: %s", vthunder.amphora_id)
@@ -196,17 +196,17 @@ class AmphoraePostMemberNetworkPlug(VThunderBaseTask):
             amphora_id = loadbalancer.amphorae[0].id
             if added_ports and amphora_id in added_ports and len(added_ports[amphora_id]) > 0:
                 self.axapi_client.system.action.write_memory()
-                self.axapi_client.system.action.reload_reboot_for_interface_attachment(
-                    vthunder.acos_version)
-                LOG.debug("Waiting for 30 seconds to trigger vThunder reload/reboot.")
-                time.sleep(30)
-                LOG.debug("Successfully rebooted/reloaded vThunder: %s", vthunder.id)
                 if CONF.a10_house_keeping.use_periodic_write_memory == 'enable':
                     self.vthunder_repo.update_last_write_mem(
                         db_apis.get_session(),
                         vthunder.ip_address,
                         vthunder.partition_name,
                         last_write_mem=datetime.datetime.utcnow())
+                self.axapi_client.system.action.reload_reboot_for_interface_attachment(
+                    vthunder.acos_version)
+                LOG.debug("Waiting for 30 seconds to trigger vThunder reload/reboot.")
+                time.sleep(30)
+                LOG.debug("Successfully rebooted/reloaded vThunder: %s", vthunder.id)
             else:
                 LOG.debug("vThunder reboot/relaod is not required for member addition.")
         except (acos_errors.ACOSException, req_exceptions.ConnectionError) as e:
@@ -1063,17 +1063,17 @@ class AmphoraePostNetworkUnplug(VThunderBaseTask):
                 amphora_id = loadbalancer.amphorae[0].id
                 if added_ports and amphora_id in added_ports and len(added_ports[amphora_id]) > 0:
                     self.axapi_client.system.action.write_memory()
-                    self.axapi_client.system.action.reload_reboot_for_interface_detachment(
-                        vthunder.acos_version)
-                    LOG.debug("Waiting for 30 seconds to trigger vThunder reload/reboot.")
-                    time.sleep(30)
-                    LOG.debug("Successfully rebooted/reloaded vThunder: %s", vthunder.id)
                     if CONF.a10_house_keeping.use_periodic_write_memory == 'enable':
                         self.vthunder_repo.update_last_write_mem(
                             db_apis.get_session(),
                             vthunder.ip_address,
                             vthunder.partition_name,
                             last_write_mem=datetime.datetime.utcnow())
+                    self.axapi_client.system.action.reload_reboot_for_interface_detachment(
+                        vthunder.acos_version)
+                    LOG.debug("Waiting for 30 seconds to trigger vThunder reload/reboot.")
+                    time.sleep(30)
+                    LOG.debug("Successfully rebooted/reloaded vThunder: %s", vthunder.id)
                 else:
                     LOG.debug("vThunder reboot/relaod is not required for member addition.")
         except (acos_errors.ACOSException, req_exceptions.ConnectionError) as e:


### PR DESCRIPTION
## Description
Enable write memory and create lbs with different networks, then on interval, lbs were going into error state except the last lb.

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-2173

## Technical Approach
- After write memory operation the updating the last_write_memory column of vthunder.

## Config Changes
<pre>
[a10_house_keeping]
use_periodic_write_memory = 'enable'
write_mem_interval = 1200
</pre>

## Manual Testing
1) Create lbs with different networks.
```
stack@victoria:~/adeeb/a10-octavia$ openstack loadbalancer create --name vs1 --vip-subnet-id private-a-subnet
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-07-19T04:01:34                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | e2e6fd36-adb6-4ce2-adf1-4097e890d142 |
| listeners           |                                      |
| name                | vs1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | bc83270643c14317b1e2653854c1e190     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.0.224                           |
| vip_network_id      | e3b0a3dd-4bb8-48b5-ab48-d6d69a009bf3 |
| vip_port_id         | 1bd1522c-0607-4a95-9357-44312f340af2 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | ea591049-7c49-444f-83d7-dbeb88848d35 |
+---------------------+--------------------------------------+
stack@victoria:~/adeeb/a10-octavia$ openstack loadbalancer create --name vs2 --vip-subnet-id private-b-subnet
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-07-19T04:07:42                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 577112b6-5837-4052-81f3-d9d57c20f7e2 |
| listeners           |                                      |
| name                | vs2                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | bc83270643c14317b1e2653854c1e190     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 11.0.0.131                           |
| vip_network_id      | d6a4c32e-6c17-4aa4-abb6-d07dbe6d60e3 |
| vip_port_id         | fcb3f5fe-7309-423f-84f3-f632db670d38 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | b8013e8b-80d1-4583-8412-78b622cfe261 |
+---------------------+--------------------------------------+
stack@victoria:~/adeeb/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| e2e6fd36-adb6-4ce2-adf1-4097e890d142 | vs1  | bc83270643c14317b1e2653854c1e190 | 10.0.0.224  | ACTIVE              | OFFLINE          | a10      |
| 577112b6-5837-4052-81f3-d9d57c20f7e2 | vs2  | bc83270643c14317b1e2653854c1e190 | 11.0.0.131  | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
stack@victoria:~/adeeb/a10-octavia$
```
![image](https://user-images.githubusercontent.com/76765492/126104569-c3603b9c-1e61-4d3d-aaa6-7518e258fccc.png)


2)On arrival of interval 

```
House-keeping logs:
Jul 19 04:21:07 victoria a10-house-keeper[1779485]: INFO a10_octavia.cmd.a10_house_keeper [-] Initiating the write memory operation for all thunders...
Jul 19 04:21:07 victoria a10-house-keeper[1779485]: INFO a10_octavia.controller.housekeeping.house_keeping [-] Check configuration lost for Thunders : [<a10_octavia.db.models.VThunder object at 0x7fb93cbf94c0>]
Jul 19 04:21:07 victoria a10-house-keeper[1779485]: INFO a10_octavia.controller.housekeeping.house_keeping [-] Finished conf lost check for 1 thunders...
Jul 19 04:21:07 victoria a10-house-keeper[1779485]: INFO a10_octavia.controller.housekeeping.house_keeping [-] Write Memory for Thunders : ['192.168.0.159:shared']
Jul 19 04:21:07 victoria a10-house-keeper[1779485]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.0.159:shared
Jul 19 04:21:07 victoria a10-house-keeper[1779485]: INFO a10_octavia.cmd.a10_house_keeper [-] Initiating the cleanup of old resources...
Jul 19 04:21:07 victoria a10-house-keeper[1779485]: INFO a10_octavia.controller.housekeeping.house_keeping [-] VThunder ids: []
Jul 19 04:21:07 victoria a10-house-keeper[1779485]: INFO a10_octavia.controller.housekeeping.house_keeping [-] Load balancer ids: []
Jul 19 04:21:17 victoria a10-house-keeper[1779485]: INFO a10_octavia.controller.housekeeping.house_keeping [-] Finished running write memory for 1 thunders...

stack@victoria:~/adeeb/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| e2e6fd36-adb6-4ce2-adf1-4097e890d142 | vs1  | bc83270643c14317b1e2653854c1e190 | 10.0.0.224  | ACTIVE              | OFFLINE          | a10      |
| 577112b6-5837-4052-81f3-d9d57c20f7e2 | vs2  | bc83270643c14317b1e2653854c1e190 | 11.0.0.131  | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
stack@victoria:~/adeeb/a10-octavia$
```

![image](https://user-images.githubusercontent.com/76765492/126104466-902ea84b-c314-4048-a71f-da5a06125be6.png)
