### PR TITLE
[STACK-2762]: Trim the description length of virtual server to 61 characters; merge it to release v1_3_2

### DIFF
--- a/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
@@ -52,7 +52,7 @@ class LoadBalancerParent(object):
             if len(desc) > 61:
                 LOG.warning('Description length exceeds the allowed character limit.'
                             ' Trimming the description length')
-                desc = '"{}"'.format(desc[0:61])
+            desc = '"{}"'.format(desc[0:61])
         config_args['description'] = desc
 
         if flavor_data:

--- a/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_server_tasks.py
@@ -49,7 +49,10 @@ class LoadBalancerParent(object):
         elif str(desc).isspace() or not str(desc):
             desc = ""
         else:
-            desc = '"{}"'.format(desc)
+            if len(desc) > 61:
+                LOG.warning('Description length exceeds the allowed character limit.'
+                            ' Trimming the description length')
+                desc = '"{}"'.format(desc[0:61])
         config_args['description'] = desc
 
         if flavor_data:


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description: Character length limit is 63 for virtual-servers.
Merge this fix in to release/v1.3.2

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-2762

## Technical Approach
- Added a warning if the description limit exceeds the character limit.
- Trim the description length to 61 characters. So that after adding double quotes ("") , it does not exceeds 63 characters.

Please look PR#491 for more details.