### PR TITLE
[STACK-2794] shutdown health manager executor threads

### DIFF
--- a/a10_octavia/cmd/a10_health_manager.py
+++ b/a10_octavia/cmd/a10_health_manager.py
@@ -47,6 +47,10 @@ def hm_listener(exit_event):
             LOG.error('A10 Health Manager listener experienced unknown error: %s',
                       ex)
 
+    LOG.info('Waiting for executor to shutdown...')
+    udp_getter.stats_executor.shutdown()
+    LOG.info('Executor shutdown finished.')
+
 
 def hm_health_check(exit_event):
     hm = a10_health_manager.A10HealthManager(exit_event)


### PR DESCRIPTION
## Description
If Bug Fix:
- Required: Severity Level: High
- Required: Issue Description
Failed to restart health manager service. The health monitor stop takes long and 5550 port is never released after service restart.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2794

## Technical Approach
The stats periodical works seems didn't shutdown after restart. reference octavia code to shutdown it when restart:
https://github.com/openstack/octavia/blob/5c8f60614e97b76d95b7f9b90bc142de4dea1cdd/octavia/cmd/health_manager.py#L53

## Config Changes
<pre>
<b>[a10_health_manager]
udp_server_ip_address = 192.168.0.200
bind_port = 5550
bind_ip = 192.168.0.200

heartbeat_interval = 20
health_check_timeout = 3
health_check_max_retries = 5

heartbeat_key = insecure
heartbeat_timeout = 30
failover_timeout = 600
health_check_interval = 10
</b>
</pre>


## Test Cases
sudo service a10-health-manager restart

## Manual Testing
Journal log for a10-health-manager:
```
Aug 24 13:07:36 ytsai-victoria1 a10-health-manager[947347]: INFO a10_octavia.cmd.a10_health_manager [-] Waiting for executor to shutdown...
Aug 24 13:07:36 ytsai-victoria1 a10-health-manager[947347]: INFO a10_octavia.cmd.a10_health_manager [-] Executor shutdown finished.
Aug 24 13:07:37 ytsai-victoria1 systemd[1]: a10-health-manager.service: Succeeded.
Aug 24 13:07:37 ytsai-victoria1 systemd[1]: Stopped Devstack a10-health-manager.service.
Aug 24 13:07:37 ytsai-victoria1 systemd[1]: Started Devstack a10-health-manager.service.
Aug 24 13:07:40 ytsai-victoria1 a10-health-manager[1001663]: INFO a10_octavia.common.config_options [-] Logging enabled!
Aug 24 13:07:40 ytsai-victoria1 a10-health-manager[1001663]: INFO a10_octavia.common.config_options [-] /usr/local/bin/a10-health-manager version 7.1.2.dev30
Aug 24 13:07:40 ytsai-victoria1 a10-health-manager[1001663]: DEBUG a10_octavia.common.config_options [-] command line: /usr/local/bin/a10-health-manager --config-dir=/etc/octavia/ --config-file=/etc/a10/a10-octavia.conf {{(pid=1001663) setup_logging /opt/stack/source/Failover/a10_octavia/common/config_options.py:409}}
Aug 24 13:07:40 ytsai-victoria1 a10-health-manager[1001663]: INFO a10_octavia.cmd.a10_health_manager [-] A10 Health Manager listener process starts:
Aug 24 13:07:40 ytsai-victoria1 a10-health-manager[1001663]: INFO a10_octavia.cmd.a10_health_manager [-] A10 Health manager check process starts:
Aug 24 13:07:40 ytsai-victoria1 a10-health-manager[1001693]: INFO a10_octavia.cmd.vthunder_heartbeat_udp [-] attempting to listen on 192.168.0.200 port 5550
Aug 24 13:07:40 ytsai-victoria1 a10-health-manager[1001694]: WARNING a10_octavia.cmd.a10_health_manager [-] Pausing before starting health check
Aug 24 13:07:41 ytsai-victoria1 a10-health-manager[1001693]: INFO a10_octavia.cmd.vthunder_heartbeat_udp [-] Received packet from 192.168.0.192

```