### PR TITLE
[STACK-2322][STACK-2709]: Dynamic Interface Detection Enhancement for loadbalancers and members

### DIFF
--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -101,6 +101,9 @@ SSL_TEMPLATE = "ssl_template"
 
 COMPUTE_BUSY = "compute_busy"
 
+# ACOS versions
+ACOS_5_2_1_P2 = "5.2.1-P2"
+
 # ============================
 # Taskflow flow and task names
 # ============================

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -123,16 +123,6 @@ class LoadBalancerFlows(object):
         lb_create_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
 
-        # For first LB, vcs just setup and need sync. config and reload vBlade severial times.
-        if not vthunder and topology == constants.TOPOLOGY_ACTIVE_STANDBY:
-            lb_create_flow.add(a10_database_tasks.GetBackupVThunderByLoadBalancer(
-                name="get-blade-thunder-for-checking",
-                requires=constants.LOADBALANCER,
-                provides=a10constants.BACKUP_VTHUNDER))
-            lb_create_flow.add(virtual_server_tasks.WaitVirtualServerReadyOnBlade(
-                requires=(constants.LOADBALANCER),
-                rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
-
         return lb_create_flow
 
     def _create_single_topology(self):
@@ -353,7 +343,7 @@ class LoadBalancerFlows(object):
             name=a10constants.GET_VTHUNDER_BY_LB,
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
-        if vthunder and topology == constants.TOPOLOGY_SINGLE:
+        if vthunder:
             new_LB_net_subflow.add(a10_database_tasks.GetLoadBalancerListByProjectID(
                 requires=a10constants.VTHUNDER,
                 provides=a10constants.LOADBALANCERS_LIST))
@@ -362,6 +352,10 @@ class LoadBalancerFlows(object):
                 provides=constants.DELTAS))
             new_LB_net_subflow.add(a10_network_tasks.HandleNetworkDeltas(
                 requires=constants.DELTAS, provides=constants.ADDED_PORTS))
+            if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+                new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
+                    name="wait-vcs-ready-before-master-reload",
+                    requires=a10constants.VTHUNDER))
             # managing interface additions here
             new_LB_net_subflow.add(vthunder_tasks.AmphoraePostVIPPlug(
                 name=a10constants.AMPHORAE_POST_VIP_PLUG,
@@ -371,6 +365,28 @@ class LoadBalancerFlows(object):
                 vthunder_tasks.VThunderComputeConnectivityWait(
                     name=a10constants.VTHUNDER_CONNECTIVITY_WAIT,
                     requires=(a10constants.VTHUNDER, constants.AMPHORA)))
+            if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+                new_LB_net_subflow.add(
+                    a10_database_tasks.GetBackupVThunderByLoadBalancer(
+                        name=a10constants.GET_BACKUP_VTHUNDER_BY_LB,
+                        requires=constants.LOADBALANCER,
+                        provides=a10constants.BACKUP_VTHUNDER))
+                new_LB_net_subflow.add(
+                    vthunder_tasks.VThunderComputeConnectivityWait(
+                        name=a10constants.BACKUP_CONNECTIVITY_WAIT,
+                        rebind={
+                            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
+                        requires=constants.AMPHORA))
+                new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
+                    name="wait-vcs-ready-after-reload",
+                    requires=a10constants.VTHUNDER))
+                new_LB_net_subflow.add(vthunder_tasks.GetMasterVThunder(
+                    name=a10constants.GET_VTHUNDER_MASTER,
+                    requires=a10constants.VTHUNDER,
+                    provides=a10constants.VTHUNDER))
+                new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
+                    name="backup-plug-wait-vcs-ready-test",
+                    requires=a10constants.VTHUNDER))
             new_LB_net_subflow.add(vthunder_tasks.EnableInterface(
                 name=a10constants.ENABLE_VTHUNDER_INTERFACE,
                 requires=(a10constants.VTHUNDER, constants.LOADBALANCER,
@@ -390,115 +406,13 @@ class LoadBalancerFlows(object):
         if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
             new_LB_net_subflow.add(
                 a10_database_tasks.GetBackupVThunderByLoadBalancer(
-                    name=a10constants.GET_BACKUP_VTHUNDER_BY_LB,
+                    name=a10constants.BACKUP_VTHUNDER,
                     requires=constants.LOADBALANCER,
                     provides=a10constants.BACKUP_VTHUNDER))
             new_LB_net_subflow.add(vthunder_tasks.UpdateAcosVersionInVthunderEntry(
                 name=a10constants.UPDATE_ACOS_VERSION_FOR_BACKUP_VTHUNDER,
                 requires=constants.LOADBALANCER,
                 rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
-            new_LB_net_subflow.add(
-                a10_database_tasks.GetBackupVThunderByLoadBalancer(
-                    name=a10constants.BACKUP_VTHUNDER,
-                    requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
-                    provides=a10constants.BACKUP_VTHUNDER))
-            if vthunder:
-                new_LB_net_subflow.add(a10_database_tasks.GetLoadBalancerListByProjectID(
-                    requires=a10constants.VTHUNDER,
-                    provides=a10constants.LOADBALANCERS_LIST))
-                new_LB_net_subflow.add(a10_network_tasks.CalculateDelta(
-                    requires=(constants.LOADBALANCER, a10constants.LOADBALANCERS_LIST),
-                    provides=constants.DELTAS))
-                new_LB_net_subflow.add(a10_network_tasks.HandleNetworkDeltas(
-                    requires=constants.DELTAS, provides=constants.ADDED_PORTS))
-
-                # Make sure vcs ready before first probe-network-devices on Master
-                new_LB_net_subflow.add(
-                    vthunder_tasks.VThunderComputeConnectivityWait(
-                        name="backup-compute-conn-wait-before-probe-device",
-                        rebind={
-                            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-                        requires=constants.AMPHORA))
-                new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
-                    name="wait-vcs-ready-before-probe-device",
-                    requires=a10constants.VTHUNDER))
-                new_LB_net_subflow.add(vthunder_tasks.AmphoraePostVIPPlug(
-                    name=a10constants.AMPHORAE_POST_VIP_PLUG_FOR_MASTER,
-                    requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
-                              constants.ADDED_PORTS)))
-                new_LB_net_subflow.add(
-                    vthunder_tasks.VThunderComputeConnectivityWait(
-                        name="make-sure-backup-is-ready-after-reload-master",
-                        rebind={
-                            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-                        requires=constants.AMPHORA))
-                new_LB_net_subflow.add(vthunder_tasks.AmphoraePostVIPPlug(
-                    name=a10constants.AMPHORAE_POST_VIP_PLUG_FOR_BACKUP,
-                    requires=(constants.LOADBALANCER, constants.ADDED_PORTS),
-                    rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
-                new_LB_net_subflow.add(
-                    vthunder_tasks.VThunderComputeConnectivityWait(
-                        name=a10constants.MASTER_CONNECTIVITY_WAIT,
-                        requires=(a10constants.VTHUNDER, constants.AMPHORA)))
-                new_LB_net_subflow.add(
-                    vthunder_tasks.VThunderComputeConnectivityWait(
-                        name=a10constants.BACKUP_CONNECTIVITY_WAIT,
-                        rebind={
-                            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-                        requires=constants.AMPHORA))
-                new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
-                    name="backup-plug-wait-vcs-ready",
-                    requires=a10constants.VTHUNDER))
-                new_LB_net_subflow.add(vthunder_tasks.GetVThunderInterface(
-                    name=a10constants.GET_MASTER_VTHUNDER_INTERFACE,
-                    requires=a10constants.VTHUNDER,
-                    provides=(a10constants.IFNUM_MASTER, a10constants.IFNUM_BACKUP)))
-                new_LB_net_subflow.add(vthunder_tasks.EnableInterface(
-                    name=a10constants.MASTER_ENABLE_INTERFACE,
-                    requires=(a10constants.VTHUNDER, constants.LOADBALANCER, constants.ADDED_PORTS,
-                              a10constants.IFNUM_MASTER, a10constants.IFNUM_BACKUP)))
-                new_LB_net_subflow.add(vthunder_tasks.GetVThunderInterface(
-                    name=a10constants.GET_BACKUP_VTHUNDER_INTERFACE,
-                    requires=a10constants.VTHUNDER,
-                    rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-                    provides=(a10constants.IFNUM_MASTER, a10constants.IFNUM_BACKUP)))
-                new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
-                    name="wait-vcs-ready-before-master-reload",
-                    requires=a10constants.VTHUNDER))
-                new_LB_net_subflow.add(vthunder_tasks.AmphoraePostVIPPlug(
-                    name=a10constants.AMP_POST_VIP_PLUG,
-                    requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
-                              constants.ADDED_PORTS)))
-                new_LB_net_subflow.add(
-                    vthunder_tasks.VThunderComputeConnectivityWait(
-                        name=a10constants.CONNECTIVITY_WAIT_FOR_MASTER_VTHUNDER,
-                        requires=(a10constants.VTHUNDER, constants.AMPHORA)))
-                new_LB_net_subflow.add(
-                    vthunder_tasks.VThunderComputeConnectivityWait(
-                        name=a10constants.CONNECTIVITY_WAIT_FOR_BACKUP_VTHUNDER,
-                        rebind={
-                            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-                        requires=constants.AMPHORA))
-                new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
-                    name="int-sync-reload-wait-vcs-ready",
-                    requires=a10constants.VTHUNDER))
-                new_LB_net_subflow.add(vthunder_tasks.GetMasterVThunder(
-                    name=a10constants.GET_VTHUNDER_MASTER,
-                    requires=a10constants.VTHUNDER,
-                    provides=a10constants.VTHUNDER))
-                new_LB_net_subflow.add(a10_database_tasks.GetBackupVThunderByLoadBalancer(
-                    name="get-backup-vthunder-after-get-master",
-                    requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
-                    provides=a10constants.BACKUP_VTHUNDER))
-                new_LB_net_subflow.add(vthunder_tasks.EnableInterface(
-                    name=a10constants.BACKUP_ENABLE_INTERFACE,
-                    requires=(a10constants.VTHUNDER, constants.LOADBALANCER, constants.ADDED_PORTS,
-                              a10constants.IFNUM_MASTER, a10constants.IFNUM_BACKUP)))
-            else:
-                new_LB_net_subflow.add(vthunder_tasks.VThunderComputeConnectivityWait(
-                    name=a10constants.CONNECTIVITY_WAIT_FOR_BACKUP_VTHUNDER,
-                    rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-                    requires=constants.AMPHORA))
             new_LB_net_subflow.add(vthunder_tasks.EnableInterface(
                 name=a10constants.ENABLE_BACKUP_VTHUNDER_INTERFACE,
                 rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -57,29 +57,33 @@ class MemberFlows(object):
         create_member_flow.add(database_tasks.GetAmphoraeFromLoadbalancer(
             requires=constants.LOADBALANCER,
             provides=constants.AMPHORA))
+        create_member_flow.add(a10_database_tasks.GetMemberListByProjectID(
+            requires=a10constants.VTHUNDER,
+            provides=a10constants.MEMBER_LIST))
         create_member_flow.add(a10_network_tasks.CalculateDelta(
-            requires=(constants.LOADBALANCER, a10constants.LOADBALANCERS_LIST),
+            requires=(constants.LOADBALANCER, a10constants.LOADBALANCERS_LIST,
+                      a10constants.MEMBER_LIST),
             provides=constants.DELTAS))
         create_member_flow.add(a10_network_tasks.HandleNetworkDeltas(
             requires=constants.DELTAS, provides=constants.ADDED_PORTS))
+        if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+            create_member_flow.add(vthunder_tasks.VCSSyncWait(
+                name="vcs_sync_wait_before_probe_device",
+                requires=a10constants.VTHUNDER))
+            create_member_flow.add(vthunder_tasks.GetMasterVThunder(
+                name=a10constants.GET_VTHUNDER_MASTER,
+                requires=a10constants.VTHUNDER,
+                provides=a10constants.VTHUNDER))
         # managing interface additions here
-        if topology == constants.TOPOLOGY_SINGLE:
-            create_member_flow.add(
-                vthunder_tasks.AmphoraePostMemberNetworkPlug(
-                    requires=(
-                        constants.LOADBALANCER,
-                        constants.ADDED_PORTS,
-                        a10constants.VTHUNDER)))
-            create_member_flow.add(vthunder_tasks.VThunderComputeConnectivityWait(
-                name=a10constants.VTHUNDER_CONNECTIVITY_WAIT,
-                requires=(a10constants.VTHUNDER, constants.AMPHORA)))
-            create_member_flow.add(
-                vthunder_tasks.EnableInterfaceForMembers(
-                    requires=[
-                        constants.ADDED_PORTS,
-                        constants.LOADBALANCER,
-                        a10constants.VTHUNDER]))
-        # configure member flow for HA
+        create_member_flow.add(
+            vthunder_tasks.AmphoraePostMemberNetworkPlug(
+                requires=(
+                    constants.LOADBALANCER,
+                    constants.ADDED_PORTS,
+                    a10constants.VTHUNDER)))
+        create_member_flow.add(vthunder_tasks.VThunderComputeConnectivityWait(
+            name=a10constants.VTHUNDER_CONNECTIVITY_WAIT,
+            requires=(a10constants.VTHUNDER, constants.AMPHORA)))
         if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
             create_member_flow.add(
                 a10_database_tasks.GetBackupVThunderByLoadBalancer(
@@ -91,71 +95,18 @@ class MemberFlows(object):
                 requires=constants.AMPHORA,
                 rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
             create_member_flow.add(vthunder_tasks.VCSSyncWait(
-                name="vcs_sync_wait_before_probe_device",
-                requires=a10constants.VTHUNDER))
-            create_member_flow.add(
-                vthunder_tasks.AmphoraePostMemberNetworkPlug(
-                    requires=(
-                        constants.LOADBALANCER,
-                        constants.ADDED_PORTS,
-                        a10constants.VTHUNDER)))
-            create_member_flow.add(
-                vthunder_tasks.AmphoraePostMemberNetworkPlug(
-                    name="backup_amphora_network_plug", requires=[
-                        constants.ADDED_PORTS, constants.LOADBALANCER], rebind={
-                        a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
-            create_member_flow.add(vthunder_tasks.VThunderComputeConnectivityWait(
-                name=a10constants.MASTER_CONNECTIVITY_WAIT,
-                requires=(a10constants.VTHUNDER, constants.AMPHORA)))
-            create_member_flow.add(vthunder_tasks.VThunderComputeConnectivityWait(
-                name=a10constants.BACKUP_CONNECTIVITY_WAIT,
-                requires=constants.AMPHORA,
-                rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
-            create_member_flow.add(vthunder_tasks.VCSSyncWait(
                 name="backup-plug-wait-vcs-ready",
                 requires=a10constants.VTHUNDER))
             create_member_flow.add(vthunder_tasks.GetMasterVThunder(
                 name=a10constants.GET_MASTER_VTHUNDER,
                 requires=a10constants.VTHUNDER,
                 provides=a10constants.VTHUNDER))
-            create_member_flow.add(a10_database_tasks.GetBackupVThunderByLoadBalancer(
-                name="get_backup_vThunder_after_get_master",
-                requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
-                provides=a10constants.BACKUP_VTHUNDER))
-            create_member_flow.add(
-                vthunder_tasks.EnableInterfaceForMembers(
-                    name=a10constants.ENABLE_MASTER_VTHUNDER_INTERFACE,
-                    requires=[
-                        constants.ADDED_PORTS,
-                        constants.LOADBALANCER,
-                        a10constants.VTHUNDER]))
-            create_member_flow.add(vthunder_tasks.AmphoraePostMemberNetworkPlug(
-                name="amphorae-post-member-network-plug-for-master",
-                requires=(constants.LOADBALANCER, constants.ADDED_PORTS,
-                          a10constants.VTHUNDER)))
-            create_member_flow.add(
-                vthunder_tasks.VThunderComputeConnectivityWait(
-                    name=a10constants.CONNECTIVITY_WAIT_FOR_MASTER_VTHUNDER,
-                    requires=(a10constants.VTHUNDER, constants.AMPHORA)))
-            create_member_flow.add(
-                vthunder_tasks.VThunderComputeConnectivityWait(
-                    name=a10constants.CONNECTIVITY_WAIT_FOR_BACKUP_VTHUNDER,
-                    rebind={
-                        a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-                    requires=constants.AMPHORA))
-            create_member_flow.add(vthunder_tasks.VCSSyncWait(
-                name="member_enable_interface_vcs_sync_wait",
-                requires=a10constants.VTHUNDER))
-            create_member_flow.add(vthunder_tasks.GetMasterVThunder(
-                name=a10constants.GET_VTHUNDER_MASTER,
-                requires=a10constants.VTHUNDER,
-                provides=a10constants.VTHUNDER))
-            create_member_flow.add(
-                vthunder_tasks.EnableInterfaceForMembers(
-                    requires=[
-                        constants.ADDED_PORTS,
-                        constants.LOADBALANCER,
-                        a10constants.VTHUNDER]))
+        create_member_flow.add(
+            vthunder_tasks.EnableInterfaceForMembers(
+                requires=[
+                    constants.ADDED_PORTS,
+                    constants.LOADBALANCER,
+                    a10constants.VTHUNDER]))
         create_member_flow.add(self.handle_vrid_for_member_subflow())
         create_member_flow.add(a10_database_tasks.CountMembersWithIP(
             requires=constants.MEMBER, provides=a10constants.MEMBER_COUNT_IP
@@ -223,11 +174,23 @@ class MemberFlows(object):
         delete_member_flow.add(a10_database_tasks.GetLoadBalancerListByProjectID(
             requires=a10constants.VTHUNDER,
             provides=a10constants.LOADBALANCERS_LIST))
+        delete_member_flow.add(a10_database_tasks.GetMemberListByProjectID(
+            requires=a10constants.VTHUNDER,
+            provides=a10constants.MEMBER_LIST))
         delete_member_flow.add(a10_network_tasks.CalculateDelta(
-            requires=(constants.LOADBALANCER, a10constants.LOADBALANCERS_LIST),
+            requires=(constants.LOADBALANCER, a10constants.LOADBALANCERS_LIST,
+                      a10constants.MEMBER_LIST),
             provides=constants.DELTAS))
         delete_member_flow.add(a10_network_tasks.HandleNetworkDeltas(
             requires=constants.DELTAS, provides=constants.ADDED_PORTS))
+        if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+            delete_member_flow.add(vthunder_tasks.VCSSyncWait(
+                name=a10constants.VCS_SYNC_WAIT,
+                requires=a10constants.VTHUNDER))
+            delete_member_flow.add(vthunder_tasks.GetMasterVThunder(
+                name=a10constants.GET_MASTER_VTHUNDER,
+                requires=a10constants.VTHUNDER,
+                provides=a10constants.VTHUNDER))
         delete_member_flow.add(
             vthunder_tasks.AmphoraePostNetworkUnplug(
                 requires=(
@@ -246,16 +209,6 @@ class MemberFlows(object):
             delete_member_flow.add(
                 vthunder_tasks.VThunderComputeConnectivityWait(
                     name=a10constants.BACKUP_CONNECTIVITY_WAIT + "-before-unplug",
-                    requires=constants.AMPHORA,
-                    rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
-            delete_member_flow.add(
-                vthunder_tasks.AmphoraePostNetworkUnplug(
-                    name=a10constants.AMPHORA_POST_NETWORK_UNPLUG_FOR_BACKUP_VTHUNDER,
-                    requires=(constants.LOADBALANCER, constants.ADDED_PORTS),
-                    rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
-            delete_member_flow.add(
-                vthunder_tasks.VThunderComputeConnectivityWait(
-                    name=a10constants.BACKUP_CONNECTIVITY_WAIT,
                     requires=constants.AMPHORA,
                     rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
             delete_member_flow.add(vthunder_tasks.VCSSyncWait(
@@ -490,7 +443,8 @@ class MemberFlows(object):
             a10_database_tasks.GetVRIDForLoadbalancerResource(
                 requires=[
                     a10constants.PARTITION_PROJECT_LIST,
-                    a10constants.VTHUNDER],
+                    a10constants.VTHUNDER,
+                    constants.LOADBALANCER],
                 provides=a10constants.VRID_LIST))
         delete_member_vrid_subflow.add(
             a10_network_tasks.DeleteVRIDPort(
@@ -534,7 +488,8 @@ class MemberFlows(object):
                 name='get_vrid_for_loadbalancer_resource' + pool,
                 requires=[
                     a10constants.PARTITION_PROJECT_LIST,
-                    a10constants.VTHUNDER],
+                    a10constants.VTHUNDER,
+                    constants.LOADBALANCER],
                 provides=a10constants.VRID_LIST))
         delete_member_vrid_subflow.add(
             a10_network_tasks.DeleteMultipleVRIDPort(
@@ -567,7 +522,8 @@ class MemberFlows(object):
             a10_database_tasks.GetVRIDForLoadbalancerResource(
                 requires=[
                     a10constants.PARTITION_PROJECT_LIST,
-                    a10constants.VTHUNDER],
+                    a10constants.VTHUNDER,
+                    constants.LOADBALANCER],
                 provides=a10constants.VRID_LIST))
         handle_vrid_for_member_subflow.add(
             a10_network_tasks.HandleVRIDFloatingIP(

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -125,6 +125,9 @@ class PoolFlows(object):
         delete_pool_flow.add(a10_database_tasks.GetLoadBalancerListByProjectID(
             requires=a10constants.VTHUNDER,
             provides=a10constants.LOADBALANCERS_LIST))
+        delete_pool_flow.add(a10_database_tasks.GetMemberListByProjectID(
+            requires=a10constants.VTHUNDER,
+            provides=a10constants.MEMBER_LIST))
         delete_pool_flow.add(a10_network_tasks.CalculateDelta(
             requires=(constants.LOADBALANCER, a10constants.LOADBALANCERS_LIST),
             provides=constants.DELTAS))

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -334,10 +334,6 @@ class VThunderFlows(object):
             requires=(a10constants.VTHUNDER, a10constants.SET_ID),
             rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
         vrrp_subflow.add(self._get_vrrp_status_subflow(sf_name))
-        # Wait for aVCS sync
-        vrrp_subflow.add(vthunder_tasks.VCSSyncWait(
-            name=sf_name + '-' + a10constants.VCS_SYNC_WAIT + '-for-thunder',
-            requires=a10constants.VTHUNDER))
 
         return vrrp_subflow
 

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -343,10 +343,21 @@ class CreateSpareVThunderEntry(BaseDatabaseTask):
 
 class GetVRIDForLoadbalancerResource(BaseDatabaseTask):
 
-    def execute(self, partition_project_list, vthunder):
+    def execute(self, partition_project_list, vthunder, loadbalancer):
         vrid_list = []
         if vthunder:
-            owner = vthunder.ip_address + "_" + vthunder.partition_name
+            topology = CONF.a10_controller_worker.loadbalancer_topology
+            if topology == "SINGLE":
+                owner = [vthunder.ip_address + "_" + vthunder.partition_name]
+            else:
+                loadbalancer_id = loadbalancer.id
+                master_vthunder = self.vthunder_repo.get_vthunder_from_lb(
+                    db_apis.get_session(), loadbalancer_id)
+                backup_vthunder = self.vthunder_repo.get_backup_vthunder_from_lb(
+                    db_apis.get_session(), loadbalancer_id)
+                owner_master = master_vthunder.ip_address + "_" + master_vthunder.partition_name
+                owner_backup = backup_vthunder.ip_address + "_" + backup_vthunder.partition_name
+                owner = [owner_master, owner_backup]
             if partition_project_list:
                 try:
                     vrid_list = self.vrid_repo.get_vrid_from_owner(
@@ -1044,3 +1055,17 @@ class CountMembersOnThunderBySubnet(BaseDatabaseTask):
                               subnet.id, str(e))
                 raise e
         return 0
+
+
+class GetMemberListByProjectID(BaseDatabaseTask):
+
+    def execute(self, vthunder):
+        try:
+            if vthunder:
+                member_list = self.member_repo.get_members_by_project_id(
+                    db_apis.get_session(),
+                    vthunder.project_id)
+                return member_list
+        except Exception as e:
+            LOG.exception('Failed to get active Members related to vthunder '
+                          'due to: {}'.format(str(e)))

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -57,7 +57,7 @@ class CalculateAmphoraDelta(BaseNetworkTask):
 
     default_provides = constants.DELTA
 
-    def execute(self, loadbalancers_list, amphora):
+    def execute(self, loadbalancers_list, amphora, member_list):
         LOG.debug("Calculating network delta for amphora id: %s", amphora.id)
         # Figure out what networks we want
         # seed with lb network(s)
@@ -69,7 +69,7 @@ class CalculateAmphoraDelta(BaseNetworkTask):
                 member_networks = [
                     self.network_driver.get_subnet(member.subnet_id).network_id
                     for member in pool.members
-                    if member.subnet_id
+                    if member.subnet_id and member in member_list
                 ]
                 desired_network_ids.update(member_networks)
 
@@ -109,7 +109,7 @@ class CalculateDelta(BaseNetworkTask):
 
     default_provides = constants.DELTAS
 
-    def execute(self, loadbalancer, loadbalancers_list):
+    def execute(self, loadbalancer, loadbalancers_list, member_list):
         """Compute which NICs need to be plugged
 
         for the amphora to become operational.
@@ -126,7 +126,7 @@ class CalculateDelta(BaseNetworkTask):
             lambda amp: amp.status == constants.AMPHORA_ALLOCATED,
                 loadbalancer.amphorae):
 
-            delta = calculate_amp.execute(loadbalancers_list, amphora)
+            delta = calculate_amp.execute(loadbalancers_list, amphora, member_list)
             deltas[amphora.id] = delta
         return deltas
 

--- a/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
@@ -17,7 +17,6 @@ from oslo_config import cfg
 from oslo_log import log as logging
 from requests import exceptions
 from taskflow import task
-import time
 
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator_for_revert
@@ -118,28 +117,3 @@ class UpdateVirtualServerTask(LoadBalancerParent, task.Task):
         except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception("Failed to update load balancer: %s", loadbalancer.id)
             raise e
-
-
-class WaitVirtualServerReadyOnBlade(LoadBalancerParent, task.Task):
-    """Task to wait vBlade get virtual-server configuration from vMaster"""
-
-    @axapi_client_decorator
-    def execute(self, loadbalancer, vthunder):
-        attempts = CONF.a10_controller_worker.amp_vcs_retries
-        while attempts >= 0:
-            try:
-                attempts = attempts - 1
-                self.axapi_client.slb.virtual_server.get(loadbalancer.id)
-                break
-            except exceptions.ReadTimeout:
-                # Don't retry for ReadTimout, since acos-client already already have
-                # tries and timeout for axapi request. And it will take very long to
-                # response this error.
-                if attempts < 0:
-                    # Don't raise, LB creation is success just not sync. to vBlade yet
-                    break
-            except Exception:
-                if attempts < 0:
-                    # Don't raise, LB creation is success just not sync. to vBlade yet
-                    break
-                time.sleep(CONF.a10_controller_worker.amp_vcs_wait_sec)

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -1067,42 +1067,6 @@ class AmphoraePostNetworkUnplug(VThunderBaseTask):
             raise e
 
 
-class GetVThunderInterface(VThunderBaseTask):
-    """Task to get interface on master and backup vThunders"""
-
-    @axapi_client_decorator
-    def execute(self, vthunder):
-        try:
-            vcs_summary = {}
-            ifnum = []
-            ifnum_master = []
-            ifnum_backup = []
-
-            vcs_summary = self.axapi_client.system.action.get_vcs_summary_oper()
-            vcs_member_list = vcs_summary['vcs-summary']['oper']['member-list']
-            interfaces = self.axapi_client.interface.get_list()
-
-            for i in range(len(interfaces['interface']['ethernet-list'])):
-                if interfaces['interface']['ethernet-list'][i]['action'] == "disable":
-                    ifnum = ifnum + [interfaces['interface']['ethernet-list'][i]['ifnum']]
-
-            for i in range(len(vcs_member_list)):
-                if vthunder.ip_address in vcs_member_list[i]['ip-list'][0]['ip']:
-                    role = vcs_member_list[i]['state'].split('(')[0]
-                    if role == "vMaster":
-                        ifnum_master = ifnum
-                        LOG.debug(
-                            "Fetched the ethernet interface for Master vThunder: %s", vthunder.id)
-                    if role == "vBlade":
-                        ifnum_backup = ifnum
-                        LOG.debug(
-                            "Fetched the ethernet interface for Backup vThunder: %s", vthunder.id)
-            return ifnum_master, ifnum_backup
-        except (acos_errors.ACOSException, req_exceptions.ConnectionError) as e:
-            LOG.exception("Failed to fetch ethernet interface Backup vThunder: %s", str(e))
-            raise e
-
-
 class VCSReload(VThunderBaseTask):
     """Task to perform VCS reload"""
 

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -465,7 +465,7 @@ class VRIDRepository(BaseRepository):
         vrid_obj_list = []
 
         model = session.query(self.model_class).filter(
-            or_(self.model_class.owner == owner,
+            or_(self.model_class.owner.in_(owner),
                 self.model_class.owner.in_(project_ids)))
         for data in model:
             vrid_obj_list.append(data.to_data_model())
@@ -544,6 +544,19 @@ class MemberRepository(repo.MemberRepository):
         if not model:
             return None
         return model.to_data_model()
+
+    def get_members_by_project_id(self, session, project_id):
+        member_list = []
+        query = session.query(self.model_class).filter(
+            self.model_class.project_id == project_id).filter(
+            or_(self.model_class.provisioning_status == "ACTIVE",
+                self.model_class.provisioning_status == "PENDING_UPDATE",
+                self.model_class.provisioning_status == "PENDING_CREATE"))
+
+        model_list = query.all()
+        for data in model_list:
+            member_list.append(data.to_data_model())
+        return member_list
 
 
 class NatPoolRepository(BaseRepository):

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -115,6 +115,7 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
 
     def test_get_vrid_for_project_member_hmt_use_partition(self):
         thunder = copy.deepcopy(HW_THUNDER)
+        lb = copy.deepcopy(LB)
         thunder.hierarchical_multitenancy = 'enable'
         thunder.vrid_floating_ip = VRID.vrid_floating_ip
         hardware_device_conf = self._generate_hardware_device_conf(thunder)
@@ -132,11 +133,12 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         mock_vrid_entry.vrid_repo = mock.Mock()
         mock_vrid_entry.vthunder_repo = mock.Mock()
         mock_vrid_entry.vrid_repo.get_vrid_from_owner.return_value = VRID
-        vrid = mock_vrid_entry.execute([a10constants.MOCK_PROJECT_ID], thunder)
+        vrid = mock_vrid_entry.execute([a10constants.MOCK_PROJECT_ID], thunder, lb)
         self.assertEqual(VRID, vrid)
 
     def test_get_vrid_for_project(self):
         thunder = copy.deepcopy(HW_THUNDER)
+        lb = copy.deepcopy(LB)
         thunder.hierarchical_multitenancy = 'disable'
         thunder.vrid_floating_ip = VRID.vrid_floating_ip
         hardware_device_conf = self._generate_hardware_device_conf(thunder)
@@ -154,7 +156,7 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         mock_vrid_entry.vrid_repo = mock.Mock()
         mock_vrid_entry.vthunder_repo = mock.Mock()
         mock_vrid_entry.vrid_repo.get_vrid_from_owner.return_value = VRID
-        vrid = mock_vrid_entry.execute(MEMBER_1, thunder)
+        vrid = mock_vrid_entry.execute(MEMBER_1, thunder, lb)
         mock_vrid_entry.vthunder_repo.get_partition_for_project.assert_not_called()
         self.assertEqual(VRID, vrid)
 

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -921,28 +921,6 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         self.client_mock.system.action.write_memory.assert_not_called()
         self.client_mock.system.action.reload_reboot_for_interface_detachment.assert_not_called()
 
-    def test_GetVThunderInterface_execute_for_vMaster(self):
-        thunder = copy.deepcopy(VTHUNDER)
-        mock_task = task.GetVThunderInterface()
-        mock_task.axapi_client = self.client_mock
-        self.client_mock.system.action.get_vcs_summary_oper.return_value = VCS_MASTER_VBLADE
-        self.client_mock.interface.get_list.return_value = INTERFACES
-        thunder.ip_address = "10.0.0.1"
-        mock_task.execute(thunder)
-        self.client_mock.system.action.setInterface.assert_not_called()
-        self.assertEqual(mock_task.execute(thunder), ([1], []))
-
-    def test_GetVThunderInterface_execute_for_vBlade(self):
-        thunder = copy.deepcopy(VTHUNDER)
-        mock_task = task.GetVThunderInterface()
-        mock_task.axapi_client = self.client_mock
-        self.client_mock.system.action.get_vcs_summary_oper.return_value = VCS_MASTER_VBLADE
-        self.client_mock.interface.get_list.return_value = INTERFACES
-        thunder.ip_address = "10.0.0.2"
-        mock_task.execute(thunder)
-        self.client_mock.system.action.setInterface.assert_not_called()
-        self.assertEqual(mock_task.execute(thunder), ([], [1]))
-
     def test_EnableInterface_execute_for_single_topology(self):
         thunder = copy.deepcopy(VTHUNDER)
         added_ports = {'amphora_id': ''}


### PR DESCRIPTION
## Description
Added support for Dynamic Interface Detection Enhancement for ACTIVE_STANDBY mode with respect to 5.2.1-p2 ACOS image.

## Design Document
https://teams.microsoft.com/l/file/8ACCF57A-2CEF-4E5E-A767-93EDC0ED77DD?tenantId=91d27ab9-8c5e-41d4-82e8-3d1bf81fcb2f&fileType=docx&objectUrl=https%3A%2F%2Fa10networks.sharepoint.com%2Fsites%2FOpenstack%2FShared%20Documents%2FDevelopment%2FResearch%20%26%20Design%2Fa10-octavia%20v2.0%20-%20Victoria%20Support%2FvThunder%20VCS%20issues%20Enhancement%2F%5BDD%5D%20vThunder%20VCS%20issues%20Enhancement.docx&baseUrl=https%3A%2F%2Fa10networks.sharepoint.com%2Fsites%2FOpenstack&serviceName=teams&threadId=19:0f1acbb173d74758b05ee8bacb000d68@thread.tacv2&groupId=37bbf3ad-c05a-4e67-b0cc-12bcd1479beb

## Related PR of acos-client side:
https://github.com/a10networks/acos-client/pull/354

## Jira Tickets

https://a10networks.atlassian.net/browse/STACK-2475
https://a10networks.atlassian.net/browse/STACK-2476
https://a10networks.atlassian.net/browse/STACK-2477
https://a10networks.atlassian.net/browse/STACK-2478
https://a10networks.atlassian.net/browse/STACK-2479
https://a10networks.atlassian.net/browse/STACK-2480
https://a10networks.atlassian.net/browse/STACK-2481
https://a10networks.atlassian.net/browse/STACK-2482
https://a10networks.atlassian.net/browse/STACK-2483
https://a10networks.atlassian.net/browse/STACK-2484
https://a10networks.atlassian.net/browse/STACK-2710
https://a10networks.atlassian.net/browse/STACK-2709

## Technical Approach
- Refined loadbalancer creation and deletion flows as per the new design by removing unnecessary tasks for ACTIVE_STANDBY mode in both the flows.
- Modified EnableInterface() task to use device_context.switch() API for enabling vMaster's and vBlade's interfaces from vMaster only at a same time.
- Refined member creation and deletion flows as per the new design by removing unnecessary tasks for ACTIVE_STANDBY mode in both the flows.
- Modified EnableMemberInterface() task to use device_context.switch() API for enabling vMaster's and vBlade's interfaces from vMaster only at a same time.
- Modified CalculateAmphoraDelta() task by passing a member_list to it which does not hold the deleting member to it sothat desired_network_ids[] will not hold the member network of that PENDING_DELETE member to it and will provide correct del_ids(n/w id of the deleting member) and will delete the network interface on member deletion without an issue.
- Added a task GetMemberListByProjectID() to get a correct member_list which is to be passed to CalculateAmphoraDelta() task for calculating correct del_nics/del_ids.
- Modified GetVRIDForLoadbalancerResource() task to fix an issue for VRID FIP deletion in ACTIVE_STANDBY mode.

## Manual Testing
1. **Create a loadbalancer in subnet provider-vlan-11-subnet**
stack@neha:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name lb1

```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-08-02T13:09:32                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 2e4a6dfc-2d17-44ca-a803-494cc52b6034 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e53e09a471d3415ab56dd29d3298d526     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.157                          |
| vip_network_id      | eab8b60f-1e06-420f-8ca5-1557d36f132a |
| vip_port_id         | 9dba8295-aa1f-4100-9bdc-97b1ef80ee7e |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | c9fb06a8-9736-49a7-9fcd-1475ba0c04f2 |
+---------------------+--------------------------------------+
```
**Result: A network interface for the LB will get attached to the vThunders without reload as it is 1st LB**
```
vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 670 bytes
!Configuration last updated at 14:19:12 IST Mon Aug 2 2021
!Configuration last saved at 14:19:18 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.158
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb virtual-server 2e4a6dfc-2d17-44ca-a803-494cc52b6034 10.0.11.157
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
```

```
vThunder-Active-vMaster[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3eb6.ad22  192.168.0.129/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e1c.3ad3  10.0.11.144/24        1  DataPort
```

```
vThunder-Standby-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 670 bytes
!Configuration last updated at 14:19:13 IST Mon Aug 2 2021
!Configuration last saved at 14:16:41 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.158
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb virtual-server 2e4a6dfc-2d17-44ca-a803-494cc52b6034 10.0.11.157
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
```

```
vThunder-Standby-vBlade[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e02.6f85  192.168.0.23/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3ed9.eb08  10.0.11.101/24        1  DataPort
```

2. **Create an another loadbalancer in a different subnet provider-vlan-12-subnet.**
stack@neha:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-12-subnet --name lb2
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-08-02T13:25:20                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | e885b3dd-af08-41d7-ac77-75feac8984b8 |
| listeners           |                                      |
| name                | lb2                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e53e09a471d3415ab56dd29d3298d526     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.12.188                          |
| vip_network_id      | a1cba96e-09df-4479-9b12-da80e17b5ba2 |
| vip_port_id         | e04b2597-5361-4865-8e15-a00467f86c25 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 9c5cbcec-c8a0-4a30-bc56-7879a064a2b2 |
+---------------------+--------------------------------------+
```
**Result: Reload takes place and a new interface will get attached for the subnet.**

```
vThunder-Standby-vMaster[1/2](NOLICENSE)#show running-config
!Current configuration: 739 bytes
!Configuration last updated at 14:32:48 IST Mon Aug 2 2021
!Configuration last saved at 14:32:58 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.158
  floating-ip 10.0.12.159
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb virtual-server 2e4a6dfc-2d17-44ca-a803-494cc52b6034 10.0.11.157
!
slb virtual-server e885b3dd-af08-41d7-ac77-75feac8984b8 10.0.12.188
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode

```
```
vThunder-Standby-vMaster[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e02.6f85  192.168.0.23/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3ed9.eb08  10.0.11.101/24        1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e17.cff1  10.0.12.157/24        1  DataPort

```

```
vThunder-Active-vBlade[1/1](NOLICENSE)#show running-config
!Current configuration: 739 bytes
!Configuration last updated at 14:32:48 IST Mon Aug 2 2021
!Configuration last saved at 14:30:02 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.158
  floating-ip 10.0.12.159
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb virtual-server 2e4a6dfc-2d17-44ca-a803-494cc52b6034 10.0.11.157
!
slb virtual-server e885b3dd-af08-41d7-ac77-75feac8984b8 10.0.12.188
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
```

```
vThunder-Active-vBlade[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3eb6.ad22  192.168.0.129/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e1c.3ad3  10.0.11.144/24        1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e52.3da7  10.0.12.174/24        1  DataPort
```

stack@neha:~$ openstack loadbalancer list

```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 2e4a6dfc-2d17-44ca-a803-494cc52b6034 | lb1  | e53e09a471d3415ab56dd29d3298d526 | 10.0.11.157 | ACTIVE              | a10      |
| e885b3dd-af08-41d7-ac77-75feac8984b8 | lb2  | e53e09a471d3415ab56dd29d3298d526 | 10.0.12.188 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+

```

3. Create a new loadbalancer in the same subnet as that of lb1 i.e provider-vlan-11-subnet
stack@neha:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name lb3
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-08-02T13:51:27                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | a8a6f479-404a-493b-be1c-850ad60043dc |
| listeners           |                                      |
| name                | lb3                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e53e09a471d3415ab56dd29d3298d526     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.103                          |
| vip_network_id      | eab8b60f-1e06-420f-8ca5-1557d36f132a |
| vip_port_id         | e0bd6be9-2cf0-4d58-b037-f6c6bb9f1950 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | c9fb06a8-9736-49a7-9fcd-1475ba0c04f2 |
+---------------------+--------------------------------------+
```

**Result: No reload takes place, no new interface will get attached as an interface for that subnet is already present on the vThunders**

```
vThunder-Standby-vMaster[1/2](NOLICENSE)#show running-config
!Current configuration: 808 bytes
!Configuration last updated at 14:51:50 IST Mon Aug 2 2021
!Configuration last saved at 14:51:57 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.158
  floating-ip 10.0.12.159
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb virtual-server 2e4a6dfc-2d17-44ca-a803-494cc52b6034 10.0.11.157
!
slb virtual-server a8a6f479-404a-493b-be1c-850ad60043dc 10.0.11.103
!
slb virtual-server e885b3dd-af08-41d7-ac77-75feac8984b8 10.0.12.188
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode

```
```
vThunder-Standby-vMaster[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e02.6f85  192.168.0.23/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3ed9.eb08  10.0.11.101/24        1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e17.cff1  10.0.12.157/24        1  DataPort
```

```
vThunder-Active-vBlade[1/1](NOLICENSE)#show running-config
!Current configuration: 808 bytes
!Configuration last updated at 14:51:50 IST Mon Aug 2 2021
!Configuration last saved at 14:30:02 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.158
  floating-ip 10.0.12.159
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb virtual-server 2e4a6dfc-2d17-44ca-a803-494cc52b6034 10.0.11.157
!
slb virtual-server a8a6f479-404a-493b-be1c-850ad60043dc 10.0.11.103
!
slb virtual-server e885b3dd-af08-41d7-ac77-75feac8984b8 10.0.12.188
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
```


```
vThunder-Active-vBlade[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3eb6.ad22  192.168.0.129/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e1c.3ad3  10.0.11.144/24        1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e52.3da7  10.0.12.174/24        1  DataPort
```



stack@neha:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 2e4a6dfc-2d17-44ca-a803-494cc52b6034 | lb1  | e53e09a471d3415ab56dd29d3298d526 | 10.0.11.157 | ACTIVE              | a10      |
| e885b3dd-af08-41d7-ac77-75feac8984b8 | lb2  | e53e09a471d3415ab56dd29d3298d526 | 10.0.12.188 | ACTIVE              | a10      |
| a8a6f479-404a-493b-be1c-850ad60043dc | lb3  | e53e09a471d3415ab56dd29d3298d526 | 10.0.11.103 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```

4. **Create a listener and pool for loadbalancer lb2**
stack@neha:~$ openstack loadbalancer listener create --protocol TCP --protocol-port 80 --name l2 lb2
```
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-08-02T13:57:29                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 1c90f044-ef96-4d2a-9c50-79646f7020d1 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | e885b3dd-af08-41d7-ac77-75feac8984b8 |
| name                        | l2                                   |
| operating_status            | OFFLINE                              |
| project_id                  | e53e09a471d3415ab56dd29d3298d526     |
| protocol                    | TCP                                  |
| protocol_port               | 80                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
+-----------------------------+--------------------------------------+
```

stack@neha:~$ openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener l2 --name p2
```
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-08-02T13:58:04                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | a99df7d1-7ac3-485f-b486-78d152720b18 |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | 1c90f044-ef96-4d2a-9c50-79646f7020d1 |
| loadbalancers        | e885b3dd-af08-41d7-ac77-75feac8984b8 |
| members              |                                      |
| name                 | p2                                   |
| operating_status     | OFFLINE                              |
| project_id           | e53e09a471d3415ab56dd29d3298d526     |
| protocol             | TCP                                  |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
+----------------------+--------------------------------------+
```

5. **Create a member in the pool p2 in subnet provider-vlan-13-subnet**
stack@neha:~$ openstack loadbalancer member create --address 10.0.13.10 --subnet-id provider-vlan-13-subnet --protocol-port 95 --name mem1 p2
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.13.10                           |
| admin_state_up      | True                                 |
| created_at          | 2021-08-02T13:58:49                  |
| id                  | 7bc47c22-c663-4df7-a873-16da8d7c703a |
| name                | mem1                                 |
| operating_status    | NO_MONITOR                           |
| project_id          | e53e09a471d3415ab56dd29d3298d526     |
| protocol_port       | 95                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | d8059ab7-4452-4859-bee2-1b7f3f5ae2d3 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
```
**Result: Reload takes place and a new interface for the subnet provider-vlan-13-subnet will get attached**
```
vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 739 bytes
!Configuration last updated at 15:06:08 IST Mon Aug 2 2021
!Configuration last saved at 15:06:13 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.158
  floating-ip 10.0.12.159
  floating-ip 10.0.13.175
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server e53e0_10_0_13_10 10.0.13.10
  port 95 tcp
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb service-group a99df7d1-7ac3-485f-b486-78d152720b18 tcp
  member e53e0_10_0_13_10 95
!
slb virtual-server 2e4a6dfc-2d17-44ca-a803-494cc52b6034 10.0.11.157
!
slb virtual-server a8a6f479-404a-493b-be1c-850ad60043dc 10.0.11.103
!
slb virtual-server e885b3dd-af08-41d7-ac77-75feac8984b8 10.0.12.188
  port 80 tcp
    name 1c90f044-ef96-4d2a-9c50-79646f7020d1
    extended-stats
    service-group a99df7d1-7ac3-485f-b486-78d152720b18
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```
```
vThunder-Active-vMaster[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3eb6.ad22  192.168.0.129/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e1c.3ad3  10.0.11.144/24        1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e52.3da7  10.0.12.174/24        1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e54.041f  10.0.13.179/24        1  DataPort
```

```
vThunder-Standby-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 739 bytes
!Configuration last updated at 15:06:09 IST Mon Aug 2 2021
!Configuration last saved at 15:03:44 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.158
  floating-ip 10.0.12.159
  floating-ip 10.0.13.175
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server e53e0_10_0_13_10 10.0.13.10
  port 95 tcp
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb service-group a99df7d1-7ac3-485f-b486-78d152720b18 tcp
  member e53e0_10_0_13_10 95
!
slb virtual-server 2e4a6dfc-2d17-44ca-a803-494cc52b6034 10.0.11.157
!
slb virtual-server a8a6f479-404a-493b-be1c-850ad60043dc 10.0.11.103
!
slb virtual-server e885b3dd-af08-41d7-ac77-75feac8984b8 10.0.12.188
  port 80 tcp
    name 1c90f044-ef96-4d2a-9c50-79646f7020d1
    extended-stats
    service-group a99df7d1-7ac3-485f-b486-78d152720b18
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```
```
vThunder-Standby-vBlade[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e02.6f85  192.168.0.23/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3ed9.eb08  10.0.11.101/24        1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e17.cff1  10.0.12.157/24        1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e0d.66f9  10.0.13.142/24        1  DataPort
```

6. **Create an another member in the same subnet as that of mem1 i.e provider-vlan-13-subnet**
stack@neha:~$ openstack loadbalancer member create --address 10.0.13.11 --subnet-id provider-vlan-13-subnet --protocol-port 96 --name mem2 p2
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.13.11                           |
| admin_state_up      | True                                 |
| created_at          | 2021-08-02T14:08:50                  |
| id                  | 52a25038-1b58-4e99-ae32-ebbac4beddcb |
| name                | mem2                                 |
| operating_status    | NO_MONITOR                           |
| project_id          | e53e09a471d3415ab56dd29d3298d526     |
| protocol_port       | 96                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | d8059ab7-4452-4859-bee2-1b7f3f5ae2d3 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
```
**Result: No reload takes place as an interface for the subnet of the member is already attached on the vThunders**

```
vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 739 bytes
!Configuration last updated at 15:08:54 IST Mon Aug 2 2021
!Configuration last saved at 15:08:58 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.158
  floating-ip 10.0.12.159
  floating-ip 10.0.13.175
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server e53e0_10_0_13_10 10.0.13.10
  port 95 tcp
!
slb server e53e0_10_0_13_11 10.0.13.11
  port 96 tcp
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb service-group a99df7d1-7ac3-485f-b486-78d152720b18 tcp
  member e53e0_10_0_13_10 95
  member e53e0_10_0_13_11 96
!
slb virtual-server 2e4a6dfc-2d17-44ca-a803-494cc52b6034 10.0.11.157
!
slb virtual-server a8a6f479-404a-493b-be1c-850ad60043dc 10.0.11.103
!
slb virtual-server e885b3dd-af08-41d7-ac77-75feac8984b8 10.0.12.188
  port 80 tcp
    name 1c90f044-ef96-4d2a-9c50-79646f7020d1
    extended-stats
    service-group a99df7d1-7ac3-485f-b486-78d152720b18
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

```
vThunder-Standby-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 739 bytes
!Configuration last updated at 15:08:54 IST Mon Aug 2 2021
!Configuration last saved at 15:03:44 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.158
  floating-ip 10.0.12.159
  floating-ip 10.0.13.175
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server e53e0_10_0_13_10 10.0.13.10
  port 95 tcp
!
slb server e53e0_10_0_13_11 10.0.13.11
  port 96 tcp
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb service-group a99df7d1-7ac3-485f-b486-78d152720b18 tcp
  member e53e0_10_0_13_10 95
  member e53e0_10_0_13_11 96
!
slb virtual-server 2e4a6dfc-2d17-44ca-a803-494cc52b6034 10.0.11.157
!
slb virtual-server a8a6f479-404a-493b-be1c-850ad60043dc 10.0.11.103
!
slb virtual-server e885b3dd-af08-41d7-ac77-75feac8984b8 10.0.12.188
  port 80 tcp
    name 1c90f044-ef96-4d2a-9c50-79646f7020d1
    extended-stats
    service-group a99df7d1-7ac3-485f-b486-78d152720b18
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

6. **Create a new member in a different subnet provider-vlan-14-subnet**
stack@neha:~$ openstack loadbalancer member create --address 10.0.14.10 --subnet-id provider-vlan-14-subnet --protocol-port 97 --name mem3 p2
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.14.10                           |
| admin_state_up      | True                                 |
| created_at          | 2021-08-02T14:11:21                  |
| id                  | 01e58b46-a492-45bf-ae58-ae2e259a9f11 |
| name                | mem3                                 |
| operating_status    | NO_MONITOR                           |
| project_id          | e53e09a471d3415ab56dd29d3298d526     |
| protocol_port       | 97                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 53a61583-bfb3-4def-b7e7-1d65656fa09e |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
```
**Result: Reload takes place and a new interface will get attached to the vThunders**

```
vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 739 bytes
!Configuration last updated at 15:17:38 IST Mon Aug 2 2021
!Configuration last saved at 15:17:43 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/4
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/4
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.158
  floating-ip 10.0.12.159
  floating-ip 10.0.13.175
  floating-ip 10.0.14.158
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server e53e0_10_0_13_10 10.0.13.10
  port 95 tcp
!
slb server e53e0_10_0_13_11 10.0.13.11
  port 96 tcp
!
slb server e53e0_10_0_14_10 10.0.14.10
  port 97 tcp
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb service-group a99df7d1-7ac3-485f-b486-78d152720b18 tcp
  member e53e0_10_0_13_10 95
  member e53e0_10_0_13_11 96
  member e53e0_10_0_14_10 97
!
slb virtual-server 2e4a6dfc-2d17-44ca-a803-494cc52b6034 10.0.11.157
!
slb virtual-server a8a6f479-404a-493b-be1c-850ad60043dc 10.0.11.103
!
slb virtual-server e885b3dd-af08-41d7-ac77-75feac8984b8 10.0.12.188
  port 80 tcp
    name 1c90f044-ef96-4d2a-9c50-79646f7020d1
    extended-stats
    service-group a99df7d1-7ac3-485f-b486-78d152720b18
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```
```
vThunder-Active-vMaster[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3eb6.ad22  192.168.0.129/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e1c.3ad3  10.0.11.144/24        1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e52.3da7  10.0.12.174/24        1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e54.041f  10.0.13.179/24        1  DataPort
4                   Up    Full  10000  none  1    N/A       fa16.3e28.9ba8  10.0.14.135/24        1  DataPort

```
```
vThunder-Standby-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 739 bytes
!Configuration last updated at 15:17:38 IST Mon Aug 2 2021
!Configuration last saved at 15:15:23 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/4
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/4
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.158
  floating-ip 10.0.12.159
  floating-ip 10.0.13.175
  floating-ip 10.0.14.158
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server e53e0_10_0_13_10 10.0.13.10
  port 95 tcp
!
slb server e53e0_10_0_13_11 10.0.13.11
  port 96 tcp
!
slb server e53e0_10_0_14_10 10.0.14.10
  port 97 tcp
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb service-group a99df7d1-7ac3-485f-b486-78d152720b18 tcp
  member e53e0_10_0_13_10 95
  member e53e0_10_0_13_11 96
  member e53e0_10_0_14_10 97
!
slb virtual-server 2e4a6dfc-2d17-44ca-a803-494cc52b6034 10.0.11.157
!
slb virtual-server a8a6f479-404a-493b-be1c-850ad60043dc 10.0.11.103
!
slb virtual-server e885b3dd-af08-41d7-ac77-75feac8984b8 10.0.12.188
  port 80 tcp
    name 1c90f044-ef96-4d2a-9c50-79646f7020d1
    extended-stats
    service-group a99df7d1-7ac3-485f-b486-78d152720b18
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```
```
vThunder-Standby-vBlade[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e02.6f85  192.168.0.23/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3ed9.eb08  10.0.11.101/24        1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e17.cff1  10.0.12.157/24        1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e0d.66f9  10.0.13.142/24        1  DataPort
4                   Up    Full  10000  none  1    N/A       fa16.3eb0.6d47  10.0.14.108/24        1  DataPort
```

stack@neha:~$ openstack loadbalancer member list p2
```
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address    | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| 7bc47c22-c663-4df7-a873-16da8d7c703a | mem1 | e53e09a471d3415ab56dd29d3298d526 | ACTIVE              | 10.0.13.10 |            95 | NO_MONITOR       |      1 |
| 52a25038-1b58-4e99-ae32-ebbac4beddcb | mem2 | e53e09a471d3415ab56dd29d3298d526 | ACTIVE              | 10.0.13.11 |            96 | NO_MONITOR       |      1 |
| 01e58b46-a492-45bf-ae58-ae2e259a9f11 | mem3 | e53e09a471d3415ab56dd29d3298d526 | ACTIVE              | 10.0.14.10 |            97 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
```

7. **Delete member mem3**
**Result: Reload takes place and the interface of subnet provider-vlan-14-subnet will get detached from the vThunders on the member deletion.**
stack@neha:~$ openstack loadbalancer member delete p2 mem3

```
vThunder-Active-vMaster[1/2](NOLICENSE)#show running-config
!Current configuration: 739 bytes
!Configuration last updated at 15:31:02 IST Mon Aug 2 2021
!Configuration last saved at 15:31:07 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.158
  floating-ip 10.0.12.159
  floating-ip 10.0.13.175
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server e53e0_10_0_13_10 10.0.13.10
  port 95 tcp
!
slb server e53e0_10_0_13_11 10.0.13.11
  port 96 tcp
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb service-group a99df7d1-7ac3-485f-b486-78d152720b18 tcp
  member e53e0_10_0_13_10 95
  member e53e0_10_0_13_11 96
!
slb virtual-server 2e4a6dfc-2d17-44ca-a803-494cc52b6034 10.0.11.157
!
slb virtual-server a8a6f479-404a-493b-be1c-850ad60043dc 10.0.11.103
!
slb virtual-server e885b3dd-af08-41d7-ac77-75feac8984b8 10.0.12.188
  port 80 tcp
    name 1c90f044-ef96-4d2a-9c50-79646f7020d1
    extended-stats
    service-group a99df7d1-7ac3-485f-b486-78d152720b18
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```
```
vThunder-Standby-vMaster[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e02.6f85  192.168.0.23/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3ed9.eb08  10.0.11.101/24        1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e17.cff1  10.0.12.157/24        1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e0d.66f9  10.0.13.142/24        1  DataPort

```

```
vThunder-Active-vBlade[1/1](NOLICENSE)#show running-config
!Current configuration: 739 bytes
!Configuration last updated at 15:31:01 IST Mon Aug 2 2021
!Configuration last saved at 15:28:12 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.158
  floating-ip 10.0.12.159
  floating-ip 10.0.13.175
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server e53e0_10_0_13_10 10.0.13.10
  port 95 tcp
!
slb server e53e0_10_0_13_11 10.0.13.11
  port 96 tcp
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb service-group a99df7d1-7ac3-485f-b486-78d152720b18 tcp
  member e53e0_10_0_13_10 95
  member e53e0_10_0_13_11 96
!
slb virtual-server 2e4a6dfc-2d17-44ca-a803-494cc52b6034 10.0.11.157
!
slb virtual-server a8a6f479-404a-493b-be1c-850ad60043dc 10.0.11.103
!
slb virtual-server e885b3dd-af08-41d7-ac77-75feac8984b8 10.0.12.188
  port 80 tcp
    name 1c90f044-ef96-4d2a-9c50-79646f7020d1
    extended-stats
    service-group a99df7d1-7ac3-485f-b486-78d152720b18
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```
```
vThunder-Active-vBlade[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3eb6.ad22  192.168.0.129/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e1c.3ad3  10.0.11.144/24        1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e52.3da7  10.0.12.174/24        1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e54.041f  10.0.13.179/24        1  DataPort
```

8. **Delete member mem2**
**Result: No reload takes place as the network interface of that member subnet is being used by member mem1**

stack@neha:~$ openstack loadbalancer member delete p2 mem2

```
vThunder-Standby-vMaster[1/2](NOLICENSE)#show running-config
!Current configuration: 739 bytes
!Configuration last updated at 15:35:02 IST Mon Aug 2 2021
!Configuration last saved at 15:35:08 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.158
  floating-ip 10.0.12.159
  floating-ip 10.0.13.175
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server e53e0_10_0_13_10 10.0.13.10
  port 95 tcp
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb service-group a99df7d1-7ac3-485f-b486-78d152720b18 tcp
  member e53e0_10_0_13_10 95
!
slb virtual-server 2e4a6dfc-2d17-44ca-a803-494cc52b6034 10.0.11.157
!
slb virtual-server a8a6f479-404a-493b-be1c-850ad60043dc 10.0.11.103
!
slb virtual-server e885b3dd-af08-41d7-ac77-75feac8984b8 10.0.12.188
  port 80 tcp
    name 1c90f044-ef96-4d2a-9c50-79646f7020d1
    extended-stats
    service-group a99df7d1-7ac3-485f-b486-78d152720b18
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```
```
vThunder-Active-vBlade[1/1](NOLICENSE)#show running-config
!Current configuration: 739 bytes
!Configuration last updated at 15:35:02 IST Mon Aug 2 2021
!Configuration last saved at 15:28:12 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.158
  floating-ip 10.0.12.159
  floating-ip 10.0.13.175
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server e53e0_10_0_13_10 10.0.13.10
  port 95 tcp
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb service-group a99df7d1-7ac3-485f-b486-78d152720b18 tcp
  member e53e0_10_0_13_10 95
!
slb virtual-server 2e4a6dfc-2d17-44ca-a803-494cc52b6034 10.0.11.157
!
slb virtual-server a8a6f479-404a-493b-be1c-850ad60043dc 10.0.11.103
!
slb virtual-server e885b3dd-af08-41d7-ac77-75feac8984b8 10.0.12.188
  port 80 tcp
    name 1c90f044-ef96-4d2a-9c50-79646f7020d1
    extended-stats
    service-group a99df7d1-7ac3-485f-b486-78d152720b18
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```
9. **Delete member mem1**
**Result: Reload takes place and the n/w interface of the subnet of mem1 will get detached from the vThunders**

stack@neha:~$ openstack loadbalancer member delete p2 mem1

```
vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 799 bytes
!Configuration last updated at 15:46:57 IST Mon Aug 2 2021
!Configuration last saved at 15:47:01 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.158
  floating-ip 10.0.12.159
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb service-group a99df7d1-7ac3-485f-b486-78d152720b18 tcp
!
slb virtual-server 2e4a6dfc-2d17-44ca-a803-494cc52b6034 10.0.11.157
!
slb virtual-server a8a6f479-404a-493b-be1c-850ad60043dc 10.0.11.103
!
slb virtual-server e885b3dd-af08-41d7-ac77-75feac8984b8 10.0.12.188
  port 80 tcp
    name 1c90f044-ef96-4d2a-9c50-79646f7020d1
    extended-stats
    service-group a99df7d1-7ac3-485f-b486-78d152720b18
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```
```
vThunder-Active-vMaster[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3eb6.ad22  192.168.0.129/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e1c.3ad3  10.0.11.144/24        1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e52.3da7  10.0.12.174/24        1  DataPort

```

```
vThunder-Standby-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 799 bytes
!Configuration last updated at 15:46:57 IST Mon Aug 2 2021
!Configuration last saved at 15:43:48 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.158
  floating-ip 10.0.12.159
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb service-group a99df7d1-7ac3-485f-b486-78d152720b18 tcp
!
slb virtual-server 2e4a6dfc-2d17-44ca-a803-494cc52b6034 10.0.11.157
!
slb virtual-server a8a6f479-404a-493b-be1c-850ad60043dc 10.0.11.103
!
slb virtual-server e885b3dd-af08-41d7-ac77-75feac8984b8 10.0.12.188
  port 80 tcp
    name 1c90f044-ef96-4d2a-9c50-79646f7020d1
    extended-stats
    service-group a99df7d1-7ac3-485f-b486-78d152720b18
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```
```
vThunder-Standby-vBlade[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e02.6f85  192.168.0.23/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3ed9.eb08  10.0.11.101/24        1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e17.cff1  10.0.12.157/24        1  DataPort
```

stack@neha:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 2e4a6dfc-2d17-44ca-a803-494cc52b6034 | lb1  | e53e09a471d3415ab56dd29d3298d526 | 10.0.11.157 | ACTIVE              | a10      |
| e885b3dd-af08-41d7-ac77-75feac8984b8 | lb2  | e53e09a471d3415ab56dd29d3298d526 | 10.0.12.188 | ACTIVE              | a10      |
| a8a6f479-404a-493b-be1c-850ad60043dc | lb3  | e53e09a471d3415ab56dd29d3298d526 | 10.0.11.103 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```

10. **Delete loadbalancer lb3**
**Result: No reload takes place as the n/w interface attached with lb3 is being used by lb1, so no interface detachment.**

stack@neha:~$ openstack loadbalancer delete lb3

```
vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 730 bytes
!Configuration last updated at 15:55:51 IST Mon Aug 2 2021
!Configuration last saved at 15:55:58 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.158
  floating-ip 10.0.12.159
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb service-group a99df7d1-7ac3-485f-b486-78d152720b18 tcp
!
slb virtual-server 2e4a6dfc-2d17-44ca-a803-494cc52b6034 10.0.11.157
!
slb virtual-server e885b3dd-af08-41d7-ac77-75feac8984b8 10.0.12.188
  port 80 tcp
    name 1c90f044-ef96-4d2a-9c50-79646f7020d1
    extended-stats
    service-group a99df7d1-7ac3-485f-b486-78d152720b18
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

```
vThunder-Standby-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 730 bytes
!Configuration last updated at 15:55:51 IST Mon Aug 2 2021
!Configuration last saved at 15:43:48 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.158
  floating-ip 10.0.12.159
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb service-group a99df7d1-7ac3-485f-b486-78d152720b18 tcp
!
slb virtual-server 2e4a6dfc-2d17-44ca-a803-494cc52b6034 10.0.11.157
!
slb virtual-server e885b3dd-af08-41d7-ac77-75feac8984b8 10.0.12.188
  port 80 tcp
    name 1c90f044-ef96-4d2a-9c50-79646f7020d1
    extended-stats
    service-group a99df7d1-7ac3-485f-b486-78d152720b18
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

11. **Delete loadbalancer lb1**
**Result: Reload takes place and the interface attached with lb1 will get detached from the vThunders.**

stack@neha:~$ openstack loadbalancer delete lb1

```
vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 661 bytes
!Configuration last updated at 16:07:14 IST Mon Aug 2 2021
!Configuration last saved at 16:07:18 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.12.159
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb service-group a99df7d1-7ac3-485f-b486-78d152720b18 tcp
!
slb virtual-server e885b3dd-af08-41d7-ac77-75feac8984b8 10.0.12.188
  port 80 tcp
    name 1c90f044-ef96-4d2a-9c50-79646f7020d1
    extended-stats
    service-group a99df7d1-7ac3-485f-b486-78d152720b18
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```
```
vThunder-Active-vMaster[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3eb6.ad22  192.168.0.129/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e52.3da7  10.0.12.174/24        1  DataPort
```

```
vThunder-Standby-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 661 bytes
!Configuration last updated at 16:07:14 IST Mon Aug 2 2021
!Configuration last saved at 16:05:03 IST Mon Aug 2 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.12.159
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.126
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.126
  health-check octavia_health_monitor
!
slb service-group a99df7d1-7ac3-485f-b486-78d152720b18 tcp
!
slb virtual-server e885b3dd-af08-41d7-ac77-75feac8984b8 10.0.12.188
  port 80 tcp
    name 1c90f044-ef96-4d2a-9c50-79646f7020d1
    extended-stats
    service-group a99df7d1-7ac3-485f-b486-78d152720b18
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```
```
vThunder-Standby-vBlade[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e02.6f85  192.168.0.23/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3e17.cff1  10.0.12.157/24        1  DataPort
```

stack@neha:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| e885b3dd-af08-41d7-ac77-75feac8984b8 | lb2  | e53e09a471d3415ab56dd29d3298d526 | 10.0.12.188 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```

11. **Delete pool, listener and lb2**
**Result: pool, listener and the last LB lb2 will get deleted without reload and vThunders will get deleted.**

stack@neha:~$ openstack loadbalancer pool delete p2

stack@neha:~$ openstack loadbalancer pool list

stack@neha:~$ openstack loadbalancer listener delete l2

stack@neha:~$ openstack loadbalancer listener list

stack@neha:~$ openstack loadbalancer delete lb2

stack@neha:~$ openstack loadbalancer list

stack@neha:~$ openstack server list
