### PR TITLE
[STACK-2891][For release/v1_3_2]: Create slb objects without specifying --name parameter failed with name-expression is used in the flavor

### DIFF
--- a/a10_octavia/controller/worker/tasks/utils.py
+++ b/a10_octavia/controller/worker/tasks/utils.py
@@ -81,7 +81,7 @@ def shared_template_modifier(template_type, template_name, device_templates):
 
 def parse_name_expressions(name, name_expressions):
     flavor_data = {}
-    if name_expressions:
+    if name and name_expressions:
         for expression in name_expressions:
             if 'regex' in expression:
                 if re.search(expression['regex'], name):

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_utils.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_utils.py
@@ -118,3 +118,8 @@ class TestUtils(base.TestCase):
     def test_dash_to_underscore(self):
         obj_flavor = utils.dash_to_underscore(DASH_FLAVOR)
         self.assertEqual(UNDERSCORE_FLAVOR, obj_flavor)
+
+    def test_parse_name_expressions_with_no_name_specified(self):
+        expect_result = {}
+        obj_flavor = utils.parse_name_expressions(None, NAME_EXPRESSIONS)
+        self.assertEqual(expect_result, obj_flavor)


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description: Facing an error when slb objects are created using a flavor with name-expression is used in the flavor and without specifying `--name` parameter during their creation.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2891

## Technical Approach
- When `--name` is not specified during slb objects creation but flavor with name-expression is used, then the name is getting passed as None to `parse_name_expressions()` method and this is causing an error at `re.search()` call in it as name is a NoneType object here.
- So checking whether name is not None before calling this `re.search()` method.
- If it is None, then flavor_data will be returned as {}

## Config Changes
N/A

## Test Cases
Given a loadbalancer, when it is created without --name parameter, then it should get created without attaching flavor-data in its name-expression to it.

## Manual Testing
1. Create a flavorprofile and a flavor as follows:

stack@openstack-3:~$ openstack loadbalancer flavorprofile create --name fp_stack2798_std --provider a10 --flavor-data '{"virtual-server":{"name-expressions":[{"regex":"1","json":{"arp-disable":1}}]},"virtual-port":{"name-expressions":[{"regex":"1","json":{"pool":"pool2"}}]},"service-group":{"name-expressions":[{"regex":"1","json":{"health-check-disable":1}}]},"server":{"name-expressions":[{"regex":"1","json":{"extended-stats":1}}]},"health-monitor":{"name-expressions":[{"regex":"1","json":{"dsr-l2-strict":1}}]},"nat-pool":{"pool-name":"pool1","start-address":"1.1.1.1","end-address":"1.1.1.2","netmask":"/24"},"nat-pool-list":[{"pool-name":"pool2","start-address":"1.1.1.11","end-address":"1.1.1.12","netmask":"/24","gateway":"1.1.1.254"}]}'
```
+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field         | Value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| id            | b0a596c4-2d93-4c33-9bca-9e92ec360be2                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
| name          | fp_stack2798_std                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
| provider_name | a10                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| flavor_data   | {"virtual-server":{"name-expressions":[{"regex":"1","json":{"arp-disable":1}}]},"virtual-port":{"name-expressions":[{"regex":"1","json":{"pool":"pool2"}}]},"service-group":{"name-expressions":[{"regex":"1","json":{"health-check-disable":1}}]},"server":{"name-expressions":[{"regex":"1","json":{"extended-stats":1}}]},"health-monitor":{"name-expressions":[{"regex":"1","json":{"dsr-l2-strict":1}}]},"nat-pool":{"pool-name":"pool1","start-address":"1.1.1.1","end-address":"1.1.1.2","netmask":"/24"},"nat-pool-list":[{"pool-name":"pool2","start-address":"1.1.1.11","end-address":"1.1.1.12","netmask":"/24","gateway":"1.1.1.254"}]} |
+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```
stack@openstack-3:~$ openstack loadbalancer flavor create --name f_stack2798_std --flavorprofile fp_stack2798_std
```
+-------------------+--------------------------------------+
| Field             | Value                                |
+-------------------+--------------------------------------+
| id                | 026b926e-6299-4425-9e83-6b8747b63c8a |
| name              | f_stack2798_std                      |
| flavor_profile_id | b0a596c4-2d93-4c33-9bca-9e92ec360be2 |
| enabled           | True                                 |
| description       |                                      |
+-------------------+--------------------------------------+
```

2. Configure the flavor-id in a10-octavia.conf
```
[a10_global]
network_type = "flat"
vrid_floating_ip = "dhcp"
default_flavor_id = "026b926e-6299-4425-9e83-6b8747b63c8a"
```

3. Create a loadbalancer without speifying --name in the command.

stack@openstack-3:~$ openstack loadbalancer create --vip-subnet-id public-14-subnet
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-09-03T08:22:32                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 6cc1eb32-6601-40bc-8c01-e423c4c41c77 |
| listeners           |                                      |
| name                |                                      |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 9ef5e94c53c940239a66dbe4a1058eee     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.14.119                          |
| vip_network_id      | 47552f2c-b192-435f-ab07-4494b7e0e66d |
| vip_port_id         | 477642a4-f561-4d87-9c99-f7e5026dd428 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | e01a4e76-22f8-4a56-8861-1bdbf06d40d1 |
+---------------------+--------------------------------------+
```

stack@openstack-3:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 6cc1eb32-6601-40bc-8c01-e423c4c41c77 |      | 9ef5e94c53c940239a66dbe4a1058eee | 10.0.14.119 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```

vThunder(NOLICENSE)#show running-config
!Current configuration: 282 bytes
!Configuration last updated at 09:26:27 IST Fri Sep 3 2021
!Configuration last saved at 09:26:30 IST Fri Sep 3 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.14.10
!
ip nat pool pool1 1.1.1.1 1.1.1.2 netmask /24
!
ip nat pool pool2 1.1.1.11 1.1.1.12 netmask /24 gateway 1.1.1.254
!
**slb virtual-server 6cc1eb32-6601-40bc-8c01-e423c4c41c77 10.0.14.119**
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode

4. Create a listener without --name in the command.

stack@openstack-3:~$ openstack loadbalancer listener create --protocol http --protocol-port 80 6cc1eb32-6601-40bc-8c01-e423c4c41c77
```
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-09-03T08:28:11                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | baf5e878-da6b-4034-8121-70e5c88cfe24 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 6cc1eb32-6601-40bc-8c01-e423c4c41c77 |
| name                        |                                      |
| operating_status            | OFFLINE                              |
| project_id                  | 9ef5e94c53c940239a66dbe4a1058eee     |
| protocol                    | HTTP                                 |
| protocol_port               | 80                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
+-----------------------------+--------------------------------------+
```
stack@openstack-3:~$ openstack loadbalancer listener list
```
+--------------------------------------+-----------------+------+----------------------------------+----------+---------------+----------------+
| id                                   | default_pool_id | name | project_id                       | protocol | protocol_port | admin_state_up |
+--------------------------------------+-----------------+------+----------------------------------+----------+---------------+----------------+
| baf5e878-da6b-4034-8121-70e5c88cfe24 | None            |      | 9ef5e94c53c940239a66dbe4a1058eee | HTTP     |            80 | True           |
+--------------------------------------+-----------------+------+----------------------------------+----------+---------------+----------------+
```


vThunder(NOLICENSE)#show running-config
!Current configuration: 213 bytes
!Configuration last updated at 09:28:11 IST Fri Sep 3 2021
!Configuration last saved at 09:28:15 IST Fri Sep 3 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.14.10
!
ip nat pool pool1 1.1.1.1 1.1.1.2 netmask /24
!
ip nat pool pool2 1.1.1.11 1.1.1.12 netmask /24 gateway 1.1.1.254
!
**slb virtual-server 6cc1eb32-6601-40bc-8c01-e423c4c41c77 10.0.14.119
  port 80 http
    name baf5e878-da6b-4034-8121-70e5c88cfe24
    extended-stats
    source-nat pool pool1**
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode

5. Create a pool without --name in the command.

stack@openstack-3:~$ openstack loadbalancer pool create --protocol HTTP --lb-algorithm LEAST_CONNECTIONS --listener baf5e878-da6b-4034-8121-70e5c88cfe24
```
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-09-03T08:29:46                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | ee7cfc94-1ccf-406c-ad7e-be707c85e886 |
| lb_algorithm         | LEAST_CONNECTIONS                    |
| listeners            | baf5e878-da6b-4034-8121-70e5c88cfe24 |
| loadbalancers        | 6cc1eb32-6601-40bc-8c01-e423c4c41c77 |
| members              |                                      |
| name                 |                                      |
| operating_status     | OFFLINE                              |
| project_id           | 9ef5e94c53c940239a66dbe4a1058eee     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
+----------------------+--------------------------------------+
```
stack@openstack-3:~$ openstack loadbalancer pool list
```
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| id                                   | name | project_id                       | provisioning_status | protocol | lb_algorithm      | admin_state_up |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| ee7cfc94-1ccf-406c-ad7e-be707c85e886 |      | 9ef5e94c53c940239a66dbe4a1058eee | ACTIVE              | HTTP     | LEAST_CONNECTIONS | True           |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
```

6. Create a member without --name in the command.

stack@openstack-3:~$ openstack loadbalancer member create --address 10.0.14.14 --subnet-id public-14-subnet --protocol-port 95 ee7cfc94-1ccf-406c-ad7e-be707c85e886
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.14.14                           |
| admin_state_up      | True                                 |
| created_at          | 2021-09-03T08:31:01                  |
| id                  | f22e646f-7535-489b-9f0a-fd06e7b85159 |
| name                |                                      |
| operating_status    | NO_MONITOR                           |
| project_id          | 9ef5e94c53c940239a66dbe4a1058eee     |
| protocol_port       | 95                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | e01a4e76-22f8-4a56-8861-1bdbf06d40d1 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
```

stack@openstack-3:~$ openstack loadbalancer member list ee7cfc94-1ccf-406c-ad7e-be707c85e886
```
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address    | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| f22e646f-7535-489b-9f0a-fd06e7b85159 |      | 9ef5e94c53c940239a66dbe4a1058eee | ACTIVE              | 10.0.14.14 |            95 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
```

7. Create a healthmonitor without --name in the command.

stack@openstack-3:~$ openstack loadbalancer healthmonitor create --delay 4 --timeout 2 --max-retries 4 --type HTTP ee7cfc94-1ccf-406c-ad7e-be707c85e886
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| project_id          | 9ef5e94c53c940239a66dbe4a1058eee     |
| name                |                                      |
| admin_state_up      | True                                 |
| pools               | ee7cfc94-1ccf-406c-ad7e-be707c85e886 |
| created_at          | 2021-09-03T08:32:15                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| delay               | 4                                    |
| expected_codes      | 200                                  |
| max_retries         | 4                                    |
| http_method         | GET                                  |
| timeout             | 2                                    |
| max_retries_down    | 3                                    |
| url_path            | /                                    |
| type                | HTTP                                 |
| id                  | e37fac2b-3abb-44c0-93eb-89637544dfca |
| operating_status    | OFFLINE                              |
| http_version        | None                                 |
| domain_name         | None                                 |
+---------------------+--------------------------------------+
```

stack@openstack-3:~$ openstack loadbalancer healthmonitor list
```
+--------------------------------------+------+----------------------------------+------+----------------+
| id                                   | name | project_id                       | type | admin_state_up |
+--------------------------------------+------+----------------------------------+------+----------------+
| e37fac2b-3abb-44c0-93eb-89637544dfca |      | 9ef5e94c53c940239a66dbe4a1058eee | HTTP | True           |
+--------------------------------------+------+----------------------------------+------+----------------+
```


vThunder(NOLICENSE)#show running-config
!Current configuration: 213 bytes
!Configuration last updated at 09:32:14 IST Fri Sep 3 2021
!Configuration last saved at 09:32:20 IST Fri Sep 3 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.14.10
!
ip nat pool pool1 1.1.1.1 1.1.1.2 netmask /24
!
ip nat pool pool2 1.1.1.11 1.1.1.12 netmask /24 gateway 1.1.1.254
!
**health monitor e37fac2b-3abb-44c0-93eb-89637544dfca
  retry 4
  override-port 80
  interval 4 timeout 2
  method http port 80 expect response-code 200 url GET /**
!
**slb server 9ef5e_10_0_14_14 10.0.14.14
  port 95 tcp**
!
**slb service-group ee7cfc94-1ccf-406c-ad7e-be707c85e886 tcp
  method least-connection
  health-check e37fac2b-3abb-44c0-93eb-89637544dfca
  member 9ef5e_10_0_14_14 95**
!
slb virtual-server 6cc1eb32-6601-40bc-8c01-e423c4c41c77 10.0.14.119
  port 80 http
    name baf5e878-da6b-4034-8121-70e5c88cfe24
    extended-stats
    source-nat pool pool1
    service-group ee7cfc94-1ccf-406c-ad7e-be707c85e886
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode