### PR TITLE
[STACK-2933] device-name flavor failed in default_flavor_id option

### DIFF
--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -12,6 +12,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import json
 from sqlalchemy.orm import exc as db_exceptions
 import tenacity
 import time
@@ -116,6 +117,8 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         self._l7rule_flows = a10_l7rule_flows.L7RuleFlows()
         self._vthunder_flows = vthunder_flows.VThunderFlows()
         self._vthunder_repo = a10repo.VThunderRepository()
+        self._flavor_repo = repo.FlavorRepository()
+        self._flavor_profile_repo = repo.FlavorProfileRepository()
         self._exclude_result_logging_tasks = ()
         self.ctx_map = None
         self.ctx_lock = None
@@ -406,6 +409,8 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             raise db_exceptions.NoResultFound
 
         flavor_id = lb.flavor_id if lb.flavor_id else CONF.a10_global.default_flavor_id
+        if not flavor and flavor_id:
+            flavor = self._get_flavor_data(flavor_id)
 
         store = {constants.LOADBALANCER_ID: load_balancer_id,
                  constants.VIP: lb.vip,
@@ -1356,3 +1361,13 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         kwargs = {'ctx_key': key, 'ctx_lock': self.ctx_lock, 'ctx_map': self.ctx_map,
                   'is_reload_thread': is_reload_thread, 'ctx_flags': flags}
         engine.notifier.register('*', flow_notification_handler, kwargs=kwargs)
+
+    def _get_flavor_data(self, flavor_id):
+        flavor = self._flavor_repo.get(db_apis.get_session(), id=flavor_id)
+        if flavor and flavor.flavor_profile_id:
+            flavor_profile = self._flavor_profile_repo.get(
+                db_apis.get_session(),
+                id=flavor.flavor_profile_id)
+            flavor_data = json.loads(flavor_profile.flavor_data)
+            return flavor_data
+        return None

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -1017,9 +1017,9 @@ class ValidateComputeForProject(BaseDatabaseTask):
     """Validate compute_id got for the project"""
 
     def execute(self, loadbalancer, role):
+        vthunder = None
         vthunder_ids = self.vthunder_repo.get_vthunders_by_project_id_and_role(
             db_apis.get_session(), loadbalancer.project_id, role)
-        vthunder = None
         for vthunder_id in vthunder_ids:
             vthunder = self.vthunder_repo.get(
                 db_apis.get_session(),
@@ -1042,10 +1042,8 @@ class ValidateComputeForProject(BaseDatabaseTask):
                               vthunder.compute_id, vthunder.project_id)
                     break
 
-        if not vthunder:
-            # should not happen
-            raise exceptions.ProjectDeviceNotFound()
-
+        if vthunder is None:
+            return None
         return vthunder.compute_id
 
 


### PR DESCRIPTION
## Description
If Bug Fix:
- Required: Severity Level High
- Required: Issue Description
It goes to vthunder flow when use device-name flavor in default_flavor_id.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2933
https://a10networks.atlassian.net/browse/STACK-2934

## Technical Approach
In controller_worker.py create_load_balancer(), 
- a10-octavia didn't get the default flavor when no flavor is specified for the loadbalander. Therefore, 
- _is_rack_flow() can't get the device-name flavor and think it is vthunder flow.
Also add some code in ValidateComputeForProject task to provide more information in log. In case customer didn't configure properly.

## Config Changes
<pre>
<b>[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"

[a10_controller_worker]
amp_image_owner_id = 99c9c2304f114685a32db30769c8a7e2
amp_secgroup_list = 2d0a3480-7f08-4184-b96f-c39bb444dd38
amp_flavor_id = 130b7c65-7901-493b-8ebe-4c8a1883e0eb
amp_boot_network_list = 7f8ddd7f-c5c3-463a-b1c3-596f988480a4, 61305531-6e3a-44b4-8e67-05e93363dddc, a66685db-31ee-46c6-928a-ac034d87dc63, ec33a88d-3290-4ad6-95cc-226fcd2a4458
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 150
amp_active_wait_sec = 10
amp_busy_wait_sec = 0
loadbalancer_topology = SINGLE
amp_image_id = 2624c20e-7f0a-4c82-abe6-334797aa29e1

[a10_global]
network_type = "flat"
default_flavor_id = abbc517c-77d3-4392-b195-b64085726237

[hardware_thunder]
devices = [
                    {
                     #"project_id": "99c9c2304f114685a32db30769c8a7e2",
                    "ip_address": "192.168.90.46",
                     "username": "admin",
                     "password": "a10",
                    "device_name": "dev2"
                     }
             ]</b>
</pre>

## Test Cases
Test the steps specified in STACK-2933 and STACK-2944

## Manual Testing
- loadbalancer can create successfully in device-name flavor device when using default_flavor_id.
