### PR TITLE
[STACK-2891][For victoria]: Create slb objects without specifying --name parameter failed with name-expression is used in the flavor

### DIFF
--- a/a10_octavia/controller/worker/tasks/utils.py
+++ b/a10_octavia/controller/worker/tasks/utils.py
@@ -81,7 +81,7 @@ def shared_template_modifier(template_type, template_name, device_templates):
 
 def parse_name_expressions(name, name_expressions):
     flavor_data = {}
-    if name_expressions:
+    if name and name_expressions:
         for expression in name_expressions:
             if 'regex' in expression:
                 if re.search(expression['regex'], name):

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_utils.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_utils.py
@@ -118,3 +118,8 @@ class TestUtils(base.TestCase):
     def test_dash_to_underscore(self):
         obj_flavor = utils.dash_to_underscore(DASH_FLAVOR)
         self.assertEqual(UNDERSCORE_FLAVOR, obj_flavor)
+
+    def test_parse_name_expressions_with_no_name_specified(self):
+        expect_result = {}
+        obj_flavor = utils.parse_name_expressions(None, NAME_EXPRESSIONS)
+        self.assertEqual(expect_result, obj_flavor)


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description: Facing an error when slb objects are created using a flavor with name-expression is used in the flavor and without specifying `--name` parameter during their creation.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2891

## Technical Approach
- When `--name` is not specified during slb objects creation but flavor with name-expression is used, then the name is getting passed as None to `parse_name_expressions()` method and this is causing an error at `re.search()` call in it as name is a NoneType object here.
- So checking whether name is not None before calling this `re.search()` method.
- If it is None, then flavor_data will be returned as {}

## Config Changes
N/A

## Test Cases
Given a loadbalancer, when it is created without --name parameter, then it should get created without attaching flavor-data in its name-expression to it.

## Manual Testing
1. Create a flavorprofile and a flavor as follows:
stack@neha-victoria:~#openstack loadbalancer flavorprofile create --name fp_stack2798_std --provider a10 --flavor-data '{"virtual-server":{"name-expressions":[{"regex":"1","json":{"arp-disable":1}}]},"virtual-port":{"name-expressions":[{"regex":"1","json":{"pool":"pool2"}}]},"service-group":{"name-expressions":[{"regex":"1","json":{"health-check-disable":1}}]},"server":{"name-expressions":[{"regex":"1","json":{"extended-stats":1}}]},"health-monitor":{"name-expressions":[{"regex":"1","json":{"dsr-l2-strict":1}}]},"nat-pool":{"pool-name":"pool1","start-address":"1.1.1.1","end-address":"1.1.1.2","netmask":"/24"},"nat-pool-list":[{"pool-name":"pool2","start-address":"1.1.1.11","end-address":"1.1.1.12","netmask":"/24","gateway":"1.1.1.254"}]}'
```
+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field         | Value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| id            | 3f83900e-5aec-4ef5-9f69-275313b55eb5                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
| name          | fp_stack2798_std                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
| provider_name | a10                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| flavor_data   | {"virtual-server":{"name-expressions":[{"regex":"1","json":{"arp-disable":1}}]},"virtual-port":{"name-expressions":[{"regex":"1","json":{"pool":"pool2"}}]},"service-group":{"name-expressions":[{"regex":"1","json":{"health-check-disable":1}}]},"server":{"name-expressions":[{"regex":"1","json":{"extended-stats":1}}]},"health-monitor":{"name-expressions":[{"regex":"1","json":{"dsr-l2-strict":1}}]},"nat-pool":{"pool-name":"pool1","start-address":"1.1.1.1","end-address":"1.1.1.2","netmask":"/24"},"nat-pool-list":[{"pool-name":"pool2","start-address":"1.1.1.11","end-address":"1.1.1.12","netmask":"/24","gateway":"1.1.1.254"}]} |
+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

stack@neha-victoria:~#openstack loadbalancer flavor create --name f_stack2798_std --flavorprofile fp_stack2798_std
```
+-------------------+--------------------------------------+
| Field             | Value                                |
+-------------------+--------------------------------------+
| id                | 89729f58-be6f-4d08-a4dc-21a8ee4ab4d4 |
| name              | f_stack2798_std                      |
| flavor_profile_id | 3f83900e-5aec-4ef5-9f69-275313b55eb5 |
| enabled           | True                                 |
| description       |                                      |
+-------------------+--------------------------------------+
```

2. Configure the flavor-id in a10-octavia.conf
```
[a10_global]
network_type = 'flat'
vrid_floating_ip = "dhcp"
default_flavor_id = 89729f58-be6f-4d08-a4dc-21a8ee4ab4d4
```

3. Create a loadbalancer without speifying --name in the command.

stack@neha-victoria:~#openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-09-03T06:24:10                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | ad52252e-eb57-4e55-b765-ce2d0f01d394 |
| listeners           |                                      |
| name                |                                      |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 64474f828b3c483eafe2be7f5025df0d     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.130                          |
| vip_network_id      | dfe0ea7a-5463-4332-827a-cbf91c86d740 |
| vip_port_id         | fe929e1a-f50a-4e65-9e67-73cc4695abae |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 452aef15-7144-4c2f-87dc-c97dbce2dd3f |
+---------------------+--------------------------------------+
```

stack@neha-victoria:~#openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| ad52252e-eb57-4e55-b765-ce2d0f01d394 |      | 64474f828b3c483eafe2be7f5025df0d | 10.0.11.130 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
```

vThunder(NOLICENSE)#show running-config
!Current configuration: 282 bytes
!Configuration last updated at 07:27:17 IST Fri Sep 3 2021
!Configuration last saved at 07:27:21 IST Fri Sep 3 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.190
!
ip nat pool pool1 1.1.1.1 1.1.1.2 netmask /24
!
ip nat pool pool2 1.1.1.11 1.1.1.12 netmask /24 gateway 1.1.1.254
!
**slb virtual-server ad52252e-eb57-4e55-b765-ce2d0f01d394 10.0.11.130**
!
!
cloud-services meta-data
  enable
  provider openstack
!
end

4.  Create a listener without --name in the command.

stack@neha-victoria:~#openstack loadbalancer listener create --protocol http --protocol-port 80 ad52252e-eb57-4e55-b765-ce2d0f01d394
```
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-09-03T06:46:44                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 868976e0-7bd6-4e33-91ac-8a1ffe1086fb |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | ad52252e-eb57-4e55-b765-ce2d0f01d394 |
| name                        |                                      |
| operating_status            | OFFLINE                              |
| project_id                  | 64474f828b3c483eafe2be7f5025df0d     |
| protocol                    | HTTP                                 |
| protocol_port               | 80                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
| allowed_cidrs               | None                                 |
| tls_ciphers                 | None                                 |
| tls_versions                | None                                 |
| alpn_protocols              | None                                 |
+-----------------------------+--------------------------------------+
```

vThunder(NOLICENSE)#show running-config
!Current configuration: 213 bytes
!Configuration last updated at 07:46:45 IST Fri Sep 3 2021
!Configuration last saved at 07:46:57 IST Fri Sep 3 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.190
!
ip nat pool pool1 1.1.1.1 1.1.1.2 netmask /24
!
ip nat pool pool2 1.1.1.11 1.1.1.12 netmask /24 gateway 1.1.1.254
!
**slb virtual-server ad52252e-eb57-4e55-b765-ce2d0f01d394 10.0.11.130
  port 80 http
    name 868976e0-7bd6-4e33-91ac-8a1ffe1086fb
    extended-stats
    source-nat pool pool1
    source-nat auto**
!
!
cloud-services meta-data
  enable
  provider openstack
!
end

5. Create a pool without --name in the command.

stack@neha-victoria:~#openstack loadbalancer pool create --protocol HTTP --lb-algorithm LEAST_CONNECTIONS --listener 868976e0-7bd6-4e33-91ac-8a1ffe1086fb
```
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-09-03T06:49:30                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | e0440791-bc50-4a4c-9f2d-03dc8ff3a7a4 |
| lb_algorithm         | LEAST_CONNECTIONS                    |
| listeners            | 868976e0-7bd6-4e33-91ac-8a1ffe1086fb |
| loadbalancers        | ad52252e-eb57-4e55-b765-ce2d0f01d394 |
| members              |                                      |
| name                 |                                      |
| operating_status     | OFFLINE                              |
| project_id           | 64474f828b3c483eafe2be7f5025df0d     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+
```

stack@neha-victoria:~#openstack loadbalancer pool list
```
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| id                                   | name | project_id                       | provisioning_status | protocol | lb_algorithm      | admin_state_up |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| e0440791-bc50-4a4c-9f2d-03dc8ff3a7a4 |      | 64474f828b3c483eafe2be7f5025df0d | ACTIVE              | HTTP     | LEAST_CONNECTIONS | True           |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
```

6. Create a member without --name in the command.

stack@neha-victoria:~#openstack loadbalancer member create --address 10.0.14.14 --subnet-id provider-vlan-14-subnet --protocol-port 95 e0440791-bc50-4a4c-9f2d-03dc8ff3a7a4
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.14.14                           |
| admin_state_up      | True                                 |
| created_at          | 2021-09-03T06:51:18                  |
| id                  | bd20c0bd-8234-478d-8590-319cd021fe12 |
| name                |                                      |
| operating_status    | NO_MONITOR                           |
| project_id          | 64474f828b3c483eafe2be7f5025df0d     |
| protocol_port       | 95                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 723bb340-33be-44d6-8808-a1aaf9dd5446 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
```

stack@neha-victoria:~#openstack loadbalancer member list e0440791-bc50-4a4c-9f2d-03dc8ff3a7a4
```
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address    | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| bd20c0bd-8234-478d-8590-319cd021fe12 |      | 64474f828b3c483eafe2be7f5025df0d | ACTIVE              | 10.0.14.14 |            95 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
```


vThunder(NOLICENSE)#show running-config
!Current configuration: 213 bytes
!Configuration last updated at 07:54:36 IST Fri Sep 3 2021
!Configuration last saved at 07:54:40 IST Fri Sep 3 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.190
  floating-ip 10.0.14.138
!
ip nat pool pool1 1.1.1.1 1.1.1.2 netmask /24
!
ip nat pool pool2 1.1.1.11 1.1.1.12 netmask /24 gateway 1.1.1.254
!
**slb server 64474_10_0_14_14 10.0.14.14
  port 95 tcp**
!
**slb service-group e0440791-bc50-4a4c-9f2d-03dc8ff3a7a4 tcp
  method least-connection
  member 64474_10_0_14_14 95**
!
slb virtual-server ad52252e-eb57-4e55-b765-ce2d0f01d394 10.0.11.130
  port 80 http
    name 868976e0-7bd6-4e33-91ac-8a1ffe1086fb
    extended-stats
    source-nat pool pool1
    source-nat auto
    service-group e0440791-bc50-4a4c-9f2d-03dc8ff3a7a4
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode

7. Create a healthmonitor without --name in the command.

stack@neha-victoria:~#openstack loadbalancer healthmonitor create --delay 4 --timeout 2 --max-retries 4 --type HTTP e0440791-bc50-4a4c-9f2d-03dc8ff3a7a4
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| project_id          | 64474f828b3c483eafe2be7f5025df0d     |
| name                |                                      |
| admin_state_up      | True                                 |
| pools               | e0440791-bc50-4a4c-9f2d-03dc8ff3a7a4 |
| created_at          | 2021-09-03T08:08:27                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| delay               | 4                                    |
| expected_codes      | 200                                  |
| max_retries         | 4                                    |
| http_method         | GET                                  |
| timeout             | 2                                    |
| max_retries_down    | 3                                    |
| url_path            | /                                    |
| type                | HTTP                                 |
| id                  | 577fbf24-6743-4503-9be4-a424377be802 |
| operating_status    | OFFLINE                              |
| http_version        | None                                 |
| domain_name         | None                                 |
+---------------------+--------------------------------------+
```

stack@neha-victoria:~#openstack loadbalancer healthmonitor list
```
+--------------------------------------+------+----------------------------------+------+----------------+
| id                                   | name | project_id                       | type | admin_state_up |
+--------------------------------------+------+----------------------------------+------+----------------+
| 577fbf24-6743-4503-9be4-a424377be802 |      | 64474f828b3c483eafe2be7f5025df0d | HTTP | True           |
+--------------------------------------+------+----------------------------------+------+----------------+
```

vThunder(NOLICENSE)#show running-config
!Current configuration: 213 bytes
!Configuration last updated at 09:08:27 IST Fri Sep 3 2021
!Configuration last saved at 09:08:58 IST Fri Sep 3 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 112 (Jul-06-2021,22:29)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.190
  floating-ip 10.0.14.138
!
ip nat pool pool1 1.1.1.1 1.1.1.2 netmask /24
!
ip nat pool pool2 1.1.1.11 1.1.1.12 netmask /24 gateway 1.1.1.254
!
**health monitor 577fbf24-6743-4503-9be4-a424377be802
  retry 4
  override-port 80
  interval 4 timeout 2
  method http port 80 expect response-code 200 url GET /**
!
slb server 64474_10_0_14_14 10.0.14.14
  port 95 tcp
!
slb service-group e0440791-bc50-4a4c-9f2d-03dc8ff3a7a4 tcp
  method least-connection
  health-check 577fbf24-6743-4503-9be4-a424377be802
  member 64474_10_0_14_14 95
!
slb virtual-server ad52252e-eb57-4e55-b765-ce2d0f01d394 10.0.11.130
  port 80 http
    name 868976e0-7bd6-4e33-91ac-8a1ffe1086fb
    extended-stats
    source-nat pool pool1
    source-nat auto
    service-group e0440791-bc50-4a4c-9f2d-03dc8ff3a7a4
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode