### PR TITLE
[STACK-2933] device-name flavor failed in default_flavor_id option

### DIFF
--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -271,7 +271,7 @@ class FailoverOnPausedCompute(acos_errors.ACOSException):
         msg = ('Failover on a paused compute, skipping....')
         super(FailoverOnPausedCompute, self).__init__(msg=msg)
 
-        
+
 class FlavorNotFound(cfg.ConfigFileValueError):
     def __init__(self, flavor):
         msg = ('Flavor {0} specified in the configuration file cannot be located,'

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -1081,6 +1081,15 @@ class ValidateComputeForProject(BaseDatabaseTask):
                 db_apis.get_session(), vthunder.loadbalancer_id)
             if lb:
                 amphora = self.amphora_repo.get(db_apis.get_session(), load_balancer_id=lb.id)
+                if not amphora:
+                    """
+                        We don't support create loadbalancer in Thunder derice and vthunder in
+                    smae project now. So, this should caused by some error configuration.
+                    """
+
+                    LOG.error("Already use hardware thunder to create loadbalancer for"
+                              " this project. Can't create vthunder for the project.")
+                    raise exceptions.ProjectDeviceNotFound()
                 if amphora.compute_id == vthunder.compute_id:
                     LOG.debug("Successfully validated comput_id %s for the project %s",
                               vthunder.compute_id, vthunder.project_id)

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -1083,8 +1083,8 @@ class ValidateComputeForProject(BaseDatabaseTask):
                 amphora = self.amphora_repo.get(db_apis.get_session(), load_balancer_id=lb.id)
                 if not amphora:
                     """
-                        We don't support create loadbalancer in Thunder derice and vthunder in
-                    smae project now. So, this should caused by some error configuration.
+                        We don't support create loadbalancer in Thunder device and vthunder in
+                    same project now. So, this should caused by some error configuration.
                     """
 
                     LOG.error("Already use hardware thunder to create loadbalancer for"


### PR DESCRIPTION
## Description
If Bug Fix:
- Required: Severity Level High
- Required: Issue Description
It goes to vthunder flow when use device-name flavor in default_flavor_id.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2933
https://a10networks.atlassian.net/browse/STACK-2934

## Technical Approach
In controller_worker.py create_load_balancer(), 
- a10-octavia didn't get the default flavor when no flavor is specified for the loadbalander. Therefore, 
- _is_rack_flow() can't get the device-name flavor and think it is vthunder flow.
Also add some code in ValidateComputeForProject task to provide more information in log. In case customer didn't configure properly.

## Config Changes
<pre>
<b>[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"

[a10_controller_worker]
amp_image_owner_id = 99c9c2304f114685a32db30769c8a7e2
amp_secgroup_list = 2d0a3480-7f08-4184-b96f-c39bb444dd38
amp_flavor_id = 130b7c65-7901-493b-8ebe-4c8a1883e0eb
amp_boot_network_list = 7f8ddd7f-c5c3-463a-b1c3-596f988480a4, 61305531-6e3a-44b4-8e67-05e93363dddc, a66685db-31ee-46c6-928a-ac034d87dc63, ec33a88d-3290-4ad6-95cc-226fcd2a4458
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 150
amp_active_wait_sec = 10
amp_busy_wait_sec = 0
loadbalancer_topology = SINGLE
amp_image_id = 2624c20e-7f0a-4c82-abe6-334797aa29e1

[a10_global]
network_type = "flat"
default_flavor_id = abbc517c-77d3-4392-b195-b64085726237

[hardware_thunder]
devices = [
                    {
                     #"project_id": "99c9c2304f114685a32db30769c8a7e2",
                    "ip_address": "192.168.90.46",
                     "username": "admin",
                     "password": "a10",
                    "device_name": "dev2"
                     }
             ]</b>
</pre>

## Test Cases
Test the steps specified in STACK-2933 and STACK-2944

## Manual Testing
- loadbalancer can create successfully in device-name flavor device when using default_flavor_id.
