### PR TITLE
[STACK-2620]: Updating allowed address pair while running set command for loadbalancer/member

### DIFF
--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -104,6 +104,7 @@ SUPPORTED_NETWORK_TYPE = [FLAT, VLAN]
 SSL_TEMPLATE = "ssl_template"
 
 COMPUTE_BUSY = "compute_busy"
+L2DSR_FLAVOR = "l2dsr_flavor"
 
 # ACOS versions
 ACOS_5_2_1_P2 = "5.2.1-P2"

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -524,6 +524,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                 update_lb_tf = self.taskflow_load(
                     self._lb_flows.get_update_load_balancer_flow(topology=topology),
                     store={constants.LOADBALANCER: lb,
+                           constants.LOADBALANCER_ID: lb.id,
                            constants.VIP: lb.vip,
                            a10constants.COMPUTE_BUSY: busy,
                            constants.LISTENERS: listeners,
@@ -705,6 +706,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                     store={constants.MEMBER: member,
                            constants.LISTENERS: listeners,
                            constants.LOADBALANCER: load_balancer,
+                           constants.LOADBALANCER_ID: load_balancer.id,
                            a10constants.COMPUTE_BUSY: busy,
                            constants.POOL: pool,
                            constants.UPDATE_DICT: member_updates,

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -476,13 +476,18 @@ class LoadBalancerFlows(object):
         update_LB_flow.add(database_tasks.GetAmphoraeFromLoadbalancer(
             requires=constants.LOADBALANCER_ID,
             provides=constants.AMPHORA))
-        update_LB_flow.add(
-            a10_database_tasks.CountLoadbalancersInProjectBySubnet(
-                requires=[constants.SUBNET, a10constants.PARTITION_PROJECT_LIST],
-                provides=a10constants.LB_COUNT_SUBNET))
+        update_LB_flow.add(a10_database_tasks.GetLoadbalancersInProjectBySubnet(
+            requires=[constants.SUBNET, a10constants.PARTITION_PROJECT_LIST],
+            provides=a10constants.LOADBALANCERS_LIST))
+        update_LB_flow.add(a10_database_tasks.CheckForL2DSRFlavor(
+            rebind={a10constants.LB_RESOURCE: a10constants.LOADBALANCERS_LIST},
+            provides=a10constants.L2DSR_FLAVOR))
+        update_LB_flow.add(a10_database_tasks.CountMembersInProjectBySubnet(
+            requires=[constants.SUBNET, a10constants.PARTITION_PROJECT_LIST],
+            provides=a10constants.MEMBER_COUNT))
         update_LB_flow.add(vthunder_tasks.UpdateL2DSR(
             requires=(constants.SUBNET, constants.AMPHORA,
-                      a10constants.LB_COUNT_SUBNET)))
+                      a10constants.MEMBER_COUNT, a10constants.L2DSR_FLAVOR)))
         update_LB_flow.add(a10_database_tasks.GetFlavorData(
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
             provides=constants.FLAVOR_DATA))

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -473,6 +473,16 @@ class LoadBalancerFlows(object):
         #    requires=[constants.LOADBALANCER, constants.LISTENERS]))
         # post_create_lb_flow.add(handle_vrid_for_loadbalancer_subflow())
         update_LB_flow.add(self.handle_vrid_for_loadbalancer_subflow())
+        update_LB_flow.add(database_tasks.GetAmphoraeFromLoadbalancer(
+            requires=constants.LOADBALANCER_ID,
+            provides=constants.AMPHORA))
+        update_LB_flow.add(
+            a10_database_tasks.CountLoadbalancersInProjectBySubnet(
+                requires=[constants.SUBNET, a10constants.PARTITION_PROJECT_LIST],
+                provides=a10constants.LB_COUNT_SUBNET))
+        update_LB_flow.add(vthunder_tasks.UpdateL2DSR(
+            requires=(constants.SUBNET, constants.AMPHORA,
+                      a10constants.LB_COUNT_SUBNET)))
         update_LB_flow.add(a10_database_tasks.GetFlavorData(
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
             provides=constants.FLAVOR_DATA))

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -574,13 +574,19 @@ class MemberFlows(object):
         update_member_flow.add(database_tasks.GetAmphoraeFromLoadbalancer(
             requires=constants.LOADBALANCER_ID,
             provides=constants.AMPHORA))
-        update_member_flow.add(
-            a10_database_tasks.CountMembersInProjectBySubnet(
-                requires=[constants.SUBNET, a10constants.PARTITION_PROJECT_LIST],
-                provides=a10constants.MEMBER_COUNT))
+        update_member_flow.add(a10_database_tasks.GetLoadbalancersInProjectBySubnet(
+            requires=[constants.SUBNET, a10constants.PARTITION_PROJECT_LIST],
+            provides=a10constants.LOADBALANCERS_LIST))
+        update_member_flow.add(a10_database_tasks.CheckForL2DSRFlavor(
+            rebind={a10constants.LB_RESOURCE: a10constants.LOADBALANCERS_LIST},
+            provides=a10constants.L2DSR_FLAVOR))
+        update_member_flow.add(a10_database_tasks.CountLoadbalancersInProjectBySubnet(
+            requires=[constants.SUBNET, a10constants.PARTITION_PROJECT_LIST],
+            provides=a10constants.LB_COUNT_SUBNET))
         update_member_flow.add(vthunder_tasks.UpdateLoadbalancerForwardWithAnySource(
-            requires=(constants.MEMBER, constants.AMPHORA,
-                      a10constants.MEMBER_COUNT)))
+            requires=(constants.SUBNET, constants.AMPHORA,
+                      a10constants.LB_COUNT_SUBNET, a10constants.L2DSR_FLAVOR)))
+
         update_member_flow.add(a10_database_tasks.GetFlavorData(
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
             provides=constants.FLAVOR))

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -571,6 +571,16 @@ class MemberFlows(object):
                 requires=a10constants.VTHUNDER,
                 provides=a10constants.VTHUNDER))
         update_member_flow.add(self.handle_vrid_for_member_subflow())
+        update_member_flow.add(database_tasks.GetAmphoraeFromLoadbalancer(
+            requires=constants.LOADBALANCER_ID,
+            provides=constants.AMPHORA))
+        update_member_flow.add(
+            a10_database_tasks.CountMembersInProjectBySubnet(
+                requires=[constants.SUBNET, a10constants.PARTITION_PROJECT_LIST],
+                provides=a10constants.MEMBER_COUNT))
+        update_member_flow.add(vthunder_tasks.UpdateLoadbalancerForwardWithAnySource(
+            requires=(constants.MEMBER, constants.AMPHORA,
+                      a10constants.MEMBER_COUNT)))
         update_member_flow.add(a10_database_tasks.GetFlavorData(
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
             provides=constants.FLAVOR))

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -445,6 +445,21 @@ class UpdateVRIDForLoadbalancerResource(BaseDatabaseTask):
                           str(vrid.vrid_floating_ip), str(e))
 
 
+class GetLoadbalancersInProjectBySubnet(BaseDatabaseTask):
+
+    def execute(self, subnet, partition_project_list):
+        if partition_project_list:
+            try:
+                return self.loadbalancer_repo.get_lbs_by_subnet(
+                    db_apis.get_session(),
+                    project_ids=partition_project_list, subnet_id=subnet.id)
+            except Exception as e:
+                LOG.exception("Failed to get LBs for subnet %s due to %s ",
+                              subnet.id, str(e))
+                raise e
+        return 0
+
+
 class CountLoadbalancersInProjectBySubnet(BaseDatabaseTask):
 
     def execute(self, subnet, partition_project_list, use_device_flavor):
@@ -710,6 +725,25 @@ class GetFlavorData(BaseDatabaseTask):
                     id=flavor.flavor_profile_id)
                 flavor_data = json.loads(flavor_profile.flavor_data)
                 return self._format_keys(flavor_data)
+
+
+class CheckForL2DSRFlavor(BaseDatabaseTask):
+
+    def execute(self, lb_resource):
+        for lb in lb_resource:
+            flavor_id = a10_task_utils.attribute_search(lb, 'flavor_id')
+            if flavor_id:
+                flavor = self.flavor_repo.get(db_apis.get_session(), id=flavor_id)
+                if flavor and flavor.flavor_profile_id:
+                    flavor_profile = self.flavor_profile_repo.get(
+                        db_apis.get_session(),
+                        id=flavor.flavor_profile_id)
+                    flavor_data = json.loads(flavor_profile.flavor_data)
+                    deployment = flavor_data.get('deployment')
+                    if deployment and 'dsr_type' in deployment and \
+                            deployment['dsr_type'] == "l2dsr_transparent":
+                        return True
+        return False
 
 
 class GetNatPoolEntry(BaseDatabaseTask):

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -180,6 +180,19 @@ class DeleteL2DSR(VThunderBaseTask):
                                 subnet.network_id, amp)
 
 
+class UpdateL2DSR(VThunderBaseTask):
+    """Task to update wildcat address in allowed_address_pair for L2DSR"""
+
+    def execute(self, subnet, amphora, lb_count_subnet):
+        if CONF.vthunder.l2dsr_support:
+            for amp in amphora:
+                self.network_driver.allow_use_any_source_ip_on_egress(subnet.network_id, amp)
+        if not CONF.vthunder.l2dsr_support:
+            if lb_count_subnet <= 1:
+                for amp in amphora:
+                    self.network_driver.remove_any_source_ip_on_egress(subnet.network_id, amp)
+
+
 class AllowLoadbalancerForwardWithAnySource(VThunderBaseTask):
     """Task to add wildcat address in allowed_address_pair to allow any SNAT"""
 
@@ -188,6 +201,20 @@ class AllowLoadbalancerForwardWithAnySource(VThunderBaseTask):
         if CONF.vthunder.slb_no_snat_support:
             for amp in amphora:
                 self.network_driver.allow_use_any_source_ip_on_egress(subnet.network_id, amp)
+
+
+class UpdateLoadbalancerForwardWithAnySource(VThunderBaseTask):
+    """Task to update wildcat address in allowed_address_pair to allow any SNAT"""
+
+    def execute(self, subnet, member, amphora, member_count):
+        if CONF.vthunder.slb_no_snat_support:
+            for amp in amphora:
+                self.network_driver.allow_use_any_source_ip_on_egress(subnet.network_id, amp)
+
+        if not CONF.vthunder.slb_no_snat_support:
+            if member_count <= 1:
+                for amp in amphora:
+                    self.network_driver.remove_any_source_ip_on_egress(subnet.network_id, amp)
 
 
 class AmphoraePostMemberNetworkPlug(VThunderBaseTask):

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -183,14 +183,16 @@ class DeleteL2DSR(VThunderBaseTask):
 class UpdateL2DSR(VThunderBaseTask):
     """Task to update wildcat address in allowed_address_pair for L2DSR"""
 
-    def execute(self, subnet, amphora, lb_count_subnet):
+    def execute(self, subnet, amphora, member_count, l2dsr_flavor):
         if CONF.vthunder.l2dsr_support:
             for amp in amphora:
                 self.network_driver.allow_use_any_source_ip_on_egress(subnet.network_id, amp)
-        if not CONF.vthunder.l2dsr_support:
-            if lb_count_subnet <= 1:
-                for amp in amphora:
-                    self.network_driver.remove_any_source_ip_on_egress(subnet.network_id, amp)
+        else:
+            if not l2dsr_flavor:
+                if (CONF.vthunder.slb_no_snat_support and member_count < 1) or \
+                        (not CONF.vthunder.slb_no_snat_support):
+                    for amp in amphora:
+                        self.network_driver.remove_any_source_ip_on_egress(subnet.network_id, amp)
 
 
 class AllowLoadbalancerForwardWithAnySource(VThunderBaseTask):
@@ -206,15 +208,16 @@ class AllowLoadbalancerForwardWithAnySource(VThunderBaseTask):
 class UpdateLoadbalancerForwardWithAnySource(VThunderBaseTask):
     """Task to update wildcat address in allowed_address_pair to allow any SNAT"""
 
-    def execute(self, subnet, member, amphora, member_count):
+    def execute(self, subnet, amphora, lb_count_subnet, l2dsr_flavor):
         if CONF.vthunder.slb_no_snat_support:
             for amp in amphora:
                 self.network_driver.allow_use_any_source_ip_on_egress(subnet.network_id, amp)
-
-        if not CONF.vthunder.slb_no_snat_support:
-            if member_count <= 1:
-                for amp in amphora:
-                    self.network_driver.remove_any_source_ip_on_egress(subnet.network_id, amp)
+        else:
+            if not l2dsr_flavor:
+                if (CONF.vthunder.l2dsr_support and lb_count_subnet < 1) or \
+                        not CONF.vthunder.l2dsr_support:
+                    for amp in amphora:
+                        self.network_driver.remove_any_source_ip_on_egress(subnet.network_id, amp)
 
 
 class AmphoraePostMemberNetworkPlug(VThunderBaseTask):

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -404,6 +404,19 @@ class LoadBalancerRepository(repo.LoadBalancerRepository):
                 or_(self.model_class.provisioning_status == consts.PENDING_DELETE,
                     self.model_class.provisioning_status == consts.ACTIVE)).count()
 
+    def get_lbs_by_subnet(self,session, project_ids, subnet_id):
+        lb_list = []
+        query = session.query(self.model_class).join(base_models.Vip).filter(
+            and_(self.model_class.project_id.in_(project_ids),
+                 base_models.Vip.subnet_id == subnet_id,
+                 or_(self.model_class.provisioning_status == consts.PENDING_DELETE,
+                     self.model_class.provisioning_status == consts.ACTIVE,
+                     self.model_class.provisioning_status == consts.PENDING_UPDATE)))
+        model_list = query.all()
+        for data in model_list:
+            lb_list.append(data.to_data_model())
+        return lb_list
+
     def check_lb_exists_in_project(self, session, project_id):
         lb = session.query(self.model_class).join(base_models.Vip).filter(
             and_(self.model_class.project_id == project_id,


### PR DESCRIPTION
## Description
- Severity Level: Medium
- Issue Description :[vthunder][l2dsr_support & slb_no_snat_support] only work when creating vthunders

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-2620

## Technical Approach
- On running set command for lb/member, adding and removing  0.0.0.0/0 from allowed address pair based on the value of l2dsr_support and slb_no_snat_support in a10_config file.
 
## Manual Testing
1) Create lb and other objects.
```
a10_config file:

[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
#l2dsr_support = True
#slb_no_snat_support=True

stack@victoria:~/addeb2/a10-octavia$ openstack loadbalancer  list
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| 43da8612-b4a3-45ba-bdcc-e770e1bbc41f | v2   | bc83270643c14317b1e2653854c1e190 | 10.0.0.97   | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
stack@victoria:~/addeb2/a10-octavia$ openstack loadbalancer listener list
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| id                                   | default_pool_id                      | name | project_id                       | protocol | protocol_port | admin_state_up |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| b572ce70-4f7f-4769-b82f-84f69a6ad354 | c5929c3f-c64b-42e2-afe7-07303c0eb367 | l2   | bc83270643c14317b1e2653854c1e190 | TCP      |            80 | True           |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
stack@victoria:~/addeb2/a10-octavia$ openstack loadbalancer pool list
+--------------------------------------+-------+----------------------------------+---------------------+----------+-------------------+----------------+
| id                                   | name  | project_id                       | provisioning_status | protocol | lb_algorithm      | admin_state_up |
+--------------------------------------+-------+----------------------------------+---------------------+----------+-------------------+----------------+
| c5929c3f-c64b-42e2-afe7-07303c0eb367 | pool1 | bc83270643c14317b1e2653854c1e190 | ACTIVE              | TCP      | LEAST_CONNECTIONS | True           |
+--------------------------------------+-------+----------------------------------+---------------------+----------+-------------------+----------------+
stack@victoria:~/addeb2/a10-octavia$ openstack loadbalancer member list pool1
+--------------------------------------+------+----------------------------------+---------------------+-----------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address   | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+-----------+---------------+------------------+--------+
| aba91253-a519-4a2a-89b0-d994830af5c7 | m1   | bc83270643c14317b1e2653854c1e190 | ACTIVE              | 11.0.0.89 |            80 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+-----------+---------------+------------------+--------+
stack@victoria:~/addeb2/a10-octavia$
```
<img width="788" alt="initial_lb_aap" src="https://user-images.githubusercontent.com/76765492/129724562-08a1fd9c-dfd7-467e-9684-670b8e0bc995.PNG">
<img width="784" alt="initial_member_aap" src="https://user-images.githubusercontent.com/76765492/129724599-3b60106b-b6b6-4063-a180-e057fa5021d5.PNG">

2) Added l2_dsr_support = True in a10_config.file , and set the lb.
0.0.0.0/0 will be added in AAP.
```
[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
l2dsr_support = True

stack@victoria:~/addeb2/a10-octavia$ sudo systemctl restart a10-controller-worker.service
stack@victoria:~/addeb2/a10-octavia$ openstack loadbalancer set v2

Aug 17 10:43:03 victoria a10-octavia-worker[3406709]: INFO a10_octavia.controller.queue.endpoint [-] Updating load balancer '43da8612-b4a3-45ba-bdcc-e770e1bbc41f'...
Aug 17 10:43:09 victoria a10-octavia-worker[3406709]: INFO octavia.controller.worker.v1.tasks.database_tasks [-] Mark ACTIVE in DB for load balancer id: 43da8612-b4a3-45ba-bdcc-e770e1bbc41f
Aug 17 10:43:09 victoria a10-octavia-worker[3406709]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.0.140:shared
```
<img width="784" alt="set_add_lb" src="https://user-images.githubusercontent.com/76765492/129724887-30c0aae4-0f5d-4f59-a7ee-1ef4e48e9805.PNG">

3) Remove the l2dsr_support from a10_config file and set the lb.
0.0.0.0/0 will be removed in AAP.
```
[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
#l2dsr_support = True

stack@victoria:~/addeb2/a10-octavia$ sudo systemctl restart a10-controller-worker.service
stack@victoria:~/addeb2/a10-octavia$ openstack loadbalancer set v2

Aug 17 10:46:16 victoria a10-octavia-worker[3407255]: INFO a10_octavia.controller.queue.endpoint [-] Updating load balancer '43da8612-b4a3-45ba-bdcc-e770e1bbc41f'...
Aug 17 10:46:21 victoria a10-octavia-worker[3407255]: INFO octavia.controller.worker.v1.tasks.database_tasks [-] Mark ACTIVE in DB for load balancer id: 43da8612-b4a3-45ba-bdcc-e770e1bbc41f
Aug 17 10:46:21 victoria a10-octavia-worker[3407255]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.0.140:shared
```
<img width="782" alt="set_remove_lb" src="https://user-images.githubusercontent.com/76765492/129725073-b9a4424c-d868-4706-803a-6dab4dc2656b.PNG">

4) Add slb_no_snat_support=True and set the member
0.0.0.0/0 will be added in AAP
```
[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
slb_no_snat_support=True

stack@victoria:~/addeb2/a10-octavia$ sudo systemctl restart a10-controller-worker.service
stack@victoria:~/addeb2/a10-octavia$ openstack loadbalancer member set pool1 m1

Aug 17 10:48:06 victoria a10-octavia-worker[3407682]: INFO a10_octavia.controller.queue.endpoint [-] Updating member 'aba91253-a519-4a2a-89b0-d994830af5c7'...
Aug 17 10:48:13 victoria a10-octavia-worker[3407682]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.0.140:shared
```
<img width="780" alt="set_add_member" src="https://user-images.githubusercontent.com/76765492/129725379-ba57fd02-cb8f-43de-8597-ef7968482bd0.PNG">

5) Remove slb_no_snat_support=True and set the member
0.0.0.0/0 will be removed in AAP
```
[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
#slb_no_snat_support=True

stack@victoria:~/addeb2/a10-octavia$ sudo systemctl restart a10-controller-worker.service
stack@victoria:~/addeb2/a10-octavia$ openstack loadbalancer member set pool1 m1

Aug 17 10:50:16 victoria a10-octavia-worker[3408185]: INFO a10_octavia.controller.queue.endpoint [-] Updating member 'aba91253-a519-4a2a-89b0-d994830af5c7'...
Aug 17 10:50:21 victoria a10-octavia-worker[3408185]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.0.140:shared
```
<img width="787" alt="set_remove_member" src="https://user-images.githubusercontent.com/76765492/129725622-f8298f94-ac75-4556-b649-06881d2ab4a7.PNG">
