### PR TITLE
[Feature][STACK-2764]: Global flavor ID configuration option support

### DIFF
--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -48,6 +48,8 @@ A10_GLOBAL_OPTS = [
     cfg.BoolOpt('use_shared_for_template_lookup',
                 default=False,
                 help=_('Use shared for template')),
+    cfg.StrOpt('default_flavor_id', default=None,
+               help=_('Default flavor ID to apply globally to all users')),
 ]
 
 A10_VTHUNDER_OPTS = [

--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -246,3 +246,10 @@ class InterfaceNotFound(acos_errors.ACOSException):
         msg = ('vThunder instance {0} has no interface in network {1}.').format(comput_id,
                                                                                 network_id)
         super(InterfaceNotFound, self).__init__(msg=msg)
+
+
+class FlavorNotFound(cfg.ConfigFileValueError):
+    def __init__(self, flavor):
+        msg = ('Flavor {0} specified in the configuration file is unable to locate,'
+               ' Please create the flavor in advance.').format(flavor)
+        super(FlavorNotFound, self).__init__(msg=msg)

--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -250,6 +250,6 @@ class InterfaceNotFound(acos_errors.ACOSException):
 
 class FlavorNotFound(cfg.ConfigFileValueError):
     def __init__(self, flavor):
-        msg = ('Flavor {0} specified in the configuration file is unable to locate,'
+        msg = ('Flavor {0} specified in the configuration file cannot be located,'
                ' Please create the flavor in advance.').format(flavor)
         super(FlavorNotFound, self).__init__(msg=msg)

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -395,6 +395,11 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                         '60 seconds.', 'load_balancer', load_balancer_id)
             raise db_exceptions.NoResultFound
 
+        if not lb.flavor_id and CONF.a10_global.default_flavor_id:
+            flavor_id = CONF.a10_global.default_flavor_id
+        else:
+            flavor_id = lb.flavor_id
+
         store = {constants.LOADBALANCER_ID: load_balancer_id,
                  constants.VIP: lb.vip,
                  constants.BUILD_TYPE_PRIORITY:
@@ -405,7 +410,8 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         topology = CONF.a10_controller_worker.loadbalancer_topology
 
         store[constants.UPDATE_DICT] = {
-            constants.TOPOLOGY: topology
+            constants.TOPOLOGY: topology,
+            constants.FLAVOR_ID: flavor_id
         }
 
         ctx_flags = [False]

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -395,10 +395,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                         '60 seconds.', 'load_balancer', load_balancer_id)
             raise db_exceptions.NoResultFound
 
-        if not lb.flavor_id and CONF.a10_global.default_flavor_id:
-            flavor_id = CONF.a10_global.default_flavor_id
-        else:
-            flavor_id = lb.flavor_id
+        flavor_id = lb.flavor_id if lb.flavor_id else CONF.a10_global.default_flavor_id
 
         store = {constants.LOADBALANCER_ID: load_balancer_id,
                  constants.VIP: lb.vip,

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -101,13 +101,13 @@ class LoadBalancerFlows(object):
         vthunder = self._vthunder_repo.get_vthunder_by_project_id(db_apis.get_session(),
                                                                   project_id)
 
+        lb_create_flow.add(a10_database_tasks.GetFlavorData(
+            rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
+            provides=constants.FLAVOR_DATA))
         lb_create_flow.add(
             self.get_post_lb_vthunder_association_flow(
                 post_amp_prefix, load_balancer_id, topology, vthunder,
                 mark_active=(not listeners)))
-        lb_create_flow.add(a10_database_tasks.GetFlavorData(
-            rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
-            provides=constants.FLAVOR_DATA))
         lb_create_flow.add(a10_database_tasks.CountLoadbalancersWithFlavor(
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
             provides=a10constants.LB_COUNT_FLAVOR))

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -717,8 +717,12 @@ class GetFlavorData(BaseDatabaseTask):
 
     def execute(self, lb_resource):
         flavor_id = a10_task_utils.attribute_search(lb_resource, 'flavor_id')
+        if not flavor_id:
+            flavor_id = CONF.a10_global.default_flavor_id
         if flavor_id:
             flavor = self.flavor_repo.get(db_apis.get_session(), id=flavor_id)
+            if not flavor and lb_resource.provisioning_status != "PENDING_DELETE":
+                raise exceptions.FlavorNotFound(flavor_id)
             if flavor and flavor.flavor_profile_id:
                 flavor_profile = self.flavor_profile_repo.get(
                     db_apis.get_session(),

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -31,6 +31,7 @@ from octavia.tests.common import constants as t_constants
 
 from a10_octavia.common import config_options
 from a10_octavia.common import data_models
+from a10_octavia.common import exceptions
 from a10_octavia.common import utils
 from a10_octavia.controller.worker.tasks import a10_database_tasks as task
 from a10_octavia.tests.common import a10constants
@@ -362,8 +363,8 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         flavor_task.flavor_repo.get.return_value = None
         flavor_task._flavor_search = mock.Mock(
             return_value=a10constants.MOCK_FLAVOR_ID)
-        ret_val = flavor_task.execute(LB)
-        self.assertEqual(ret_val, None)
+        ret_val = flavor_task.execute
+        self.assertRaises(exceptions.FlavorNotFound, ret_val, LB)
 
         flavor_task.flavor_repo.reset_mock()
         flavor_task.flavor_repo = mock.Mock()

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -48,6 +48,7 @@ HW_THUNDER = data_models.HardwareThunder(
     partition_name="shared")
 LB = o_data_models.LoadBalancer(id=a10constants.MOCK_LOAD_BALANCER_ID,
                                 flavor_id=a10constants.MOCK_FLAVOR_ID)
+LB2 = o_data_models.LoadBalancer(id=a10constants.MOCK_LOAD_BALANCER_ID)
 FIXED_IP = n_data_models.FixedIP(ip_address='10.10.10.10')
 PORT = n_data_models.Port(id=uuidutils.generate_uuid(), fixed_ips=[FIXED_IP])
 VRID = data_models.VRID(id=1, vrid=0,
@@ -87,6 +88,8 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         self.conf.register_opts(
             config_options.A10_HARDWARE_THUNDER_OPTS,
             group=a10constants.HARDWARE_THUNDER_CONF_SECTION)
+        self.conf.register_opts(config_options.A10_GLOBAL_OPTS,
+                                group=a10constants.A10_GLOBAL_OPTS)
         self.db_session = mock.patch(
             'a10_octavia.controller.worker.tasks.a10_database_tasks.db_apis.get_session')
         self.db_session.start()
@@ -373,6 +376,20 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         flavor_task.flavor_repo.get.return_value = flavor
         ret_val = flavor_task.execute(LB)
         self.assertEqual(ret_val, None)
+
+    def test_GetFlavorData_execute_with_default_flavor_id(self):
+        flavor_task = task.GetFlavorData()
+        flavor = copy.deepcopy(FLAVOR)
+        flavor_prof = copy.deepcopy(FLAVOR_PROFILE)
+        flavor_prof.flavor_data = "{}"
+        flavor_task.flavor_repo = mock.Mock()
+        flavor_task.flavor_repo.get.return_value = flavor
+        self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
+                         default_flavor_id=flavor)
+        flavor_task.flavor_profile_repo = mock.Mock()
+        flavor_task.flavor_profile_repo.get.return_value = flavor_prof
+        ret_val = flavor_task.execute(LB2)
+        self.assertEqual(ret_val, {})
 
     def test_GetFlavorData_execute_return_flavor(self):
         flavor_task = task.GetFlavorData()


### PR DESCRIPTION
## Description
Added support for **default_flavor_id** config option so that users working with a limited feature set don't have to specify as much information during loadbalancer create.

## Design Document
https://teams.microsoft.com/l/file/18D8570C-E48A-4177-A841-7F1F19168BD3?tenantId=91d27ab9-8c5e-41d4-82e8-3d1bf81fcb2f&fileType=docx&objectUrl=https%3A%2F%2Fa10networks.sharepoint.com%2Fsites%2FOpenstack%2FShared%20Documents%2FDevelopment%2FResearch%20%26%20Design%2Fa10-octavia%20v1.3.2%20Default%20Flavor-ID%20Support%2FDefault%20flavor-ID%20configuration%20option%20support.docx&baseUrl=https%3A%2F%2Fa10networks.sharepoint.com%2Fsites%2FOpenstack&serviceName=teams&threadId=19:0f1acbb173d74758b05ee8bacb000d68@thread.tacv2&groupId=37bbf3ad-c05a-4e67-b0cc-12bcd1479beb

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2764
https://a10networks.atlassian.net/browse/STACK-2795
https://a10networks.atlassian.net/browse/STACK-2796
https://a10networks.atlassian.net/browse/STACK-2816
https://a10networks.atlassian.net/browse/STACK-2818

## Technical Approach
- Added a config option `default_flavor_id` in `a10_global` section of a10-octavia.conf file.
- In `GetFlavorData()` task, assigning default_flavor_id to flavor_id iff a flavor with --flavor parameter is not passed during the loadbalancer creation.
- If flavor with the default_flavor_id is not present in flavor table of octavia DB, then raising an exception **FlavorNotFound**.
- Created FlavorNotFound exception which will give a message as " **Flavor <flavor_id> specified in the configuration file is unable to locate, Please create the flavor in advance**."
- In `create_load_balancer()` method of controller_worker.py, if lb.flavor_id is None and CONF.a10_global.default_flavor_id exists, then making entry of the CONF.a10_global.default_flavor_id into flavor_id column of load_balancer table via `UpdateLoadbalancerInDB()` task.


## Config Changes
Added a new option default_flavor_id in a10_global section

```
[a10_global]
default_flavor_id = <flavor_id>
```

## Test Cases
- Given a default_flavor_id in config file, when flavor with --flavor is not passed while loadbalancer creation, then the flavor with default_flavor_id should be attached to the loadbalancer.
- Given a default_flavor_id in config file, when flavor with --flavor is passed while loadbalancer creation, then the flavor passed with --flavor parameter should be attached to the loadbalancer.
- Given a default_flavor_id in config file, when flavor with --flavor-id is not passed while loadbalancer creation and the flavor does not exist in flavor table, then FlavorNotFount exception should be raised.

## Manual Testing
1. Create a flavorprofile and flavor for virtual-server.

stack@neha-victoria:~#**openstack loadbalancer flavorprofile create --name fp1 --provider a10 --flavor-data '{"virtual-server": {"vport-disable-action":"drop-packet"}}'**

```
+---------------+------------------------------------------------------------+
| Field         | Value                                                      |
+---------------+------------------------------------------------------------+
| id            | 19dd372f-ea9e-4504-96fc-0bd797404687                       |
| name          | fp1                                                        |
| provider_name | a10                                                        |
| flavor_data   | {"virtual-server": {"vport-disable-action":"drop-packet"}} |
+---------------+------------------------------------------------------------+
```
stack@neha-victoria:~#**openstack loadbalancer flavor create --name f1 --flavorprofile fp1 --description "vtest" --enable**
```
+-------------------+--------------------------------------+
| Field             | Value                                |
+-------------------+--------------------------------------+
| id                | 8c5eef93-cc1d-446f-923c-ae4e351b2bc7 |
| name              | f1                                   |
| flavor_profile_id | 19dd372f-ea9e-4504-96fc-0bd797404687 |
| enabled           | True                                 |
| description       | vtest                                |
+-------------------+--------------------------------------+
```

2. Configure the flavor-id to default_flavor_id option in a10-octavia.conf file and restart a10-controller-worker.service
```
[a10_global]
network_type = 'flat'
vrid_floating_ip = "dhcp"
default_flavor_id = "8c5eef93-cc1d-446f-923c-ae4e351b2bc7"
```

3. Create a loadbalancer

stack@neha-victoria:~#**openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name lb1**
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-08-30T06:21:04                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 9fb2e875-4bc9-4c09-a7c7-d7828e73cd92 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 64474f828b3c483eafe2be7f5025df0d     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.175                          |
| vip_network_id      | dfe0ea7a-5463-4332-827a-cbf91c86d740 |
| vip_port_id         | a81c2aca-4110-468e-a036-f856f7316299 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 452aef15-7144-4c2f-87dc-c97dbce2dd3f |
+---------------------+--------------------------------------+
```

stack@neha-victoria:~#openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| 9fb2e875-4bc9-4c09-a7c7-d7828e73cd92 | lb1  | 64474f828b3c483eafe2be7f5025df0d | 10.0.11.175 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
```

mysql> select * from load_balancer;
```
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------------+-----------------+---------------------+---------------------+----------+--------------------------------------+-------------------+
| project_id                       | id                                   | name | description | provisioning_status | operating_status | enabled | topology       | server_group_id | created_at          | updated_at          | provider | flavor_id                            | availability_zone |
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------------+-----------------+---------------------+---------------------+----------+--------------------------------------+-------------------+
| 64474f828b3c483eafe2be7f5025df0d | 9fb2e875-4bc9-4c09-a7c7-d7828e73cd92 | lb1  | NULL        | ACTIVE              | OFFLINE          |       1 | ACTIVE_STANDBY | NULL            | 2021-08-30 06:21:04 | 2021-08-30 06:28:16 | a10      | 8c5eef93-cc1d-446f-923c-ae4e351b2bc7 | NULL              |
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------------+-----------------+---------------------+---------------------+----------+--------------------------------------+-------------------+
```


vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 721 bytes
!Configuration last updated at 07:28:15 IST Mon Aug 30 2021
!Configuration last saved at 07:28:19 IST Mon Aug 30 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.118
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
**slb virtual-server 9fb2e875-4bc9-4c09-a7c7-d7828e73cd92 10.0.11.175
  vport-disable-action drop-packet
  arp-disable**
!
!
cloud-services meta-data
  enable
  provider openstack
!
end


vThunder-Active-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 721 bytes
!Configuration last updated at 07:28:15 IST Mon Aug 30 2021
!Configuration last saved at 07:26:28 IST Mon Aug 30 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.118
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
**slb virtual-server 9fb2e875-4bc9-4c09-a7c7-d7828e73cd92 10.0.11.175
  vport-disable-action drop-packet
  arp-disable**
!
!
cloud-services meta-data
  enable
  provider openstack
!
end


4. Create a new flavorprofile and flavor f_snat_list

stack@neha-victoria:~#**openstack loadbalancer flavorprofile create --name fp_snat_list --provider a10 --flavor-data '{"nat-pool":{"pool-name":"pool1", "start-address":"192.168.8.10", "end-address":"192.168.8.11", "netmask":"/24", "gateway":"192.168.8.1"}, "nat-pool-list":[{"pool-name":"pool2", "start-address":"192.168.8.12", "end-address":"192.168.8.13", "netmask":"/24", "gateway":"192.168.8.3"}, {"pool-name":"pool3", "start-address":"192.168.8.14", "end-address":"192.168.8.15", "netmask":"/24", "gateway":"192.168.8.2"}]}'**

stack@neha-victoria:~#**openstack loadbalancer flavor create --name f_snat_list --flavorprofile fp_snat_list --description "flaovr all test1" --enable**

stack@neha-victoria:~#openstack loadbalancer flavor list
```
+--------------------------------------+-------------+--------------------------------------+---------+
| id                                   | name        | flavor_profile_id                    | enabled |
+--------------------------------------+-------------+--------------------------------------+---------+
| 8c5eef93-cc1d-446f-923c-ae4e351b2bc7 | f1          | 19dd372f-ea9e-4504-96fc-0bd797404687 | True    |
| eb3fa018-f393-4528-9fd6-a1ef773dc98d | f_snat_list | 8666d074-7b68-4616-b880-8bc43723d055 | True    |
+--------------------------------------+-------------+--------------------------------------+---------+
```

5. Keep the default_flavor_id = "8c5eef93-cc1d-446f-923c-ae4e351b2bc7" as it is in a10-octavia.conf and use --flavor eb3fa018-f393-4528-9fd6-a1ef773dc98d while creating a new LB

**Here, --flaovr will take precedence over default_flavor_id option.**

stack@neha-victoria:~#**openstack loadbalancer create --vip-subnet-id provider-vlan-12-subnet --name lb2 --flavor eb3fa018-f393-4528-9fd6-a1ef773dc98d**
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-08-30T06:34:03                  |
| description         |                                      |
| flavor_id           | eb3fa018-f393-4528-9fd6-a1ef773dc98d |
| id                  | 1f93b602-7ac1-4998-9634-3c2bd5d2594a |
| listeners           |                                      |
| name                | lb2                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 64474f828b3c483eafe2be7f5025df0d     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.12.108                          |
| vip_network_id      | 3074e6e3-a3d0-4e5f-a5c3-5e7bc8faafe8 |
| vip_port_id         | 2370d8df-79f9-402a-88ef-911b379c8a97 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 63ce3334-2482-4c12-bdf6-ef65521db3e2 |
+---------------------+--------------------------------------+
```


stack@neha-victoria:~#openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| 9fb2e875-4bc9-4c09-a7c7-d7828e73cd92 | lb1  | 64474f828b3c483eafe2be7f5025df0d | 10.0.11.175 | ACTIVE              | OFFLINE          | a10      |
| 1f93b602-7ac1-4998-9634-3c2bd5d2594a | lb2  | 64474f828b3c483eafe2be7f5025df0d | 10.0.12.108 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
```

mysql> select * from load_balancer;
```
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------------+-----------------+---------------------+---------------------+----------+--------------------------------------+-------------------+
| project_id                       | id                                   | name | description | provisioning_status | operating_status | enabled | topology       | server_group_id | created_at          | updated_at          | provider | flavor_id                            | availability_zone |
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------------+-----------------+---------------------+---------------------+----------+--------------------------------------+-------------------+
| 64474f828b3c483eafe2be7f5025df0d | 1f93b602-7ac1-4998-9634-3c2bd5d2594a | lb2  | NULL        | ACTIVE              | OFFLINE          |       1 | ACTIVE_STANDBY | NULL            | 2021-08-30 06:34:03 | 2021-08-30 06:39:06 | a10      | eb3fa018-f393-4528-9fd6-a1ef773dc98d | NULL              |
| 64474f828b3c483eafe2be7f5025df0d | 9fb2e875-4bc9-4c09-a7c7-d7828e73cd92 | lb1  | NULL        | ACTIVE              | OFFLINE          |       1 | ACTIVE_STANDBY | NULL            | 2021-08-30 06:21:04 | 2021-08-30 06:28:16 | a10      | 8c5eef93-cc1d-446f-923c-ae4e351b2bc7 | NULL              |
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------------+-----------------+---------------------+---------------------+----------+--------------------------------------+-------------------+
```

vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 1036 bytes
!Configuration last updated at 07:39:06 IST Mon Aug 30 2021
!Configuration last saved at 07:39:09 IST Mon Aug 30 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.118
  floating-ip 10.0.12.122
!
**ip nat pool pool1 192.168.8.10 192.168.8.11 netmask /24 gateway 192.168.8.1
!
ip nat pool pool2 192.168.8.12 192.168.8.13 netmask /24 gateway 192.168.8.3
!
ip nat pool pool3 192.168.8.14 192.168.8.15 netmask /24 gateway 192.168.8.2**
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb virtual-server 1f93b602-7ac1-4998-9634-3c2bd5d2594a 10.0.12.108
  arp-disable
!
slb virtual-server 9fb2e875-4bc9-4c09-a7c7-d7828e73cd92 10.0.11.175
  vport-disable-action drop-packet
  arp-disable
!
!
cloud-services meta-data
  enable
  provider openstack
!
end


vThunder-Active-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 1036 bytes
!Configuration last updated at 07:39:06 IST Mon Aug 30 2021
!Configuration last saved at 07:36:53 IST Mon Aug 30 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.118
  floating-ip 10.0.12.122
!
**ip nat pool pool1 192.168.8.10 192.168.8.11 netmask /24 gateway 192.168.8.1
!
ip nat pool pool2 192.168.8.12 192.168.8.13 netmask /24 gateway 192.168.8.3
!
ip nat pool pool3 192.168.8.14 192.168.8.15 netmask /24 gateway 192.168.8.2**
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb virtual-server 1f93b602-7ac1-4998-9634-3c2bd5d2594a 10.0.12.108
  arp-disable
!
slb virtual-server 9fb2e875-4bc9-4c09-a7c7-d7828e73cd92 10.0.11.175
  vport-disable-action drop-packet
  arp-disable
!
!
cloud-services meta-data
  enable
  provider openstack
!
end


6. Configure a flavor-id "c42eef93-cc1d-446f-923c-ae4e351b2b12" where the flavor is not present in octavia and try to create a LB with that.

```
[a10_global]
network_type = 'flat'
vrid_floating_ip = "dhcp"
default_flavor_id = "c42eef93-cc1d-446f-923c-ae4e351b2b12"
```

stack@neha-victoria:~#**openstack loadbalancer create --vip-subnet-id provider-vlan-12-subnet --name lb3**
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-08-30T06:45:35                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 93e9b186-3180-4cce-85d6-5e961aee5331 |
| listeners           |                                      |
| name                | lb3                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 64474f828b3c483eafe2be7f5025df0d     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.12.159                          |
| vip_network_id      | 3074e6e3-a3d0-4e5f-a5c3-5e7bc8faafe8 |
| vip_port_id         | 4ac5fd6a-f54a-42fb-9566-e7be1574bc1a |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 63ce3334-2482-4c12-bdf6-ef65521db3e2 |
+---------------------+--------------------------------------+
```

**An exception will be thrown in this case, and the LB will go into ERROR state.**

Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server [-] Exception during message handling: a10_octavia.common.exceptions.FlavorNotFound: Flavor c42eef93-cc1d-446f-923c-ae4e351b2b12 specified in the configuration file is unable to locate, Please create the flavor in advance.
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server Traceback (most recent call last):
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/oslo_messaging/rpc/server.py", line 165, in _process_incoming
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server     res = self.dispatcher.dispatch(message)
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/oslo_messaging/rpc/dispatcher.py", line 309, in dispatch
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server     return self._do_dispatch(endpoint, method, ctxt, args)
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/oslo_messaging/rpc/dispatcher.py", line 229, in _do_dispatch
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server     result = func(ctxt, **new_args)
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server   File "/opt/stack/neha/a10-octavia/a10_octavia/controller/queue/endpoint.py", line 46, in create_load_balancer
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server     self.worker.create_load_balancer(load_balancer_id, flavor)
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/tenacity/__init__.py", line 329, in wrapped_f
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server     return self.call(f, *args, **kw)
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/tenacity/__init__.py", line 409, in call
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server     do = self.iter(retry_state=retry_state)
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/tenacity/__init__.py", line 356, in iter
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server     return fut.result()
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server   File "/usr/lib/python3.8/concurrent/futures/_base.py", line 437, in result
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server     return self.__get_result()
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server   File "/usr/lib/python3.8/concurrent/futures/_base.py", line 389, in __get_result
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server     raise self._exception
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/tenacity/__init__.py", line 412, in call
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server     result = fn(*args, **kwargs)
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server   File "/opt/stack/neha/a10-octavia/a10_octavia/controller/worker/controller_worker.py", line 441, in create_load_balancer
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server     create_lb_tf.run()
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/taskflow/engines/action_engine/engine.py", line 247, in run
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server     for _state in self.run_iter(timeout=timeout):
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/taskflow/engines/action_engine/engine.py", line 340, in run_iter
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server     failure.Failure.reraise_if_any(er_failures)
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/taskflow/types/failure.py", line 339, in reraise_if_any
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server     failures[0].reraise()
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/taskflow/types/failure.py", line 346, in reraise
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server     six.reraise(*self._exc_info)
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/six.py", line 703, in reraise
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server     raise value
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server     result = task.execute(**arguments)
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server   File "/opt/stack/neha/a10-octavia/a10_octavia/controller/worker/tasks/a10_database_tasks.py", line 725, in execute
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server     raise exceptions.FlavorNotFound(flavor_id)
Aug 30 06:45:38 neha-victoria a10-octavia-worker[4057223]: ERROR oslo_messaging.rpc.server **a10_octavia.common.exceptions.FlavorNotFound: Flavor c42eef93-cc1d-446f-923c-ae4e351b2b12 specified in the configuration file is unable to locate, Please create the flavor in advance.**

stack@neha-victoria:~#openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| 9fb2e875-4bc9-4c09-a7c7-d7828e73cd92 | lb1  | 64474f828b3c483eafe2be7f5025df0d | 10.0.11.175 | ACTIVE              | OFFLINE          | a10      |
| 1f93b602-7ac1-4998-9634-3c2bd5d2594a | lb2  | 64474f828b3c483eafe2be7f5025df0d | 10.0.12.108 | ACTIVE              | OFFLINE          | a10      |
| 93e9b186-3180-4cce-85d6-5e961aee5331 | lb3  | 64474f828b3c483eafe2be7f5025df0d | 10.0.12.159 | ERROR               | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
```


7. Create a LB without --flaovr paranmeter and default_flavor_id option.

stack@neha-victoria:~#**openstack loadbalancer create --vip-subnet-id provider-vlan-12-subnet --name lb4**
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-08-30T06:50:34                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 8cadbe6b-c1e0-49df-a322-e80d1cb42787 |
| listeners           |                                      |
| name                | lb4                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 64474f828b3c483eafe2be7f5025df0d     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.12.102                          |
| vip_network_id      | 3074e6e3-a3d0-4e5f-a5c3-5e7bc8faafe8 |
| vip_port_id         | c7e25447-f9df-4b6c-9d45-08863207f4aa |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 63ce3334-2482-4c12-bdf6-ef65521db3e2 |
+---------------------+--------------------------------------+
```

stack@neha-victoria:~#openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| 9fb2e875-4bc9-4c09-a7c7-d7828e73cd92 | lb1  | 64474f828b3c483eafe2be7f5025df0d | 10.0.11.175 | ACTIVE              | OFFLINE          | a10      |
| 1f93b602-7ac1-4998-9634-3c2bd5d2594a | lb2  | 64474f828b3c483eafe2be7f5025df0d | 10.0.12.108 | ACTIVE              | OFFLINE          | a10      |
| 93e9b186-3180-4cce-85d6-5e961aee5331 | lb3  | 64474f828b3c483eafe2be7f5025df0d | 10.0.12.159 | ERROR               | OFFLINE          | a10      |
| 8cadbe6b-c1e0-49df-a322-e80d1cb42787 | lb4  | 64474f828b3c483eafe2be7f5025df0d | 10.0.12.102 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+

```

mysql> select * from load_balancer where provisioning_status="ACTIVE";
```
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------------+-----------------+---------------------+---------------------+----------+--------------------------------------+-------------------+
| project_id                       | id                                   | name | description | provisioning_status | operating_status | enabled | topology       | server_group_id | created_at          | updated_at          | provider | flavor_id                            | availability_zone |
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------------+-----------------+---------------------+---------------------+----------+--------------------------------------+-------------------+
| 64474f828b3c483eafe2be7f5025df0d | 1f93b602-7ac1-4998-9634-3c2bd5d2594a | lb2  | NULL        | ACTIVE              | OFFLINE          |       1 | ACTIVE_STANDBY | NULL            | 2021-08-30 06:34:03 | 2021-08-30 06:39:06 | a10      | eb3fa018-f393-4528-9fd6-a1ef773dc98d | NULL              |
| 64474f828b3c483eafe2be7f5025df0d | 8cadbe6b-c1e0-49df-a322-e80d1cb42787 | lb4  | NULL        | ACTIVE              | OFFLINE          |       1 | ACTIVE_STANDBY | NULL            | 2021-08-30 06:50:34 | 2021-08-30 06:50:45 | a10      | NULL                                 | NULL              |
| 64474f828b3c483eafe2be7f5025df0d | 9fb2e875-4bc9-4c09-a7c7-d7828e73cd92 | lb1  | NULL        | ACTIVE              | OFFLINE          |       1 | ACTIVE_STANDBY | NULL            | 2021-08-30 06:21:04 | 2021-08-30 06:28:16 | a10      | 8c5eef93-cc1d-446f-923c-ae4e351b2bc7 | NULL              |
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------------+-----------------+---------------------+---------------------+----------+--------------------------------------+-------------------+
```
3 rows in set (0.00 sec)


vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 1120 bytes
!Configuration last updated at 07:50:44 IST Mon Aug 30 2021
!Configuration last saved at 07:50:49 IST Mon Aug 30 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.118
  floating-ip 10.0.12.122
!
ip nat pool pool1 192.168.8.10 192.168.8.11 netmask /24 gateway 192.168.8.1
!
ip nat pool pool2 192.168.8.12 192.168.8.13 netmask /24 gateway 192.168.8.3
!
ip nat pool pool3 192.168.8.14 192.168.8.15 netmask /24 gateway 192.168.8.2
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb virtual-server 1f93b602-7ac1-4998-9634-3c2bd5d2594a 10.0.12.108
  arp-disable
!
**slb virtual-server 8cadbe6b-c1e0-49df-a322-e80d1cb42787 10.0.12.102
  arp-disable**
!
slb virtual-server 9fb2e875-4bc9-4c09-a7c7-d7828e73cd92 10.0.11.175
  vport-disable-action drop-packet
  arp-disable
!
!
cloud-services meta-data
  enable
  provider openstack
!
end


vThunder-Active-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 1120 bytes
!Configuration last updated at 07:50:44 IST Mon Aug 30 2021
!Configuration last saved at 07:36:53 IST Mon Aug 30 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.118
  floating-ip 10.0.12.122
!
ip nat pool pool1 192.168.8.10 192.168.8.11 netmask /24 gateway 192.168.8.1
!
ip nat pool pool2 192.168.8.12 192.168.8.13 netmask /24 gateway 192.168.8.3
!
ip nat pool pool3 192.168.8.14 192.168.8.15 netmask /24 gateway 192.168.8.2
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb virtual-server 1f93b602-7ac1-4998-9634-3c2bd5d2594a 10.0.12.108
  arp-disable
!
**slb virtual-server 8cadbe6b-c1e0-49df-a322-e80d1cb42787 10.0.12.102
  arp-disable**
!
slb virtual-server 9fb2e875-4bc9-4c09-a7c7-d7828e73cd92 10.0.11.175
  vport-disable-action drop-packet
  arp-disable
!
!
cloud-services meta-data
  enable
  provider openstack
!
end

8. Create a LB with --flaovr 8c5eef93-cc1d-446f-923c-ae4e351b2bc7 and without default_flavor_id config option

stack@neha-victoria:~#**openstack loadbalancer create --vip-subnet-id provider-vlan-13-subnet --name lb5 --flavor 8c5eef93-cc1d-446f-923c-ae4e351b2bc7**
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-08-30T06:54:18                  |
| description         |                                      |
| flavor_id           | 8c5eef93-cc1d-446f-923c-ae4e351b2bc7 |
| id                  | b1922de9-f7b0-448e-92a4-1b10e96d97e1 |
| listeners           |                                      |
| name                | lb5                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 64474f828b3c483eafe2be7f5025df0d     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.13.143                          |
| vip_network_id      | e54253f4-2784-44b9-add9-0e7c333d5af2 |
| vip_port_id         | 7cfef894-41b6-4aff-a48c-a36b93362887 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 5699a7e6-bec9-40d1-87a7-067a4d7197be |
+---------------------+--------------------------------------+
```

stack@neha-victoria:~#openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| 9fb2e875-4bc9-4c09-a7c7-d7828e73cd92 | lb1  | 64474f828b3c483eafe2be7f5025df0d | 10.0.11.175 | ACTIVE              | OFFLINE          | a10      |
| 1f93b602-7ac1-4998-9634-3c2bd5d2594a | lb2  | 64474f828b3c483eafe2be7f5025df0d | 10.0.12.108 | ACTIVE              | OFFLINE          | a10      |
| 93e9b186-3180-4cce-85d6-5e961aee5331 | lb3  | 64474f828b3c483eafe2be7f5025df0d | 10.0.12.159 | ERROR               | OFFLINE          | a10      |
| 8cadbe6b-c1e0-49df-a322-e80d1cb42787 | lb4  | 64474f828b3c483eafe2be7f5025df0d | 10.0.12.102 | ACTIVE              | OFFLINE          | a10      |
| b1922de9-f7b0-448e-92a4-1b10e96d97e1 | lb5  | 64474f828b3c483eafe2be7f5025df0d | 10.0.13.143 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
```

mysql> select * from load_balancer where provisioning_status="ACTIVE";
```
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------------+-----------------+---------------------+---------------------+----------+--------------------------------------+-------------------+
| project_id                       | id                                   | name | description | provisioning_status | operating_status | enabled | topology       | server_group_id | created_at          | updated_at          | provider | flavor_id                            | availability_zone |
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------------+-----------------+---------------------+---------------------+----------+--------------------------------------+-------------------+
| 64474f828b3c483eafe2be7f5025df0d | 1f93b602-7ac1-4998-9634-3c2bd5d2594a | lb2  | NULL        | ACTIVE              | OFFLINE          |       1 | ACTIVE_STANDBY | NULL            | 2021-08-30 06:34:03 | 2021-08-30 06:39:06 | a10      | eb3fa018-f393-4528-9fd6-a1ef773dc98d | NULL              |
| 64474f828b3c483eafe2be7f5025df0d | 8cadbe6b-c1e0-49df-a322-e80d1cb42787 | lb4  | NULL        | ACTIVE              | OFFLINE          |       1 | ACTIVE_STANDBY | NULL            | 2021-08-30 06:50:34 | 2021-08-30 06:50:45 | a10      | NULL                                 | NULL              |
| 64474f828b3c483eafe2be7f5025df0d | 9fb2e875-4bc9-4c09-a7c7-d7828e73cd92 | lb1  | NULL        | ACTIVE              | OFFLINE          |       1 | ACTIVE_STANDBY | NULL            | 2021-08-30 06:21:04 | 2021-08-30 06:28:16 | a10      | 8c5eef93-cc1d-446f-923c-ae4e351b2bc7 | NULL              |
| 64474f828b3c483eafe2be7f5025df0d | b1922de9-f7b0-448e-92a4-1b10e96d97e1 | lb5  | NULL        | ACTIVE              | OFFLINE          |       1 | ACTIVE_STANDBY | NULL            | 2021-08-30 06:54:18 | 2021-08-30 07:02:16 | a10      | 8c5eef93-cc1d-446f-923c-ae4e351b2bc7 | NULL              |
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------------+-----------------+---------------------+---------------------+----------+--------------------------------------+-------------------+
```

vThunder-Active-vMaster[1/2](NOLICENSE)#show running-config
!Current configuration: 1240 bytes
!Configuration last updated at 08:02:15 IST Mon Aug 30 2021
!Configuration last saved at 08:02:19 IST Mon Aug 30 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.118
  floating-ip 10.0.12.122
  floating-ip 10.0.13.115
!
ip nat pool pool1 192.168.8.10 192.168.8.11 netmask /24 gateway 192.168.8.1
!
ip nat pool pool2 192.168.8.12 192.168.8.13 netmask /24 gateway 192.168.8.3
!
ip nat pool pool3 192.168.8.14 192.168.8.15 netmask /24 gateway 192.168.8.2
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb virtual-server 1f93b602-7ac1-4998-9634-3c2bd5d2594a 10.0.12.108
  arp-disable
!
slb virtual-server 8cadbe6b-c1e0-49df-a322-e80d1cb42787 10.0.12.102
  arp-disable
!
slb virtual-server 9fb2e875-4bc9-4c09-a7c7-d7828e73cd92 10.0.11.175
  vport-disable-action drop-packet
  arp-disable
!
**slb virtual-server b1922de9-f7b0-448e-92a4-1b10e96d97e1 10.0.13.143
  vport-disable-action drop-packet
  arp-disable**
!
!
cloud-services meta-data
  enable
  provider openstack
!
end


vThunder-Active-vBlade[1/1](NOLICENSE)#show running-config
!Current configuration: 1240 bytes
!Configuration last updated at 08:02:15 IST Mon Aug 30 2021
!Configuration last saved at 07:59:42 IST Mon Aug 30 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.118
  floating-ip 10.0.12.122
  floating-ip 10.0.13.115
!
ip nat pool pool1 192.168.8.10 192.168.8.11 netmask /24 gateway 192.168.8.1
!
ip nat pool pool2 192.168.8.12 192.168.8.13 netmask /24 gateway 192.168.8.3
!
ip nat pool pool3 192.168.8.14 192.168.8.15 netmask /24 gateway 192.168.8.2
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb virtual-server 1f93b602-7ac1-4998-9634-3c2bd5d2594a 10.0.12.108
  arp-disable
!
slb virtual-server 8cadbe6b-c1e0-49df-a322-e80d1cb42787 10.0.12.102
  arp-disable
!
slb virtual-server 9fb2e875-4bc9-4c09-a7c7-d7828e73cd92 10.0.11.175
  vport-disable-action drop-packet
  arp-disable
!
**slb virtual-server b1922de9-f7b0-448e-92a4-1b10e96d97e1 10.0.13.143
  vport-disable-action drop-packet
  arp-disable**
!
!
cloud-services meta-data
  enable
  provider openstack
!
end

