### PR TITLE
[STACK-2776][vthunder member] failed to set member disable/enable for the 1st  time

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -576,7 +576,8 @@ class MemberFlows(object):
             provides=constants.FLAVOR))
         update_member_flow.add(server_tasks.MemberUpdate(
             requires=(constants.MEMBER, a10constants.VTHUNDER,
-                      constants.POOL, constants.FLAVOR)))
+                      constants.POOL, constants.FLAVOR,
+                      constants.UPDATE_DICT)))
         update_member_flow.add(database_tasks.UpdateMemberInDB(
             requires=[constants.MEMBER, constants.UPDATE_DICT]))
         update_member_flow.add(database_tasks.MarkMemberActiveInDB(
@@ -629,7 +630,8 @@ class MemberFlows(object):
         update_member_flow.add(self.handle_vrid_for_member_subflow())
         update_member_flow.add(server_tasks.MemberUpdate(
             requires=(constants.MEMBER, a10constants.VTHUNDER,
-                      constants.POOL, constants.FLAVOR)))
+                      constants.POOL, constants.FLAVOR,
+                      constants.UPDATE_DICT)))
         update_member_flow.add(database_tasks.UpdateMemberInDB(
             requires=[constants.MEMBER, constants.UPDATE_DICT]))
         if CONF.a10_global.network_type == 'vlan':

--- a/a10_octavia/controller/worker/tasks/server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/server_tasks.py
@@ -166,7 +166,8 @@ class MemberUpdate(task.Task):
     """Task to update member"""
 
     @axapi_client_decorator
-    def execute(self, member, vthunder, pool, flavor=None):
+    def execute(self, member, vthunder, pool, flavor=None, update_dict={}):
+        member.__dict__.update(update_dict)
         server_args = utils.meta(member, 'server', {})
         server_args = utils.dash_to_underscore(server_args)
         server_args['conn_limit'] = CONF.server.conn_limit


### PR DESCRIPTION
## Description

Failed to set member disable/enable for the 1st  time

**Severity Level :** Medium

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2776

## Technical Approach
- Updated the object of a **member**  as per the current values specified on Openstack CLI.
- Used **update_dict** for getting current values from Openstack CLI and to update the member object.

## Manual Testing

**Automated flow:**

**1. Create a loadbalancer**

```
stack@sana:~$ openstack loadbalancer create --name v4 --vip-subnet-id vip_subnet

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-08-12T07:26:19                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 44a1d14b-eccc-48fd-8fdc-18395183099d |
| listeners           |                                      |
| name                | v4                                   |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.12.251                       |
| vip_network_id      | 144533bf-db26-440f-a0ca-8ba072769e4a |
| vip_port_id         | df2093e5-ec31-4b6c-b9c6-1ac9fbc553d7 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
+---------------------+--------------------------------------+

stack@sana:~$

```
**2. Create a listener**

```
stack@sana:~$ openstack loadbalancer listener create --name l4 v4 --protocol http --protocol-port 80

+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-08-12T07:33:06                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 5a45ddb2-ab75-4d29-8c92-8ef439067fbc |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 44a1d14b-eccc-48fd-8fdc-18395183099d |
| name                        | l4                                   |
| operating_status            | OFFLINE                              |
| project_id                  | e1fe759747844dd1871092efe9079a26     |
| protocol                    | HTTP                                 |
| protocol_port               | 80                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
| allowed_cidrs               | None                                 |
| tls_ciphers                 | None                                 |
| tls_versions                | None                                 |
| alpn_protocols              | None                                 |
+-----------------------------+--------------------------------------+

stack@sana:~$
```

**3. Create a pool**

```
stack@sana:~$ openstack loadbalancer pool create --name p4 --protocol http --lb-algorithm LEAST_CONNECTIONS --listener l4

+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-08-12T07:33:42                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | 8aeca934-f2a4-466a-bb13-a2f1ce4ebd22 |
| lb_algorithm         | LEAST_CONNECTIONS                    |
| listeners            | 5a45ddb2-ab75-4d29-8c92-8ef439067fbc |
| loadbalancers        | 44a1d14b-eccc-48fd-8fdc-18395183099d |
| members              |                                      |
| name                 | p4                                   |
| operating_status     | OFFLINE                              |
| project_id           | e1fe759747844dd1871092efe9079a26     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+

stack@sana:~$

```

**4. Create a member**

```
stack@sana:~$ openstack loadbalancer member create --address 10.0.12.73 --subnet member_subnet --protocol-port 80 --name p4m1 p4

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.12.73                           |
| admin_state_up      | True                                 |
| created_at          | 2021-08-12T07:34:46                  |
| id                  | 620e9539-a018-4ad5-a886-afdd6d5b208a |
| name                | p4m1                                 |
| operating_status    | NO_MONITOR                           |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| protocol_port       | 80                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | ba00407c-739e-4563-8344-5be03587582a |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+


```
**Vthunder Configuration:**

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 99 bytes
!Configuration last updated at 08:37:21 IST Thu Aug 12 2021
!Configuration last saved at 08:37:26 IST Thu Aug 12 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1, build 153 (Dec-11-2020,14:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2
  name DataPort
  enable
  ip address dhcp
!
!
slb server e1fe7_10_0_12_73 10.0.12.73
  port 80 tcp
!
slb service-group 8aeca934-f2a4-466a-bb13-a2f1ce4ebd22 tcp
  method least-connection
  member e1fe7_10_0_12_73 80
!
slb virtual-server 44a1d14b-eccc-48fd-8fdc-18395183099d 192.168.12.251
  port 80 http
    name 5a45ddb2-ab75-4d29-8c92-8ef439067fbc
    conn-limit 20000
    extended-stats
    source-nat auto
    service-group 8aeca934-f2a4-466a-bb13-a2f1ce4ebd22
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#
vThunder(NOLICENSE)#
```

**5. Set a member** 

```
stack@sana:~$ openstack loadbalancer member set p4 p4m1 --disable

stack@sana:~$ openstack loadbalancer member show p4 p4m1

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.12.73                           |
| admin_state_up      | False                                |
| created_at          | 2021-08-12T07:34:46                  |
| id                  | 620e9539-a018-4ad5-a886-afdd6d5b208a |
| name                | p4m1                                 |
| operating_status    | NO_MONITOR                           |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| protocol_port       | 80                                   |
| provisioning_status | ACTIVE                               |
| subnet_id           | ba00407c-739e-4563-8344-5be03587582a |
| updated_at          | 2021-08-12T07:39:53                  |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+

stack@sana:~$
```

**Vthunder Configuration:**

```
vThunder(NOLICENSE)#show running-config slb server
!Section configuration: 68 bytes
!
slb server e1fe7_10_0_12_73 10.0.12.73
  disable
  port 80 tcp
!
vThunder(NOLICENSE)#

```

**6. set a member**

```
stack@sana:~$ openstack loadbalancer member set p4 p4m1 --enable

stack@sana:~$ openstack loadbalancer member show p4 p4m1

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.12.73                           |
| admin_state_up      | True                                 |
| created_at          | 2021-08-12T07:34:46                  |
| id                  | 620e9539-a018-4ad5-a886-afdd6d5b208a |
| name                | p4m1                                 |
| operating_status    | NO_MONITOR                           |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| protocol_port       | 80                                   |
| provisioning_status | ACTIVE                               |
| subnet_id           | ba00407c-739e-4563-8344-5be03587582a |
| updated_at          | 2021-08-12T07:42:39                  |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+

stack@sana:~$
```

**Vthunder Configuration**

```
vThunder(NOLICENSE)#show running-config slb server
!Section configuration: 57 bytes
!
slb server e1fe7_10_0_12_73 10.0.12.73
  port 80 tcp
!
vThunder(NOLICENSE)#
```

**Rack flow:**

**1. Create a loadbalancer**

```
stack@sana:~$ openstack loadbalancer create --name v4 --vip-subnet-id vip_subnet

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-08-12T08:00:03                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | ee2e1c77-9b59-4264-8b7c-2bbfbca50b5b |
| listeners           |                                      |
| name                | v4                                   |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.12.128                       |
| vip_network_id      | 144533bf-db26-440f-a0ca-8ba072769e4a |
| vip_port_id         | 838b2daa-8fa3-4b15-bdc6-b2facb86d806 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 8330780e-25fd-4ec7-a6dd-fd412ec81e48 |
+---------------------+--------------------------------------+

stack@sana:~$

```

2. Create a listener

```
stack@sana:~$  openstack loadbalancer listener create --name l4 v4 --protocol http --protocol-port 80

+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-08-12T08:01:05                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 1da1628c-b205-4286-9939-60a8b9cc3891 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | ee2e1c77-9b59-4264-8b7c-2bbfbca50b5b |
| name                        | l4                                   |
| operating_status            | OFFLINE                              |
| project_id                  | e1fe759747844dd1871092efe9079a26     |
| protocol                    | HTTP                                 |
| protocol_port               | 80                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
| allowed_cidrs               | None                                 |
| tls_ciphers                 | None                                 |
| tls_versions                | None                                 |
| alpn_protocols              | None                                 |
+-----------------------------+--------------------------------------+

stack@sana:~$

```
**3. Create a pool**

```
stack@sana:~$ openstack loadbalancer pool create --name p4 --protocol http --lb-algorithm LEAST_CONNECTIONS --listener l4

+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-08-12T08:01:59                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | db77713c-bef2-47c3-b078-0ee524d77b65 |
| lb_algorithm         | LEAST_CONNECTIONS                    |
| listeners            | 1da1628c-b205-4286-9939-60a8b9cc3891 |
| loadbalancers        | ee2e1c77-9b59-4264-8b7c-2bbfbca50b5b |
| members              |                                      |
| name                 | p4                                   |
| operating_status     | OFFLINE                              |
| project_id           | e1fe759747844dd1871092efe9079a26     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+

stack@sana:~$
```

**4. Create a member**

```
stack@sana:~$ openstack loadbalancer member create --address 10.0.12.73 --subnet member_subnet --protocol-port 80 --name p4m1 p4

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.12.73                           |
| admin_state_up      | True                                 |
| created_at          | 2021-08-12T08:04:12                  |
| id                  | f606c335-addc-4273-af68-6955822ac9a6 |
| name                | p4m1                                 |
| operating_status    | NO_MONITOR                           |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| protocol_port       | 80                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | ba00407c-739e-4563-8344-5be03587582a |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+

stack@sana:~$
```

**Vthunder Configuration:**

```
ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 432 bytes
!
slb server e1fe7_10_0_12_73 10.0.12.73
  port 80 tcp
!
slb service-group db77713c-bef2-47c3-b078-0ee524d77b65 tcp
  method least-connection
  member e1fe7_10_0_12_73 80
!
slb virtual-server ee2e1c77-9b59-4264-8b7c-2bbfbca50b5b 192.168.12.128
  port 80 http
    name 1da1628c-b205-4286-9939-60a8b9cc3891
    conn-limit 20000
    extended-stats
    source-nat auto
    service-group db77713c-bef2-47c3-b078-0ee524d77b65
!
ACOS-Active-vMaster[15/2]#

```
**5. Set a member** 

```
stack@sana:~$ openstack loadbalancer member set p4 p4m1 --disable

stack@sana:~$ openstack loadbalancer member show p4 p4m1

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.12.73                           |
| admin_state_up      | False                                |
| created_at          | 2021-08-12T08:04:12                  |
| id                  | f606c335-addc-4273-af68-6955822ac9a6 |
| name                | p4m1                                 |
| operating_status    | NO_MONITOR                           |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| protocol_port       | 80                                   |
| provisioning_status | ACTIVE                               |
| subnet_id           | ba00407c-739e-4563-8344-5be03587582a |
| updated_at          | 2021-08-12T08:09:01                  |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+

stack@sana:~$
```

**Vthunder Configuration:**

```
ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 443 bytes
!
slb server e1fe7_10_0_12_73 10.0.12.73
  disable
  port 80 tcp
!
slb service-group db77713c-bef2-47c3-b078-0ee524d77b65 tcp
  method least-connection
  member e1fe7_10_0_12_73 80
!
slb virtual-server ee2e1c77-9b59-4264-8b7c-2bbfbca50b5b 192.168.12.128
  port 80 http
    name 1da1628c-b205-4286-9939-60a8b9cc3891
    conn-limit 20000
    extended-stats
    source-nat auto
    service-group db77713c-bef2-47c3-b078-0ee524d77b65
!
ACOS-Active-vMaster[15/2]#
ACOS-Active-vMaster[15/2]#
```

**6. set a member**

```
stack@sana:~$ openstack loadbalancer member set p4 p4m1 --enable

stack@sana:~$ openstack loadbalancer member show p4 p4m1

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.12.73                           |
| admin_state_up      | True                                 |
| created_at          | 2021-08-12T08:04:12                  |
| id                  | f606c335-addc-4273-af68-6955822ac9a6 |
| name                | p4m1                                 |
| operating_status    | NO_MONITOR                           |
| project_id          | e1fe759747844dd1871092efe9079a26     |
| protocol_port       | 80                                   |
| provisioning_status | ACTIVE                               |
| subnet_id           | ba00407c-739e-4563-8344-5be03587582a |
| updated_at          | 2021-08-12T08:11:42                  |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+

stack@sana:~$
```

**Vthunder Configuration**

```
ACOS-Active-vMaster[15/2]#show running-config slb
!Section configuration: 432 bytes
!
slb server e1fe7_10_0_12_73 10.0.12.73
  port 80 tcp
!
slb service-group db77713c-bef2-47c3-b078-0ee524d77b65 tcp
  method least-connection
  member e1fe7_10_0_12_73 80
!
slb virtual-server ee2e1c77-9b59-4264-8b7c-2bbfbca50b5b 192.168.12.128
  port 80 http
    name 1da1628c-b205-4286-9939-60a8b9cc3891
    conn-limit 20000
    extended-stats
    source-nat auto
    service-group db77713c-bef2-47c3-b078-0ee524d77b65
!
ACOS-Active-vMaster[15/2]#
```





