### PR TITLE
[STACK-2666][STACK-2667][STACK-2668][STACK-2669]unset option for pool rack flow 

### DIFF
--- a/a10_octavia/controller/worker/tasks/persist_tasks.py
+++ b/a10_octavia/controller/worker/tasks/persist_tasks.py
@@ -32,7 +32,10 @@ class HandleSessionPersistenceDelta(task.Task):
     @axapi_client_decorator
     def execute(self, vthunder, pool):
         sess_pers = pool.session_persistence
-        if sess_pers and sess_pers.type in SP_OBJ_DICT:
+        if pool.session_persistence and hasattr(pool.session_persistence, 'to_dict'):
+            sess_pers = pool.session_persistence.to_dict()
+        if sess_pers and sess_pers['type'] in SP_OBJ_DICT:
+
             # Remove existing persistence template if any
             for sp_type in PERS_TYPE:
                 try:
@@ -46,11 +49,11 @@ class HandleSessionPersistenceDelta(task.Task):
                     LOG.exception("Failed to delete existing session persistence for pool: %s",
                                   pool.id)
                     raise e
-            sp_template = getattr(self.axapi_client.slb.template, SP_OBJ_DICT[sess_pers.type])
+            sp_template = getattr(self.axapi_client.slb.template, SP_OBJ_DICT[sess_pers['type']])
 
             try:
-                if sess_pers.cookie_name:
-                    sp_template.create(pool.id, cookie_name=sess_pers.cookie_name)
+                if sess_pers['cookie_name']:
+                    sp_template.create(pool.id, cookie_name=sess_pers['cookie_name'])
                 else:
                     sp_template.create(pool.id)
                 LOG.debug("Successfully created session persistence template for pool: %s", pool.id)

--- a/a10_octavia/controller/worker/tasks/service_group_tasks.py
+++ b/a10_octavia/controller/worker/tasks/service_group_tasks.py
@@ -136,8 +136,8 @@ class PoolUpdate(PoolParent, task.Task):
     """Task to update pool"""
 
     @axapi_client_decorator
-    def execute(self, pool, vthunder, update_dict, flavor=None):
-        pool.update(update_dict)
+    def execute(self, pool, vthunder, update_dict={}, flavor=None):
+        pool.__dict__.update(update_dict)
         try:
             service_group = self.axapi_client.slb.service_group.get(
                 pool.id)['service-group']

--- a/a10_octavia/controller/worker/tasks/utils.py
+++ b/a10_octavia/controller/worker/tasks/utils.py
@@ -42,9 +42,11 @@ def get_sess_pers_templates(pool):
     c_pers, s_pers, sp = None, None, None
     if pool and pool.session_persistence:
         sp = pool.session_persistence
-        if sp.type == 'HTTP_COOKIE' or sp.type == 'APP_COOKIE':
+        if hasattr(pool.session_persistence, 'to_dict'):
+            sp = pool.session_persistence.to_dict()
+        if sp['type'] == 'HTTP_COOKIE' or sp['type'] == 'APP_COOKIE':
             c_pers = pool.id
-        elif sp.type == 'SOURCE_IP':
+        elif sp['type'] == 'SOURCE_IP':
             s_pers = pool.id
     return c_pers, s_pers
 

--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -94,7 +94,7 @@ class ListenersParent(object):
             if (update_dict and 'default_tls_container_ref' in update_dict
                     and update_dict["default_tls_container_ref"] is None):
                 template_args["template_client_ssl"] = None
-            else:
+            elif listener.protocol == 'https':
                 template_args["template_client_ssl"] = listener.id
 
             template_http = CONF.listener.template_http

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_persist_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_persist_tasks.py
@@ -130,3 +130,11 @@ class TestPersistTasks(BaseTaskTestCase):
         mock_session_persist.axapi_client = self.client_mock
         mock_session_persist.execute(VTHUNDER, self.pool)
         self.client_mock.slb.template.cookie_persistence.delete.assert_not_called()
+
+    def test_unset_session_persistence(self):
+        mock_session_persist = persist_tasks.HandleSessionPersistenceDelta()
+        mock_session_persist.axapi_client = self.client_mock
+        self.pool.session_persistence = None
+        mock_session_persist.execute(VTHUNDER, self.pool)
+        self.client_mock.slb.template.src_ip_persistence.delete.assert_not_called()
+        self.client_mock.slb.template.src_ip_persistence.create.assert_not_called()


### PR DESCRIPTION
## Description

Add support for the pool Unset and member unset operation in both Rack flow and Automated flow.

**Design Document**

https://teams.microsoft.com/l/file/FB58C9F5-594E-4EBB-BF00-72E1406DC12B?tenantId=91d27ab9-8c5e-41d4-82e8-3d1bf81fcb2f&fileType=docx&objectUrl=https%3A%2F%2Fa10networks.sharepoint.com%2Fsites%2FOpenstack%2FShared%20Documents%2FDevelopment%2FResearch%20%26%20Design%2Fa10-octavia%20v2.0%20-%20Victoria%20Support%2FUnset%20Operation%20Support%2F%5BDD%5D%20Unset%20Operation%20Support.docx&baseUrl=https%3A%2F%2Fa10networks.sharepoint.com%2Fsites%2FOpenstack&serviceName=teams&threadId=19:0f1acbb173d74758b05ee8bacb000d68@thread.tacv2&groupId=37bbf3ad-c05a-4e67-b0cc-12bcd1479beb

## Jira Ticket

https://a10networks.atlassian.net/browse/STACK-2666
https://a10networks.atlassian.net/browse/STACK-2667
https://a10networks.atlassian.net/browse/STACK-2668
https://a10networks.atlassian.net/browse/STACK-2669

## Technical Approach

- Updated the object of a **Pool**  with current values specified on Openstack CLI.
- Used **update_dict** for getting current values from Openstack CLI to update the **Pool** object.
- Updated the **pool.session_persistence** object using **update_dict** for getting current values specified on Openstack CLI
- Converted **pool.session_persistence** in **dict()** format to support pool set and unset operation with updated object for the parameter **session_persistence**.

## Manual Testing

**- Verified the code by providing session persistence during creating pool as well as during set operation**

```
Steps:
- Create a loadabalancer
- Create a listener
- Create a pool
- Unset a pool
- Update a pool
- Unset a pool

```

**- Verified the code for member unset operation by setting and un-seting member name parameter**
```
Steps:
- Create a member
- Unset a member 
- Set a member
- Unset a member  

```

**Automated Flow:**

**1. Create a LB**

```
stack@sana:~$ openstack loadbalancer create --vip-subnet-id vip_subnet --name lb1 --description "LB1"

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-08-02T04:42:29                  |
| description         | LB1                                  |
| flavor_id           | None                                 |
| id                  | 0878b1a0-84b8-4fc0-98fd-3d5d81cc2e58 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.12.140                       |
| vip_network_id      | 144533bf-db26-440f-a0ca-8ba072769e4a |
| vip_port_id         | f42dd869-9790-4608-bbf5-a09d4d1bba0b |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
+---------------------+--------------------------------------+

stack@sana:~$
```

**2. Create a Listener**

```
stack@sana:~$ openstack loadbalancer listener create --protocol HTTP --protocol-port 90 lb1     

+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-08-02T04:48:25                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 3a3cbe41-93bb-4425-b790-58e550e34c87 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 0878b1a0-84b8-4fc0-98fd-3d5d81cc2e58 |
| name                        |                                      |
| operating_status            | OFFLINE                              |
| project_id                  | e1fe759747844dd1871092efe9079a26     |
| protocol                    | HTTP                                 |
| protocol_port               | 90                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
| allowed_cidrs               | None                                 |
| tls_ciphers                 | None                                 |
| tls_versions                | None                                 |
| alpn_protocols              | None                                 |
+-----------------------------+--------------------------------------+

stack@sana:~$

```

**3. Create a pool with session persistence**

```
stack@sana:~$ openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener 3a3cbe41-93bb-4425-b790-58e550e34c87 --name pool1 --description "Pool1" --session-persistence type=SOURCE_IP

+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-08-02T04:51:03                  |
| description          | Pool1                                |
| healthmonitor_id     |                                      |
| id                   | 09017cc8-4f56-4957-bcb9-bed22baf345c |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | 3a3cbe41-93bb-4425-b790-58e550e34c87 |
| loadbalancers        | 0878b1a0-84b8-4fc0-98fd-3d5d81cc2e58 |
| members              |                                      |
| name                 | pool1                                |
| operating_status     | OFFLINE                              |
| project_id           | e1fe759747844dd1871092efe9079a26     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | type=SOURCE_IP                       |
|                      | cookie_name=None                     |
|                      | persistence_timeout=None             |
|                      | persistence_granularity=None         |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+

stack@sana:~$
```

**VThunder Configuration:**

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 228 bytes
!Configuration last updated at 05:51:04 IST Mon Aug 2 2021
!Configuration last saved at 05:51:07 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
slb service-group 09017cc8-4f56-4957-bcb9-bed22baf345c tcp
!
slb template persist source-ip 09017cc8-4f56-4957-bcb9-bed22baf345c
!
slb virtual-server 0878b1a0-84b8-4fc0-98fd-3d5d81cc2e58 192.168.12.140
  description "LB1"
  port 90 http
    name 3a3cbe41-93bb-4425-b790-58e550e34c87
    extended-stats
    service-group 09017cc8-4f56-4957-bcb9-bed22baf345c
    template persist source-ip 09017cc8-4f56-4957-bcb9-bed22baf345c
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#
```

**4. unset pool session persistence**

```
stack@sana:~$ openstack loadbalancer pool unset --session-persistence 09017cc8-4f56-4957-bcb9-bed22baf345c

stack@sana:~$ openstack loadbalancer pool show 09017cc8-4f56-4957-bcb9-bed22baf345c

+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-08-02T04:51:03                  |
| description          | Pool1                                |
| healthmonitor_id     |                                      |
| id                   | 09017cc8-4f56-4957-bcb9-bed22baf345c |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | 3a3cbe41-93bb-4425-b790-58e550e34c87 |
| loadbalancers        | 0878b1a0-84b8-4fc0-98fd-3d5d81cc2e58 |
| members              |                                      |
| name                 | pool1                                |
| operating_status     | OFFLINE                              |
| project_id           | e1fe759747844dd1871092efe9079a26     |
| protocol             | HTTP                                 |
| provisioning_status  | ACTIVE                               |
| session_persistence  | None                                 |
| updated_at           | 2021-08-02T04:52:50                  |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+

stack@sana:~$

```
**VThunder Configuration:**

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 228 bytes
!Configuration last updated at 05:52:49 IST Mon Aug 2 2021
!Configuration last saved at 05:52:53 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
slb service-group 09017cc8-4f56-4957-bcb9-bed22baf345c tcp
!
slb template persist source-ip 09017cc8-4f56-4957-bcb9-bed22baf345c
!
slb virtual-server 0878b1a0-84b8-4fc0-98fd-3d5d81cc2e58 192.168.12.140
  description "LB1"
  port 90 http
    name 3a3cbe41-93bb-4425-b790-58e550e34c87
    extended-stats
    service-group 09017cc8-4f56-4957-bcb9-bed22baf345c
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#

```

**5. Set pool session Persistence** 

```
stack@sana:~$ openstack loadbalancer pool set --session-persistence type=SOURCE_IP --name pool1 --description "POOL1" 09017cc8-4f56-4957-bcb9-bed22baf345c

stack@sana:~$ openstack loadbalancer pool show 09017cc8-4f56-4957-bcb9-bed22baf345c

+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-08-02T04:51:03                  |
| description          | POOL1                                |
| healthmonitor_id     |                                      |
| id                   | 09017cc8-4f56-4957-bcb9-bed22baf345c |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | 3a3cbe41-93bb-4425-b790-58e550e34c87 |
| loadbalancers        | 0878b1a0-84b8-4fc0-98fd-3d5d81cc2e58 |
| members              |                                      |
| name                 | pool1                                |
| operating_status     | OFFLINE                              |
| project_id           | e1fe759747844dd1871092efe9079a26     |
| protocol             | HTTP                                 |
| provisioning_status  | ACTIVE                               |
| session_persistence  | type=SOURCE_IP                       |
|                      | cookie_name=None                     |
|                      | persistence_timeout=None             |
|                      | persistence_granularity=None         |
| updated_at           | 2021-08-02T04:54:53                  |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+

stack@sana:~$
```

**VThunder Configuration:**

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 228 bytes
!Configuration last updated at 05:54:52 IST Mon Aug 2 2021
!Configuration last saved at 05:54:56 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
slb service-group 09017cc8-4f56-4957-bcb9-bed22baf345c tcp
!
slb template persist source-ip 09017cc8-4f56-4957-bcb9-bed22baf345c
!
slb virtual-server 0878b1a0-84b8-4fc0-98fd-3d5d81cc2e58 192.168.12.140
  description "LB1"
  port 90 http
    name 3a3cbe41-93bb-4425-b790-58e550e34c87
    extended-stats
    service-group 09017cc8-4f56-4957-bcb9-bed22baf345c
    template persist source-ip 09017cc8-4f56-4957-bcb9-bed22baf345c
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#
```

**6. Unset pool session persistence**

```
stack@sana:~$ openstack loadbalancer pool unset --session-persistence --name --description 09017cc8-4f56-4957-bcb9-bed22baf345c

stack@sana:~$ openstack loadbalancer pool show 09017cc8-4f56-4957-bcb9-bed22baf345c

+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-08-02T04:51:03                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | 09017cc8-4f56-4957-bcb9-bed22baf345c |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | 3a3cbe41-93bb-4425-b790-58e550e34c87 |
| loadbalancers        | 0878b1a0-84b8-4fc0-98fd-3d5d81cc2e58 |
| members              |                                      |
| name                 |                                      |
| operating_status     | OFFLINE                              |
| project_id           | e1fe759747844dd1871092efe9079a26     |
| protocol             | HTTP                                 |
| provisioning_status  | ACTIVE                               |
| session_persistence  | None                                 |
| updated_at           | 2021-08-02T04:57:11                  |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+

stack@sana:~$

```
**VThunder Configuration:**

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 228 bytes
!Configuration last updated at 05:57:10 IST Mon Aug 2 2021
!Configuration last saved at 05:57:13 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
slb service-group 09017cc8-4f56-4957-bcb9-bed22baf345c tcp
!
slb template persist source-ip 09017cc8-4f56-4957-bcb9-bed22baf345c
!
slb virtual-server 0878b1a0-84b8-4fc0-98fd-3d5d81cc2e58 192.168.12.140
  description "LB1"
  port 90 http
    name 3a3cbe41-93bb-4425-b790-58e550e34c87
    extended-stats
    service-group 09017cc8-4f56-4957-bcb9-bed22baf345c
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#
```

**7. Create  a member**

```
stack@sana:~$  openstack loadbalancer member create --subnet-id vip_subnet --protocol-port 81 --address 10.10.10.15 --name member1 09017cc8-4f56-4957-bcb9-bed22baf345c

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.10.10.15                          |
| admin_state_up      | True                                 |
| created_at          | 2021-08-02T05:00:07                  |
| id                  | c773d3dc-0d98-463a-b00f-812748d77fed |
| name                | member1                              |
| operating_status    | NO_MONITOR                           |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| protocol_port       | 81                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+

stack@sana:~$
```

**VThunder Configuration:**

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 168 bytes
!Configuration last updated at 06:00:10 IST Mon Aug 2 2021
!Configuration last saved at 06:00:13 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
slb server e1fe7_10_10_10_15 10.10.10.15
  port 81 tcp
!
slb service-group 09017cc8-4f56-4957-bcb9-bed22baf345c tcp
  member e1fe7_10_10_10_15 81
!
slb template persist source-ip 09017cc8-4f56-4957-bcb9-bed22baf345c
!
slb virtual-server 0878b1a0-84b8-4fc0-98fd-3d5d81cc2e58 192.168.12.140
  description "LB1"
  port 90 http
    name 3a3cbe41-93bb-4425-b790-58e550e34c87
    extended-stats
    service-group 09017cc8-4f56-4957-bcb9-bed22baf345c
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#
```

**8. Unset name of a member**

```
stack@sana:~$ openstack loadbalancer member unset --name 09017cc8-4f56-4957-bcb9-bed22baf345c c773d3dc-0d98-463a-b00f-812748d77fed

stack@sana:~$ openstack loadbalancer member show 09017cc8-4f56-4957-bcb9-bed22baf345c c773d3dc-0d98-463a-b00f-812748d77fed

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.10.10.15                          |
| admin_state_up      | True                                 |
| created_at          | 2021-08-02T05:00:07                  |
| id                  | c773d3dc-0d98-463a-b00f-812748d77fed |
| name                |                                      |
| operating_status    | NO_MONITOR                           |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| protocol_port       | 81                                   |
| provisioning_status | ACTIVE                               |
| subnet_id           | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
| updated_at          | 2021-08-02T05:01:55                  |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+

stack@sana:~$
```

**9. set Name of a member**

```
stack@sana:~$ openstack loadbalancer member set --name member1 09017cc8-4f56-4957-bcb9-bed22baf345c c773d3dc-0d98-463a-b00f-812748d77fed

stack@sana:~$ openstack loadbalancer member list 09017cc8-4f56-4957-bcb9-bed22baf345c

+--------------------------------------+---------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| id                                   | name    | project_id                       | provisioning_status | address     | protocol_port | operating_status | weight |
+--------------------------------------+---------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| c773d3dc-0d98-463a-b00f-812748d77fed | member1 | e1fe759747844dd1871092efe9079a26 | ACTIVE              | 10.10.10.15 |            81 | NO_MONITOR       |      1 |
+--------------------------------------+---------+----------------------------------+---------------------+-------------+---------------+------------------+--------+

stack@sana:~$
```

**10. unset name of a member** 

```
stack@sana:~$ openstack loadbalancer member unset --name 09017cc8-4f56-4957-bcb9-bed22baf345c c773d3dc-0d98-463a-b00f-812748d77fed

stack@sana:~$ openstack loadbalancer member list 09017cc8-4f56-4957-bcb9-bed22baf345c

+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address     | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| c773d3dc-0d98-463a-b00f-812748d77fed |      | e1fe759747844dd1871092efe9079a26 | ACTIVE              | 10.10.10.15 |            81 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
stack@sana:~$
```

**Rackflow :**

**1. Create a LB**

```
stack@sana:~$ openstack loadbalancer create --vip-subnet-id vip_subnet --name lb1 --description "LB1"

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-08-02T05:17:33                  |
| description         | LB1                                  |
| flavor_id           | None                                 |
| id                  | d4d1d75e-2044-46cd-b3ce-b16ff0ff76ae |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.12.7                         |
| vip_network_id      | 144533bf-db26-440f-a0ca-8ba072769e4a |
| vip_port_id         | 37422faf-08fb-44fc-9f35-cc74818e540f |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
+---------------------+--------------------------------------+

stack@sana:~$
```

**2. Create a Listener**

```
stack@sana:~$ openstack loadbalancer listener create --protocol HTTP --protocol-port 90 lb1  

+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-08-02T05:18:19                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 7b4dab2e-38ff-4df1-b12d-049e581ffe77 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | d4d1d75e-2044-46cd-b3ce-b16ff0ff76ae |
| name                        |                                      |
| operating_status            | OFFLINE                              |
| project_id                  | e1fe759747844dd1871092efe9079a26     |
| protocol                    | HTTP                                 |
| protocol_port               | 90                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
| allowed_cidrs               | None                                 |
| tls_ciphers                 | None                                 |
| tls_versions                | None                                 |
| alpn_protocols              | None                                 |
+-----------------------------+--------------------------------------+

stack@sana:~$

```
**3. Create a pool with session persistence**

```
stack@sana:~$ openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener 7b4dab2e-38ff-4df1-b12d-049e581ffe77 --name pool1 --description "Pool1" --session-persistence type=SOURCE_IP

+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-08-02T05:19:26                  |
| description          | Pool1                                |
| healthmonitor_id     |                                      |
| id                   | e3efc21d-9ccc-4737-beaf-cb872a670acf |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | 7b4dab2e-38ff-4df1-b12d-049e581ffe77 |
| loadbalancers        | d4d1d75e-2044-46cd-b3ce-b16ff0ff76ae |
| members              |                                      |
| name                 | pool1                                |
| operating_status     | OFFLINE                              |
| project_id           | e1fe759747844dd1871092efe9079a26     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | type=SOURCE_IP                       |
|                      | cookie_name=None                     |
|                      | persistence_timeout=None             |
|                      | persistence_granularity=None         |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+

stack@sana:~$

```
**VThunder Configuration:**

```
ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 433 bytes
!
slb template persist source-ip e3efc21d-9ccc-4737-beaf-cb872a670acf
!
slb service-group e3efc21d-9ccc-4737-beaf-cb872a670acf tcp
!
slb virtual-server d4d1d75e-2044-46cd-b3ce-b16ff0ff76ae 192.168.12.7
  description "LB1"
  port 90 http
    name 7b4dab2e-38ff-4df1-b12d-049e581ffe77
    extended-stats
    service-group e3efc21d-9ccc-4737-beaf-cb872a670acf
    template persist source-ip e3efc21d-9ccc-4737-beaf-cb872a670acf
!
ACOS-Active-vMaster[15/2]#
```

**4. unset pool session persistence**

```
stack@sana:~$ openstack loadbalancer pool unset --name --description --session-persistence e3efc21d-9ccc-4737-beaf-cb872a670acf

stack@sana:~$ openstack loadbalancer pool show e3efc21d-9ccc-4737-beaf-cb872a670acf

+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-08-02T05:19:26                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | e3efc21d-9ccc-4737-beaf-cb872a670acf |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | 7b4dab2e-38ff-4df1-b12d-049e581ffe77 |
| loadbalancers        | d4d1d75e-2044-46cd-b3ce-b16ff0ff76ae |
| members              |                                      |
| name                 |                                      |
| operating_status     | OFFLINE                              |
| project_id           | e1fe759747844dd1871092efe9079a26     |
| protocol             | HTTP                                 |
| provisioning_status  | ACTIVE                               |
| session_persistence  | None                                 |
| updated_at           | 2021-08-02T05:22:27                  |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+

stack@sana:~$
```

**VThunder Configuration:**

```
ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 364 bytes
!
slb template persist source-ip e3efc21d-9ccc-4737-beaf-cb872a670acf
!
slb service-group e3efc21d-9ccc-4737-beaf-cb872a670acf tcp
!
slb virtual-server d4d1d75e-2044-46cd-b3ce-b16ff0ff76ae 192.168.12.7
  description "LB1"
  port 90 http
    name 7b4dab2e-38ff-4df1-b12d-049e581ffe77
    extended-stats
    service-group e3efc21d-9ccc-4737-beaf-cb872a670acf
!
ACOS-Active-vMaster[15/2]#
```

**5. Set pool session Persistence** 

```
stack@sana:~$ openstack loadbalancer pool set --session-persistence type=HTTP_COOKIE --name pool1 --description "POOL1" e3efc21d-9ccc-4737-beaf-cb872a670acf

stack@sana:~$ openstack loadbalancer pool show e3efc21d-9ccc-4737-beaf-cb872a670acf

+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-08-02T05:19:26                  |
| description          | POOL1                                |
| healthmonitor_id     |                                      |
| id                   | e3efc21d-9ccc-4737-beaf-cb872a670acf |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | 7b4dab2e-38ff-4df1-b12d-049e581ffe77 |
| loadbalancers        | d4d1d75e-2044-46cd-b3ce-b16ff0ff76ae |
| members              |                                      |
| name                 | pool1                                |
| operating_status     | OFFLINE                              |
| project_id           | e1fe759747844dd1871092efe9079a26     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_UPDATE                       |
| session_persistence  | type=HTTP_COOKIE                     |
|                      | cookie_name=None                     |
|                      | persistence_timeout=None             |
|                      | persistence_granularity=None         |
| updated_at           | 2021-08-02T05:24:34                  |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+

stack@sana:~$
```

**VThunder Configuration:**

```
ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 427 bytes
!
slb template persist cookie e3efc21d-9ccc-4737-beaf-cb872a670acf
!
slb service-group e3efc21d-9ccc-4737-beaf-cb872a670acf tcp
!
slb virtual-server d4d1d75e-2044-46cd-b3ce-b16ff0ff76ae 192.168.12.7
  description "LB1"
  port 90 http
    name 7b4dab2e-38ff-4df1-b12d-049e581ffe77
    extended-stats
    service-group e3efc21d-9ccc-4737-beaf-cb872a670acf
    template persist cookie e3efc21d-9ccc-4737-beaf-cb872a670acf
!
ACOS-Active-vMaster[15/2]#
```

**6. Unset pool session persistence**

```
stack@sana:~$ openstack loadbalancer pool unset --name --description --session-persistence e3efc21d-9ccc-4737-beaf-cb872a670acf

stack@sana:~$ openstack loadbalancer pool show e3efc21d-9ccc-4737-beaf-cb872a670acf
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-08-02T05:19:26                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | e3efc21d-9ccc-4737-beaf-cb872a670acf |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | 7b4dab2e-38ff-4df1-b12d-049e581ffe77 |
| loadbalancers        | d4d1d75e-2044-46cd-b3ce-b16ff0ff76ae |
| members              |                                      |
| name                 |                                      |
| operating_status     | OFFLINE                              |
| project_id           | e1fe759747844dd1871092efe9079a26     |
| protocol             | HTTP                                 |
| provisioning_status  | ACTIVE                               |
| session_persistence  | None                                 |
| updated_at           | 2021-08-02T05:25:59                  |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+

stack@sana:~$

```

**VThunder Configuration:**

```
ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 361 bytes
!
slb template persist cookie e3efc21d-9ccc-4737-beaf-cb872a670acf
!
slb service-group e3efc21d-9ccc-4737-beaf-cb872a670acf tcp
!
slb virtual-server d4d1d75e-2044-46cd-b3ce-b16ff0ff76ae 192.168.12.7
  description "LB1"
  port 90 http
    name 7b4dab2e-38ff-4df1-b12d-049e581ffe77
    extended-stats
    service-group e3efc21d-9ccc-4737-beaf-cb872a670acf
!
ACOS-Active-vMaster[15/2]#

```
**7. Create  a member**

```
stack@sana:~$ openstack loadbalancer member create --subnet-id vip_subnet --protocol-port 81 --address 10.10.10.15 --name member1 e3efc21d-9ccc-4737-beaf-cb872a670acf

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.10.10.15                          |
| admin_state_up      | True                                 |
| created_at          | 2021-08-02T05:28:24                  |
| id                  | b87d1edd-05d9-44e0-92ca-ed0ec93b6afc |
| name                | member1                              |
| operating_status    | NO_MONITOR                           |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| protocol_port       | 81                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+

stack@sana:~$
```

**VThunder Configuration:**

```
ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 451 bytes
!
slb template persist cookie e3efc21d-9ccc-4737-beaf-cb872a670acf
!
slb server e1fe7_10_10_10_15 10.10.10.15
  port 81 tcp
!
slb service-group e3efc21d-9ccc-4737-beaf-cb872a670acf tcp
  member e1fe7_10_10_10_15 81
!
slb virtual-server d4d1d75e-2044-46cd-b3ce-b16ff0ff76ae 192.168.12.7
  description "LB1"
  port 90 http
    name 7b4dab2e-38ff-4df1-b12d-049e581ffe77
    extended-stats
    service-group e3efc21d-9ccc-4737-beaf-cb872a670acf
!
ACOS-Active-vMaster[15/2]#
```

**8. Unset name of a member**

```
stack@sana:~$ openstack loadbalancer member unset --name e3efc21d-9ccc-4737-beaf-cb872a670acf b87d1edd-05d9-44e0-92ca-ed0ec93b6afc

stack@sana:~$ openstack loadbalancer member list e3efc21d-9ccc-4737-beaf-cb872a670acf
+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address     | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| b87d1edd-05d9-44e0-92ca-ed0ec93b6afc |      | e1fe759747844dd1871092efe9079a26 | ACTIVE              | 10.10.10.15 |            81 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+

stack@sana:~$
```

**9. set Name of a member**

```
stack@sana:~$ openstack loadbalancer member set --name Member1 e3efc21d-9ccc-4737-beaf-cb872a670acf b87d1edd-05d9-44e0-92ca-ed0ec93b6afc

stack@sana:~$ openstack loadbalancer member list e3efc21d-9ccc-4737-beaf-cb872a670acf

+--------------------------------------+---------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| id                                   | name    | project_id                       | provisioning_status | address     | protocol_port | operating_status | weight |
+--------------------------------------+---------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| b87d1edd-05d9-44e0-92ca-ed0ec93b6afc | Member1 | e1fe759747844dd1871092efe9079a26 | ACTIVE              | 10.10.10.15 |            81 | NO_MONITOR       |      1 |
+--------------------------------------+---------+----------------------------------+---------------------+-------------+---------------+------------------+--------+

stack@sana:~$
```

**10. unset name of a member** 

```
stack@sana:~$ openstack loadbalancer member unset --name e3efc21d-9ccc-4737-beaf-cb872a670acf b87d1edd-05d9-44e0-92ca-ed0ec93b6afc

stack@sana:~$ openstack loadbalancer member list e3efc21d-9ccc-4737-beaf-cb872a670acf

+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address     | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| b87d1edd-05d9-44e0-92ca-ed0ec93b6afc |      | e1fe759747844dd1871092efe9079a26 | ACTIVE              | 10.10.10.15 |            81 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+

stack@sana:~$

```