### PR TITLE
[STACK-2723]: Merge the latest master branch into experimental/victoria_ff branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ this provider driver uses a "Thunder per Tenant" architecture. Therefore, each t
 | a10-octavia    | acos-client   | ACOS Version        |
 | v1.1           | v2.6.1        | 5.2.1, 4.1.4-GR1-P5 |
 | v1.2           | v2.7.0        | 5.2.1-p1            |
-| v1.3           | v2.8.0        | 5.2.1-p1            |
+| v1.3, v1.3.1   | v2.8.0        | 5.2.1-p1            |
 ```
 
 ## Project Resources

--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -104,6 +104,9 @@ SSL_TEMPLATE = "ssl_template"
 
 COMPUTE_BUSY = "compute_busy"
 
+# ACOS versions
+ACOS_5_2_1_P2 = "5.2.1-P2"
+
 # ============================
 # Taskflow flow and task names
 # ============================

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -125,16 +125,6 @@ class LoadBalancerFlows(object):
         lb_create_flow.add(a10_database_tasks.SetThunderUpdatedAt(
             requires=a10constants.VTHUNDER))
 
-        # For first LB, vcs just setup and need sync. config and reload vBlade severial times.
-        if not vthunder and topology == constants.TOPOLOGY_ACTIVE_STANDBY:
-            lb_create_flow.add(a10_database_tasks.GetBackupVThunderByLoadBalancer(
-                name="get-blade-thunder-for-checking",
-                requires=constants.LOADBALANCER,
-                provides=a10constants.BACKUP_VTHUNDER))
-            lb_create_flow.add(virtual_server_tasks.WaitVirtualServerReadyOnBlade(
-                requires=(constants.LOADBALANCER),
-                rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
-
         return lb_create_flow
 
     def _create_single_topology(self):
@@ -244,11 +234,19 @@ class LoadBalancerFlows(object):
                 requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
                 provides=a10constants.BACKUP_VTHUNDER))
         if not deleteCompute:
+            delete_LB_flow.add(a10_database_tasks.GetMemberListByProjectID(
+                requires=a10constants.VTHUNDER,
+                provides=a10constants.MEMBER_LIST))
             delete_LB_flow.add(a10_network_tasks.CalculateDelta(
-                requires=(constants.LOADBALANCER, a10constants.LOADBALANCERS_LIST),
+                requires=(constants.LOADBALANCER, a10constants.LOADBALANCERS_LIST,
+                          a10constants.MEMBER_LIST),
                 provides=constants.DELTAS))
             delete_LB_flow.add(a10_network_tasks.HandleNetworkDeltas(
                 requires=constants.DELTAS, provides=constants.ADDED_PORTS))
+            if lb.topology == "ACTIVE_STANDBY":
+                delete_LB_flow.add(vthunder_tasks.VCSSyncWait(
+                    name="wait-vcs-ready-before-master-reload",
+                    requires=a10constants.VTHUNDER))
             delete_LB_flow.add(vthunder_tasks.AmphoraePostNetworkUnplug(
                 name=a10constants.AMPHORA_POST_NETWORK_UNPLUG,
                 requires=(constants.LOADBALANCER, constants.ADDED_PORTS, a10constants.VTHUNDER)))
@@ -257,15 +255,6 @@ class LoadBalancerFlows(object):
                     name=a10constants.VTHUNDER_CONNECTIVITY_WAIT,
                     requires=(a10constants.VTHUNDER, constants.AMPHORA)))
             if lb.topology == "ACTIVE_STANDBY":
-                delete_LB_flow.add(
-                    vthunder_tasks.VThunderComputeConnectivityWait(
-                        name=a10constants.BACKUP_CONNECTIVITY_WAIT + "-before-unplug",
-                        rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-                        requires=constants.AMPHORA))
-                delete_LB_flow.add(vthunder_tasks.AmphoraePostNetworkUnplug(
-                    name=a10constants.AMPHORA_POST_NETWORK_UNPLUG_FOR_BACKUP_VTHUNDER,
-                    requires=(constants.LOADBALANCER, constants.ADDED_PORTS),
-                    rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
                 delete_LB_flow.add(
                     vthunder_tasks.VThunderComputeConnectivityWait(
                         name=a10constants.BACKUP_CONNECTIVITY_WAIT,
@@ -359,15 +348,27 @@ class LoadBalancerFlows(object):
             name=a10constants.GET_VTHUNDER_BY_LB,
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
-        if vthunder and topology == constants.TOPOLOGY_SINGLE:
+        if vthunder:
             new_LB_net_subflow.add(a10_database_tasks.GetLoadBalancerListByProjectID(
                 requires=a10constants.VTHUNDER,
                 provides=a10constants.LOADBALANCERS_LIST))
+            new_LB_net_subflow.add(a10_database_tasks.GetMemberListByProjectID(
+                requires=a10constants.VTHUNDER,
+                provides=a10constants.MEMBER_LIST))
             new_LB_net_subflow.add(a10_network_tasks.CalculateDelta(
-                requires=(constants.LOADBALANCER, a10constants.LOADBALANCERS_LIST),
+                requires=(constants.LOADBALANCER, a10constants.LOADBALANCERS_LIST,
+                          a10constants.MEMBER_LIST),
                 provides=constants.DELTAS))
             new_LB_net_subflow.add(a10_network_tasks.HandleNetworkDeltas(
                 requires=constants.DELTAS, provides=constants.ADDED_PORTS))
+            if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+                new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
+                    name="wait-vcs-ready-before-master-reload",
+                    requires=a10constants.VTHUNDER))
+                new_LB_net_subflow.add(vthunder_tasks.GetMasterVThunder(
+                    name=a10constants.GET_MASTER_VTHUNDER,
+                    requires=a10constants.VTHUNDER,
+                    provides=a10constants.VTHUNDER))
             # managing interface additions here
             new_LB_net_subflow.add(vthunder_tasks.AmphoraePostVIPPlug(
                 name=a10constants.AMPHORAE_POST_VIP_PLUG,
@@ -377,6 +378,25 @@ class LoadBalancerFlows(object):
                 vthunder_tasks.VThunderComputeConnectivityWait(
                     name=a10constants.VTHUNDER_CONNECTIVITY_WAIT,
                     requires=(a10constants.VTHUNDER, constants.AMPHORA)))
+            if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
+                new_LB_net_subflow.add(
+                    a10_database_tasks.GetBackupVThunderByLoadBalancer(
+                        name=a10constants.GET_BACKUP_VTHUNDER_BY_LB,
+                        requires=constants.LOADBALANCER,
+                        provides=a10constants.BACKUP_VTHUNDER))
+                new_LB_net_subflow.add(
+                    vthunder_tasks.VThunderComputeConnectivityWait(
+                        name=a10constants.BACKUP_CONNECTIVITY_WAIT,
+                        rebind={
+                            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
+                        requires=constants.AMPHORA))
+                new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
+                    name="wait-vcs-ready-after-reload",
+                    requires=a10constants.VTHUNDER))
+                new_LB_net_subflow.add(vthunder_tasks.GetMasterVThunder(
+                    name=a10constants.GET_VTHUNDER_MASTER,
+                    requires=a10constants.VTHUNDER,
+                    provides=a10constants.VTHUNDER))
             new_LB_net_subflow.add(vthunder_tasks.EnableInterface(
                 name=a10constants.ENABLE_VTHUNDER_INTERFACE,
                 requires=(a10constants.VTHUNDER, constants.LOADBALANCER,
@@ -396,115 +416,13 @@ class LoadBalancerFlows(object):
         if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
             new_LB_net_subflow.add(
                 a10_database_tasks.GetBackupVThunderByLoadBalancer(
-                    name=a10constants.GET_BACKUP_VTHUNDER_BY_LB,
+                    name=a10constants.BACKUP_VTHUNDER,
                     requires=constants.LOADBALANCER,
                     provides=a10constants.BACKUP_VTHUNDER))
             new_LB_net_subflow.add(vthunder_tasks.UpdateAcosVersionInVthunderEntry(
                 name=a10constants.UPDATE_ACOS_VERSION_FOR_BACKUP_VTHUNDER,
                 requires=constants.LOADBALANCER,
                 rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
-            new_LB_net_subflow.add(
-                a10_database_tasks.GetBackupVThunderByLoadBalancer(
-                    name=a10constants.BACKUP_VTHUNDER,
-                    requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
-                    provides=a10constants.BACKUP_VTHUNDER))
-            if vthunder:
-                new_LB_net_subflow.add(a10_database_tasks.GetLoadBalancerListByProjectID(
-                    requires=a10constants.VTHUNDER,
-                    provides=a10constants.LOADBALANCERS_LIST))
-                new_LB_net_subflow.add(a10_network_tasks.CalculateDelta(
-                    requires=(constants.LOADBALANCER, a10constants.LOADBALANCERS_LIST),
-                    provides=constants.DELTAS))
-                new_LB_net_subflow.add(a10_network_tasks.HandleNetworkDeltas(
-                    requires=constants.DELTAS, provides=constants.ADDED_PORTS))
-
-                # Make sure vcs ready before first probe-network-devices on Master
-                new_LB_net_subflow.add(
-                    vthunder_tasks.VThunderComputeConnectivityWait(
-                        name="backup-compute-conn-wait-before-probe-device",
-                        rebind={
-                            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-                        requires=constants.AMPHORA))
-                new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
-                    name="wait-vcs-ready-before-probe-device",
-                    requires=a10constants.VTHUNDER))
-                new_LB_net_subflow.add(vthunder_tasks.AmphoraePostVIPPlug(
-                    name=a10constants.AMPHORAE_POST_VIP_PLUG_FOR_MASTER,
-                    requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
-                              constants.ADDED_PORTS)))
-                new_LB_net_subflow.add(
-                    vthunder_tasks.VThunderComputeConnectivityWait(
-                        name="make-sure-backup-is-ready-after-reload-master",
-                        rebind={
-                            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-                        requires=constants.AMPHORA))
-                new_LB_net_subflow.add(vthunder_tasks.AmphoraePostVIPPlug(
-                    name=a10constants.AMPHORAE_POST_VIP_PLUG_FOR_BACKUP,
-                    requires=(constants.LOADBALANCER, constants.ADDED_PORTS),
-                    rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
-                new_LB_net_subflow.add(
-                    vthunder_tasks.VThunderComputeConnectivityWait(
-                        name=a10constants.MASTER_CONNECTIVITY_WAIT,
-                        requires=(a10constants.VTHUNDER, constants.AMPHORA)))
-                new_LB_net_subflow.add(
-                    vthunder_tasks.VThunderComputeConnectivityWait(
-                        name=a10constants.BACKUP_CONNECTIVITY_WAIT,
-                        rebind={
-                            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-                        requires=constants.AMPHORA))
-                new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
-                    name="backup-plug-wait-vcs-ready",
-                    requires=a10constants.VTHUNDER))
-                new_LB_net_subflow.add(vthunder_tasks.GetVThunderInterface(
-                    name=a10constants.GET_MASTER_VTHUNDER_INTERFACE,
-                    requires=a10constants.VTHUNDER,
-                    provides=(a10constants.IFNUM_MASTER, a10constants.IFNUM_BACKUP)))
-                new_LB_net_subflow.add(vthunder_tasks.EnableInterface(
-                    name=a10constants.MASTER_ENABLE_INTERFACE,
-                    requires=(a10constants.VTHUNDER, constants.LOADBALANCER, constants.ADDED_PORTS,
-                              a10constants.IFNUM_MASTER, a10constants.IFNUM_BACKUP)))
-                new_LB_net_subflow.add(vthunder_tasks.GetVThunderInterface(
-                    name=a10constants.GET_BACKUP_VTHUNDER_INTERFACE,
-                    requires=a10constants.VTHUNDER,
-                    rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-                    provides=(a10constants.IFNUM_MASTER, a10constants.IFNUM_BACKUP)))
-                new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
-                    name="wait-vcs-ready-before-master-reload",
-                    requires=a10constants.VTHUNDER))
-                new_LB_net_subflow.add(vthunder_tasks.AmphoraePostVIPPlug(
-                    name=a10constants.AMP_POST_VIP_PLUG,
-                    requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
-                              constants.ADDED_PORTS)))
-                new_LB_net_subflow.add(
-                    vthunder_tasks.VThunderComputeConnectivityWait(
-                        name=a10constants.CONNECTIVITY_WAIT_FOR_MASTER_VTHUNDER,
-                        requires=(a10constants.VTHUNDER, constants.AMPHORA)))
-                new_LB_net_subflow.add(
-                    vthunder_tasks.VThunderComputeConnectivityWait(
-                        name=a10constants.CONNECTIVITY_WAIT_FOR_BACKUP_VTHUNDER,
-                        rebind={
-                            a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-                        requires=constants.AMPHORA))
-                new_LB_net_subflow.add(vthunder_tasks.VCSSyncWait(
-                    name="int-sync-reload-wait-vcs-ready",
-                    requires=a10constants.VTHUNDER))
-                new_LB_net_subflow.add(vthunder_tasks.GetMasterVThunder(
-                    name=a10constants.GET_VTHUNDER_MASTER,
-                    requires=a10constants.VTHUNDER,
-                    provides=a10constants.VTHUNDER))
-                new_LB_net_subflow.add(a10_database_tasks.GetBackupVThunderByLoadBalancer(
-                    name="get-backup-vthunder-after-get-master",
-                    requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
-                    provides=a10constants.BACKUP_VTHUNDER))
-                new_LB_net_subflow.add(vthunder_tasks.EnableInterface(
-                    name=a10constants.BACKUP_ENABLE_INTERFACE,
-                    requires=(a10constants.VTHUNDER, constants.LOADBALANCER, constants.ADDED_PORTS,
-                              a10constants.IFNUM_MASTER, a10constants.IFNUM_BACKUP)))
-            else:
-                new_LB_net_subflow.add(vthunder_tasks.VThunderComputeConnectivityWait(
-                    name=a10constants.CONNECTIVITY_WAIT_FOR_BACKUP_VTHUNDER,
-                    rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
-                    requires=constants.AMPHORA))
             new_LB_net_subflow.add(vthunder_tasks.EnableInterface(
                 name=a10constants.ENABLE_BACKUP_VTHUNDER_INTERFACE,
                 rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
@@ -828,7 +746,8 @@ class LoadBalancerFlows(object):
             a10_database_tasks.GetVRIDForLoadbalancerResource(
                 requires=[
                     a10constants.PARTITION_PROJECT_LIST,
-                    a10constants.VTHUNDER],
+                    a10constants.VTHUNDER,
+                    constants.LOADBALANCER],
                 provides=a10constants.VRID_LIST))
         handle_vrid_for_lb_subflow.add(vthunder_tasks.ConfigureVRID(
             requires=a10constants.VTHUNDER))
@@ -874,7 +793,8 @@ class LoadBalancerFlows(object):
             a10_database_tasks.GetVRIDForLoadbalancerResource(
                 requires=[
                     a10constants.PARTITION_PROJECT_LIST,
-                    a10constants.VTHUNDER],
+                    a10constants.VTHUNDER,
+                    constants.LOADBALANCER],
                 provides=a10constants.VRID_LIST))
         delete_lb_vrid_subflow.add(
             a10_network_tasks.DeleteVRIDPort(
@@ -909,7 +829,8 @@ class LoadBalancerFlows(object):
             a10_database_tasks.GetVRIDForLoadbalancerResource(
                 requires=[
                     a10constants.PARTITION_PROJECT_LIST,
-                    a10constants.VTHUNDER],
+                    a10constants.VTHUNDER,
+                    constants.LOADBALANCER],
                 provides=a10constants.VRID_LIST))
         delete_lb_vrid_subflow.add(
             a10_network_tasks.DeleteVRIDPort(

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -125,6 +125,9 @@ class PoolFlows(object):
         delete_pool_flow.add(a10_database_tasks.GetLoadBalancerListByProjectID(
             requires=a10constants.VTHUNDER,
             provides=a10constants.LOADBALANCERS_LIST))
+        delete_pool_flow.add(a10_database_tasks.GetMemberListByProjectID(
+            requires=a10constants.VTHUNDER,
+            provides=a10constants.MEMBER_LIST))
         delete_pool_flow.add(a10_network_tasks.CalculateDelta(
             requires=(constants.LOADBALANCER, a10constants.LOADBALANCERS_LIST),
             provides=constants.DELTAS))

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -334,10 +334,6 @@ class VThunderFlows(object):
             requires=(a10constants.VTHUNDER, a10constants.SET_ID),
             rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
         vrrp_subflow.add(self._get_vrrp_status_subflow(sf_name))
-        # Wait for aVCS sync
-        vrrp_subflow.add(vthunder_tasks.VCSSyncWait(
-            name=sf_name + '-' + a10constants.VCS_SYNC_WAIT + '-for-thunder',
-            requires=a10constants.VTHUNDER))
 
         return vrrp_subflow
 

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -343,10 +343,21 @@ class CreateSpareVThunderEntry(BaseDatabaseTask):
 
 class GetVRIDForLoadbalancerResource(BaseDatabaseTask):
 
-    def execute(self, partition_project_list, vthunder):
+    def execute(self, partition_project_list, vthunder, loadbalancer):
         vrid_list = []
         if vthunder:
-            owner = vthunder.ip_address + "_" + vthunder.partition_name
+            topology = CONF.a10_controller_worker.loadbalancer_topology
+            if topology == "SINGLE":
+                owner = [vthunder.ip_address + "_" + vthunder.partition_name]
+            else:
+                loadbalancer_id = loadbalancer.id
+                master_vthunder = self.vthunder_repo.get_vthunder_from_lb(
+                    db_apis.get_session(), loadbalancer_id)
+                backup_vthunder = self.vthunder_repo.get_backup_vthunder_from_lb(
+                    db_apis.get_session(), loadbalancer_id)
+                owner_master = master_vthunder.ip_address + "_" + master_vthunder.partition_name
+                owner_backup = backup_vthunder.ip_address + "_" + backup_vthunder.partition_name
+                owner = [owner_master, owner_backup]
             if partition_project_list:
                 try:
                     vrid_list = self.vrid_repo.get_vrid_from_owner(
@@ -1044,3 +1055,17 @@ class CountMembersOnThunderBySubnet(BaseDatabaseTask):
                               subnet.id, str(e))
                 raise e
         return 0
+
+
+class GetMemberListByProjectID(BaseDatabaseTask):
+
+    def execute(self, vthunder):
+        try:
+            if vthunder:
+                member_list = self.member_repo.get_members_by_project_id(
+                    db_apis.get_session(),
+                    vthunder.project_id)
+                return member_list
+        except Exception as e:
+            LOG.exception('Failed to get active Members related to vthunder '
+                          'due to: {}'.format(str(e)))

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -57,7 +57,7 @@ class CalculateAmphoraDelta(BaseNetworkTask):
 
     default_provides = constants.DELTA
 
-    def execute(self, loadbalancers_list, amphora):
+    def execute(self, loadbalancers_list, amphora, member_list):
         LOG.debug("Calculating network delta for amphora id: %s", amphora.id)
         # Figure out what networks we want
         # seed with lb network(s)
@@ -69,7 +69,7 @@ class CalculateAmphoraDelta(BaseNetworkTask):
                 member_networks = [
                     self.network_driver.get_subnet(member.subnet_id).network_id
                     for member in pool.members
-                    if member.subnet_id
+                    if member.subnet_id and member in member_list
                 ]
                 desired_network_ids.update(member_networks)
 
@@ -109,7 +109,7 @@ class CalculateDelta(BaseNetworkTask):
 
     default_provides = constants.DELTAS
 
-    def execute(self, loadbalancer, loadbalancers_list):
+    def execute(self, loadbalancer, loadbalancers_list, member_list):
         """Compute which NICs need to be plugged
 
         for the amphora to become operational.
@@ -126,7 +126,7 @@ class CalculateDelta(BaseNetworkTask):
             lambda amp: amp.status == constants.AMPHORA_ALLOCATED,
                 loadbalancer.amphorae):
 
-            delta = calculate_amp.execute(loadbalancers_list, amphora)
+            delta = calculate_amp.execute(loadbalancers_list, amphora, member_list)
             deltas[amphora.id] = delta
         return deltas
 

--- a/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
@@ -17,7 +17,6 @@ from oslo_config import cfg
 from oslo_log import log as logging
 from requests import exceptions
 from taskflow import task
-import time
 
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator_for_revert
@@ -119,28 +118,3 @@ class UpdateVirtualServerTask(LoadBalancerParent, task.Task):
         except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception("Failed to update load balancer: %s", loadbalancer.id)
             raise e
-
-
-class WaitVirtualServerReadyOnBlade(LoadBalancerParent, task.Task):
-    """Task to wait vBlade get virtual-server configuration from vMaster"""
-
-    @axapi_client_decorator
-    def execute(self, loadbalancer, vthunder):
-        attempts = CONF.a10_controller_worker.amp_vcs_retries
-        while attempts >= 0:
-            try:
-                attempts = attempts - 1
-                self.axapi_client.slb.virtual_server.get(loadbalancer.id)
-                break
-            except exceptions.ReadTimeout:
-                # Don't retry for ReadTimout, since acos-client already already have
-                # tries and timeout for axapi request. And it will take very long to
-                # response this error.
-                if attempts < 0:
-                    # Don't raise, LB creation is success just not sync. to vBlade yet
-                    break
-            except Exception:
-                if attempts < 0:
-                    # Don't raise, LB creation is success just not sync. to vBlade yet
-                    break
-                time.sleep(CONF.a10_controller_worker.amp_vcs_wait_sec)

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -235,24 +235,21 @@ class EnableInterface(VThunderBaseTask):
 
         try:
             if added_ports and amphora_id in added_ports and len(added_ports[amphora_id]) > 0:
+                interfaces = self.axapi_client.interface.get_list()
                 if (not lb_exists_flag and topology == "ACTIVE_STANDBY") or topology == "SINGLE":
-                    interfaces = self.axapi_client.interface.get_list()
                     for i in range(len(interfaces['interface']['ethernet-list'])):
                         if interfaces['interface']['ethernet-list'][i]['action'] == "disable":
                             ifnum = interfaces['interface']['ethernet-list'][i]['ifnum']
                             self.axapi_client.system.action.setInterface(ifnum)
                     LOG.debug("Configured the ethernet interface for vThunder: %s", vthunder.id)
                 else:
-                    if ifnum_master:
-                        for i in range(len(ifnum_master)):
-                            self.axapi_client.system.action.setInterface(ifnum_master[i])
-                            LOG.debug("Configured the ethernet interface for "
-                                      "master vThunder: %s", vthunder.id)
-                    elif ifnum_backup:
-                        for i in range(len(ifnum_backup)):
-                            self.axapi_client.system.action.setInterface(ifnum_backup[i])
-                            LOG.debug("Configured the ethernet interface for "
-                                      "backup vThunder: %s", vthunder.id)
+                    for i in range(len(interfaces['interface']['ethernet-list'])):
+                        if interfaces['interface']['ethernet-list'][i]['action'] == "disable":
+                            ifnum = interfaces['interface']['ethernet-list'][i]['ifnum']
+                            self.axapi_client.device_context.switch(1, None)
+                            self.axapi_client.system.action.setInterface(ifnum)
+                            self.axapi_client.device_context.switch(2, None)
+                            self.axapi_client.system.action.setInterface(ifnum)
         except(acos_errors.ACOSException, req_exceptions.ConnectionError) as e:
             LOG.exception("Failed to configure ethernet interface vThunder: %s", str(e))
             raise e
@@ -265,6 +262,7 @@ class EnableInterfaceForMembers(VThunderBaseTask):
     def execute(self, added_ports, loadbalancer, vthunder):
         """Enable specific interface of amphora"""
         try:
+            topology = CONF.a10_controller_worker.loadbalancer_topology
             amphora_id = loadbalancer.amphorae[0].id
             compute_id = loadbalancer.amphorae[0].compute_id
             network_driver = utils.get_network_driver()
@@ -275,7 +273,13 @@ class EnableInterfaceForMembers(VThunderBaseTask):
                 while attempts > 0 and configured_interface is False:
                     try:
                         target_interface = len(nics)
-                        self.axapi_client.system.action.setInterface(target_interface - 1)
+                        if topology == "SINGLE":
+                            self.axapi_client.system.action.setInterface(target_interface - 1)
+                        else:
+                            self.axapi_client.device_context.switch(1, None)
+                            self.axapi_client.system.action.setInterface(target_interface - 1)
+                            self.axapi_client.device_context.switch(2, None)
+                            self.axapi_client.system.action.setInterface(target_interface - 1)
                         configured_interface = True
                         LOG.debug("Configured the new interface required for member.")
                     except (req_exceptions.ConnectionError, acos_errors.ACOSException,
@@ -1083,42 +1087,6 @@ class AmphoraePostNetworkUnplug(VThunderBaseTask):
             raise e
 
 
-class GetVThunderInterface(VThunderBaseTask):
-    """Task to get interface on master and backup vThunders"""
-
-    @axapi_client_decorator
-    def execute(self, vthunder):
-        try:
-            vcs_summary = {}
-            ifnum = []
-            ifnum_master = []
-            ifnum_backup = []
-
-            vcs_summary = self.axapi_client.system.action.get_vcs_summary_oper()
-            vcs_member_list = vcs_summary['vcs-summary']['oper']['member-list']
-            interfaces = self.axapi_client.interface.get_list()
-
-            for i in range(len(interfaces['interface']['ethernet-list'])):
-                if interfaces['interface']['ethernet-list'][i]['action'] == "disable":
-                    ifnum = ifnum + [interfaces['interface']['ethernet-list'][i]['ifnum']]
-
-            for i in range(len(vcs_member_list)):
-                if vthunder.ip_address in vcs_member_list[i]['ip-list'][0]['ip']:
-                    role = vcs_member_list[i]['state'].split('(')[0]
-                    if role == "vMaster":
-                        ifnum_master = ifnum
-                        LOG.debug(
-                            "Fetched the ethernet interface for Master vThunder: %s", vthunder.id)
-                    if role == "vBlade":
-                        ifnum_backup = ifnum
-                        LOG.debug(
-                            "Fetched the ethernet interface for Backup vThunder: %s", vthunder.id)
-            return ifnum_master, ifnum_backup
-        except (acos_errors.ACOSException, req_exceptions.ConnectionError) as e:
-            LOG.exception("Failed to fetch ethernet interface Backup vThunder: %s", str(e))
-            raise e
-
-
 class VCSReload(VThunderBaseTask):
     """Task to perform VCS reload"""
 
@@ -1145,30 +1113,41 @@ class VCSSyncWait(VThunderBaseTask):
 
         attempts = CONF.a10_controller_worker.amp_vcs_retries
         while attempts >= 0:
-            vmaster_ready = False
-            vblade_ready = False
             try:
                 attempts = attempts - 1
                 vcs_summary = {}
                 vcs_summary = self.axapi_client.system.action.get_vcs_summary_oper()
-                vcs_member_list = vcs_summary['vcs-summary']['oper']['member-list']
-                for i in range(len(vcs_member_list)):
-                    role = vcs_member_list[i]['state'].split('(')[0]
-                    if role == "vMaster":
-                        vmaster_ready = True
-                    if role == "vBlade":
-                        vblade_ready = True
-                    if vmaster_ready is True and vblade_ready is True:
+                vcs_summary = vcs_summary['vcs-summary']['oper']
+
+                if acos_client.utils.acos_version_cmp(vthunder.acos_version,
+                                                      a10constants.ACOS_5_2_1_P2) >= 0:
+                    vcs_ready = False
+                    for peer_vcs_state in vcs_summary['vcs-handshake-completed-list']:
+                        if peer_vcs_state['vcs-handshake-completed'] == 1:
+                            vcs_ready = True
+                            break
+                    if vcs_ready is True:
                         break
                 else:
-                    # TODO(ytsai) maybe reload the device and try again
-                    if vmaster_ready:
+                    vmaster_ready = False
+                    vblade_ready = False
+                    vcs_member_list = vcs_summary['member-list']
+                    for i in range(len(vcs_member_list)):
+                        role = vcs_member_list[i]['state'].split('(')[0]
+                        if role == "vMaster":
+                            vmaster_ready = True
+                        if role == "vBlade":
+                            vblade_ready = True
+                        if vmaster_ready is True and vblade_ready is True:
+                            break
+                    else:
+                        if vmaster_ready:
+                            raise acos_errors.AxapiJsonFormatError(
+                                msg="vBlade not found in vcs-summary")
                         raise acos_errors.AxapiJsonFormatError(
-                            msg="vBlade not found in vcs-summary")
-                    raise acos_errors.AxapiJsonFormatError(
-                        msg="vMaster not found in vcs-summary")
-                if vmaster_ready is True and vblade_ready is True:
-                    break
+                            msg="vMaster not found in vcs-summary")
+                    if vmaster_ready is True and vblade_ready is True:
+                        break
             except (acos_errors.ACOSSystemIsBusy, acos_errors.ACOSSystemNotReady,
                     req_exceptions.ConnectionError, req_exceptions.ReadTimeout) as e:
                 # acos-client already wait default_axapi_timeout for these exceptions.

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -465,7 +465,7 @@ class VRIDRepository(BaseRepository):
         vrid_obj_list = []
 
         model = session.query(self.model_class).filter(
-            or_(self.model_class.owner == owner,
+            or_(self.model_class.owner.in_(owner),
                 self.model_class.owner.in_(project_ids)))
         for data in model:
             vrid_obj_list.append(data.to_data_model())
@@ -544,6 +544,19 @@ class MemberRepository(repo.MemberRepository):
         if not model:
             return None
         return model.to_data_model()
+
+    def get_members_by_project_id(self, session, project_id):
+        member_list = []
+        query = session.query(self.model_class).filter(
+            self.model_class.project_id == project_id).filter(
+            or_(self.model_class.provisioning_status == "ACTIVE",
+                self.model_class.provisioning_status == "PENDING_UPDATE",
+                self.model_class.provisioning_status == "PENDING_CREATE"))
+
+        model_list = query.all()
+        for data in model_list:
+            member_list.append(data.to_data_model())
+        return member_list
 
 
 class NatPoolRepository(BaseRepository):

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -115,6 +115,7 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
 
     def test_get_vrid_for_project_member_hmt_use_partition(self):
         thunder = copy.deepcopy(HW_THUNDER)
+        lb = copy.deepcopy(LB)
         thunder.hierarchical_multitenancy = 'enable'
         thunder.vrid_floating_ip = VRID.vrid_floating_ip
         hardware_device_conf = self._generate_hardware_device_conf(thunder)
@@ -132,11 +133,12 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         mock_vrid_entry.vrid_repo = mock.Mock()
         mock_vrid_entry.vthunder_repo = mock.Mock()
         mock_vrid_entry.vrid_repo.get_vrid_from_owner.return_value = VRID
-        vrid = mock_vrid_entry.execute([a10constants.MOCK_PROJECT_ID], thunder)
+        vrid = mock_vrid_entry.execute([a10constants.MOCK_PROJECT_ID], thunder, lb)
         self.assertEqual(VRID, vrid)
 
     def test_get_vrid_for_project(self):
         thunder = copy.deepcopy(HW_THUNDER)
+        lb = copy.deepcopy(LB)
         thunder.hierarchical_multitenancy = 'disable'
         thunder.vrid_floating_ip = VRID.vrid_floating_ip
         hardware_device_conf = self._generate_hardware_device_conf(thunder)
@@ -154,7 +156,7 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         mock_vrid_entry.vrid_repo = mock.Mock()
         mock_vrid_entry.vthunder_repo = mock.Mock()
         mock_vrid_entry.vrid_repo.get_vrid_from_owner.return_value = VRID
-        vrid = mock_vrid_entry.execute(MEMBER_1, thunder)
+        vrid = mock_vrid_entry.execute(MEMBER_1, thunder, lb)
         mock_vrid_entry.vthunder_repo.get_partition_for_project.assert_not_called()
         self.assertEqual(VRID, vrid)
 

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_vthunder_tasks.py
@@ -921,28 +921,6 @@ class TestVThunderTasks(base.BaseTaskTestCase):
         self.client_mock.system.action.write_memory.assert_not_called()
         self.client_mock.system.action.reload_reboot_for_interface_detachment.assert_not_called()
 
-    def test_GetVThunderInterface_execute_for_vMaster(self):
-        thunder = copy.deepcopy(VTHUNDER)
-        mock_task = task.GetVThunderInterface()
-        mock_task.axapi_client = self.client_mock
-        self.client_mock.system.action.get_vcs_summary_oper.return_value = VCS_MASTER_VBLADE
-        self.client_mock.interface.get_list.return_value = INTERFACES
-        thunder.ip_address = "10.0.0.1"
-        mock_task.execute(thunder)
-        self.client_mock.system.action.setInterface.assert_not_called()
-        self.assertEqual(mock_task.execute(thunder), ([1], []))
-
-    def test_GetVThunderInterface_execute_for_vBlade(self):
-        thunder = copy.deepcopy(VTHUNDER)
-        mock_task = task.GetVThunderInterface()
-        mock_task.axapi_client = self.client_mock
-        self.client_mock.system.action.get_vcs_summary_oper.return_value = VCS_MASTER_VBLADE
-        self.client_mock.interface.get_list.return_value = INTERFACES
-        thunder.ip_address = "10.0.0.2"
-        mock_task.execute(thunder)
-        self.client_mock.system.action.setInterface.assert_not_called()
-        self.assertEqual(mock_task.execute(thunder), ([], [1]))
-
     @mock.patch('stevedore.driver.DriverManager')
     def test_EnableInterface_execute_for_single_topology(self, mock_drivermgr):
         thunder = copy.deepcopy(VTHUNDER)


### PR DESCRIPTION
## Description
Merged the latest master branch into experimental/victoria_ff branch

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2723

## Related PR on acos-client side:
https://github.com/a10networks/acos-client/pull/356

## Technical Approach
- Resolved the merge conflicts.

## Manual Testing
Tested Dynamic Interface Detection Enhancement feature for ACTIVE_STANDBY mode after the merging of master branch into experimental/victoria_ff branch

**1. Create a loadbalancer in subnet provider-vlan-11-subnet**
stack@neha-victoria:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name lb1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-08-09T07:40:54                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 44e3757d7249463499953b9fb4df87e5     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.156                          |
| vip_network_id      | e83f7025-7db6-49ec-84fe-b19931716d27 |
| vip_port_id         | 94a40d37-6f60-4bcf-b08c-e939e3c886c5 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 6b4c8ac7-cbf0-4a59-90d2-ded705273765 |
+---------------------+--------------------------------------+
```

**Result on vThunders:
No Reload as it is 1st LB.**

```
vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 670 bytes
!Configuration last updated at 08:52:23 IST Mon Aug 9 2021
!Configuration last saved at 08:52:27 IST Mon Aug 9 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.113
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb virtual-server 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 10.0.11.156
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

```
vThunder-Active-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 670 bytes
!Configuration last updated at 08:52:23 IST Mon Aug 9 2021
!Configuration last saved at 08:49:16 IST Mon Aug 9 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.113
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb virtual-server 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 10.0.11.156
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

**2. Create an another loadbalancer in subnet provider-vlan-12-subnet**
stack@neha-victoria:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-12-subnet --name lb2
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-08-09T08:29:47                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 3993f88c-75b0-45c1-b66d-ebd0f05e28d9 |
| listeners           |                                      |
| name                | lb2                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 44e3757d7249463499953b9fb4df87e5     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.12.111                          |
| vip_network_id      | 79558c33-0bd3-4b1f-abf6-a7fb85a29f3a |
| vip_port_id         | 5fb49572-ea20-4396-8768-427261ad20c8 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | bdcaa4ce-1c2c-427c-a00c-afc5dde2bd13 |
+---------------------+--------------------------------------+
```

**Result on vThunders:
Reload takes place and new interface gets attached on both vThunders**

```
vThunder-Active-vMaster[1/2](NOLICENSE)#show running-config
!Current configuration: 739 bytes
!Configuration last updated at 09:41:13 IST Mon Aug 9 2021
!Configuration last saved at 09:41:39 IST Mon Aug 9 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.113
  floating-ip 10.0.12.195
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb virtual-server 3993f88c-75b0-45c1-b66d-ebd0f05e28d9 10.0.12.111
!
slb virtual-server 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 10.0.11.156
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

```
vThunder-Active-vMaster[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ea0.0df0  192.168.0.192/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3ef7.cf4d  10.0.11.40/24         1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e28.2e0d  10.0.12.84/24         1  DataPort
```

```
vThunder-Active-vBlade[1/1](NOLICENSE)#show running-config
!Current configuration: 739 bytes
!Configuration last updated at 09:41:13 IST Mon Aug 9 2021
!Configuration last saved at 09:38:24 IST Mon Aug 9 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.113
  floating-ip 10.0.12.195
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb virtual-server 3993f88c-75b0-45c1-b66d-ebd0f05e28d9 10.0.12.111
!
slb virtual-server 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 10.0.11.156
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

```
vThunder-Active-vBlade[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ebe.0bd9  192.168.0.129/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e6d.6e8c  10.0.11.88/24         1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e0b.8612  10.0.12.83/24         1  DataPort

```

**3. Create one more loadbalancer in the same subnet as that of lb1**
stack@neha-victoria:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name lb3
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-08-09T08:48:03                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 6d1a062d-d1f0-45e8-ae51-17ff8df35a4b |
| listeners           |                                      |
| name                | lb3                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 44e3757d7249463499953b9fb4df87e5     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.173                          |
| vip_network_id      | e83f7025-7db6-49ec-84fe-b19931716d27 |
| vip_port_id         | ae6ea010-c48f-43cb-97be-369395999294 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 6b4c8ac7-cbf0-4a59-90d2-ded705273765 |
+---------------------+--------------------------------------+
```

stack@neha-victoria:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 | lb1  | 44e3757d7249463499953b9fb4df87e5 | 10.0.11.156 | ACTIVE              | OFFLINE          | a10      |
| 3993f88c-75b0-45c1-b66d-ebd0f05e28d9 | lb2  | 44e3757d7249463499953b9fb4df87e5 | 10.0.12.111 | ACTIVE              | OFFLINE          | a10      |
| 6d1a062d-d1f0-45e8-ae51-17ff8df35a4b | lb3  | 44e3757d7249463499953b9fb4df87e5 | 10.0.11.173 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+

```

**Result on vThunders:
No reload as an interface for the subnet in already present on the vThunders**

```
vThunder-Active-vMaster[1/2](NOLICENSE)#show running-config
!Current configuration: 808 bytes
!Configuration last updated at 09:48:27 IST Mon Aug 9 2021
!Configuration last saved at 09:48:44 IST Mon Aug 9 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.113
  floating-ip 10.0.12.195
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb virtual-server 3993f88c-75b0-45c1-b66d-ebd0f05e28d9 10.0.12.111
!
slb virtual-server 6d1a062d-d1f0-45e8-ae51-17ff8df35a4b 10.0.11.173
!
slb virtual-server 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 10.0.11.156
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

```
vThunder-Active-vMaster[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ea0.0df0  192.168.0.192/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3ef7.cf4d  10.0.11.40/24         1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e28.2e0d  10.0.12.84/24         1  DataPort
```

```
vThunder-Active-vBlade[1/1](NOLICENSE)#show running-config
!Current configuration: 808 bytes
!Configuration last updated at 09:48:27 IST Mon Aug 9 2021
!Configuration last saved at 09:38:24 IST Mon Aug 9 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.113
  floating-ip 10.0.12.195
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb virtual-server 3993f88c-75b0-45c1-b66d-ebd0f05e28d9 10.0.12.111
!
slb virtual-server 6d1a062d-d1f0-45e8-ae51-17ff8df35a4b 10.0.11.173
!
slb virtual-server 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 10.0.11.156
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

```
vThunder-Active-vBlade[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ebe.0bd9  192.168.0.129/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e6d.6e8c  10.0.11.88/24         1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e0b.8612  10.0.12.83/24         1  DataPort
```

**4. Create a listener and pool for LB lb1**
stack@neha-victoria:~$ openstack loadbalancer listener create --protocol TCP --protocol-port 80 --name l1 lb1
```
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-08-09T08:55:08                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 5df1211e-cbf7-4044-916c-ac8ac9ed6cbf |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 |
| name                        | l1                                   |
| operating_status            | OFFLINE                              |
| project_id                  | 44e3757d7249463499953b9fb4df87e5     |
| protocol                    | TCP                                  |
| protocol_port               | 80                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
| allowed_cidrs               | None                                 |
| tls_ciphers                 | None                                 |
| tls_versions                | None                                 |
| alpn_protocols              | None                                 |
+-----------------------------+--------------------------------------+
```

stack@neha-victoria:~$ openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --name p1 --listener l1
```
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-08-09T08:56:12                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | d94f1705-52ae-4655-8fbf-e0ffe29aeb3f |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | 5df1211e-cbf7-4044-916c-ac8ac9ed6cbf |
| loadbalancers        | 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 |
| members              |                                      |
| name                 | p1                                   |
| operating_status     | OFFLINE                              |
| project_id           | 44e3757d7249463499953b9fb4df87e5     |
| protocol             | TCP                                  |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+
```

**5. Create a member in subnet provider-vlan-13-subnet**
stack@neha-victoria:~$ openstack loadbalancer member create --address 10.0.13.10 --subnet-id provider-vlan-13-subnet --protocol-port 91 --name mem1 p1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.13.10                           |
| admin_state_up      | True                                 |
| created_at          | 2021-08-09T09:14:03                  |
| id                  | b020caad-3cd3-495e-bc5d-ae34c99077c7 |
| name                | mem1                                 |
| operating_status    | NO_MONITOR                           |
| project_id          | 44e3757d7249463499953b9fb4df87e5     |
| protocol_port       | 91                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | e9a6ee07-6519-4210-9b0d-9e8a2f76b560 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
```

**Result on vThunders:
Reload takes place and a new interface gets attached to both the vThunders**

```
vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 739 bytes
!Configuration last updated at 10:22:26 IST Mon Aug 9 2021
!Configuration last saved at 10:23:25 IST Mon Aug 9 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.113
  floating-ip 10.0.12.195
  floating-ip 10.0.13.173
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server 44e37_10_0_13_10 10.0.13.10
  port 91 tcp
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f tcp
  member 44e37_10_0_13_10 91
!
slb virtual-server 3993f88c-75b0-45c1-b66d-ebd0f05e28d9 10.0.12.111
!
slb virtual-server 6d1a062d-d1f0-45e8-ae51-17ff8df35a4b 10.0.11.173
!
slb virtual-server 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 10.0.11.156
  port 80 tcp
    name 5df1211e-cbf7-4044-916c-ac8ac9ed6cbf
    extended-stats
    service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

```
vThunder-Active-vMaster[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ebe.0bd9  192.168.0.129/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e6d.6e8c  10.0.11.88/24         1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e0b.8612  10.0.12.83/24         1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3eb5.39a6  10.0.13.147/24        1  DataPort
```

```
vThunder-Standby-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 739 bytes
!Configuration last updated at 10:22:26 IST Mon Aug 9 2021
!Configuration last saved at 10:19:44 IST Mon Aug 9 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.113
  floating-ip 10.0.12.195
  floating-ip 10.0.13.173
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server 44e37_10_0_13_10 10.0.13.10
  port 91 tcp
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f tcp
  member 44e37_10_0_13_10 91
!
slb virtual-server 3993f88c-75b0-45c1-b66d-ebd0f05e28d9 10.0.12.111
!
slb virtual-server 6d1a062d-d1f0-45e8-ae51-17ff8df35a4b 10.0.11.173
!
slb virtual-server 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 10.0.11.156
  port 80 tcp
    name 5df1211e-cbf7-4044-916c-ac8ac9ed6cbf
    extended-stats
    service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

```
vThunder-Standby-vBlade[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ea0.0df0  192.168.0.192/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3ef7.cf4d  10.0.11.40/24         1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e28.2e0d  10.0.12.84/24         1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e28.d07e  10.0.13.114/24        1  DataPort
```

**6. Create an another member in subnet provider-vlan-14-subnet**
stack@neha-victoria:~$ openstack loadbalancer member create --address 10.0.14.14 --subnet-id provider-vlan-14-subnet --protocol-port 95 --name mem2 p1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.14.14                           |
| admin_state_up      | True                                 |
| created_at          | 2021-08-09T10:21:18                  |
| id                  | 86285af9-00db-468e-b3ac-c7557bcf880a |
| name                | mem2                                 |
| operating_status    | NO_MONITOR                           |
| project_id          | 44e3757d7249463499953b9fb4df87e5     |
| protocol_port       | 95                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 8bc7318a-1cc3-44a5-8c24-4aa2da98fad2 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
``` 

**Result on vThunders:
Reload takes place and a new interface gets attached on both the vThunders.**

```
vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 739 bytes
!Configuration last updated at 11:33:09 IST Mon Aug 9 2021
!Configuration last saved at 11:33:20 IST Mon Aug 9 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/4
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/4
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.113
  floating-ip 10.0.12.195
  floating-ip 10.0.13.173
  floating-ip 10.0.14.194
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server 44e37_10_0_13_10 10.0.13.10
  port 91 tcp
!
slb server 44e37_10_0_14_14 10.0.14.14
  port 95 tcp
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f tcp
  member 44e37_10_0_13_10 91
  member 44e37_10_0_14_14 95
!
slb virtual-server 3993f88c-75b0-45c1-b66d-ebd0f05e28d9 10.0.12.111
!
slb virtual-server 6d1a062d-d1f0-45e8-ae51-17ff8df35a4b 10.0.11.173
!
slb virtual-server 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 10.0.11.156
  port 80 tcp
    name 5df1211e-cbf7-4044-916c-ac8ac9ed6cbf
    extended-stats
    service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

```
vThunder-Active-vMaster[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ebe.0bd9  192.168.0.129/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e6d.6e8c  10.0.11.88/24         1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e0b.8612  10.0.12.83/24         1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3eb5.39a6  10.0.13.147/24        1  DataPort
4                   Up    Full  10000  none  1    N/A       fa16.3e5c.fdf7  10.0.14.65/24         1  DataPort
```

```
vThunder-Standby-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 739 bytes
!Configuration last updated at 11:33:09 IST Mon Aug 9 2021
!Configuration last saved at 11:30:09 IST Mon Aug 9 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/4
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/4
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.113
  floating-ip 10.0.12.195
  floating-ip 10.0.13.173
  floating-ip 10.0.14.194
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server 44e37_10_0_13_10 10.0.13.10
  port 91 tcp
!
slb server 44e37_10_0_14_14 10.0.14.14
  port 95 tcp
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f tcp
  member 44e37_10_0_13_10 91
  member 44e37_10_0_14_14 95
!
slb virtual-server 3993f88c-75b0-45c1-b66d-ebd0f05e28d9 10.0.12.111
!
slb virtual-server 6d1a062d-d1f0-45e8-ae51-17ff8df35a4b 10.0.11.173
!
slb virtual-server 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 10.0.11.156
  port 80 tcp
    name 5df1211e-cbf7-4044-916c-ac8ac9ed6cbf
    extended-stats
    service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

```
vThunder-Standby-vBlade[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ea0.0df0  192.168.0.192/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3ef7.cf4d  10.0.11.40/24         1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e28.2e0d  10.0.12.84/24         1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e28.d07e  10.0.13.114/24        1  DataPort
4                   Up    Full  10000  none  1    N/A       fa16.3e51.a61b  10.0.14.79/24         1  DataPort
```

stack@neha-victoria:~$ openstack loadbalancer member list p1
```
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address    | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| b020caad-3cd3-495e-bc5d-ae34c99077c7 | mem1 | 44e3757d7249463499953b9fb4df87e5 | ACTIVE              | 10.0.13.10 |            91 | NO_MONITOR       |      1 |
| 86285af9-00db-468e-b3ac-c7557bcf880a | mem2 | 44e3757d7249463499953b9fb4df87e5 | ACTIVE              | 10.0.14.14 |            95 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
```

**7. Delete member mem1**
stack@neha-victoria:~$ openstack loadbalancer member delete p1 mem1

**Result on vThunders:
Reload takes place and the member mem1 and its interface gets detached from both vThunders**

```
vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 739 bytes
!Configuration last updated at 12:42:42 IST Mon Aug 9 2021
!Configuration last saved at 12:42:49 IST Mon Aug 9 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.113
  floating-ip 10.0.12.195
  floating-ip 10.0.14.194
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server 44e37_10_0_14_14 10.0.14.14
  port 95 tcp
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f tcp
  member 44e37_10_0_14_14 95
!
slb virtual-server 3993f88c-75b0-45c1-b66d-ebd0f05e28d9 10.0.12.111
!
slb virtual-server 6d1a062d-d1f0-45e8-ae51-17ff8df35a4b 10.0.11.173
!
slb virtual-server 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 10.0.11.156
  port 80 tcp
    name 5df1211e-cbf7-4044-916c-ac8ac9ed6cbf
    extended-stats
    service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```
```
vThunder-Active-vMaster[1/1](NOLICENSE)#show interface brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ebe.0bd9  192.168.0.129/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e6d.6e8c  10.0.11.88/24         1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e0b.8612  10.0.12.83/24         1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e5c.fdf7  10.0.14.65/24         1  DataPort

```

```
vThunder-Active-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 739 bytes
!Configuration last updated at 12:42:43 IST Mon Aug 9 2021
!Configuration last saved at 12:37:29 IST Mon Aug 9 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.113
  floating-ip 10.0.12.195
  floating-ip 10.0.14.194
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server 44e37_10_0_14_14 10.0.14.14
  port 95 tcp
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f tcp
  member 44e37_10_0_14_14 95
!
slb virtual-server 3993f88c-75b0-45c1-b66d-ebd0f05e28d9 10.0.12.111
!
slb virtual-server 6d1a062d-d1f0-45e8-ae51-17ff8df35a4b 10.0.11.173
!
slb virtual-server 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 10.0.11.156
  port 80 tcp
    name 5df1211e-cbf7-4044-916c-ac8ac9ed6cbf
    extended-stats
    service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```
```
vThunder-Active-vBlade[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ea0.0df0  192.168.0.192/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3ef7.cf4d  10.0.11.40/24         1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e28.2e0d  10.0.12.84/24         1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e51.a61b  10.0.14.79/24         1  DataPort

```

**8. Delete member mem2**
stack@neha-victoria:~$ openstack loadbalancer member delete p1 mem2

**Result on vThunders:
Reload takes place and the member mem2 and its interface gets detached from both vThunders**

```
vThunder-Active-vMaster[1/2](NOLICENSE)#show running-config
!Current configuration: 799 bytes
!Configuration last updated at 13:03:56 IST Mon Aug 9 2021
!Configuration last saved at 13:04:00 IST Mon Aug 9 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.113
  floating-ip 10.0.12.195
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f tcp
!
slb virtual-server 3993f88c-75b0-45c1-b66d-ebd0f05e28d9 10.0.12.111
!
slb virtual-server 6d1a062d-d1f0-45e8-ae51-17ff8df35a4b 10.0.11.173
!
slb virtual-server 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 10.0.11.156
  port 80 tcp
    name 5df1211e-cbf7-4044-916c-ac8ac9ed6cbf
    extended-stats
    service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

```
vThunder-Active-vMaster[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ea0.0df0  192.168.0.192/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3ef7.cf4d  10.0.11.40/24         1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e28.2e0d  10.0.12.84/24         1  DataPort
```

```
vThunder-Active-vBlade[1/1](NOLICENSE)#show running-config
!Current configuration: 799 bytes
!Configuration last updated at 13:03:55 IST Mon Aug 9 2021
!Configuration last saved at 12:58:32 IST Mon Aug 9 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.113
  floating-ip 10.0.12.195
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f tcp
!
slb virtual-server 3993f88c-75b0-45c1-b66d-ebd0f05e28d9 10.0.12.111
!
slb virtual-server 6d1a062d-d1f0-45e8-ae51-17ff8df35a4b 10.0.11.173
!
slb virtual-server 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 10.0.11.156
  port 80 tcp
    name 5df1211e-cbf7-4044-916c-ac8ac9ed6cbf
    extended-stats
    service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

```
vThunder-Active-vBlade[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ebe.0bd9  192.168.0.129/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e6d.6e8c  10.0.11.88/24         1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e0b.8612  10.0.12.83/24         1  DataPort
```

stack@neha-victoria:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 | lb1  | 44e3757d7249463499953b9fb4df87e5 | 10.0.11.156 | ACTIVE              | OFFLINE          | a10      |
| 3993f88c-75b0-45c1-b66d-ebd0f05e28d9 | lb2  | 44e3757d7249463499953b9fb4df87e5 | 10.0.12.111 | ACTIVE              | OFFLINE          | a10      |
| 6d1a062d-d1f0-45e8-ae51-17ff8df35a4b | lb3  | 44e3757d7249463499953b9fb4df87e5 | 10.0.11.173 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
```

**9. Delete loadbalancer lb3**
stack@neha-victoria:~$ openstack loadbalancer delete lb3

**Result on vThunders:
No reload and interface detachment as the interface attached for lb3 is being used by lb1**

```
vThunder-Active-vMaster[1/2](NOLICENSE)#show running-config
!Current configuration: 730 bytes
!Configuration last updated at 13:16:24 IST Mon Aug 9 2021
!Configuration last saved at 13:16:29 IST Mon Aug 9 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.113
  floating-ip 10.0.12.195
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f tcp
!
slb virtual-server 3993f88c-75b0-45c1-b66d-ebd0f05e28d9 10.0.12.111
!
slb virtual-server 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 10.0.11.156
  port 80 tcp
    name 5df1211e-cbf7-4044-916c-ac8ac9ed6cbf
    extended-stats
    service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

```
vThunder-Active-vMaster[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ea0.0df0  192.168.0.192/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3ef7.cf4d  10.0.11.40/24         1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e28.2e0d  10.0.12.84/24         1  DataPort
```

```
vThunder-Active-vBlade[1/1](NOLICENSE)#show running-config
!Current configuration: 730 bytes
!Configuration last updated at 13:16:24 IST Mon Aug 9 2021
!Configuration last saved at 12:58:32 IST Mon Aug 9 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.113
  floating-ip 10.0.12.195
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f tcp
!
slb virtual-server 3993f88c-75b0-45c1-b66d-ebd0f05e28d9 10.0.12.111
!
slb virtual-server 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 10.0.11.156
  port 80 tcp
    name 5df1211e-cbf7-4044-916c-ac8ac9ed6cbf
    extended-stats
    service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

```
vThunder-Active-vBlade[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ebe.0bd9  192.168.0.129/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e6d.6e8c  10.0.11.88/24         1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e0b.8612  10.0.12.83/24         1  DataPort
```

stack@neha-victoria:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 | lb1  | 44e3757d7249463499953b9fb4df87e5 | 10.0.11.156 | ACTIVE              | OFFLINE          | a10      |
| 3993f88c-75b0-45c1-b66d-ebd0f05e28d9 | lb2  | 44e3757d7249463499953b9fb4df87e5 | 10.0.12.111 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
```

**10. Delete loadbalancer lb2**
stack@neha-victoria:~$ openstack loadbalancer delete lb2

**Result on vThunders:
Reload takes place and the interface attached for the lb2 gets detached from the vThunders**

```
vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 661 bytes
!Configuration last updated at 13:28:38 IST Mon Aug 9 2021
!Configuration last saved at 13:28:44 IST Mon Aug 9 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.113
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f tcp
!
slb virtual-server 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 10.0.11.156
  port 80 tcp
    name 5df1211e-cbf7-4044-916c-ac8ac9ed6cbf
    extended-stats
    service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

```
vThunder-Active-vMaster[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ebe.0bd9  192.168.0.129/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e6d.6e8c  10.0.11.88/24         1  DataPort
```

```
vThunder-Active-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 661 bytes
!Configuration last updated at 13:28:38 IST Mon Aug 9 2021
!Configuration last saved at 13:24:28 IST Mon Aug 9 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.113
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f tcp
!
slb virtual-server 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 10.0.11.156
  port 80 tcp
    name 5df1211e-cbf7-4044-916c-ac8ac9ed6cbf
    extended-stats
    service-group d94f1705-52ae-4655-8fbf-e0ffe29aeb3f
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

```
vThunder-Active-vBlade[1/2](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ea0.0df0  192.168.0.192/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3ef7.cf4d  10.0.11.40/24         1  DataPort
```

**11. Delete pool and listener and last loadbalancer lb1**

**Result on vThunders:
No reload as the loadbalancer is last one. Instances get deleted on the LB deletion.**

stack@neha-victoria:~$ openstack loadbalancer pool delete p1

stack@neha-victoria:~$ openstack loadbalancer listener delete l1

stack@neha-victoria:~$ openstack loadbalancer delete lb1

stack@neha-victoria:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| 8c71423d-a2d2-46b2-8fc3-fd874a3e5906 | lb1  | 44e3757d7249463499953b9fb4df87e5 | 10.0.11.156 | PENDING_DELETE      | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
```

stack@neha-victoria:~$ openstack loadbalancer list


stack@neha-victoria:~$ openstack server list

