### PR TITLE
[STACK-2663][STACK-2664][STACK-2665]unset option for loadbalancer rack/vthunder flow

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -560,7 +560,7 @@ class LoadBalancerFlows(object):
             provides=constants.FLAVOR_DATA))
         update_LB_flow.add(virtual_server_tasks.UpdateVirtualServerTask(
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
-                      constants.FLAVOR_DATA)))
+                      constants.FLAVOR_DATA, constants.UPDATE_DICT)))
         update_LB_flow.add(database_tasks.UpdateLoadbalancerInDB(
             requires=[constants.LOADBALANCER, constants.UPDATE_DICT]))
         update_LB_flow.add(database_tasks.MarkLBActiveInDB(
@@ -613,7 +613,7 @@ class LoadBalancerFlows(object):
 
         update_LB_flow.add(virtual_server_tasks.UpdateVirtualServerTask(
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
-                      constants.FLAVOR_DATA)))
+                      constants.FLAVOR_DATA, constants.UPDATE_DICT)))
         update_LB_flow.add(database_tasks.UpdateLoadbalancerInDB(
             requires=[constants.LOADBALANCER, constants.UPDATE_DICT]))
         if CONF.a10_global.network_type == 'vlan':

--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -91,6 +91,12 @@ class ListenersParent(object):
                 # Adding TERMINATED_HTTPS SSL cert, created in previous task
                 template_args["template_client_ssl"] = listener.id
 
+            if (update_dict and 'default_tls_container_ref' in update_dict
+                    and update_dict["default_tls_container_ref"] is None):
+                template_args["template_client_ssl"] = None
+            else:
+                template_args["template_client_ssl"] = listener.id
+
             template_http = CONF.listener.template_http
             if template_http and template_http.lower() != 'none':
                 template_key = 'template-http'
@@ -195,9 +201,10 @@ class ListenerUpdate(ListenersParent, task.Task):
     """Task to update listener"""
 
     @axapi_client_decorator
-    def execute(self, loadbalancer, listener, vthunder, flavor_data=None, update_dict=None):
+    def execute(self, loadbalancer, listener, vthunder, flavor_data=None, update_dict={}):
         try:
             if listener:
+                listener.__dict__.update(update_dict)
                 self.set(self.axapi_client.slb.virtual_server.vport.replace,
                          loadbalancer, listener, vthunder, flavor_data, update_dict)
                 LOG.debug("Successfully updated listener: %s", listener.id)

--- a/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
@@ -108,8 +108,9 @@ class UpdateVirtualServerTask(LoadBalancerParent, task.Task):
     """Task to update a virtual server"""
 
     @axapi_client_decorator
-    def execute(self, loadbalancer, vthunder, flavor_data=None):
+    def execute(self, loadbalancer, vthunder, flavor_data=None, update_dict={}):
         try:
+            loadbalancer.__dict__.update(update_dict)
             port_list = self.axapi_client.slb.virtual_server.get(
                 loadbalancer.id)['virtual-server'].get('port-list')
             self.set(self.axapi_client.slb.virtual_server.replace, loadbalancer,

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
@@ -492,3 +492,15 @@ class TestHandlerVirtualPortTasks(base.BaseTaskTestCase):
 
         args, kwargs = self.client_mock.slb.virtual_server.vport.replace.call_args
         self.assertEqual(kwargs['conn_limit'], 200)
+
+    def test_unset_http_virtual_port_conn_limit_with_config(self):
+        UPDATE_DICT = {"conn_limit": -1, "default_tls_container_ref": None}
+        listener = self._mock_listener('HTTP', -1)
+        listener_task = task.ListenerUpdate()
+        listener_task.axapi_client = self.client_mock
+        with mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol',
+                        return_value=listener.protocol):
+            listener_task.execute(LB, listener, VTHUNDER, None, UPDATE_DICT)
+        args, kwargs = self.client_mock.slb.virtual_server.vport.replace.call_args
+        self.assertEqual(kwargs['conn_limit'], 64000000)
+        self.assertEqual(kwargs['template_client_ssl'], None)


### PR DESCRIPTION
## Description
- Add unset operation support for load balancer and listener in Rack and Automated flow 

**Design Document:**

https://teams.microsoft.com/l/file/FB58C9F5-594E-4EBB-BF00-72E1406DC12B?tenantId=91d27ab9-8c5e-41d4-82e8-3d1bf81fcb2f&fileType=docx&objectUrl=https%3A%2F%2Fa10networks.sharepoint.com%2Fsites%2FOpenstack%2FShared%20Documents%2FDevelopment%2FResearch%20%26%20Design%2Fa10-octavia%20v2.0%20-%20Victoria%20Support%2FUnset%20Operation%20Support%2F%5BDD%5D%20Unset%20Operation%20Support.docx&baseUrl=https%3A%2F%2Fa10networks.sharepoint.com%2Fsites%2FOpenstack&serviceName=teams&threadId=19:0f1acbb173d74758b05ee8bacb000d68@thread.tacv2&groupId=37bbf3ad-c05a-4e67-b0cc-12bcd1479beb

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2663
https://a10networks.atlassian.net/browse/STACK-2664
https://a10networks.atlassian.net/browse/STACK-2665

## Technical Approach

- Added unset operation support for the **loadbalancer** and **listener** object for both automated flow and rack flow.
- Updated the objects of **Loadbalancer** and **Listener** to get current values specified on Openstack CLI.
- Used **update_dict** for getting current values from Openstack CLI to update the Loadbalancer and Listener object.

## Test Cases

- Added a Unit test for load balancer unset operation
- Added a Unit test for listener unset operation

## Manual Testing

**Automated Flow Result:**

**Loadbalancer:**

1. Create a Lodabalancder with name  and description:

```
stack@sana:~$ openstack loadbalancer create --vip-subnet-id vip_subnet --name lb1 --description "LB1"

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-07-29T13:41:55                  |
| description         | LB1                                |
| flavor_id           | None                                 |
| id                  | 34efd904-b5cb-4654-92a7-2c57ac27e492 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.12.153                       |
| vip_network_id      | 144533bf-db26-440f-a0ca-8ba072769e4a |
| vip_port_id         | 7aa4eccd-9d4e-4f05-8301-914436436a59 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
+---------------------+--------------------------------------+

stack@sana:~$

```
```
stack@sana:~$ openstack server list
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------+----------------+-----------------+
| ID                                   | Name                                         | Status | Networks                                             | Image          | Flavor          |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------+----------------+-----------------+
| 755b3e05-d872-40ba-a55e-bd6358258cbb | amphora-f0f6e8fc-ec16-4b6b-952d-d61d7f00995d | ACTIVE | lb-mgmt-net=192.168.0.118; vip_network=192.168.12.61 | vThunder.qcow2 | vThunder_flavor |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------+----------------+-----------------+

```

**Vthunder Configurations:**

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 192 bytes
!Configuration last updated at 14:58:12 IST Thu Jul 29 2021
!Configuration last saved at 14:58:17 IST Thu Jul 29 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
slb virtual-server 34efd904-b5cb-4654-92a7-2c57ac27e492 192.168.12.153
  description "LB1"
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#

```

2. Unset name and description of Load balancer

**stack@sana:~$ openstack loadbalancer unset --name --description lb1**

**Openstack:**

```
stack@sana:~$ openstack loadbalancer show 34efd904-b5cb-4654-92a7-2c57ac27e492

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-07-29T13:41:55                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 34efd904-b5cb-4654-92a7-2c57ac27e492 |
| listeners           |                                      |
| name                |                                      |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| provider            | a10                                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-07-29T14:02:49                  |
| vip_address         | 192.168.12.153                       |
| vip_network_id      | 144533bf-db26-440f-a0ca-8ba072769e4a |
| vip_port_id         | 7aa4eccd-9d4e-4f05-8301-914436436a59 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
+---------------------+--------------------------------------+

stack@sana:~$
```

**Vthunder Configuration:**

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 171 bytes
!Configuration last updated at 15:02:47 IST Thu Jul 29 2021
!Configuration last saved at 15:02:53 IST Thu Jul 29 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
slb virtual-server 34efd904-b5cb-4654-92a7-2c57ac27e492 192.168.12.153
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#

```

3. Update loadbalancer with name and description 

**stack@sana:~$ openstack loadbalancer set --name "Loadbalancer1" --description "First Loadbalancer" 34efd904-b5cb-4654-92a7-2c57ac27e492**

**Openstack:**

```
stack@sana:~$ openstack loadbalancer show 34efd904-b5cb-4654-92a7-2c57ac27e492

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-07-29T13:41:55                  |
| description         | First Loadbalancer                   |
| flavor_id           | None                                 |
| id                  | 34efd904-b5cb-4654-92a7-2c57ac27e492 |
| listeners           |                                      |
| name                | Loadbalancer1                        |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| provider            | a10                                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-07-29T14:06:21                  |
| vip_address         | 192.168.12.153                       |
| vip_network_id      | 144533bf-db26-440f-a0ca-8ba072769e4a |
| vip_port_id         | 7aa4eccd-9d4e-4f05-8301-914436436a59 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
+---------------------+--------------------------------------+

stack@sana:~$
```


**Vthunder Configuration:**

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 206 bytes
!Configuration last updated at 15:06:19 IST Thu Jul 29 2021
!Configuration last saved at 15:06:24 IST Thu Jul 29 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
slb virtual-server 34efd904-b5cb-4654-92a7-2c57ac27e492 192.168.12.153
  description "First Loadbalancer"
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#

```

4. Unset name and description 

**stack@sana:~$ openstack loadbalancer unset --name --description 34efd904-b5cb-4654-92a7-2c57ac27e492**

**Openstack:**

```
stack@sana:~$ openstack loadbalancer show 34efd904-b5cb-4654-92a7-2c57ac27e492

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-07-29T13:41:55                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 34efd904-b5cb-4654-92a7-2c57ac27e492 |
| listeners           |                                      |
| name                |                                      |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| provider            | a10                                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-07-29T14:09:06                  |
| vip_address         | 192.168.12.153                       |
| vip_network_id      | 144533bf-db26-440f-a0ca-8ba072769e4a |
| vip_port_id         | 7aa4eccd-9d4e-4f05-8301-914436436a59 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
+---------------------+--------------------------------------+

stack@sana:~$

```

**Vthunder Configuration:**

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 171 bytes
!Configuration last updated at 15:09:05 IST Thu Jul 29 2021
!Configuration last saved at 15:09:09 IST Thu Jul 29 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
slb virtual-server 34efd904-b5cb-4654-92a7-2c57ac27e492 192.168.12.153
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#

```

**Listener:**

```
stack@sana:~$ openstack loadbalancer listener create --protocol TERMINATED_HTTPS --default-tls-container-ref http://10.64.28.69/key-manager/v1/containers/2a2839a6-7449-477a-a4e1-7f4334e03f32 --protocol-port 9001 34efd904-b5cb-4654-92a7-2c57ac27e492 --name l1 --connection-limit 4567

+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | 4567                                                                                                                                                                                                                                                                               |
| created_at                  | 2021-07-29T14:17:25                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | http://10.64.28.69/key-manager/v1/containers/2a2839a6-7449-477a-a4e1-7f4334e03f32                                                                                                                                                                                                  |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | 5f05d906-87a3-4eb5-a7c9-09b763100a78                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | 34efd904-b5cb-4654-92a7-2c57ac27e492                                                                                                                                                                                                                                               |
| name                        | l1                                                                                                                                                                                                                                                                                 |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | e1fe759747844dd1871092efe9079a26                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 9001                                                                                                                                                                                                                                                                               |
| provisioning_status         | PENDING_CREATE                                                                                                                                                                                                                                                                     |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | None                                                                                                                                                                                                                                                                               |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

stack@sana:~$

```

**Vthunder Configuration:**

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 189 bytes
!Configuration last updated at 15:17:30 IST Thu Jul 29 2021
!Configuration last saved at 15:17:39 IST Thu Jul 29 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
slb template client-ssl 5f05d906-87a3-4eb5-a7c9-09b763100a78
  cert mycert
  key mykey
!
slb virtual-server 34efd904-b5cb-4654-92a7-2c57ac27e492 192.168.12.153
  port 9001 https
    name 5f05d906-87a3-4eb5-a7c9-09b763100a78
    conn-limit 4567
    extended-stats
    template client-ssl 5f05d906-87a3-4eb5-a7c9-09b763100a78
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#

```

2. Unset name, connection-limit and default-tls-container-ref of listener

**stack@sana:~$ openstack loadbalancer listener unset --name --connection-limit --default-tls-container-ref  l1**

**Openstack:**

```
stack@sana:~$ openstack loadbalancer listener show 5f05d906-87a3-4eb5-a7c9-09b763100a78

+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | -1                                                                                                                                                                                                                                                                                 |
| created_at                  | 2021-07-29T14:17:25                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | None                                                                                                                                                                                                                                                                               |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | 5f05d906-87a3-4eb5-a7c9-09b763100a78                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | 34efd904-b5cb-4654-92a7-2c57ac27e492                                                                                                                                                                                                                                               |
| name                        |                                                                                                                                                                                                                                                                                    |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | e1fe759747844dd1871092efe9079a26                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 9001                                                                                                                                                                                                                                                                               |
| provisioning_status         | ACTIVE                                                                                                                                                                                                                                                                             |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | 2021-07-29T14:21:41                                                                                                                                                                                                                                                                |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

stack@sana:~$
```

**Vthunder Configuration:**

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 189 bytes
!Configuration last updated at 15:21:39 IST Thu Jul 29 2021
!Configuration last saved at 15:21:45 IST Thu Jul 29 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
slb template client-ssl 5f05d906-87a3-4eb5-a7c9-09b763100a78
  cert mycert
  key mykey
!
slb virtual-server 34efd904-b5cb-4654-92a7-2c57ac27e492 192.168.12.153
  port 9001 https
    name 5f05d906-87a3-4eb5-a7c9-09b763100a78
    extended-stats
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#
```


3. Set name, connection-limit and default-tls-container-ref of listener

**stack@sana:~$ openstack loadbalancer listener set --name l1 --connection-limit 6789 --default-tls-container-ref http://10.64.28.69/key-manager/v1/containers/2a2839a6-7449-477a-a4e1-7f4334e03f32 5f05d906-87a3-4eb5-a7c9-09b763100a78**

**Openstack:**

```
stack@sana:~$ openstack loadbalancer listener show 5f05d906-87a3-4eb5-a7c9-09b763100a78

+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | 6789                                                                                                                                                                                                                                                                               |
| created_at                  | 2021-07-29T14:17:25                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | http://10.64.28.69/key-manager/v1/containers/2a2839a6-7449-477a-a4e1-7f4334e03f32                                                                                                                                                                                                  |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | 5f05d906-87a3-4eb5-a7c9-09b763100a78                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | 34efd904-b5cb-4654-92a7-2c57ac27e492                                                                                                                                                                                                                                               |
| name                        | l1                                                                                                                                                                                                                                                                                 |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | e1fe759747844dd1871092efe9079a26                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 9001                                                                                                                                                                                                                                                                               |
| provisioning_status         | ACTIVE                                                                                                                                                                                                                                                                             |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | 2021-07-29T14:26:16                                                                                                                                                                                                                                                                |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

**Vthunder Configuration:**

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 189 bytes
!Configuration last updated at 15:26:15 IST Thu Jul 29 2021
!Configuration last saved at 15:26:19 IST Thu Jul 29 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
slb template client-ssl 5f05d906-87a3-4eb5-a7c9-09b763100a78
  cert mycert
  key mykey
!
slb virtual-server 34efd904-b5cb-4654-92a7-2c57ac27e492 192.168.12.153
  port 9001 https
    name 5f05d906-87a3-4eb5-a7c9-09b763100a78
    conn-limit 6789
    extended-stats
    template client-ssl 5f05d906-87a3-4eb5-a7c9-09b763100a78
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#
```

4. Unset name, connection-limit and default-tls-container-ref of listener

**stack@sana:~$ openstack loadbalancer listener unset --name --connection-limit --default-tls-container-ref l1**

**Openstack:**

```
stack@sana:~$ openstack loadbalancer listener show 5f05d906-87a3-4eb5-a7c9-09b763100a78

+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | -1                                                                                                                                                                                                                                                                                 |
| created_at                  | 2021-07-29T14:17:25                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | None                                                                                                                                                                                                                                                                               |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | 5f05d906-87a3-4eb5-a7c9-09b763100a78                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | 34efd904-b5cb-4654-92a7-2c57ac27e492                                                                                                                                                                                                                                               |
| name                        |                                                                                                                                                                                                                                                                                    |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | e1fe759747844dd1871092efe9079a26                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 9001                                                                                                                                                                                                                                                                               |
| provisioning_status         | ACTIVE                                                                                                                                                                                                                                                                             |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | 2021-07-29T14:21:41                                                                                                                                                                                                                                                                |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

stack@sana:~$
```
```
Vthunder Configuration:

vThunder(NOLICENSE)#show running-config
!Current configuration: 189 bytes
!Configuration last updated at 15:21:39 IST Thu Jul 29 2021
!Configuration last saved at 15:21:45 IST Thu Jul 29 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
slb template client-ssl 5f05d906-87a3-4eb5-a7c9-09b763100a78
  cert mycert
  key mykey
!
slb virtual-server 34efd904-b5cb-4654-92a7-2c57ac27e492 192.168.12.153
  port 9001 https
    name 5f05d906-87a3-4eb5-a7c9-09b763100a78
    extended-stats
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#
```

**Rack flow:**

**Load balancer:**

1. Create a load balancer with name and description 

```
**stack@sana:~$ openstack loadbalancer create --vip-subnet-id vip_subnet --name lb1 --description "LB1"**

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-07-29T14:35:42                  |
| description         | LB1                                  |
| flavor_id           | None                                 |
| id                  | e0541873-779f-40a3-9447-0f4e0797cd31 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.12.13                        |
| vip_network_id      | 144533bf-db26-440f-a0ca-8ba072769e4a |
| vip_port_id         | 0ee6502c-4336-47ff-8c55-5b163f846e05 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
+---------------------+--------------------------------------+

stack@sana:~$
```

**Vthunder Configuration:**

```
ACOS-Active-vMaster[15/2]#show running-config
!Current configuration: 1333 bytes
!Configuration last updated at 06:18:00 CST Fri Jul 30 2021
!Configuration last saved at 06:16:05 CST Fri Jul 30 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!

slb template client-ssl 28f5c3a7-82ab-4df0-9a1c-8228e3bc1629
  cert mycert
  key mykey
!
slb virtual-server e0541873-779f-40a3-9447-0f4e0797cd31 192.168.12.13
  description "LB1"
!
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
ACOS-Active-vMaster[15/2]#
```


2. Unset name and description of Loadbalancer

**stack@sana:~$ openstack loadbalancer unset --name --description lb1**

**Openstack:**

```
stack@sana:~$ openstack loadbalancer show e0541873-779f-40a3-9447-0f4e0797cd31

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-07-29T14:35:42                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | e0541873-779f-40a3-9447-0f4e0797cd31 |
| listeners           |                                      |
| name                |                                      |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| provider            | a10                                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-07-29T14:40:09                  |
| vip_address         | 192.168.12.13                        |
| vip_network_id      | 144533bf-db26-440f-a0ca-8ba072769e4a |
| vip_port_id         | 0ee6502c-4336-47ff-8c55-5b163f846e05 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
+---------------------+--------------------------------------+

stack@sana:~$
```

**Vthunder Configuration:**

```
ACOS-Active-vMaster[15/2]#show running-config slb virtual-server
!Section configuration: 73 bytes
!
slb virtual-server e0541873-779f-40a3-9447-0f4e0797cd31 192.168.12.13
!
ACOS-Active-vMaster[15/2]#
```

3. Update name and description of loadbalancer 

**stack@sana:~$ openstack loadbalancer set --name lb1 --description "First Loadbalancer" e0541873-779f-40a3-9447-0f4e0797cd31**

**Openstack:**

```
stack@sana:~$ openstack loadbalancer show e0541873-779f-40a3-9447-0f4e0797cd31

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-07-29T14:35:42                  |
| description         | First Loadbalancer                   |
| flavor_id           | None                                 |
| id                  | e0541873-779f-40a3-9447-0f4e0797cd31 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| provider            | a10                                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-07-29T14:42:56                  |
| vip_address         | 192.168.12.13                        |
| vip_network_id      | 144533bf-db26-440f-a0ca-8ba072769e4a |
| vip_port_id         | 0ee6502c-4336-47ff-8c55-5b163f846e05 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
+---------------------+--------------------------------------+

stack@sana:~$
```

**Vthunder Configuration:**

```
ACOS-Active-vMaster[15/2]#show running-config slb virtual-server
!Section configuration: 108 bytes
!
slb virtual-server e0541873-779f-40a3-9447-0f4e0797cd31 192.168.12.13
  description "First Loadbalancer"
!
ACOS-Active-vMaster[15/2]#
```

4. Unset name and description of a loadbalancer 

**stack@sana:~$ openstack loadbalancer unset --name --description lb1**

**Openstack:**

```
stack@sana:~$ openstack loadbalancer show e0541873-779f-40a3-9447-0f4e0797cd31

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-07-29T14:35:42                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | e0541873-779f-40a3-9447-0f4e0797cd31 |
| listeners           |                                      |
| name                |                                      |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| provider            | a10                                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-07-29T14:45:16                  |
| vip_address         | 192.168.12.13                        |
| vip_network_id      | 144533bf-db26-440f-a0ca-8ba072769e4a |
| vip_port_id         | 0ee6502c-4336-47ff-8c55-5b163f846e05 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
+---------------------+--------------------------------------+

stack@sana:~$
```

**Vthunder Configuration:**

```
ACOS-Active-vMaster[15/2]#show running-config slb virtual-server
!Section configuration: 73 bytes
!
slb virtual-server e0541873-779f-40a3-9447-0f4e0797cd31 192.168.12.13
!
ACOS-Active-vMaster[15/2]#
```

**Listener:**

1. Create a listener with name, connection-limit and default-tls-container-ref 

**stack@sana:~$ openstack loadbalancer listener create --protocol TERMINATED_HTTPS --default-tls-container-ref http://10.64.28.69/key-manager/v1/containers/2a2839a6-7449-477a-a4e1-7f4334e03f32 --protocol-port 9001 e0541873-779f-40a3-9447-0f4e0797cd31 --name l1 --connection-limit 4567**

```
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | 4567                                                                                                                                                                                                                                                                               |
| created_at                  | 2021-07-29T14:47:34                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | http://10.64.28.69/key-manager/v1/containers/2a2839a6-7449-477a-a4e1-7f4334e03f32                                                                                                                                                                                                  |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | 95bcdc22-143b-4f58-8204-e1b973b861a9                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | e0541873-779f-40a3-9447-0f4e0797cd31                                                                                                                                                                                                                                               |
| name                        | l1                                                                                                                                                                                                                                                                                 |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | e1fe759747844dd1871092efe9079a26                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 9001                                                                                                                                                                                                                                                                               |
| provisioning_status         | PENDING_CREATE                                                                                                                                                                                                                                                                     |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | None                                                                                                                                                                                                                                                                               |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

stack@sana:~$
```

**Vthunder Configuration:**

```
ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 334 bytes
!
slb template client-ssl 95bcdc22-143b-4f58-8204-e1b973b861a9
  cert mycert
  key mykey
!
slb virtual-server e0541873-779f-40a3-9447-0f4e0797cd31 192.168.12.13
  port 9001 https
    name 95bcdc22-143b-4f58-8204-e1b973b861a9
    conn-limit 4567
    extended-stats
    template client-ssl 95bcdc22-143b-4f58-8204-e1b973b861a9
!
ACOS-Active-vMaster[15/2]#
```

2. Unset name, conn-limit and default-tls-container-ref of listener

**stack@sana:~$ openstack loadbalancer listener unset --name --connection-limit --default-tls-container-ref l1**

**Openstack:**

```
stack@sana:~$ openstack loadbalancer listener show 95bcdc22-143b-4f58-8204-e1b973b861a9

+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | -1                                                                                                                                                                                                                                                                                 |
| created_at                  | 2021-07-29T14:47:34                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | None                                                                                                                                                                                                                                                                               |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | 95bcdc22-143b-4f58-8204-e1b973b861a9                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | e0541873-779f-40a3-9447-0f4e0797cd31                                                                                                                                                                                                                                               |
| name                        |                                                                                                                                                                                                                                                                                    |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | e1fe759747844dd1871092efe9079a26                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 9001                                                                                                                                                                                                                                                                               |
| provisioning_status         | ACTIVE                                                                                                                                                                                                                                                                             |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | 2021-07-29T14:53:15                                                                                                                                                                                                                                                                |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

stack@sana:~$
```

**Vthunder Configuration:**

```
ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 251 bytes
!
slb template client-ssl 95bcdc22-143b-4f58-8204-e1b973b861a9
  cert mycert
  key mykey
!
slb virtual-server e0541873-779f-40a3-9447-0f4e0797cd31 192.168.12.13
  port 9001 https
    name 95bcdc22-143b-4f58-8204-e1b973b861a9
    extended-stats
!
ACOS-Active-vMaster[15/2]#

```

2. Update name, conn-limit and default-tls-container-ref of a listener

**stack@sana:~$ openstack loadbalancer listener set --name l1 --connection-limit 6789 --default-tls-container-ref http://10.64.28.69/key-manager/v1/containers/2a2839a6-7449-477a-a4e1-7f4334e03f32 95bcdc22-143b-4f58-8204-e1b973b861a9**

**Vthunder Configuration:**

```
ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 334 bytes
!
slb template client-ssl 95bcdc22-143b-4f58-8204-e1b973b861a9
  cert mycert
  key mykey
!
slb virtual-server e0541873-779f-40a3-9447-0f4e0797cd31 192.168.12.13
  port 9001 https
    name 95bcdc22-143b-4f58-8204-e1b973b861a9
    conn-limit 6789
    extended-stats
    template client-ssl 95bcdc22-143b-4f58-8204-e1b973b861a9
!
ACOS-Active-vMaster[15/2]#

```

4. Unset name, conn-limit and default-tls-container-ref of a listener

**stack@sana:~$ openstack loadbalancer listener unset --name --connection-limit --default-tls-container-ref l1**

**Openstack:**

**stack@sana:~$ openstack loadbalancer listener show 95bcdc22-143b-4f58-8204-e1b973b861a9**

```
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | -1                                                                                                                                                                                                                                                                                 |
| created_at                  | 2021-07-29T14:47:34                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | None                                                                                                                                                                                                                                                                               |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | 95bcdc22-143b-4f58-8204-e1b973b861a9                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | e0541873-779f-40a3-9447-0f4e0797cd31                                                                                                                                                                                                                                               |
| name                        |                                                                                                                                                                                                                                                                                    |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | e1fe759747844dd1871092efe9079a26                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 9001                                                                                                                                                                                                                                                                               |
| provisioning_status         | ACTIVE                                                                                                                                                                                                                                                                             |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | 2021-07-29T15:01:35                                                                                                                                                                                                                                                                |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

stack@sana:~$

```

**Vthunder Configuration:**

```
ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 251 bytes
!
slb template client-ssl 95bcdc22-143b-4f58-8204-e1b973b861a9
  cert mycert
  key mykey
!
slb virtual-server e0541873-779f-40a3-9447-0f4e0797cd31 192.168.12.13
  port 9001 https
    name 95bcdc22-143b-4f58-8204-e1b973b861a9
    extended-stats
!
ACOS-Active-vMaster[15/2]#
```



