### PR TITLE
[STACK-2845]: Merge global flavor ID configuration option support feature to release/v1_3_2 branch

### DIFF
--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -101,6 +101,7 @@ SSL_TEMPLATE = "ssl_template"
 
 COMPUTE_BUSY = "compute_busy"
 L2DSR_FLAVOR = "l2dsr_flavor"
+FLAVOR_ID = "flavor_id"
 
 # ============================
 # Taskflow flow and task names

--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -48,6 +48,8 @@ A10_GLOBAL_OPTS = [
     cfg.BoolOpt('use_shared_for_template_lookup',
                 default=False,
                 help=_('Use shared for template')),
+    cfg.StrOpt('default_flavor_id', default=None,
+               help=_('Default flavor ID to apply globally to all users')),
 ]
 
 A10_VTHUNDER_OPTS = [

--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -246,3 +246,10 @@ class InterfaceNotFound(acos_errors.ACOSException):
         msg = ('vThunder instance {0} has no interface in network {1}.').format(comput_id,
                                                                                 network_id)
         super(InterfaceNotFound, self).__init__(msg=msg)
+
+
+class FlavorNotFound(cfg.ConfigFileValueError):
+    def __init__(self, flavor):
+        msg = ('Flavor {0} specified in the configuration file cannot be located,'
+               ' Please create the flavor in advance.').format(flavor)
+        super(FlavorNotFound, self).__init__(msg=msg)

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -405,6 +405,8 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                         '60 seconds.', 'load_balancer', load_balancer_id)
             raise db_exceptions.NoResultFound
 
+        flavor_id = lb.flavor_id if lb.flavor_id else CONF.a10_global.default_flavor_id
+
         store = {constants.LOADBALANCER_ID: load_balancer_id,
                  constants.VIP: lb.vip,
                  constants.BUILD_TYPE_PRIORITY:
@@ -415,7 +417,8 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         topology = CONF.a10_controller_worker.loadbalancer_topology
 
         store[constants.UPDATE_DICT] = {
-            constants.TOPOLOGY: topology
+            constants.TOPOLOGY: topology,
+            a10constants.FLAVOR_ID: flavor_id
         }
 
         ctx_flags = [False]

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -99,13 +99,13 @@ class LoadBalancerFlows(object):
         vthunder = self._vthunder_repo.get_vthunder_by_project_id(db_apis.get_session(),
                                                                   project_id)
 
+        lb_create_flow.add(a10_database_tasks.GetFlavorData(
+            rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
+            provides=constants.FLAVOR_DATA))
         lb_create_flow.add(
             self.get_post_lb_vthunder_association_flow(
                 post_amp_prefix, load_balancer_id, topology, vthunder,
                 mark_active=(not listeners)))
-        lb_create_flow.add(a10_database_tasks.GetFlavorData(
-            rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
-            provides=constants.FLAVOR_DATA))
         lb_create_flow.add(a10_database_tasks.CountLoadbalancersWithFlavor(
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
             provides=a10constants.LB_COUNT_FLAVOR))

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -704,8 +704,12 @@ class GetFlavorData(BaseDatabaseTask):
 
     def execute(self, lb_resource):
         flavor_id = a10_task_utils.attribute_search(lb_resource, 'flavor_id')
+        if not flavor_id:
+            flavor_id = CONF.a10_global.default_flavor_id
         if flavor_id:
             flavor = self.flavor_repo.get(db_apis.get_session(), id=flavor_id)
+            if not flavor and lb_resource.provisioning_status != "PENDING_DELETE":
+                raise exceptions.FlavorNotFound(flavor_id)
             if flavor and flavor.flavor_profile_id:
                 flavor_profile = self.flavor_profile_repo.get(
                     db_apis.get_session(),

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -31,6 +31,7 @@ from octavia.tests.common import constants as t_constants
 
 from a10_octavia.common import config_options
 from a10_octavia.common import data_models
+from a10_octavia.common import exceptions
 from a10_octavia.common import utils
 from a10_octavia.controller.worker.tasks import a10_database_tasks as task
 from a10_octavia.tests.common import a10constants
@@ -47,6 +48,7 @@ HW_THUNDER = data_models.HardwareThunder(
     partition_name="shared")
 LB = o_data_models.LoadBalancer(id=a10constants.MOCK_LOAD_BALANCER_ID,
                                 flavor_id=a10constants.MOCK_FLAVOR_ID)
+LB2 = o_data_models.LoadBalancer(id=a10constants.MOCK_LOAD_BALANCER_ID)
 FIXED_IP = n_data_models.FixedIP(ip_address='10.10.10.10')
 PORT = n_data_models.Port(id=uuidutils.generate_uuid(), fixed_ips=[FIXED_IP])
 VRID = data_models.VRID(id=1, vrid=0,
@@ -360,8 +362,8 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         flavor_task.flavor_repo.get.return_value = None
         flavor_task._flavor_search = mock.Mock(
             return_value=a10constants.MOCK_FLAVOR_ID)
-        ret_val = flavor_task.execute(LB)
-        self.assertEqual(ret_val, None)
+        ret_val = flavor_task.execute
+        self.assertRaises(exceptions.FlavorNotFound, ret_val, LB)
 
         flavor_task.flavor_repo.reset_mock()
         flavor_task.flavor_repo = mock.Mock()
@@ -370,6 +372,20 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         flavor_task.flavor_repo.get.return_value = flavor
         ret_val = flavor_task.execute(LB)
         self.assertEqual(ret_val, None)
+
+    def test_GetFlavorData_execute_with_default_flavor_id(self):
+        flavor_task = task.GetFlavorData()
+        flavor = copy.deepcopy(FLAVOR)
+        flavor_prof = copy.deepcopy(FLAVOR_PROFILE)
+        flavor_prof.flavor_data = "{}"
+        flavor_task.flavor_repo = mock.Mock()
+        flavor_task.flavor_repo.get.return_value = flavor
+        self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
+                         default_flavor_id=flavor)
+        flavor_task.flavor_profile_repo = mock.Mock()
+        flavor_task.flavor_profile_repo.get.return_value = flavor_prof
+        ret_val = flavor_task.execute(LB2)
+        self.assertEqual(ret_val, {})
 
     def test_GetFlavorData_execute_return_flavor(self):
         flavor_task = task.GetFlavorData()


### PR DESCRIPTION
## Description
Merged global flavor ID configuration option feature to release/v1_3_2 branch and tested it on stein version.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2845

## Technical Approach
- Added a config option default_flavor_id in a10_global section of a10-octavia.conf file.
- In GetFlavorData() task, assigning default_flavor_id to flavor_id iff a flavor with --flavor parameter is not passed during the loadbalancer creation.
- If flavor with the default_flavor_id is not present in flavor table of octavia DB, then raising an exception FlavorNotFound.
- Created FlavorNotFound exception which will give a message as " Flavor <flavor_id> specified in the configuration file is unable to locate, Please create the flavor in advance."
- In create_load_balancer() method of controller_worker.py, if lb.flavor_id is None and CONF.a10_global.default_flavor_id exists, then making entry of the CONF.a10_global.default_flavor_id into flavor_id column of load_balancer table via UpdateLoadbalancerInDB() task.
- **Added FLAVOR_ID constant in a10_constants.py as FLAVOR_ID is not present in stein version octavia/common/constants.py**

## Config changes
Added a new option default_flavor_id in a10_global section

```
[a10_global]
default_flavor_id = <flavor_id>
```

## Test Cases
- Given a default_flavor_id in config file, when flavor with --flavor is not passed while loadbalancer creation, then the flavor with default_flavor_id should be attached to the loadbalancer.
- Given a default_flavor_id in config file, when flavor with --flavor is passed while loadbalancer creation, then the flavor passed with --flavor parameter should be attached to the loadbalancer.
- Given a default_flavor_id in config file, when flavor with --flavor-id is not passed while loadbalancer creation and the flavor does not exist in flavor table, then FlavorNotFount exception should be raised.

## Manual Testing
Tested all the testcases same as that of in PR https://github.com/a10networks/a10-octavia/pull/501
