### PR TITLE
[STACK-2235][Active-Standby]: Support for deleting lb when one node is shutdown in active-standby

### DIFF
--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -105,6 +105,8 @@ SSL_TEMPLATE = "ssl_template"
 
 COMPUTE_BUSY = "compute_busy"
 L2DSR_FLAVOR = "l2dsr_flavor"
+MASTER_AMPHORA_STATUS = "master_amphora_status"
+BACKUP_AMPHORA_STATUS = "backup_amphora_status"
 
 # ACOS versions
 ACOS_5_2_1_P2 = "5.2.1-P2"

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -215,7 +215,7 @@ class LoadBalancerFlows(object):
                 requires=a10constants.VTHUNDER,
                 provides=a10constants.MASTER_AMPHORA_STATUS))
             delete_LB_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
-                name="get vthunder on the basis of master amphora status",
+                name="get-vthunder-on-the-basis-of-master-amphora-status",
                 requires=(constants.LOADBALANCER, a10constants.MASTER_AMPHORA_STATUS),
                 provides=a10constants.VTHUNDER))
             delete_LB_flow.add(vthunder_tasks.GetMasterVThunder(

--- a/a10_octavia/controller/worker/tasks/a10_compute_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_compute_tasks.py
@@ -143,10 +143,15 @@ class CheckAmphoraStatus(BaseComputeTask):
     def execute(self, vthunder):
         """Check for the compute driver for the amphora status."""
         if vthunder:
-            amp, fault = self.compute.get_amphora(vthunder.compute_id)
-            if amp.status != constants.ACTIVE:
+            try:
+                amp, fault = self.compute.get_amphora(vthunder.compute_id)
+                if amp.status != constants.ACTIVE:
+                    return False
+                return True
+            except Exception as e:
+                LOG.exception("Failed to find compute %s du to: %s",
+                              vthunder.compute_id, str(e))
                 return False
-            return True
 
 
 class DeleteStaleCompute(BaseComputeTask):

--- a/a10_octavia/controller/worker/tasks/a10_compute_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_compute_tasks.py
@@ -124,3 +124,15 @@ class NovaServerGroupCreate(BaseComputeTask):
                       "still be in use for server group: %(sg)s due to "
                       "error: %(except)s",
                       {'sg': server_group_id, 'except': e})
+
+
+class CheckAmphoraStatus(BaseComputeTask):
+    """Check for the compute driver for the amphora status."""
+
+    def execute(self, vthunder):
+        """Check for the compute driver for the amphora status."""
+        if vthunder:
+            amp, fault = self.compute.get_amphora(vthunder.compute_id)
+            if amp.status != constants.ACTIVE:
+                return False
+            return True

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -164,10 +164,13 @@ class DeleteVThunderEntry(BaseDatabaseTask):
 class GetVThunderByLoadBalancer(BaseDatabaseTask):
     """Get VThunder from db using LoadBalancer"""
 
-    def execute(self, loadbalancer):
+    def execute(self, loadbalancer, master_amphora_status=True):
         loadbalancer_id = loadbalancer.id
         vthunder = self.vthunder_repo.get_vthunder_from_lb(
             db_apis.get_session(), loadbalancer_id)
+        if not master_amphora_status:
+            vthunder = self.vthunder_repo.get_backup_vthunder_from_lb(
+                db_apis.get_session(), loadbalancer_id)
         if vthunder is None:
             return None
         return vthunder

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -69,10 +69,12 @@ class VThunderBaseTask(task.Task):
 class VThunderComputeConnectivityWait(VThunderBaseTask):
     """Task to wait for the compute instance to be up"""
 
-    def execute(self, vthunder, amphora):
+    def execute(self, vthunder, amphora, master_amphora_status=True):
         """Execute get_info routine for a vThunder until it responds."""
         try:
             if vthunder:
+                if not master_amphora_status:
+                    return
                 axapi_client = a10_utils.get_axapi_client(vthunder)
                 LOG.info("Attempting to connect vThunder device for connection.")
                 attempts = CONF.a10_controller_worker.amp_active_retries
@@ -1140,8 +1142,11 @@ class VCSSyncWait(VThunderBaseTask):
     """Task to wait VCS reload, VCS negotiagtion or VCS configuration sync ready."""
 
     @axapi_client_decorator
-    def execute(self, vthunder):
+    def execute(self, vthunder, master_amphora_status=True, backup_amphora_status=True):
         if not vthunder or CONF.a10_controller_worker.loadbalancer_topology != "ACTIVE_STANDBY":
+            return
+
+        if not (master_amphora_status and backup_amphora_status):
             return
 
         attempts = CONF.a10_controller_worker.amp_vcs_retries

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_compute_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_compute_tasks.py
@@ -1,0 +1,52 @@
+#    Copyright 2020, A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+from oslo_utils import uuidutils
+
+from octavia.common import constants as o_constants
+
+from a10_octavia.common import data_models
+from a10_octavia.controller.worker.tasks import a10_compute_tasks as task
+from a10_octavia.tests.unit import base
+
+VTHUNDER = data_models.VThunder()
+COMPUTE_ID = uuidutils.generate_uuid()
+
+
+class TestA10ComputeTasks(base.BaseTaskTestCase):
+
+    @mock.patch('stevedore.driver.DriverManager.driver')
+    def test_compute_amphora_status_active(self, mock_driver):
+        VTHUNDER.compute_id = COMPUTE_ID
+        _amphora_mock = mock.MagicMock()
+        _amphora_mock.status = o_constants.ACTIVE
+        mock_driver.get_amphora.return_value = _amphora_mock, None
+        computestatus = task.CheckAmphoraStatus()
+        status = computestatus.execute(VTHUNDER)
+        self.assertEqual(status, True)
+
+    @mock.patch('stevedore.driver.DriverManager.driver')
+    def test_compute_amphora_status_shutdown(self, mock_driver):
+        VTHUNDER.compute_id = COMPUTE_ID
+        _amphora_mock = mock.MagicMock()
+        _amphora_mock.status = "SHUT_OFF"
+        mock_driver.get_amphora.return_value = _amphora_mock, None
+        computestatus = task.CheckAmphoraStatus()
+        status = computestatus.execute(VTHUNDER)
+        self.assertEqual(status, False)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_compute_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_compute_tasks.py
@@ -42,10 +42,10 @@ class TestA10ComputeTasks(base.BaseTaskTestCase):
         self.assertEqual(status, True)
 
     @mock.patch('stevedore.driver.DriverManager.driver')
-    def test_compute_amphora_status_shutdown(self, mock_driver):
+    def test_compute_amphora_status_shutoff(self, mock_driver):
         VTHUNDER.compute_id = COMPUTE_ID
         _amphora_mock = mock.MagicMock()
-        _amphora_mock.status = "SHUT_OFF"
+        _amphora_mock.status = "SHUTOFF"
         mock_driver.get_amphora.return_value = _amphora_mock, None
         computestatus = task.CheckAmphoraStatus()
         status = computestatus.execute(VTHUNDER)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -125,16 +125,17 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         self.assertEqual(vthunder, None)
 
     def test_get_backup_vthunder_by_loadbalancer(self):
+        vthunder = copy.deepcopy(VTHUNDER)
+        vthunder.role = "BACKUP"
         self.conf.config(
             group=a10constants.A10_GLOBAL_CONF_SECTION,
             use_parent_partition=True)
         mock_get_vthunder = task.GetVThunderByLoadBalancer()
         mock_get_vthunder.vthunder_repo = mock.MagicMock()
         mock_get_vthunder.vthunder_repo.get_vthunder_from_lb.return_value = None
-        VTHUNDER.role = "BACKUP"
-        mock_get_vthunder.vthunder_repo.get_backup_vthunder_from_lb.return_value = VTHUNDER
-        vthunder = mock_get_vthunder.execute(LB, False)
-        self.assertEqual(vthunder, VTHUNDER)
+        mock_get_vthunder.vthunder_repo.get_backup_vthunder_from_lb.return_value = vthunder
+        backup_vthunder = mock_get_vthunder.execute(LB, False)
+        self.assertEqual(backup_vthunder, vthunder)
 
     def test_get_vrid_for_project_member_hmt_use_partition(self):
         thunder = copy.deepcopy(HW_THUNDER)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -113,7 +113,7 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         vthunder = mock_get_vthunder.execute(LB)
         self.assertEqual(vthunder, None)
 
-    def test_get_vthunder_by_loadbalancer_backup(self):
+    def test_get_backup_vthunder_by_loadbalancer(self):
         self.conf.config(
             group=a10constants.A10_GLOBAL_CONF_SECTION,
             use_parent_partition=True)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -113,6 +113,18 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         vthunder = mock_get_vthunder.execute(LB)
         self.assertEqual(vthunder, None)
 
+    def test_get_vthunder_by_loadbalancer_backup(self):
+        self.conf.config(
+            group=a10constants.A10_GLOBAL_CONF_SECTION,
+            use_parent_partition=True)
+        mock_get_vthunder = task.GetVThunderByLoadBalancer()
+        mock_get_vthunder.vthunder_repo = mock.MagicMock()
+        mock_get_vthunder.vthunder_repo.get_vthunder_from_lb.return_value = None
+        VTHUNDER.role = "BACKUP"
+        mock_get_vthunder.vthunder_repo.get_backup_vthunder_from_lb.return_value = VTHUNDER
+        vthunder = mock_get_vthunder.execute(LB, False)
+        self.assertEqual(vthunder, VTHUNDER)
+
     def test_get_vrid_for_project_member_hmt_use_partition(self):
         thunder = copy.deepcopy(HW_THUNDER)
         lb = copy.deepcopy(LB)


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description: [vthunder: active-standby] the lb is failed to be deleted if the vthunder pair get damaged

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-2235

## Technical Approach 
- Check the status of amphora whether it is active or not.
- On the value of status of amphora, check the Vthuder connectivity and VCSSyncWait

## Config Changes
- N/A

## Test Cases
- Added _test_compute_amphora_status_active_, _test_compute_amphora_status_shutoff_ and _test_get_backup_vthunder_by_loadbalancer_ unit test cases. 

## Manual Testing
Case 1: shutdown the master node and delete lb
1) Create lbs
```
 openstack loadbalancer create --name v1 --vip-subnet-id private-a-subnet
 openstack loadbalancer create --name v2 --vip-subnet-id private-a-subnet
 
stack@victoria:~/addeb2/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| a0f1f4b7-ba9c-4131-ba21-98afc6679b49 | v1   | bc83270643c14317b1e2653854c1e190 | 10.0.0.44   | ACTIVE              | OFFLINE          | a10      |
| 6c17ae6e-194d-4480-b546-d2dbb343b570 | v2   | bc83270643c14317b1e2653854c1e190 | 10.0.0.91   | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
stack@victoria:~/addeb2/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------+----------------+-----------------+
| ID                                   | Name                                         | Status | Networks                                            | Image          | Flavor          |
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------+----------------+-----------------+
| 5230eb09-82ad-4c49-8b30-31a3c18e719f | amphora-33bc8013-dd52-4eef-8660-ba304a5bec56 | ACTIVE | lb-mgmt-net=192.168.0.38; private-net-a=10.0.0.184  | vThunder.qcow2 | vThunder_flavor |
| bbbaefd0-8b08-4762-bf18-74be4d46994f | amphora-4aed5401-b5a1-4828-9f3c-231ffcda6f43 | ACTIVE | lb-mgmt-net=192.168.0.168; private-net-a=10.0.0.139 | vThunder.qcow2 | vThunder_flavor |
| b089a0fc-1026-4db3-9aea-1b31dd08d795 | client                                       | ACTIVE | lb-mgmt-net=192.168.0.62; private-net-a=10.0.0.168  | server         | m1.small        |
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------+----------------+-----------------+
stack@victoria:~/addeb2/a10-octavia$
```

2) Shutdown the master node.
```
vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config slb
!Section configuration: 238 bytes
!
slb server octavia_health_manager_controller 192.168.0.82
  health-check octavia_health_monitor
!
slb virtual-server 6c17ae6e-194d-4480-b546-d2dbb343b570 10.0.0.91
!
slb virtual-server a0f1f4b7-ba9c-4131-ba21-98afc6679b49 10.0.0.44
!
vThunder-Active-vMaster[1/1](NOLICENSE)#
vThunder-Active-vMaster[1/1](NOLICENSE)#
vThunder-Active-vMaster[1/1](NOLICENSE)#shutdown
Proceed with shutdown? [yes/no]:yes
vThunder-Active-vMaster[1/1](NOLICENSE)#Connection to 192.168.0.38 closed by remote host.
Connection to 192.168.0.38 closed.
root@victoria:~#
```

3) Delete the lb
openstack loadbalancer delete v2

```
Logs:
Aug 31 03:55:04 victoria a10-octavia-worker[2173176]: INFO a10_octavia.controller.queue.endpoint [-] Deleting load balancer '6c17ae6e-194d-4480-b546-d2dbb343b570'...
Aug 31 03:55:06 victoria a10-octavia-worker[2173176]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Attempting to connect vThunder device for connection.
Aug 31 03:55:09 victoria a10-octavia-worker[2173176]: INFO octavia.network.drivers.neutron.allowed_address_pairs [-] Deleted security group fa77da41-2abb-48b4-a790-57182950ca38
Aug 31 03:55:11 victoria a10-octavia-worker[2173176]: WARNING a10_octavia.controller.worker.tasks.nat_pool_tasks [-] Cannot delete Nat-pool(s) in flavor None as they are in use by another loadbalancer(s)
Aug 31 03:55:11 victoria a10-octavia-worker[2173176]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.0.168:shared

stack@victoria:~/addeb2/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| a0f1f4b7-ba9c-4131-ba21-98afc6679b49 | v1   | bc83270643c14317b1e2653854c1e190 | 10.0.0.44   | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
stack@victoria:~/addeb2/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+---------+-----------------------------------------------------+----------------+-----------------+
| ID                                   | Name                                         | Status  | Networks                                            | Image          | Flavor          |
+--------------------------------------+----------------------------------------------+---------+-----------------------------------------------------+----------------+-----------------+
| 5230eb09-82ad-4c49-8b30-31a3c18e719f | amphora-33bc8013-dd52-4eef-8660-ba304a5bec56 | SHUTOFF | lb-mgmt-net=192.168.0.38; private-net-a=10.0.0.184  | vThunder.qcow2 | vThunder_flavor |
| bbbaefd0-8b08-4762-bf18-74be4d46994f | amphora-4aed5401-b5a1-4828-9f3c-231ffcda6f43 | ACTIVE  | lb-mgmt-net=192.168.0.168; private-net-a=10.0.0.139 | vThunder.qcow2 | vThunder_flavor |
| b089a0fc-1026-4db3-9aea-1b31dd08d795 | client                                       | ACTIVE  | lb-mgmt-net=192.168.0.62; private-net-a=10.0.0.168  | server         | m1.small        |
+--------------------------------------+----------------------------------------------+---------+-----------------------------------------------------+----------------+-----------------+
stack@victoria:~/addeb2/a10-octavia$

```

Case 2: shutdown the backup node and delete lb
1) Create lbs
```
openstack loadbalancer create --name v1 --vip-subnet-id private-a-subnet
openstack loadbalancer create --name v2 --vip-subnet-id private-a-subnet

stack@victoria:~/addeb2/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| 55296a5c-de16-4a9c-b56b-78d5f3f1b1aa | v1   | bc83270643c14317b1e2653854c1e190 | 10.0.0.49   | ACTIVE              | OFFLINE          | a10      |
| 1e1bfedc-8119-4215-bdef-45e52cc571ac | v2   | bc83270643c14317b1e2653854c1e190 | 10.0.0.204  | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
stack@victoria:~/addeb2/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+----------------------------------------------------+----------------+-----------------+
| ID                                   | Name                                         | Status | Networks                                           | Image          | Flavor          |
+--------------------------------------+----------------------------------------------+--------+----------------------------------------------------+----------------+-----------------+
| 07e74008-5b7a-4a6f-b271-1ed0618d5410 | amphora-5e3d918c-8682-4277-a65d-45fa19b852f8 | ACTIVE | lb-mgmt-net=192.168.0.8; private-net-a=10.0.0.186  | vThunder.qcow2 | vThunder_flavor |
| c342b172-bfcd-476b-8e6a-c373b95b4a19 | amphora-9aba424e-90bf-4310-ac75-4feee035affc | ACTIVE | lb-mgmt-net=192.168.0.33; private-net-a=10.0.0.145 | vThunder.qcow2 | vThunder_flavor |
| b089a0fc-1026-4db3-9aea-1b31dd08d795 | client                                       | ACTIVE | lb-mgmt-net=192.168.0.62; private-net-a=10.0.0.168 | server         | m1.small        |
+--------------------------------------+----------------------------------------------+--------+----------------------------------------------------+----------------+-----------------+
stack@victoria:~/addeb2/a10-octavia$
```

2) Shutdown the backup node
```
vThunder-Standby-vBlade[1/2](NOLICENSE)#show running-config slb
!Section configuration: 239 bytes
!
slb server octavia_health_manager_controller 192.168.0.82
  health-check octavia_health_monitor
!
slb virtual-server 1e1bfedc-8119-4215-bdef-45e52cc571ac 10.0.0.204
!
slb virtual-server 55296a5c-de16-4a9c-b56b-78d5f3f1b1aa 10.0.0.49
!
vThunder-Standby-vBlade[1/2](NOLICENSE)#
vThunder-Standby-vBlade[1/2](NOLICENSE)#
vThunder-Standby-vBlade[1/2](NOLICENSE)#shutdown
Proceed with shutdown? [yes/no]:yes
vThunder-Standby-vBlade[1/2](NOLICENSE)#Connection to 192.168.0.33 closed by remote host.
Connection to 192.168.0.33 closed.
root@victoria:~
```

3) Delete the lb
openstack loadbalancer delete v2

```
Logs:
Aug 31 15:07:38 victoria a10-octavia-worker[2173176]: INFO a10_octavia.controller.queue.endpoint [-] Deleting load balancer '1e1bfedc-8119-4215-bdef-45e52cc571ac'...
Aug 31 15:07:39 victoria a10-octavia-worker[2173176]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Attempting to connect vThunder device for connection.
Aug 31 15:07:42 victoria a10-octavia-worker[2173176]: INFO octavia.network.drivers.neutron.allowed_address_pairs [-] Deleted security group 5d5df39f-8a1a-43c9-aa9e-831e29cd5a63
Aug 31 15:07:43 victoria a10-octavia-worker[2173176]: WARNING a10_octavia.controller.worker.tasks.nat_pool_tasks [-] Cannot delete Nat-pool(s) in flavor None as they are in use by another loadbalancer(s)
Aug 31 15:07:43 victoria a10-octavia-worker[2173176]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.0.8:shared

stack@victoria:~/addeb2/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| 55296a5c-de16-4a9c-b56b-78d5f3f1b1aa | v1   | bc83270643c14317b1e2653854c1e190 | 10.0.0.49   | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
stack@victoria:~/addeb2/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+---------+----------------------------------------------------+----------------+-----------------+
| ID                                   | Name                                         | Status  | Networks                                           | Image          | Flavor          |
+--------------------------------------+----------------------------------------------+---------+----------------------------------------------------+----------------+-----------------+
| 07e74008-5b7a-4a6f-b271-1ed0618d5410 | amphora-5e3d918c-8682-4277-a65d-45fa19b852f8 | ACTIVE  | lb-mgmt-net=192.168.0.8; private-net-a=10.0.0.186  | vThunder.qcow2 | vThunder_flavor |
| c342b172-bfcd-476b-8e6a-c373b95b4a19 | amphora-9aba424e-90bf-4310-ac75-4feee035affc | SHUTOFF | lb-mgmt-net=192.168.0.33; private-net-a=10.0.0.145 | vThunder.qcow2 | vThunder_flavor |
| b089a0fc-1026-4db3-9aea-1b31dd08d795 | client                                       | ACTIVE  | lb-mgmt-net=192.168.0.62; private-net-a=10.0.0.168 | server         | m1.small        |
+--------------------------------------+----------------------------------------------+---------+----------------------------------------------------+----------------+-----------------+
stack@victoria:~/addeb2/a10-octavia$

vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config slb
!Section configuration: 169 bytes
!
slb server octavia_health_manager_controller 192.168.0.82
  health-check octavia_health_monitor
!
slb virtual-server 55296a5c-de16-4a9c-b56b-78d5f3f1b1aa 10.0.0.49
!
vThunder-Active-vMaster[1/1](NOLICENSE)#
```

