### PR TITLE
[2359]PR to Merge Unset Operation support feature/unset branch into experimental/victoria_ff branch

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -560,7 +560,7 @@ class LoadBalancerFlows(object):
             provides=constants.FLAVOR_DATA))
         update_LB_flow.add(virtual_server_tasks.UpdateVirtualServerTask(
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
-                      constants.FLAVOR_DATA)))
+                      constants.FLAVOR_DATA, constants.UPDATE_DICT)))
         update_LB_flow.add(database_tasks.UpdateLoadbalancerInDB(
             requires=[constants.LOADBALANCER, constants.UPDATE_DICT]))
         update_LB_flow.add(database_tasks.MarkLBActiveInDB(
@@ -613,7 +613,7 @@ class LoadBalancerFlows(object):
 
         update_LB_flow.add(virtual_server_tasks.UpdateVirtualServerTask(
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
-                      constants.FLAVOR_DATA)))
+                      constants.FLAVOR_DATA, constants.UPDATE_DICT)))
         update_LB_flow.add(database_tasks.UpdateLoadbalancerInDB(
             requires=[constants.LOADBALANCER, constants.UPDATE_DICT]))
         if CONF.a10_global.network_type == 'vlan':

--- a/a10_octavia/controller/worker/tasks/persist_tasks.py
+++ b/a10_octavia/controller/worker/tasks/persist_tasks.py
@@ -32,7 +32,10 @@ class HandleSessionPersistenceDelta(task.Task):
     @axapi_client_decorator
     def execute(self, vthunder, pool):
         sess_pers = pool.session_persistence
-        if sess_pers and sess_pers.type in SP_OBJ_DICT:
+        if pool.session_persistence and hasattr(pool.session_persistence, 'to_dict'):
+            sess_pers = pool.session_persistence.to_dict()
+        if sess_pers and sess_pers['type'] in SP_OBJ_DICT:
+
             # Remove existing persistence template if any
             for sp_type in PERS_TYPE:
                 try:
@@ -46,11 +49,11 @@ class HandleSessionPersistenceDelta(task.Task):
                     LOG.exception("Failed to delete existing session persistence for pool: %s",
                                   pool.id)
                     raise e
-            sp_template = getattr(self.axapi_client.slb.template, SP_OBJ_DICT[sess_pers.type])
+            sp_template = getattr(self.axapi_client.slb.template, SP_OBJ_DICT[sess_pers['type']])
 
             try:
-                if sess_pers.cookie_name:
-                    sp_template.create(pool.id, cookie_name=sess_pers.cookie_name)
+                if sess_pers['cookie_name']:
+                    sp_template.create(pool.id, cookie_name=sess_pers['cookie_name'])
                 else:
                     sp_template.create(pool.id)
                 LOG.debug("Successfully created session persistence template for pool: %s", pool.id)

--- a/a10_octavia/controller/worker/tasks/service_group_tasks.py
+++ b/a10_octavia/controller/worker/tasks/service_group_tasks.py
@@ -136,8 +136,8 @@ class PoolUpdate(PoolParent, task.Task):
     """Task to update pool"""
 
     @axapi_client_decorator
-    def execute(self, pool, vthunder, update_dict, flavor=None):
-        pool.update(update_dict)
+    def execute(self, pool, vthunder, update_dict={}, flavor=None):
+        pool.__dict__.update(update_dict)
         try:
             service_group = self.axapi_client.slb.service_group.get(
                 pool.id)['service-group']

--- a/a10_octavia/controller/worker/tasks/utils.py
+++ b/a10_octavia/controller/worker/tasks/utils.py
@@ -42,9 +42,11 @@ def get_sess_pers_templates(pool):
     c_pers, s_pers, sp = None, None, None
     if pool and pool.session_persistence:
         sp = pool.session_persistence
-        if sp.type == 'HTTP_COOKIE' or sp.type == 'APP_COOKIE':
+        if hasattr(pool.session_persistence, 'to_dict'):
+            sp = pool.session_persistence.to_dict()
+        if sp['type'] == 'HTTP_COOKIE' or sp['type'] == 'APP_COOKIE':
             c_pers = pool.id
-        elif sp.type == 'SOURCE_IP':
+        elif sp['type'] == 'SOURCE_IP':
             s_pers = pool.id
     return c_pers, s_pers
 

--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -94,7 +94,7 @@ class ListenersParent(object):
             if (update_dict and 'default_tls_container_ref' in update_dict
                     and update_dict["default_tls_container_ref"] is None):
                 template_args["template_client_ssl"] = None
-            else:
+            elif listener.protocol == 'https':
                 template_args["template_client_ssl"] = listener.id
 
             template_http = CONF.listener.template_http

--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -91,6 +91,12 @@ class ListenersParent(object):
                 # Adding TERMINATED_HTTPS SSL cert, created in previous task
                 template_args["template_client_ssl"] = listener.id
 
+            if (update_dict and 'default_tls_container_ref' in update_dict
+                    and update_dict["default_tls_container_ref"] is None):
+                template_args["template_client_ssl"] = None
+            else:
+                template_args["template_client_ssl"] = listener.id
+
             template_http = CONF.listener.template_http
             if template_http and template_http.lower() != 'none':
                 template_key = 'template-http'
@@ -195,9 +201,10 @@ class ListenerUpdate(ListenersParent, task.Task):
     """Task to update listener"""
 
     @axapi_client_decorator
-    def execute(self, loadbalancer, listener, vthunder, flavor_data=None, update_dict=None):
+    def execute(self, loadbalancer, listener, vthunder, flavor_data=None, update_dict={}):
         try:
             if listener:
+                listener.__dict__.update(update_dict)
                 self.set(self.axapi_client.slb.virtual_server.vport.replace,
                          loadbalancer, listener, vthunder, flavor_data, update_dict)
                 LOG.debug("Successfully updated listener: %s", listener.id)

--- a/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
@@ -108,8 +108,9 @@ class UpdateVirtualServerTask(LoadBalancerParent, task.Task):
     """Task to update a virtual server"""
 
     @axapi_client_decorator
-    def execute(self, loadbalancer, vthunder, flavor_data=None):
+    def execute(self, loadbalancer, vthunder, flavor_data=None, update_dict={}):
         try:
+            loadbalancer.__dict__.update(update_dict)
             port_list = self.axapi_client.slb.virtual_server.get(
                 loadbalancer.id)['virtual-server'].get('port-list')
             self.set(self.axapi_client.slb.virtual_server.replace, loadbalancer,

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_persist_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_persist_tasks.py
@@ -130,3 +130,11 @@ class TestPersistTasks(BaseTaskTestCase):
         mock_session_persist.axapi_client = self.client_mock
         mock_session_persist.execute(VTHUNDER, self.pool)
         self.client_mock.slb.template.cookie_persistence.delete.assert_not_called()
+
+    def test_unset_session_persistence(self):
+        mock_session_persist = persist_tasks.HandleSessionPersistenceDelta()
+        mock_session_persist.axapi_client = self.client_mock
+        self.pool.session_persistence = None
+        mock_session_persist.execute(VTHUNDER, self.pool)
+        self.client_mock.slb.template.src_ip_persistence.delete.assert_not_called()
+        self.client_mock.slb.template.src_ip_persistence.create.assert_not_called()

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_virtual_port_tasks.py
@@ -492,3 +492,15 @@ class TestHandlerVirtualPortTasks(base.BaseTaskTestCase):
 
         args, kwargs = self.client_mock.slb.virtual_server.vport.replace.call_args
         self.assertEqual(kwargs['conn_limit'], 200)
+
+    def test_unset_http_virtual_port_conn_limit_with_config(self):
+        UPDATE_DICT = {"conn_limit": -1, "default_tls_container_ref": None}
+        listener = self._mock_listener('HTTP', -1)
+        listener_task = task.ListenerUpdate()
+        listener_task.axapi_client = self.client_mock
+        with mock.patch('a10_octavia.common.openstack_mappings.virtual_port_protocol',
+                        return_value=listener.protocol):
+            listener_task.execute(LB, listener, VTHUNDER, None, UPDATE_DICT)
+        args, kwargs = self.client_mock.slb.virtual_server.vport.replace.call_args
+        self.assertEqual(kwargs['conn_limit'], 64000000)
+        self.assertEqual(kwargs['template_client_ssl'], None)


### PR DESCRIPTION
## Description
Add Unset Operation support for automated and rack flow 

**Design Document:** 

https://teams.microsoft.com/l/file/FB58C9F5-594E-4EBB-BF00-72E1406DC12B?tenantId=91d27ab9-8c5e-41d4-82e8-3d1bf81fcb2f&fileType=docx&objectUrl=https%3A%2F%2Fa10networks.sharepoint.com%2Fsites%2FOpenstack%2FShared%20Documents%2FDevelopment%2FResearch%20%26%20Design%2Fa10-octavia%20v2.0%20-%20Victoria%20Support%2FUnset%20Operation%20Support%2F%5BDD%5D%20Unset%20Operation%20Support.docx&baseUrl=https%3A%2F%2Fa10networks.sharepoint.com%2Fsites%2FOpenstack&serviceName=teams&threadId=19:0f1acbb173d74758b05ee8bacb000d68@thread.tacv2&groupId=37bbf3ad-c05a-4e67-b0cc-12bcd1479beb

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2359

## Technical Approach
- Updated the objects of Loadbalancer and Listener to get current values specified on Openstack CLI.
- Used **update_dict** for getting current values from Openstack CLI to update the Loadbalancer and Listener object.
- Updated the object of a **Pool** with current values specified on Openstack CLI.
- Used **update_dict** for getting current values from Openstack CLI to update the Pool object.
- Updated the **pool.session_persistence** object using **update_dict** for getting current values specified on Openstack CLI
- Converted **pool.session_persistence** in dict() format to support pool set and unset operation with updated object for the parameter session_persistence.

## Manual Testing
**Automated flow and Rack flow :**
Verified every SLB component by unsetting it after Create and Update operation

**Steps:**

**Automated flow:** 

Create a Load balancer

stack@sana:~$ openstack loadbalancer create --vip-subnet-id vip_subnet --name lb1 --description "LB1"

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-08-05T11:21:06                  |
| description         | LB1                                  |
| flavor_id           | None                                 |
| id                  | ee9859bb-ab76-438c-9054-512e864a9922 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.12.15                        |
| vip_network_id      | 144533bf-db26-440f-a0ca-8ba072769e4a |
| vip_port_id         | 228813a1-0ba3-456b-b907-a22e81be5526 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
+---------------------+--------------------------------------+

stack@sana:~$

stack@sana:~$ openstack server list

+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------+----------------+-----------------+
| ID                                   | Name                                         | Status | Networks                                            | Image          | Flavor          |
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------+----------------+-----------------+
| 3e694103-bd56-4f2e-84a1-cfa91da645b8 | amphora-f6da55c4-7853-4167-933e-4c1194c0e973 | ACTIVE | lb-mgmt-net=192.168.0.3; vip_network=192.168.12.233 | vThunder.qcow2 | vThunder_flavor |
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------+----------------+-----------------+
stack@sana:~$

**Vthunder Configuration:**

vThunder(NOLICENSE)#show running-config
!Current configuration: 190 bytes
!Configuration last updated at 12:27:53 IST Thu Aug 5 2021
!Configuration last saved at 12:27:57 IST Thu Aug 5 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
slb virtual-server ee9859bb-ab76-438c-9054-512e864a9922 192.168.12.15
  description "LB1"
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#

**Unset a LB**

stack@sana:~$ openstack loadbalancer unset --name --description ee9859bb-ab76-438c-9054-512e864a9922

stack@sana:~$ openstack loadbalancer show ee9859bb-ab76-438c-9054-512e864a9922

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-08-05T11:21:06                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | ee9859bb-ab76-438c-9054-512e864a9922 |
| listeners           |                                      |
| name                |                                      |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| provider            | a10                                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-08-05T11:33:43                  |
| vip_address         | 192.168.12.15                        |
| vip_network_id      | 144533bf-db26-440f-a0ca-8ba072769e4a |
| vip_port_id         | 228813a1-0ba3-456b-b907-a22e81be5526 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
+---------------------+--------------------------------------+

stack@sana:~$

**vThunder Configuration**

vThunder(NOLICENSE)#show running-config
!Current configuration: 170 bytes
!Configuration last updated at 12:33:42 IST Thu Aug 5 2021
!Configuration last saved at 12:33:46 IST Thu Aug 5 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
slb virtual-server ee9859bb-ab76-438c-9054-512e864a9922 192.168.12.15
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#

**Set a Load Balancer**

stack@sana:~$ openstack loadbalancer set --name "Loadbalancer1" --description "First Loadbalancer" ee9859bb-ab76-438c-9054-512e864a9922

stack@sana:~$ openstack loadbalancer show ee9859bb-ab76-438c-9054-512e864a9922

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-08-05T11:21:06                  |
| description         | First Loadbalancer                   |
| flavor_id           | None                                 |
| id                  | ee9859bb-ab76-438c-9054-512e864a9922 |
| listeners           |                                      |
| name                | Loadbalancer1                        |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| provider            | a10                                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-08-05T11:46:57                  |
| vip_address         | 192.168.12.15                        |
| vip_network_id      | 144533bf-db26-440f-a0ca-8ba072769e4a |
| vip_port_id         | 228813a1-0ba3-456b-b907-a22e81be5526 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration:**

vThunder(NOLICENSE)#show running-config
!Current configuration: 205 bytes
!Configuration last updated at 12:46:56 IST Thu Aug 5 2021
!Configuration last saved at 12:47:00 IST Thu Aug 5 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
slb virtual-server ee9859bb-ab76-438c-9054-512e864a9922 192.168.12.15
  description "First Loadbalancer"
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#

**Unset a LB**

stack@sana:~$ openstack loadbalancer unset --name --description ee9859bb-ab76-438c-9054-512e864a9922

stack@sana:~$ openstack loadbalancer show ee9859bb-ab76-438c-9054-512e864a9922

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-08-05T11:21:06                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | ee9859bb-ab76-438c-9054-512e864a9922 |
| listeners           |                                      |
| name                |                                      |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| provider            | a10                                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-08-05T11:48:57                  |
| vip_address         | 192.168.12.15                        |
| vip_network_id      | 144533bf-db26-440f-a0ca-8ba072769e4a |
| vip_port_id         | 228813a1-0ba3-456b-b907-a22e81be5526 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration:**

vThunder(NOLICENSE)#show running-config
!Current configuration: 170 bytes
!Configuration last updated at 12:48:56 IST Thu Aug 5 2021
!Configuration last saved at 12:49:01 IST Thu Aug 5 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
slb virtual-server ee9859bb-ab76-438c-9054-512e864a9922 192.168.12.15
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#


**Create a Listener**

stack@sana:~$ openstack loadbalancer listener create --protocol TERMINATED_HTTPS --default-tls-container-ref http://10.64.28.69/key-manager/v1/containers/2a2839a6-7449-477a-a4e1-7f4334e03f32 --protocol-port 9001 ee9859bb-ab76-438c-9054-512e864a9922 --name l1 --connection-limit 4567

+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | 4567                                                                                                                                                                                                                                                                               |
| created_at                  | 2021-08-05T11:51:59                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | http://10.64.28.69/key-manager/v1/containers/2a2839a6-7449-477a-a4e1-7f4334e03f32                                                                                                                                                                                                  |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | eff16270-d4e3-4bd8-8332-f99e57b16cef                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | ee9859bb-ab76-438c-9054-512e864a9922                                                                                                                                                                                                                                               |
| name                        | l1                                                                                                                                                                                                                                                                                 |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | e1fe759747844dd1871092efe9079a26                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 9001                                                                                                                                                                                                                                                                               |
| provisioning_status         | PENDING_CREATE                                                                                                                                                                                                                                                                     |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | None                                                                                                                                                                                                                                                                               |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

stack@sana:~$

**VThunder Configuration:**

vThunder(NOLICENSE)#show running-config slb
!Section configuration: 334 bytes
!
slb template client-ssl eff16270-d4e3-4bd8-8332-f99e57b16cef
  cert mycert
  key mykey
!
slb virtual-server ee9859bb-ab76-438c-9054-512e864a9922 192.168.12.15
  port 9001 https
    name eff16270-d4e3-4bd8-8332-f99e57b16cef
    conn-limit 4567
    extended-stats
    template client-ssl eff16270-d4e3-4bd8-8332-f99e57b16cef
!
vThunder(NOLICENSE)#

**Unset a Listener**

stack@sana:~$ openstack loadbalancer listener unset --name --connection-limit --default-tls-container-ref eff16270-d4e3-4bd8-8332-f99e57b16cef

stack@sana:~$ openstack loadbalancer listener show eff16270-d4e3-4bd8-8332-f99e57b16cef

+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | -1                                                                                                                                                                                                                                                                                 |
| created_at                  | 2021-08-05T11:51:59                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | None                                                                                                                                                                                                                                                                               |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | eff16270-d4e3-4bd8-8332-f99e57b16cef                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | ee9859bb-ab76-438c-9054-512e864a9922                                                                                                                                                                                                                                               |
| name                        |                                                                                                                                                                                                                                                                                    |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | e1fe759747844dd1871092efe9079a26                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 9001                                                                                                                                                                                                                                                                               |
| provisioning_status         | ACTIVE                                                                                                                                                                                                                                                                             |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | 2021-08-05T11:53:34                                                                                                                                                                                                                                                                |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

stack@sana:~$

**VThunder Configuration**

vThunder(NOLICENSE)#show running-config slb
!Section configuration: 251 bytes
!
slb template client-ssl eff16270-d4e3-4bd8-8332-f99e57b16cef
  cert mycert
  key mykey
!
slb virtual-server ee9859bb-ab76-438c-9054-512e864a9922 192.168.12.15
  port 9001 https
    name eff16270-d4e3-4bd8-8332-f99e57b16cef
    extended-stats
!
vThunder(NOLICENSE)#

**Set a Listener**

stack@sana:~$ openstack loadbalancer listener set --name l1 --connection-limit 6789 --default-tls-container-ref http://10.64.28.69/key-manager/v1/containers/2a2839a6-7449-477a-a4e1-7f4334e03f32 eff16270-d4e3-4bd8-8332-f99e57b16cef

stack@sana:~$ openstack loadbalancer listener show eff16270-d4e3-4bd8-8332-f99e57b16cef

+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | 6789                                                                                                                                                                                                                                                                               |
| created_at                  | 2021-08-05T11:51:59                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | http://10.64.28.69/key-manager/v1/containers/2a2839a6-7449-477a-a4e1-7f4334e03f32                                                                                                                                                                                                  |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | eff16270-d4e3-4bd8-8332-f99e57b16cef                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | ee9859bb-ab76-438c-9054-512e864a9922                                                                                                                                                                                                                                               |
| name                        | l1                                                                                                                                                                                                                                                                                 |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | e1fe759747844dd1871092efe9079a26                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 9001                                                                                                                                                                                                                                                                               |
| provisioning_status         | ACTIVE                                                                                                                                                                                                                                                                             |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | 2021-08-05T11:55:53                                                                                                                                                                                                                                                                |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

stack@sana:~$

**VThunder Configuration:**

vThunder(NOLICENSE)#show running-config slb
!Section configuration: 334 bytes
!
slb template client-ssl eff16270-d4e3-4bd8-8332-f99e57b16cef
  cert mycert
  key mykey
!
slb virtual-server ee9859bb-ab76-438c-9054-512e864a9922 192.168.12.15
  port 9001 https
    name eff16270-d4e3-4bd8-8332-f99e57b16cef
    conn-limit 6789
    extended-stats
    template client-ssl eff16270-d4e3-4bd8-8332-f99e57b16cef
!
vThunder(NOLICENSE)#

**Unset a Listener**

stack@sana:~$ openstack loadbalancer listener unset --name --connection-limit --default-tls-container-ref eff16270-d4e3-4bd8-8332-f99e57b16cef

stack@sana:~$ openstack loadbalancer listener show eff16270-d4e3-4bd8-8332-f99e57b16cef

+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | -1                                                                                                                                                                                                                                                                                 |
| created_at                  | 2021-08-05T11:51:59                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | None                                                                                                                                                                                                                                                                               |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | eff16270-d4e3-4bd8-8332-f99e57b16cef                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | ee9859bb-ab76-438c-9054-512e864a9922                                                                                                                                                                                                                                               |
| name                        |                                                                                                                                                                                                                                                                                    |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | e1fe759747844dd1871092efe9079a26                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 9001                                                                                                                                                                                                                                                                               |
| provisioning_status         | ACTIVE                                                                                                                                                                                                                                                                             |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | 2021-08-05T11:58:01                                                                                                                                                                                                                                                                |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

stack@sana:~$

**VThunder Configuration**

vThunder(NOLICENSE)#show running-config slb
!Section configuration: 251 bytes
!
slb template client-ssl eff16270-d4e3-4bd8-8332-f99e57b16cef
  cert mycert
  key mykey
!
slb virtual-server ee9859bb-ab76-438c-9054-512e864a9922 192.168.12.15
  port 9001 https
    name eff16270-d4e3-4bd8-8332-f99e57b16cef
    extended-stats
!
vThunder(NOLICENSE)#

**Create a Pool**

stack@sana:~$ openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener eff16270-d4e3-4bd8-8332-f99e57b16cef --name pool1 --description "Pool1" --session-persistence type=SOURCE_IP

+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-08-05T12:01:17                  |
| description          | Pool1                                |
| healthmonitor_id     |                                      |
| id                   | d061bb9e-a580-41d3-b6bb-882e0de7e46f |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | eff16270-d4e3-4bd8-8332-f99e57b16cef |
| loadbalancers        | ee9859bb-ab76-438c-9054-512e864a9922 |
| members              |                                      |
| name                 | pool1                                |
| operating_status     | OFFLINE                              |
| project_id           | e1fe759747844dd1871092efe9079a26     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | type=SOURCE_IP                       |
|                      | cookie_name=None                     |
|                      | persistence_timeout=None             |
|                      | persistence_granularity=None         |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration**

vThunder(NOLICENSE)#show running-config slb
!Section configuration: 509 bytes
!
slb template client-ssl eff16270-d4e3-4bd8-8332-f99e57b16cef
  cert mycert
  key mykey
!
slb template persist source-ip d061bb9e-a580-41d3-b6bb-882e0de7e46f
!
slb service-group d061bb9e-a580-41d3-b6bb-882e0de7e46f tcp
!
slb virtual-server ee9859bb-ab76-438c-9054-512e864a9922 192.168.12.15
  port 9001 https
    name eff16270-d4e3-4bd8-8332-f99e57b16cef
    extended-stats
    service-group d061bb9e-a580-41d3-b6bb-882e0de7e46f
    template persist source-ip d061bb9e-a580-41d3-b6bb-882e0de7e46f
!
vThunder(NOLICENSE)#

**Unset a Pool**

stack@sana:~$ openstack loadbalancer pool unset --name --session-persistence d061bb9e-a580-41d3-b6bb-882e0de7e46f

stack@sana:~$ openstack loadbalancer pool show d061bb9e-a580-41d3-b6bb-882e0de7e46f

+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-08-05T12:01:17                  |
| description          | Pool1                                |
| healthmonitor_id     |                                      |
| id                   | d061bb9e-a580-41d3-b6bb-882e0de7e46f |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | eff16270-d4e3-4bd8-8332-f99e57b16cef |
| loadbalancers        | ee9859bb-ab76-438c-9054-512e864a9922 |
| members              |                                      |
| name                 |                                      |
| operating_status     | OFFLINE                              |
| project_id           | e1fe759747844dd1871092efe9079a26     |
| protocol             | HTTP                                 |
| provisioning_status  | ACTIVE                               |
| session_persistence  | None                                 |
| updated_at           | 2021-08-05T12:02:52                  |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+
stack@sana:~$

**VThunder Configuration**

vThunder(NOLICENSE)#show running-config slb
!Section configuration: 440 bytes
!
slb template client-ssl eff16270-d4e3-4bd8-8332-f99e57b16cef
  cert mycert
  key mykey
!
slb template persist source-ip d061bb9e-a580-41d3-b6bb-882e0de7e46f
!
slb service-group d061bb9e-a580-41d3-b6bb-882e0de7e46f tcp
!
slb virtual-server ee9859bb-ab76-438c-9054-512e864a9922 192.168.12.15
  port 9001 https
    name eff16270-d4e3-4bd8-8332-f99e57b16cef
    extended-stats
    service-group d061bb9e-a580-41d3-b6bb-882e0de7e46f
!
vThunder(NOLICENSE)#

**Set a pool**

stack@sana:~$ openstack loadbalancer pool set --session-persistence type=SOURCE_IP --name pool1 d061bb9e-a580-41d3-b6bb-882e0de7e46f

stack@sana:~$ openstack loadbalancer pool show d061bb9e-a580-41d3-b6bb-882e0de7e46f

+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-08-05T12:01:17                  |
| description          | Pool1                                |
| healthmonitor_id     |                                      |
| id                   | d061bb9e-a580-41d3-b6bb-882e0de7e46f |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | eff16270-d4e3-4bd8-8332-f99e57b16cef |
| loadbalancers        | ee9859bb-ab76-438c-9054-512e864a9922 |
| members              |                                      |
| name                 | pool1                                |
| operating_status     | OFFLINE                              |
| project_id           | e1fe759747844dd1871092efe9079a26     |
| protocol             | HTTP                                 |
| provisioning_status  | ACTIVE                               |
| session_persistence  | type=SOURCE_IP                       |
|                      | cookie_name=None                     |
|                      | persistence_timeout=None             |
|                      | persistence_granularity=None         |
| updated_at           | 2021-08-05T12:04:28                  |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+
stack@sana:~$

**VThunder Configuration**

vThunder(NOLICENSE)#show running-config slb
!Section configuration: 509 bytes
!
slb template client-ssl eff16270-d4e3-4bd8-8332-f99e57b16cef
  cert mycert
  key mykey
!
slb template persist source-ip d061bb9e-a580-41d3-b6bb-882e0de7e46f
!
slb service-group d061bb9e-a580-41d3-b6bb-882e0de7e46f tcp
!
slb virtual-server ee9859bb-ab76-438c-9054-512e864a9922 192.168.12.15
  port 9001 https
    name eff16270-d4e3-4bd8-8332-f99e57b16cef
    extended-stats
    service-group d061bb9e-a580-41d3-b6bb-882e0de7e46f
    template persist source-ip d061bb9e-a580-41d3-b6bb-882e0de7e46f
!
vThunder(NOLICENSE)#

**Unset a pool**

stack@sana:~$ openstack loadbalancer pool unset --name --session-persistence d061bb9e-a580-41d3-b6bb-882e0de7e46f

stack@sana:~$ openstack loadbalancer pool show d061bb9e-a580-41d3-b6bb-882e0de7e46f

+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-08-05T12:01:17                  |
| description          | Pool1                                |
| healthmonitor_id     |                                      |
| id                   | d061bb9e-a580-41d3-b6bb-882e0de7e46f |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | eff16270-d4e3-4bd8-8332-f99e57b16cef |
| loadbalancers        | ee9859bb-ab76-438c-9054-512e864a9922 |
| members              |                                      |
| name                 |                                      |
| operating_status     | OFFLINE                              |
| project_id           | e1fe759747844dd1871092efe9079a26     |
| protocol             | HTTP                                 |
| provisioning_status  | ACTIVE                               |
| session_persistence  | None                                 |
| updated_at           | 2021-08-05T12:05:29                  |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration**

vThunder(NOLICENSE)#show running-config slb
!Section configuration: 440 bytes
!
slb template client-ssl eff16270-d4e3-4bd8-8332-f99e57b16cef
  cert mycert
  key mykey
!
slb template persist source-ip d061bb9e-a580-41d3-b6bb-882e0de7e46f
!
slb service-group d061bb9e-a580-41d3-b6bb-882e0de7e46f tcp
!
slb virtual-server ee9859bb-ab76-438c-9054-512e864a9922 192.168.12.15
  port 9001 https
    name eff16270-d4e3-4bd8-8332-f99e57b16cef
    extended-stats
    service-group d061bb9e-a580-41d3-b6bb-882e0de7e46f
!
vThunder(NOLICENSE)#

**Create a Member**

stack@sana:~$ openstack loadbalancer member create --subnet-id vip_subnet --protocol-port 81 --address 10.10.10.15 --name member1 d061bb9e-a580-41d3-b6bb-882e0de7e46f

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.10.10.15                          |
| admin_state_up      | True                                 |
| created_at          | 2021-08-05T12:29:57                  |
| id                  | fe94325b-011c-457f-bfc6-6861a54964dc |
| name                | member1                              |
| operating_status    | OFFLINE                              |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| protocol_port       | 81                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
stack@sana:~$

**VThunder Configuration**

vThunder(NOLICENSE)#show running-config
!Current configuration: 258 bytes
!Configuration last updated at 13:30:01 IST Thu Aug 5 2021
!Configuration last saved at 13:30:05 IST Thu Aug 5 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
health monitor e11e9e80-560d-4021-a430-236e772d6f01
  retry 6
  override-port 9001
  interval 10 timeout 3
  method http port 9001 expect response-code 200 url GET /
!
slb server e1fe7_10_10_10_15 10.10.10.15
  port 81 tcp
!
slb service-group d061bb9e-a580-41d3-b6bb-882e0de7e46f tcp
  health-check e11e9e80-560d-4021-a430-236e772d6f01
  member e1fe7_10_10_10_15 81
!
slb template client-ssl eff16270-d4e3-4bd8-8332-f99e57b16cef
  cert mycert
  key mykey
!
slb template persist source-ip d061bb9e-a580-41d3-b6bb-882e0de7e46f
!
slb virtual-server ee9859bb-ab76-438c-9054-512e864a9922 192.168.12.15
  port 9001 https
    name eff16270-d4e3-4bd8-8332-f99e57b16cef
    extended-stats
    service-group d061bb9e-a580-41d3-b6bb-882e0de7e46f
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode

**Unset a member** 

stack@sana:~$ openstack loadbalancer member unset --name d061bb9e-a580-41d3-b6bb-882e0de7e46f fe94325b-011c-457f-bfc6-6861a54964dc

stack@sana:~$ openstack loadbalancer member list d061bb9e-a580-41d3-b6bb-882e0de7e46f

+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address     | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| fe94325b-011c-457f-bfc6-6861a54964dc |      | e1fe759747844dd1871092efe9079a26 | ACTIVE              | 10.10.10.15 |            81 | OFFLINE          |      1 |
+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+

stack@sana:~$

**Set a member**

stack@sana:~$ openstack loadbalancer member set --name Member1 d061bb9e-a580-41d3-b6bb-882e0de7e46f fe94325b-011c-457f-bfc6-6861a54964dc

stack@sana:~$ openstack loadbalancer member list d061bb9e-a580-41d3-b6bb-882e0de7e46f

+--------------------------------------+---------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| id                                   | name    | project_id                       | provisioning_status | address     | protocol_port | operating_status | weight |
+--------------------------------------+---------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| fe94325b-011c-457f-bfc6-6861a54964dc | Member1 | e1fe759747844dd1871092efe9079a26 | ACTIVE              | 10.10.10.15 |            81 | OFFLINE          |      1 |
+--------------------------------------+---------+----------------------------------+---------------------+-------------+---------------+------------------+--------+

stack@sana:~$

**Unset a Member**

stack@sana:~$ openstack loadbalancer member unset --name d061bb9e-a580-41d3-b6bb-882e0de7e46f fe94325b-011c-457f-bfc6-6861a54964dc

stack@sana:~$ openstack loadbalancer member list d061bb9e-a580-41d3-b6bb-882e0de7e46f

+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address     | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| fe94325b-011c-457f-bfc6-6861a54964dc |      | e1fe759747844dd1871092efe9079a26 | ACTIVE              | 10.10.10.15 |            81 | OFFLINE          |      1 |
+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
stack@sana:~$


**Create a Health Monitor**

stack@sana:~$ openstack loadbalancer healthmonitor create --delay 10 --timeout 3 --max-retries 6 --type HTTP --name hm1 --url-path "/abc" --http-method HEAD --expected-codes 221 d061bb9e-a580-41d3-b6bb-882e0de7e46f

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| project_id          | e1fe759747844dd1871092efe9079a26     |
| name                | hm1                                  |
| admin_state_up      | True                                 |
| pools               | d061bb9e-a580-41d3-b6bb-882e0de7e46f |
| created_at          | 2021-08-05T12:10:01                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| delay               | 10                                   |
| expected_codes      | 221                                  |
| max_retries         | 6                                    |
| http_method         | HEAD                                 |
| timeout             | 3                                    |
| max_retries_down    | 3                                    |
| url_path            | /abc                                 |
| type                | HTTP                                 |
| id                  | e11e9e80-560d-4021-a430-236e772d6f01 |
| operating_status    | OFFLINE                              |
| http_version        | None                                 |
| domain_name         | None                                 |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration**

vThunder(NOLICENSE)#show running-config
!Current configuration: 371 bytes
!Configuration last updated at 13:10:02 IST Thu Aug 5 2021
!Configuration last saved at 13:10:11 IST Thu Aug 5 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
health monitor e11e9e80-560d-4021-a430-236e772d6f01
  retry 6
  override-port 9001
  interval 10 timeout 3
  method http port 9001 expect response-code 221 url HEAD /abc
!
slb service-group d061bb9e-a580-41d3-b6bb-882e0de7e46f tcp
  health-check e11e9e80-560d-4021-a430-236e772d6f01
!
slb template client-ssl eff16270-d4e3-4bd8-8332-f99e57b16cef
  cert mycert
  key mykey
!
slb template persist source-ip d061bb9e-a580-41d3-b6bb-882e0de7e46f
!
slb virtual-server ee9859bb-ab76-438c-9054-512e864a9922 192.168.12.15
  port 9001 https
    name eff16270-d4e3-4bd8-8332-f99e57b16cef
    extended-stats
    service-group d061bb9e-a580-41d3-b6bb-882e0de7e46f
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#

**Unset a health Monitor**

stack@sana:~$ openstack loadbalancer healthmonitor unset --name --url-path --http-method --expected-codes e11e9e80-560d-4021-a430-236e772d6f01

stack@sana:~$ openstack loadbalancer healthmonitor show e11e9e80-560d-4021-a430-236e772d6f01

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| project_id          | e1fe759747844dd1871092efe9079a26     |
| name                |                                      |
| admin_state_up      | True                                 |
| pools               | d061bb9e-a580-41d3-b6bb-882e0de7e46f |
| created_at          | 2021-08-05T12:10:01                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-08-05T12:14:51                  |
| delay               | 10                                   |
| expected_codes      | 200                                  |
| max_retries         | 6                                    |
| http_method         | GET                                  |
| timeout             | 3                                    |
| max_retries_down    | 3                                    |
| url_path            | /                                    |
| type                | HTTP                                 |
| id                  | e11e9e80-560d-4021-a430-236e772d6f01 |
| operating_status    | ONLINE                               |
| http_version        | None                                 |
| domain_name         | None                                 |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration**

vThunder(NOLICENSE)#show running-config health monitor
!Section configuration: 173 bytes
!
health monitor e11e9e80-560d-4021-a430-236e772d6f01
  retry 6
  override-port 9001
  interval 10 timeout 3
  method http port 9001 expect response-code 200 url GET /
!
vThunder(NOLICENSE)#

**Set a healthmonitor**

stack@sana:~$ openstack loadbalancer healthmonitor set --name  hm1 --url-path "/xyz" --http-method HEAD --expected-codes 223 e11e9e80-560d-4021-a430-236e772d6f01

stack@sana:~$ openstack loadbalancer healthmonitor show e11e9e80-560d-4021-a430-236e772d6f01

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| project_id          | e1fe759747844dd1871092efe9079a26     |
| name                | hm1                                  |
| admin_state_up      | True                                 |
| pools               | d061bb9e-a580-41d3-b6bb-882e0de7e46f |
| created_at          | 2021-08-05T12:10:01                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-08-05T12:18:39                  |
| delay               | 10                                   |
| expected_codes      | 223                                  |
| max_retries         | 6                                    |
| http_method         | HEAD                                 |
| timeout             | 3                                    |
| max_retries_down    | 3                                    |
| url_path            | /xyz                                 |
| type                | HTTP                                 |
| id                  | e11e9e80-560d-4021-a430-236e772d6f01 |
| operating_status    | ONLINE                               |
| http_version        | None                                 |
| domain_name         | None                                 |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration**

vThunder(NOLICENSE)#show running-config health monitor
!Section configuration: 177 bytes
!
health monitor e11e9e80-560d-4021-a430-236e772d6f01
  retry 6
  override-port 9001
  interval 10 timeout 3
  method http port 9001 expect response-code 223 url HEAD /xyz
!
vThunder(NOLICENSE)#

**Unset a Health Monitor**

stack@sana:~$ openstack loadbalancer healthmonitor unset --name --url-path --http-method --expected-codes e11e9e80-560d-4021-a430-236e772d6f01

stack@sana:~$ openstack loadbalancer healthmonitor show e11e9e80-560d-4021-a430-236e772d6f01

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| project_id          | e1fe759747844dd1871092efe9079a26     |
| name                |                                      |
| admin_state_up      | True                                 |
| pools               | d061bb9e-a580-41d3-b6bb-882e0de7e46f |
| created_at          | 2021-08-05T12:10:01                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-08-05T12:20:22                  |
| delay               | 10                                   |
| expected_codes      | 200                                  |
| max_retries         | 6                                    |
| http_method         | GET                                  |
| timeout             | 3                                    |
| max_retries_down    | 3                                    |
| url_path            | /                                    |
| type                | HTTP                                 |
| id                  | e11e9e80-560d-4021-a430-236e772d6f01 |
| operating_status    | ONLINE                               |
| http_version        | None                                 |
| domain_name         | None                                 |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder  Configuration**

!Section configuration: 173 bytes
!
health monitor e11e9e80-560d-4021-a430-236e772d6f01
  retry 6
  override-port 9001
  interval 10 timeout 3
  method http port 9001 expect response-code 200 url GET /
!
vThunder(NOLICENSE)#

**Create a L7 Policy**

stack@sana:~$ openstack loadbalancer l7policy create --action REJECT eff16270-d4e3-4bd8-8332-f99e57b16cef --name policy1

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| listener_id         | eff16270-d4e3-4bd8-8332-f99e57b16cef |
| description         |                                      |
| admin_state_up      | True                                 |
| rules               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| created_at          | 2021-08-05T12:35:16                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| redirect_pool_id    | None                                 |
| redirect_url        | None                                 |
| redirect_prefix     | None                                 |
| action              | REJECT                               |
| position            | 1                                    |
| id                  | 0e2b3865-118d-47a7-b65e-733823e7e464 |
| operating_status    | OFFLINE                              |
| name                | policy1                              |
| redirect_http_code  | None                                 |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration**

vThunder(NOLICENSE)#show aflex 0e2b3865-118d-47a7-b65e-733823e7e464
Name:                    0e2b3865-118d-47a7-b65e-733823e7e464
Syntax:                  Check
Virtual port:            Bind
                         ee9859bb-ab76-438c-9054-512e864a9922: 9001
Statistics:
    Event HTTP_REQUEST         execute 0 times (0 failures, 0 aborts)
Content:
 when HTTP_REQUEST {

        if { ( true ) } {

        HTTP::close

        }

        }
vThunder(NOLICENSE)#

**Unset a L7policy**

stack@sana:~$ openstack loadbalancer l7policy unset --name 0e2b3865-118d-47a7-b65e-733823e7e464

stack@sana:~$ openstack loadbalancer l7policy list

+--------------------------------------+------+----------------------------------+---------------------+--------+----------+----------------+
| id                                   | name | project_id                       | provisioning_status | action | position | admin_state_up |
+--------------------------------------+------+----------------------------------+---------------------+--------+----------+----------------+
| 0e2b3865-118d-47a7-b65e-733823e7e464 |      | e1fe759747844dd1871092efe9079a26 | ACTIVE              | REJECT |        1 | True           |
+--------------------------------------+------+----------------------------------+---------------------+--------+----------+----------------+

stack@sana:~$

**Set a L7policy**

stack@sana:~$ openstack loadbalancer l7policy set --name "Policy1" 0e2b3865-118d-47a7-b65e-733823e7e464

stack@sana:~$ openstack loadbalancer l7policy list

+--------------------------------------+---------+----------------------------------+---------------------+--------+----------+----------------+
| id                                   | name    | project_id                       | provisioning_status | action | position | admin_state_up |
+--------------------------------------+---------+----------------------------------+---------------------+--------+----------+----------------+
| 0e2b3865-118d-47a7-b65e-733823e7e464 | Policy1 | e1fe759747844dd1871092efe9079a26 | ACTIVE              | REJECT |        1 | True           |
+--------------------------------------+---------+----------------------------------+---------------------+--------+----------+----------------+

stack@sana:~$

**Unset a l7policy**

stack@sana:~$ openstack loadbalancer l7policy unset --name 0e2b3865-118d-47a7-b65e-733823e7e464

stack@sana:~$ openstack loadbalancer l7policy list

+--------------------------------------+------+----------------------------------+---------------------+--------+----------+----------------+
| id                                   | name | project_id                       | provisioning_status | action | position | admin_state_up |
+--------------------------------------+------+----------------------------------+---------------------+--------+----------+----------------+
| 0e2b3865-118d-47a7-b65e-733823e7e464 |      | e1fe759747844dd1871092efe9079a26 | ACTIVE              | REJECT |        1 | True           |
+--------------------------------------+------+----------------------------------+---------------------+--------+----------+----------------+

stack@sana:~$

**Create a L7rule** 

stack@sana:~$ openstack loadbalancer l7rule create --compare-type REGEX --invert --value abc  --type FILE_TYPE 0e2b3865-118d-47a7-b65e-733823e7e464

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| created_at          | 2021-08-05T12:43:57                  |
| compare_type        | REGEX                                |
| provisioning_status | PENDING_CREATE                       |
| invert              | True                                 |
| admin_state_up      | True                                 |
| updated_at          | None                                 |
| value               | abc                                  |
| key                 | None                                 |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| type                | FILE_TYPE                            |
| id                  | c53ef6d2-6e39-462e-b3a3-46016d45a1f2 |
| operating_status    | OFFLINE                              |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration**

vThunder(NOLICENSE)#show aflex 0e2b3865-118d-47a7-b65e-733823e7e464
Name:                    0e2b3865-118d-47a7-b65e-733823e7e464
Syntax:                  Check
Virtual port:            Bind
                         ee9859bb-ab76-438c-9054-512e864a9922: 9001
Statistics:
    Event HTTP_REQUEST         execute 0 times (0 failures, 0 aborts)
Content:
 when HTTP_REQUEST {

        if { not([HTTP::uri] matches_regex "abc") } {

        HTTP::close

        }

        }
vThunder(NOLICENSE)#

**Unset a L7rule** 

stack@sana:~$ openstack loadbalancer l7rule unset --invert 0e2b3865-118d-47a7-b65e-733823e7e464 c53ef6d2-6e39-462e-b3a3-46016d45a1f2

stack@sana:~$ openstack loadbalancer l7rule show 0e2b3865-118d-47a7-b65e-733823e7e464 c53ef6d2-6e39-462e-b3a3-46016d45a1f2

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| created_at          | 2021-08-05T12:43:57                  |
| compare_type        | REGEX                                |
| provisioning_status | ACTIVE                               |
| invert              | False                                |
| admin_state_up      | True                                 |
| updated_at          | 2021-08-05T12:45:55                  |
| value               | abc                                  |
| key                 | None                                 |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| type                | FILE_TYPE                            |
| id                  | c53ef6d2-6e39-462e-b3a3-46016d45a1f2 |
| operating_status    | ONLINE                               |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration**

vThunder(NOLICENSE)#show aflex 0e2b3865-118d-47a7-b65e-733823e7e464
Name:                    0e2b3865-118d-47a7-b65e-733823e7e464
Syntax:                  Check
Virtual port:            Bind
                         ee9859bb-ab76-438c-9054-512e864a9922: 9001
Statistics:
    Event HTTP_REQUEST         execute 0 times (0 failures, 0 aborts)
Content:
 when HTTP_REQUEST {

        if { ([HTTP::uri] matches_regex "abc") } {

        HTTP::close

        }

        }
vThunder(NOLICENSE)#

**Set a L7rule**

stack@sana:~$ openstack loadbalancer l7rule set --invert 0e2b3865-118d-47a7-b65e-733823e7e464 c53ef6d2-6e39-462e-b3a3-46016d45a1f2

stack@sana:~$ openstack loadbalancer l7rule show 0e2b3865-118d-47a7-b65e-733823e7e464 c53ef6d2-6e39-462e-b3a3-46016d45a1f2

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| created_at          | 2021-08-05T12:43:57                  |
| compare_type        | REGEX                                |
| provisioning_status | ACTIVE                               |
| invert              | True                                 |
| admin_state_up      | True                                 |
| updated_at          | 2021-08-05T12:47:30                  |
| value               | abc                                  |
| key                 | None                                 |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| type                | FILE_TYPE                            |
| id                  | c53ef6d2-6e39-462e-b3a3-46016d45a1f2 |
| operating_status    | ONLINE                               |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration**

vThunder(NOLICENSE)#show aflex 0e2b3865-118d-47a7-b65e-733823e7e464
Name:                    0e2b3865-118d-47a7-b65e-733823e7e464
Syntax:                  Check
Virtual port:            Bind
                         ee9859bb-ab76-438c-9054-512e864a9922: 9001
Statistics:
    Event HTTP_REQUEST         execute 0 times (0 failures, 0 aborts)
Content:
 when HTTP_REQUEST {

        if { not([HTTP::uri] matches_regex "abc") } {

        HTTP::close

        }

        }
vThunder(NOLICENSE)#

**Unset a L7rule**

stack@sana:~$ openstack loadbalancer l7rule unset --invert 0e2b3865-118d-47a7-b65e-733823e7e464 c53ef6d2-6e39-462e-b3a3-46016d45a1f2

stack@sana:~$ openstack loadbalancer l7rule show 0e2b3865-118d-47a7-b65e-733823e7e464 c53ef6d2-6e39-462e-b3a3-46016d45a1f2

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| created_at          | 2021-08-05T12:43:57                  |
| compare_type        | REGEX                                |
| provisioning_status | ACTIVE                               |
| invert              | False                                |
| admin_state_up      | True                                 |
| updated_at          | 2021-08-05T12:48:54                  |
| value               | abc                                  |
| key                 | None                                 |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| type                | FILE_TYPE                            |
| id                  | c53ef6d2-6e39-462e-b3a3-46016d45a1f2 |
| operating_status    | ONLINE                               |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration**

vThunder(NOLICENSE)#show aflex 0e2b3865-118d-47a7-b65e-733823e7e464
Name:                    0e2b3865-118d-47a7-b65e-733823e7e464
Syntax:                  Check
Virtual port:            Bind
                         ee9859bb-ab76-438c-9054-512e864a9922: 9001
Statistics:
    Event HTTP_REQUEST         execute 0 times (0 failures, 0 aborts)
Content:
 when HTTP_REQUEST {

        if { ([HTTP::uri] matches_regex "abc") } {

        HTTP::close

        }

        }
vThunder(NOLICENSE)#

**Rack Flow :**

**1. Create a LB**

stack@sana:~$ openstack loadbalancer create --vip-subnet-id vip_subnet --name lb1 --description "LB1"

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-08-05T10:09:22                  |
| description         | LB1                                  |
| flavor_id           | None                                 |
| id                  | 3497a35b-60d6-476a-9232-790a72b6d206 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.12.244                       |
| vip_network_id      | 144533bf-db26-440f-a0ca-8ba072769e4a |
| vip_port_id         | 53ed0ca8-7481-48fa-ae61-419fc1b4d895 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration:**

ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 94 bytes
!
slb virtual-server 3497a35b-60d6-476a-9232-790a72b6d206 192.168.12.244
  description "LB1"
!
ACOS-Active-vMaster[15/2]#

**Unset a LB**

stack@sana:~$ openstack loadbalancer unset --name --description 3497a35b-60d6-476a-9232-790a72b6d206

stack@sana:~$ openstack loadbalancer show 3497a35b-60d6-476a-9232-790a72b6d206

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-08-05T10:09:22                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 3497a35b-60d6-476a-9232-790a72b6d206 |
| listeners           |                                      |
| name                |                                      |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| provider            | a10                                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-08-05T10:11:28                  |
| vip_address         | 192.168.12.244                       |
| vip_network_id      | 144533bf-db26-440f-a0ca-8ba072769e4a |
| vip_port_id         | 53ed0ca8-7481-48fa-ae61-419fc1b4d895 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration**

ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 74 bytes
!
slb virtual-server 3497a35b-60d6-476a-9232-790a72b6d206 192.168.12.244
!
ACOS-Active-vMaster[15/2]#

Set a LB

stack@sana:~$ openstack loadbalancer set --name Loadbalancer1 --description "First Loadbalancer" 3497a35b-60d6-476a-9232-790a72b6d206

stack@sana:~$ openstack loadbalancer show 3497a35b-60d6-476a-9232-790a72b6d206

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-08-05T10:09:22                  |
| description         | First Loadbalancer                   |
| flavor_id           | None                                 |
| id                  | 3497a35b-60d6-476a-9232-790a72b6d206 |
| listeners           |                                      |
| name                | Loadbalancer1                        |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| provider            | a10                                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-08-05T10:13:20                  |
| vip_address         | 192.168.12.244                       |
| vip_network_id      | 144533bf-db26-440f-a0ca-8ba072769e4a |
| vip_port_id         | 53ed0ca8-7481-48fa-ae61-419fc1b4d895 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration**

ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 109 bytes
!
slb virtual-server 3497a35b-60d6-476a-9232-790a72b6d206 192.168.12.244
  description "First Loadbalancer"
!
ACOS-Active-vMaster[15/2]#

**Unset a LB**

stack@sana:~$ openstack loadbalancer unset --name --description 3497a35b-60d6-476a-9232-790a72b6d206

stack@sana:~$ openstack loadbalancer show 3497a35b-60d6-476a-9232-790a72b6d206

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-08-05T10:09:22                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 3497a35b-60d6-476a-9232-790a72b6d206 |
| listeners           |                                      |
| name                |                                      |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| provider            | a10                                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-08-05T10:14:51                  |
| vip_address         | 192.168.12.244                       |
| vip_network_id      | 144533bf-db26-440f-a0ca-8ba072769e4a |
| vip_port_id         | 53ed0ca8-7481-48fa-ae61-419fc1b4d895 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder configuration:**

ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 74 bytes
!
slb virtual-server 3497a35b-60d6-476a-9232-790a72b6d206 192.168.12.244
!
ACOS-Active-vMaster[15/2]#

**Create a Listener**

stack@sana:~$ openstack loadbalancer listener create --protocol TERMINATED_HTTPS --default-tls-container-ref http://10.64.28.69/key-manager/v1/containers/2a2839a6-7449-477a-a4e1-7f4334e03f32 --protocol-port 9001 3497a35b-60d6-476a-9232-790a72b6d206 --name l1 --connection-limit 4567

+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | 4567                                                                                                                                                                                                                                                                               |
| created_at                  | 2021-08-05T10:17:15                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | http://10.64.28.69/key-manager/v1/containers/2a2839a6-7449-477a-a4e1-7f4334e03f32                                                                                                                                                                                                  |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | bbf10bb0-4468-4ad8-bdb3-26b6377a2f71                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | 3497a35b-60d6-476a-9232-790a72b6d206                                                                                                                                                                                                                                               |
| name                        | l1                                                                                                                                                                                                                                                                                 |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | e1fe759747844dd1871092efe9079a26                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 9001                                                                                                                                                                                                                                                                               |
| provisioning_status         | PENDING_CREATE                                                                                                                                                                                                                                                                     |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | None                                                                                                                                                                                                                                                                               |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

stack@sana:~$

**VThunder Configuration:**

ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 335 bytes
!
slb template client-ssl bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
  cert mycert
  key mykey
!
slb virtual-server 3497a35b-60d6-476a-9232-790a72b6d206 192.168.12.244
  port 9001 https
    name bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
    conn-limit 4567
    extended-stats
    template client-ssl bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
!
ACOS-Active-vMaster[15/2]#

**Unset a listener**

stack@sana:~$ openstack loadbalancer listener unset --name --connection-limit --default-tls-container-ref bbf10bb0-4468-4ad8-bdb3-26b6377a2f71

stack@sana:~$ openstack loadbalancer listener show bbf10bb0-4468-4ad8-bdb3-26b6377a2f71

+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | -1                                                                                                                                                                                                                                                                                 |
| created_at                  | 2021-08-05T10:17:15                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | None                                                                                                                                                                                                                                                                               |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | bbf10bb0-4468-4ad8-bdb3-26b6377a2f71                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | 3497a35b-60d6-476a-9232-790a72b6d206                                                                                                                                                                                                                                               |
| name                        |                                                                                                                                                                                                                                                                                    |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | e1fe759747844dd1871092efe9079a26                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 9001                                                                                                                                                                                                                                                                               |
| provisioning_status         | ACTIVE                                                                                                                                                                                                                                                                             |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | 2021-08-05T10:20:57                                                                                                                                                                                                                                                                |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

stack@sana:~$

**Vthunder Configuration:**

ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 252 bytes
!
slb template client-ssl bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
  cert mycert
  key mykey
!
slb virtual-server 3497a35b-60d6-476a-9232-790a72b6d206 192.168.12.244
  port 9001 https
    name bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
    extended-stats
!
ACOS-Active-vMaster[15/2]#


**Set a Listener**

stack@sana:~$ openstack loadbalancer listener set --name l1 --connection-limit 6789 --default-tls-container-ref http://10.64.28.69/key-manager/v1/containers/2a2839a6-7449-477a-a4e1-7f4334e03f32 bbf10bb0-4468-4ad8-bdb3-26b6377a2f71

stack@sana:~$ openstack loadbalancer listener show bbf10bb0-4468-4ad8-bdb3-26b6377a2f71

+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | 6789                                                                                                                                                                                                                                                                               |
| created_at                  | 2021-08-05T10:17:15                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | http://10.64.28.69/key-manager/v1/containers/2a2839a6-7449-477a-a4e1-7f4334e03f32                                                                                                                                                                                                  |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | bbf10bb0-4468-4ad8-bdb3-26b6377a2f71                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | 3497a35b-60d6-476a-9232-790a72b6d206                                                                                                                                                                                                                                               |
| name                        | l1                                                                                                                                                                                                                                                                                 |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | e1fe759747844dd1871092efe9079a26                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 9001                                                                                                                                                                                                                                                                               |
| provisioning_status         | ACTIVE                                                                                                                                                                                                                                                                             |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | 2021-08-05T10:24:01                                                                                                                                                                                                                                                                |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

stack@sana:~$

**VThunder Configuration**

ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 335 bytes
!
slb template client-ssl bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
  cert mycert
  key mykey
!
slb virtual-server 3497a35b-60d6-476a-9232-790a72b6d206 192.168.12.244
  port 9001 https
    name bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
    conn-limit 6789
    extended-stats
    template client-ssl bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
!
ACOS-Active-vMaster[15/2]#

**Unset a Listener**

stack@sana:~$ openstack loadbalancer listener unset --name --connection-limit --default-tls-container-ref bbf10bb0-4468-4ad8-bdb3-26b6377a2f71

stack@sana:~$ openstack loadbalancer listener show bbf10bb0-4468-4ad8-bdb3-26b6377a2f71

+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | -1                                                                                                                                                                                                                                                                                 |
| created_at                  | 2021-08-05T10:17:15                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | None                                                                                                                                                                                                                                                                               |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | bbf10bb0-4468-4ad8-bdb3-26b6377a2f71                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | 3497a35b-60d6-476a-9232-790a72b6d206                                                                                                                                                                                                                                               |
| name                        |                                                                                                                                                                                                                                                                                    |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | e1fe759747844dd1871092efe9079a26                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 9001                                                                                                                                                                                                                                                                               |
| provisioning_status         | PENDING_UPDATE                                                                                                                                                                                                                                                                     |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | 2021-08-05T10:24:48                                                                                                                                                                                                                                                                |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

stack@sana:~$

**VThunder Configuration:**

ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 252 bytes
!
slb template client-ssl bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
  cert mycert
  key mykey
!
slb virtual-server 3497a35b-60d6-476a-9232-790a72b6d206 192.168.12.244
  port 9001 https
    name bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
    extended-stats
!
ACOS-Active-vMaster[15/2]#

**Create a Pool**

stack@sana:~$ openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener bbf10bb0-4468-4ad8-bdb3-26b6377a2f71 --name pool1 --description "Pool1" --session-persistence type=SOURCE_IP

+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-08-05T10:28:23                  |
| description          | Pool1                                |
| healthmonitor_id     |                                      |
| id                   | b9e64f3b-3a47-4468-a440-5eab8e9bfdbb |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | bbf10bb0-4468-4ad8-bdb3-26b6377a2f71 |
| loadbalancers        | 3497a35b-60d6-476a-9232-790a72b6d206 |
| members              |                                      |
| name                 | pool1                                |
| operating_status     | OFFLINE                              |
| project_id           | e1fe759747844dd1871092efe9079a26     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | type=SOURCE_IP                       |
|                      | cookie_name=None                     |
|                      | persistence_timeout=None             |
|                      | persistence_granularity=None         |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration**

ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 510 bytes
!
slb template client-ssl bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
  cert mycert
  key mykey
!
slb template persist source-ip b9e64f3b-3a47-4468-a440-5eab8e9bfdbb
!
slb service-group b9e64f3b-3a47-4468-a440-5eab8e9bfdbb tcp
!
slb virtual-server 3497a35b-60d6-476a-9232-790a72b6d206 192.168.12.244
  port 9001 https
    name bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
    extended-stats
    service-group b9e64f3b-3a47-4468-a440-5eab8e9bfdbb
    template persist source-ip b9e64f3b-3a47-4468-a440-5eab8e9bfdbb
!
ACOS-Active-vMaster[15/2]#

Unset a pool

stack@sana:~$ openstack loadbalancer pool unset --name --session-persistence b9e64f3b-3a47-4468-a440-5eab8e9bfdbb

stack@sana:~$ openstack loadbalancer pool show b9e64f3b-3a47-4468-a440-5eab8e9bfdbb

+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-08-05T10:28:23                  |
| description          | Pool1                                |
| healthmonitor_id     |                                      |
| id                   | b9e64f3b-3a47-4468-a440-5eab8e9bfdbb |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | bbf10bb0-4468-4ad8-bdb3-26b6377a2f71 |
| loadbalancers        | 3497a35b-60d6-476a-9232-790a72b6d206 |
| members              |                                      |
| name                 |                                      |
| operating_status     | OFFLINE                              |
| project_id           | e1fe759747844dd1871092efe9079a26     |
| protocol             | HTTP                                 |
| provisioning_status  | ACTIVE                               |
| session_persistence  | None                                 |
| updated_at           | 2021-08-05T10:30:16                  |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration:**

ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 441 bytes
!
slb template client-ssl bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
  cert mycert
  key mykey
!
slb template persist source-ip b9e64f3b-3a47-4468-a440-5eab8e9bfdbb
!
slb service-group b9e64f3b-3a47-4468-a440-5eab8e9bfdbb tcp
!
slb virtual-server 3497a35b-60d6-476a-9232-790a72b6d206 192.168.12.244
  port 9001 https
    name bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
    extended-stats
    service-group b9e64f3b-3a47-4468-a440-5eab8e9bfdbb
!
ACOS-Active-vMaster[15/2]#

**Set a Pool** 

stack@sana:~$ openstack loadbalancer pool set --session-persistence type=SOURCE_IP --name pool1 b9e64f3b-3a47-4468-a440-5eab8e9bfdbb

stack@sana:~$ openstack loadbalancer pool show b9e64f3b-3a47-4468-a440-5eab8e9bfdbb

+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-08-05T10:28:23                  |
| description          | Pool1                                |
| healthmonitor_id     |                                      |
| id                   | b9e64f3b-3a47-4468-a440-5eab8e9bfdbb |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | bbf10bb0-4468-4ad8-bdb3-26b6377a2f71 |
| loadbalancers        | 3497a35b-60d6-476a-9232-790a72b6d206 |
| members              |                                      |
| name                 | pool1                                |
| operating_status     | OFFLINE                              |
| project_id           | e1fe759747844dd1871092efe9079a26     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_UPDATE                       |
| session_persistence  | type=SOURCE_IP                       |
|                      | cookie_name=None                     |
|                      | persistence_timeout=None             |
|                      | persistence_granularity=None         |
| updated_at           | 2021-08-05T10:32:44                  |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration**

ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 510 bytes
!
slb template client-ssl bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
  cert mycert
  key mykey
!
slb template persist source-ip b9e64f3b-3a47-4468-a440-5eab8e9bfdbb
!
slb service-group b9e64f3b-3a47-4468-a440-5eab8e9bfdbb tcp
!
slb virtual-server 3497a35b-60d6-476a-9232-790a72b6d206 192.168.12.244
  port 9001 https
    name bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
    extended-stats
    service-group b9e64f3b-3a47-4468-a440-5eab8e9bfdbb
    template persist source-ip b9e64f3b-3a47-4468-a440-5eab8e9bfdbb
!
ACOS-Active-vMaster[15/2]#

**Unset a pool**

stack@sana:~$ openstack loadbalancer pool unset --name --session-persistence b9e64f3b-3a47-4468-a440-5eab8e9bfdbb

stack@sana:~$ openstack loadbalancer pool show b9e64f3b-3a47-4468-a440-5eab8e9bfdbb

+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-08-05T10:28:23                  |
| description          | Pool1                                |
| healthmonitor_id     |                                      |
| id                   | b9e64f3b-3a47-4468-a440-5eab8e9bfdbb |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | bbf10bb0-4468-4ad8-bdb3-26b6377a2f71 |
| loadbalancers        | 3497a35b-60d6-476a-9232-790a72b6d206 |
| members              |                                      |
| name                 |                                      |
| operating_status     | OFFLINE                              |
| project_id           | e1fe759747844dd1871092efe9079a26     |
| protocol             | HTTP                                 |
| provisioning_status  | ACTIVE                               |
| session_persistence  | None                                 |
| updated_at           | 2021-08-05T10:34:21                  |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration:**

ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 441 bytes
!
slb template client-ssl bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
  cert mycert
  key mykey
!
slb template persist source-ip b9e64f3b-3a47-4468-a440-5eab8e9bfdbb
!
slb service-group b9e64f3b-3a47-4468-a440-5eab8e9bfdbb tcp
!
slb virtual-server 3497a35b-60d6-476a-9232-790a72b6d206 192.168.12.244
  port 9001 https
    name bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
    extended-stats
    service-group b9e64f3b-3a47-4468-a440-5eab8e9bfdbb
!
ACOS-Active-vMaster[15/2]#

**Create a Member**

stack@sana:~$ openstack loadbalancer member create --subnet-id vip_subnet --protocol-port 81 --address 10.10.10.15 --name member1 b9e64f3b-3a47-4468-a440-5eab8e9bfdbb

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.10.10.15                          |
| admin_state_up      | True                                 |
| created_at          | 2021-08-05T10:36:54                  |
| id                  | 32c36f23-2ce4-4c1b-8c62-7391323c6cce |
| name                | member1                              |
| operating_status    | NO_MONITOR                           |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| protocol_port       | 81                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration:**

ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 531 bytes
!
slb template client-ssl bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
  cert mycert
  key mykey
!
slb template persist source-ip b9e64f3b-3a47-4468-a440-5eab8e9bfdbb
!
slb server e1fe7_10_10_10_15 10.10.10.15
  port 81 tcp
!
slb service-group b9e64f3b-3a47-4468-a440-5eab8e9bfdbb tcp
  member e1fe7_10_10_10_15 81
!
slb virtual-server 3497a35b-60d6-476a-9232-790a72b6d206 192.168.12.244
  port 9001 https
    name bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
    extended-stats
    service-group b9e64f3b-3a47-4468-a440-5eab8e9bfdbb
!
ACOS-Active-vMaster[15/2]#

**Unset a member**

stack@sana:~$ openstack loadbalancer member unset --name b9e64f3b-3a47-4468-a440-5eab8e9bfdbb 32c36f23-2ce4-4c1b-8c62-7391323c6cce

stack@sana:~$ openstack loadbalancer member list b9e64f3b-3a47-4468-a440-5eab8e9bfdbb

+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address     | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| 32c36f23-2ce4-4c1b-8c62-7391323c6cce |      | e1fe759747844dd1871092efe9079a26 | ACTIVE              | 10.10.10.15 |            81 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+

stack@sana:~$

**Set a Member**

stack@sana:~$ openstack loadbalancer member set --name "Member1" b9e64f3b-3a47-4468-a440-5eab8e9bfdbb 32c36f23-2ce4-4c1b-8c62-7391323c6cce

stack@sana:~$ openstack loadbalancer member list b9e64f3b-3a47-4468-a440-5eab8e9bfdbb

+--------------------------------------+---------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| id                                   | name    | project_id                       | provisioning_status | address     | protocol_port | operating_status | weight |
+--------------------------------------+---------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| 32c36f23-2ce4-4c1b-8c62-7391323c6cce | Member1 | e1fe759747844dd1871092efe9079a26 | ACTIVE              | 10.10.10.15 |            81 | NO_MONITOR       |      1 |
+--------------------------------------+---------+----------------------------------+---------------------+-------------+---------------+------------------+--------+

**Unset a Member**

stack@sana:~$ openstack loadbalancer member unset --name b9e64f3b-3a47-4468-a440-5eab8e9bfdbb 32c36f23-2ce4-4c1b-8c62-7391323c6cce

stack@sana:~$ openstack loadbalancer member list b9e64f3b-3a47-4468-a440-5eab8e9bfdbb

+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address     | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| 32c36f23-2ce4-4c1b-8c62-7391323c6cce |      | e1fe759747844dd1871092efe9079a26 | ACTIVE              | 10.10.10.15 |            81 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+-------------+---------------+------------------+--------+

stack@sana:~$

**Create a healthmonitor**

stack@sana:~$ openstack loadbalancer healthmonitor create --delay 10 --timeout 3 --max-retries 6 --type HTTP --name hm1 --url-path "/abc" --http-method HEAD --expected-codes 221 b9e64f3b-3a47-4468-a440-5eab8e9bfdbb

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| project_id          | e1fe759747844dd1871092efe9079a26     |
| name                | hm1                                  |
| admin_state_up      | True                                 |
| pools               | b9e64f3b-3a47-4468-a440-5eab8e9bfdbb |
| created_at          | 2021-08-05T10:44:57                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| delay               | 10                                   |
| expected_codes      | 221                                  |
| max_retries         | 6                                    |
| http_method         | HEAD                                 |
| timeout             | 3                                    |
| max_retries_down    | 3                                    |
| url_path            | /abc                                 |
| type                | HTTP                                 |
| id                  | 7cb07559-e1a9-47aa-94ec-3444fff8fd29 |
| operating_status    | OFFLINE                              |
| http_version        | None                                 |
| domain_name         | None                                 |
+---------------------+--------------------------------------+

stack@sana:~$

**Vthunder Configuration:**

health monitor 7cb07559-e1a9-47aa-94ec-3444fff8fd29
  retry 6
  override-port 9001
  interval 10 timeout 3
  method http port 9001 expect response-code 221 url HEAD /abc
!
slb server e1fe7_10_10_10_15 10.10.10.15
  port 81 tcp
!
slb service-group b9e64f3b-3a47-4468-a440-5eab8e9bfdbb tcp
  health-check 7cb07559-e1a9-47aa-94ec-3444fff8fd29
  member e1fe7_10_10_10_15 81
!
slb template client-ssl bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
  cert mycert
  key mykey
!
slb template persist source-ip b9e64f3b-3a47-4468-a440-5eab8e9bfdbb
!
slb virtual-server 3497a35b-60d6-476a-9232-790a72b6d206 192.168.12.244
  port 9001 https
    name bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
    extended-stats
    service-group b9e64f3b-3a47-4468-a440-5eab8e9bfdbb
!
sflow setting local-collection
!
sflow collector ip 127.0.0.1 6343
!
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
ACOS-Active-vMaster[15/2]#

**Unset a health monitor**

stack@sana:~$ openstack loadbalancer healthmonitor unset --name --url-path --http-method --expected-codes 7cb07559-e1a9-47aa-94ec-3444fff8fd29

stack@sana:~$ openstack loadbalancer healthmonitor show 7cb07559-e1a9-47aa-94ec-3444fff8fd29

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| project_id          | e1fe759747844dd1871092efe9079a26     |
| name                |                                      |
| admin_state_up      | True                                 |
| pools               | b9e64f3b-3a47-4468-a440-5eab8e9bfdbb |
| created_at          | 2021-08-05T10:44:57                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-08-05T10:48:53                  |
| delay               | 10                                   |
| expected_codes      | 200                                  |
| max_retries         | 6                                    |
| http_method         | GET                                  |
| timeout             | 3                                    |
| max_retries_down    | 3                                    |
| url_path            | /                                    |
| type                | HTTP                                 |
| id                  | 7cb07559-e1a9-47aa-94ec-3444fff8fd29 |
| operating_status    | ONLINE                               |
| http_version        | None                                 |
| domain_name         | None                                 |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration**

ACOS-Active-vMaster[15/2]#show json-config health monitor 7cb07559-e1a9-47aa-94ec-3444fff8fd29

a10-url:/axapi/v3/health/monitor/7cb07559-e1a9-47aa-94ec-3444fff8fd29
{
  "monitor": {
    "name":"7cb07559-e1a9-47aa-94ec-3444fff8fd29",
    "retry":6,
    "override-port":9001,
    "interval":10,
    "timeout":3,
    "uuid":"6af4d220-f61a-11eb-9424-6742a21a08a9",
    "method": {
      "http": {
        "http":1,
        "http-port":9001,
        "http-expect":1,
        "http-response-code":"200",
        "http-url":1,
        "url-type":"GET",
        "url-path":"/",
        "uuid":"6af5b1e0-f61a-11eb-9424-6742a21a08a9"
      }
    }
  }
}
ACOS-Active-vMaster[15/2]#

**Set a Health Monitor**

stack@sana:~$ openstack loadbalancer healthmonitor set --name  hm1 --url-path "/xyz" --http-method HEAD --expected-codes 223 7cb07559-e1a9-47aa-94ec-3444fff8fd29

stack@sana:~$ openstack loadbalancer healthmonitor show 7cb07559-e1a9-47aa-94ec-3444fff8fd29

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| project_id          | e1fe759747844dd1871092efe9079a26     |
| name                | hm1                                  |
| admin_state_up      | True                                 |
| pools               | b9e64f3b-3a47-4468-a440-5eab8e9bfdbb |
| created_at          | 2021-08-05T10:44:57                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-08-05T10:52:51                  |
| delay               | 10                                   |
| expected_codes      | 223                                  |
| max_retries         | 6                                    |
| http_method         | HEAD                                 |
| timeout             | 3                                    |
| max_retries_down    | 3                                    |
| url_path            | /xyz                                 |
| type                | HTTP                                 |
| id                  | 7cb07559-e1a9-47aa-94ec-3444fff8fd29 |
| operating_status    | ONLINE                               |
| http_version        | None                                 |
| domain_name         | None                                 |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration:**

ACOS-Active-vMaster[15/2]#show json-config health monitor 7cb07559-e1a9-47aa-94ec-3444fff8fd29

a10-url:/axapi/v3/health/monitor/7cb07559-e1a9-47aa-94ec-3444fff8fd29
{
  "monitor": {
    "name":"7cb07559-e1a9-47aa-94ec-3444fff8fd29",
    "retry":6,
    "override-port":9001,
    "interval":10,
    "timeout":3,
    "uuid":"6af4d220-f61a-11eb-9424-6742a21a08a9",
    "method": {
      "http": {
        "http":1,
        "http-port":9001,
        "http-expect":1,
        "http-response-code":"223",
        "http-url":1,
        "url-type":"HEAD",
        "url-path":"/xyz",
        "uuid":"6af5b1e0-f61a-11eb-9424-6742a21a08a9"
      }
    }
  }
}
ACOS-Active-vMaster[15/2]#

**Unset a health Monitor**

stack@sana:~$ openstack loadbalancer healthmonitor unset --name --url-path --http-method --expected-codes 7cb07559-e1a9-47aa-94ec-3444fff8fd29

stack@sana:~$ openstack loadbalancer healthmonitor show 7cb07559-e1a9-47aa-94ec-3444fff8fd29

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| project_id          | e1fe759747844dd1871092efe9079a26     |
| name                |                                      |
| admin_state_up      | True                                 |
| pools               | b9e64f3b-3a47-4468-a440-5eab8e9bfdbb |
| created_at          | 2021-08-05T10:44:57                  |
| provisioning_status | ACTIVE                               |
| updated_at          | 2021-08-05T10:54:32                  |
| delay               | 10                                   |
| expected_codes      | 200                                  |
| max_retries         | 6                                    |
| http_method         | GET                                  |
| timeout             | 3                                    |
| max_retries_down    | 3                                    |
| url_path            | /                                    |
| type                | HTTP                                 |
| id                  | 7cb07559-e1a9-47aa-94ec-3444fff8fd29 |
| operating_status    | ONLINE                               |
| http_version        | None                                 |
| domain_name         | None                                 |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration**

ACOS-Active-vMaster[15/2]#show json-config health monitor 7cb07559-e1a9-47aa-94ec-3444fff8fd29

a10-url:/axapi/v3/health/monitor/7cb07559-e1a9-47aa-94ec-3444fff8fd29
{
  "monitor": {
    "name":"7cb07559-e1a9-47aa-94ec-3444fff8fd29",
    "retry":6,
    "override-port":9001,
    "interval":10,
    "timeout":3,
    "uuid":"6af4d220-f61a-11eb-9424-6742a21a08a9",
    "method": {
      "http": {
        "http":1,
        "http-port":9001,
        "http-expect":1,
        "http-response-code":"200",
        "http-url":1,
        "url-type":"GET",
        "url-path":"/",
        "uuid":"6af5b1e0-f61a-11eb-9424-6742a21a08a9"
      }
    }
  }
}
ACOS-Active-vMaster[15/2]#

**Create a L7Policy**

stack@sana:~$ openstack loadbalancer l7policy create --action REJECT bbf10bb0-4468-4ad8-bdb3-26b6377a2f71 --name policy1

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| listener_id         | bbf10bb0-4468-4ad8-bdb3-26b6377a2f71 |
| description         |                                      |
| admin_state_up      | True                                 |
| rules               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| created_at          | 2021-08-05T10:58:18                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| redirect_pool_id    | None                                 |
| redirect_url        | None                                 |
| redirect_prefix     | None                                 |
| action              | REJECT                               |
| position            | 1                                    |
| id                  | 6984e77e-d874-4f50-ba1e-ea2df8cea172 |
| operating_status    | OFFLINE                              |
| name                | policy1                              |
| redirect_http_code  | None                                 |
+---------------------+--------------------------------------+

stack@sana:~$

ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 632 bytes
!
slb template client-ssl bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
  cert mycert
  key mykey
!
slb template persist source-ip b9e64f3b-3a47-4468-a440-5eab8e9bfdbb
!
slb server e1fe7_10_10_10_15 10.10.10.15
  port 81 tcp
!
slb service-group b9e64f3b-3a47-4468-a440-5eab8e9bfdbb tcp
  health-check 7cb07559-e1a9-47aa-94ec-3444fff8fd29
  member e1fe7_10_10_10_15 81
!
slb virtual-server 3497a35b-60d6-476a-9232-790a72b6d206 192.168.12.244
  port 9001 https
    name bbf10bb0-4468-4ad8-bdb3-26b6377a2f71
    extended-stats
    aflex 6984e77e-d874-4f50-ba1e-ea2df8cea172
    service-group b9e64f3b-3a47-4468-a440-5eab8e9bfdbb
!
ACOS-Active-vMaster[15/2]#

Unset a L7policy

stack@sana:~$ openstack loadbalancer l7policy unset --name 6984e77e-d874-4f50-ba1e-ea2df8cea172

stack@sana:~$ openstack loadbalancer l7policy list

+--------------------------------------+------+----------------------------------+---------------------+--------+----------+----------------+
| id                                   | name | project_id                       | provisioning_status | action | position | admin_state_up |
+--------------------------------------+------+----------------------------------+---------------------+--------+----------+----------------+
| 6984e77e-d874-4f50-ba1e-ea2df8cea172 |      | e1fe759747844dd1871092efe9079a26 | ACTIVE              | REJECT |        1 | True           |
+--------------------------------------+------+----------------------------------+---------------------+--------+----------+----------------+

stack@sana:~$

**Set a L7Policy** 

stack@sana:~$ openstack loadbalancer l7policy set --name "Policy1" 6984e77e-d874-4f50-ba1e-ea2df8cea172

stack@sana:~$ openstack loadbalancer l7policy list

+--------------------------------------+---------+----------------------------------+---------------------+--------+----------+----------------+
| id                                   | name    | project_id                       | provisioning_status | action | position | admin_state_up |
+--------------------------------------+---------+----------------------------------+---------------------+--------+----------+----------------+
| 6984e77e-d874-4f50-ba1e-ea2df8cea172 | Policy1 | e1fe759747844dd1871092efe9079a26 | ACTIVE              | REJECT |        1 | True           |
+--------------------------------------+---------+----------------------------------+---------------------+--------+----------+----------------+

stack@sana:~$

**Unset a L7policy** 

stack@sana:~$ openstack loadbalancer l7policy unset --name 6984e77e-d874-4f50-ba1e-ea2df8cea172

stack@sana:~$ openstack loadbalancer l7policy list

+--------------------------------------+------+----------------------------------+---------------------+--------+----------+----------------+
| id                                   | name | project_id                       | provisioning_status | action | position | admin_state_up |
+--------------------------------------+------+----------------------------------+---------------------+--------+----------+----------------+
| 6984e77e-d874-4f50-ba1e-ea2df8cea172 |      | e1fe759747844dd1871092efe9079a26 | ACTIVE              | REJECT |        1 | True           |
+--------------------------------------+------+----------------------------------+---------------------+--------+----------+----------------+

stack@sana:~$

**Create a L7rule**

stack@sana:~$ openstack loadbalancer l7rule create --compare-type REGEX --invert --value abc  --type FILE_TYPE 6984e77e-d874-4f50-ba1e-ea2df8cea172

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| created_at          | 2021-08-05T11:02:56                  |
| compare_type        | REGEX                                |
| provisioning_status | PENDING_CREATE                       |
| invert              | True                                 |
| admin_state_up      | True                                 |
| updated_at          | None                                 |
| value               | abc                                  |
| key                 | None                                 |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| type                | FILE_TYPE                            |
| id                  | 94f9ef9d-c0b9-4da6-955f-481c213ce8d0 |
| operating_status    | OFFLINE                              |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration:**

ACOS-Active-vMaster[15/2]#show aflex 6984e77e-d874-4f50-ba1e-ea2df8cea172
Name:                    6984e77e-d874-4f50-ba1e-ea2df8cea172
Syntax:                  Check
Virtual port:            Bind
                         3497a35b-60d6-476a-9232-790a72b6d206: 9001
Statistics:
    Event HTTP_REQUEST         execute 0 times (0 failures, 0 aborts)
Content:
 when HTTP_REQUEST {

        if { not([HTTP::uri] matches_regex "abc") } {

        HTTP::close

        }

        }
ACOS-Active-vMaster[15/2]#

**Unset a L7rule**

stack@sana:~$ openstack loadbalancer l7rule unset --invert 6984e77e-d874-4f50-ba1e-ea2df8cea172 94f9ef9d-c0b9-4da6-955f-481c213ce8d0

stack@sana:~$ openstack loadbalancer l7rule show 6984e77e-d874-4f50-ba1e-ea2df8cea172 94f9ef9d-c0b9-4da6-955f-481c213ce8d0

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| created_at          | 2021-08-05T11:02:56                  |
| compare_type        | REGEX                                |
| provisioning_status | ACTIVE                               |
| invert              | False                                |
| admin_state_up      | True                                 |
| updated_at          | 2021-08-05T11:04:47                  |
| value               | abc                                  |
| key                 | None                                 |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| type                | FILE_TYPE                            |
| id                  | 94f9ef9d-c0b9-4da6-955f-481c213ce8d0 |
| operating_status    | ONLINE                               |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder  Configuration**

ACOS-Active-vMaster[15/2]#show aflex 6984e77e-d874-4f50-ba1e-ea2df8cea172
Name:                    6984e77e-d874-4f50-ba1e-ea2df8cea172
Syntax:                  Check
Virtual port:            Bind
                         3497a35b-60d6-476a-9232-790a72b6d206: 9001
Statistics:
    Event HTTP_REQUEST         execute 0 times (0 failures, 0 aborts)
Content:
 when HTTP_REQUEST {

        if { ([HTTP::uri] matches_regex "abc") } {

        HTTP::close

        }

        }
ACOS-Active-vMaster[15/2]#


**Set a L7rule** 

stack@sana:~$ openstack loadbalancer l7rule set --invert 6984e77e-d874-4f50-ba1e-ea2df8cea172 94f9ef9d-c0b9-4da6-955f-481c213ce8d0

stack@sana:~$ openstack loadbalancer l7rule show 6984e77e-d874-4f50-ba1e-ea2df8cea172 94f9ef9d-c0b9-4da6-955f-481c213ce8d0

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| created_at          | 2021-08-05T11:02:56                  |
| compare_type        | REGEX                                |
| provisioning_status | ACTIVE                               |
| invert              | True                                 |
| admin_state_up      | True                                 |
| updated_at          | 2021-08-05T11:06:30                  |
| value               | abc                                  |
| key                 | None                                 |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| type                | FILE_TYPE                            |
| id                  | 94f9ef9d-c0b9-4da6-955f-481c213ce8d0 |
| operating_status    | ONLINE                               |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration**

ACOS-Active-vMaster[15/2]#show aflex 6984e77e-d874-4f50-ba1e-ea2df8cea172
Name:                    6984e77e-d874-4f50-ba1e-ea2df8cea172
Syntax:                  Check
Virtual port:            Bind
                         3497a35b-60d6-476a-9232-790a72b6d206: 9001
Statistics:
    Event HTTP_REQUEST         execute 0 times (0 failures, 0 aborts)
Content:
 when HTTP_REQUEST {

        if { not([HTTP::uri] matches_regex "abc") } {

        HTTP::close

        }

        }
ACOS-Active-vMaster[15/2]#

**Unset a L7rule** 

stack@sana:~$ openstack loadbalancer l7rule unset --invert 6984e77e-d874-4f50-ba1e-ea2df8cea172 94f9ef9d-c0b9-4da6-955f-481c213ce8d0

stack@sana:~$ openstack loadbalancer l7rule show 6984e77e-d874-4f50-ba1e-ea2df8cea172 94f9ef9d-c0b9-4da6-955f-481c213ce8d0

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| created_at          | 2021-08-05T11:02:56                  |
| compare_type        | REGEX                                |
| provisioning_status | ACTIVE                               |
| invert              | False                                |
| admin_state_up      | True                                 |
| updated_at          | 2021-08-05T11:07:35                  |
| value               | abc                                  |
| key                 | None                                 |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| type                | FILE_TYPE                            |
| id                  | 94f9ef9d-c0b9-4da6-955f-481c213ce8d0 |
| operating_status    | ONLINE                               |
+---------------------+--------------------------------------+

stack@sana:~$

**VThunder Configuration**

ACOS-Active-vMaster[15/2]#show aflex 6984e77e-d874-4f50-ba1e-ea2df8cea172
Name:                    6984e77e-d874-4f50-ba1e-ea2df8cea172
Syntax:                  Check
Virtual port:            Bind
                         3497a35b-60d6-476a-9232-790a72b6d206: 9001
Statistics:
    Event HTTP_REQUEST         execute 0 times (0 failures, 0 aborts)
Content:
 when HTTP_REQUEST {

        if { ([HTTP::uri] matches_regex "abc") } {

        HTTP::close

        }

        }
ACOS-Active-vMaster[15/2]#






