### PR TITLE
[STACK-2811]: Batch Member Update support for rack flows.

### DIFF
--- a/a10_octavia/api/drivers/driver.py
+++ b/a10_octavia/api/drivers/driver.py
@@ -19,6 +19,8 @@ from oslo_log import log as logging
 import oslo_messaging as messaging
 
 from octavia.common import constants
+from octavia.db import api as db_apis
+from octavia.db import repositories
 from octavia_lib.api.drivers import exceptions
 from octavia_lib.api.drivers import provider_base as driver_base
 
@@ -41,6 +43,7 @@ class A10ProviderDriver(driver_base.ProviderDriver):
         self._args['version'] = '1.0'
         self.target = messaging.Target(**self._args)
         self.client = messaging.RPCClient(self.transport, target=self.target)
+        self.repositories = repositories.Repositories()
 
     # Load Balancer
     def loadbalancer_create(self, loadbalancer):
@@ -148,6 +151,41 @@ class A10ProviderDriver(driver_base.ProviderDriver):
         payload = {constants.MEMBER_ID: member_id,
                    constants.MEMBER_UPDATES: member_dict}
         self.client.cast({}, 'update_member', **payload)
+
+    def member_batch_update(self, members):
+        # The DB should not have updated yet, so we can still use the pool
+        pool_id = members[0].pool_id
+        db_pool = self.repositories.pool.get(db_apis.get_session(), id=pool_id)
+        old_members = db_pool.members
+        old_member_ids = [m.id for m in old_members]
+        # The driver will always pass objects with IDs.
+        new_member_ids = [m.member_id for m in members]
+
+        # Find members that are brand new or updated
+        new_members = []
+        updated_members = []
+        for m in members:
+            if m.member_id not in old_member_ids:
+                new_members.append(m)
+            else:
+                member_dict = m.to_dict(render_unsets=False)
+                member_dict['id'] = member_dict.pop('member_id')
+                if 'address' in member_dict:
+                    member_dict['ip_address'] = member_dict.pop('address')
+                if 'admin_state_up' in member_dict:
+                    member_dict['enabled'] = member_dict.pop('admin_state_up')
+                updated_members.append(member_dict)
+
+        # Find members that are deleted
+        deleted_members = []
+        for m in old_members:
+            if m.id not in new_member_ids:
+                deleted_members.append(m)
+
+        payload = {'old_member_ids': [m.id for m in deleted_members],
+                   'new_member_ids': [m.member_id for m in new_members],
+                   'updated_members': updated_members}
+        self.client.cast({}, 'batch_update_members', **payload)
 
     # Health Monitor
     def health_monitor_create(self, healthmonitor):

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -662,12 +662,57 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         finally:
             self._set_vthunder_available(member.project_id, True, ctx_flags, load_balancer)
 
+    @tenacity.retry(
+        retry=tenacity.retry_if_exception_type(db_exceptions.NoResultFound),
+        wait=tenacity.wait_incrementing(
+            RETRY_INITIAL_DELAY, RETRY_BACKOFF, RETRY_MAX),
+        stop=tenacity.stop_after_attempt(RETRY_ATTEMPTS))
     def batch_update_members(self, old_member_ids, new_member_ids,
                              updated_members):
 
-        raise exceptions.NotImplementedError(
-            user_fault_string='This provider does not support members yet',
-            operator_fault_string='This provider does not support members yet')
+        new_members = [self._member_repo.get(db_apis.get_session(), id=mid)
+                       for mid in new_member_ids]
+        # The API may not have commited all of the new member records yet.
+        # Make sure we retry looking them up.
+        if None in new_members or len(new_members) != len(new_member_ids):
+            LOG.warning('Failed to fetch one of the new members from DB. '
+                        'Retrying for up to 60 seconds.')
+            raise db_exceptions.NoResultFound
+
+        old_members = [self._member_repo.get(db_apis.get_session(), id=mid)
+                       for mid in old_member_ids]
+
+        updated_members = [
+                (self._member_repo.get(db_apis.get_session(), id=m.get('id')), m)
+                 for m in updated_members]
+
+        if old_members:
+            pool = old_members[0].pool
+        elif new_members:
+            pool = new_members[0].pool
+        else:
+            pool = updated_members[0][0].pool
+        
+        load_balancer = pool.load_balancer
+        listeners = pool.listeners
+
+        ctx_flags = [False]
+        try:
+            if self._is_rack_flow(pool.project_id, loadbalancer=load_balancer):
+                vthunder_conf = CONF.hardware_thunder.devices.get(load_balancer.project_id, None)
+                device_dict = CONF.hardware_thunder.devices
+                batch_update_members_tf = self._taskflow_load(
+                    self._member_flows.get_rack_vthunder_batch_update_members_flow(
+                        old_members, new_members, updated_members,
+                        vthunder_conf, device_dict),
+                        store={constants.LISTENERS: listeners,
+                               constants.LOADBALANCER: load_balancer,
+                               constants.POOL: pool})
+                with tf_logging.DynamicLoggingListener(batch_update_members_tf,
+                                                       log=LOG):
+                    batch_update_members_tf.run()
+        finally:
+            self._set_vthunder_available(pool.project_id, True, ctx_flags, load_balancer)
 
     def update_member(self, member_id, member_updates):
         """Updates a pool member.

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -682,9 +682,9 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         old_members = [self._member_repo.get(db_apis.get_session(), id=mid)
                        for mid in old_member_ids]
 
-        updated_members = [
-                (self._member_repo.get(db_apis.get_session(), id=m.get('id')), m)
-                 for m in updated_members]
+        updated_members = [(self._member_repo.get(
+                            db_apis.get_session(), id=m.get('id')), m)
+                           for m in updated_members]
 
         if old_members:
             pool = old_members[0].pool
@@ -692,7 +692,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             pool = new_members[0].pool
         else:
             pool = updated_members[0][0].pool
-        
+
         load_balancer = pool.load_balancer
         listeners = pool.listeners
 
@@ -705,9 +705,9 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                     self._member_flows.get_rack_vthunder_batch_update_members_flow(
                         old_members, new_members, updated_members,
                         vthunder_conf, device_dict),
-                        store={constants.LISTENERS: listeners,
-                               constants.LOADBALANCER: load_balancer,
-                               constants.POOL: pool})
+                    store={constants.LISTENERS: listeners,
+                           constants.LOADBALANCER: load_balancer,
+                           constants.POOL: pool})
                 with tf_logging.DynamicLoggingListener(batch_update_members_tf,
                                                        log=LOG):
                     batch_update_members_tf.run()

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -854,7 +854,7 @@ class MemberFlows(object):
             batch_update_members_flow.add(server_tasks.MemberFindNatPool(
                 name='member-find-nat-pool-' + m.id,
                 inject={constants.MEMBER: m},
-                requires=[a10constants.VTHUNDER, constants.POOL,
+                requires=[constants.MEMBER, a10constants.VTHUNDER, constants.POOL,
                           constants.FLAVOR],
                 provides=a10constants.NAT_FLAVOR))
 
@@ -873,7 +873,7 @@ class MemberFlows(object):
             batch_update_members_flow.add(server_tasks.MemberDelete(
                 name='member-delete-' + m.id,
                 inject={constants.MEMBER: m},
-                requires=(a10constants.VTHUNDER, constants.POOL,
+                requires=(constants.MEMBER, a10constants.VTHUNDER, constants.POOL,
                           a10constants.MEMBER_COUNT_IP,
                           a10constants.MEMBER_COUNT_IP_PORT_PROTOCOL)))
             """For deleting Interface tag and vrid"""
@@ -906,7 +906,7 @@ class MemberFlows(object):
         for m in new_members:
             batch_update_members_flow.add(database_tasks.MarkMemberPendingCreateInDB(
                 name='mark-member-pending-create-in-db-' + m.id,
-                requires=constants.MEMBER))
+                inject={constants.MEMBER: m}))
 
             """For deleting Interface tag and vrid
             create_member_flow.add(self.handle_vrid_for_member_subflow())
@@ -927,7 +927,7 @@ class MemberFlows(object):
             batch_update_members_flow.add(server_tasks.MemberCreate(
                 name='member-create-' + m.id,
                 inject={constants.MEMBER: m},
-                requires=(a10constants.VTHUNDER, constants.POOL,
+                requires=(constants.MEMBER, a10constants.VTHUNDER, constants.POOL,
                           a10constants.MEMBER_COUNT_IP, constants.FLAVOR)))
             batch_update_members_flow.add(database_tasks.MarkMemberActiveInDB(
                 inject={constants.MEMBER: m},
@@ -955,7 +955,7 @@ class MemberFlows(object):
             batch_update_members_flow.add(server_tasks.MemberUpdate(
                 name='member-update-' + m.id,
                 inject={constants.MEMBER: m},
-                requires=(a10constants.VTHUNDER,
+                requires=(constants.MEMBER, a10constants.VTHUNDER,
                           constants.POOL, constants.FLAVOR)))
             #need to see what will be UPDATE_DICT is in batch member==>um
             #batch_update_members_flow.add(database_tasks.UpdateMemberInDB(
@@ -986,10 +986,10 @@ class MemberFlows(object):
         batch_update_member_snat_subflow = linear_flow.Flow(
             a10constants.CREATE_MEMBER_SNAT_POOL_SUBFLOW)
         batch_update_member_snat_subflow.add(server_tasks.MemberFindNatPool(
-            name='find-member-nat-pool-' + member.id,
+            name='member-find-nat-pool-' + member.id,
             inject={constants.MEMBER: member},
-            requires=[a10constants.VTHUNDER, constants.POOL,
-                      constants.FLAVOR], provides=a10constants.NAT_FLAVOR))
+            requires=(constants.MEMBER, a10constants.VTHUNDER, constants.POOL, constants.FLAVOR),
+            provides=a10constants.NAT_FLAVOR))
         batch_update_member_snat_subflow.add(a10_database_tasks.GetNatPoolEntry(
             name='get-nat-pool-entry-' + member.id,
             inject={constants.MEMBER: member},

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -780,8 +780,8 @@ class MemberFlows(object):
                       a10constants.NAT_POOL, a10constants.SUBNET_PORT]))
         return create_member_snat_subflow
 
-    def get_rack_batch_update_members_flow(self, old_members, new_members,
-                                           updated_members, vthunder_conf, device_dict):
+    def get_rack_vthunder_batch_update_members_flow(self, old_members, new_members,
+                                                    updated_members, vthunder_conf, device_dict):
         """Create a flow to batch update members
         :returns: The flow for batch updating members
         """

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -173,10 +173,8 @@ class PoolFlows(object):
             delete_member_vthunder_subflow.add(
                 self.member_flow.get_delete_member_vthunder_internal_subflow(member.id, pool))
         if members:
-            pool_members = pool + 'members'
-            store.update({pool_members: members})
             delete_member_vthunder_subflow.add(
-                self.member_flow.get_delete_member_vrid_internal_subflow(pool, pool_members))
+                self.member_flow.get_delete_member_vrid_internal_subflow(pool, members))
         store.update(member_store)
         return delete_member_vthunder_subflow
 

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -862,7 +862,7 @@ class TagInterfaceForMember(TagInterfaceBaseTask):
                         LOG.warning("Subnet id argument was not specified during "
                                     "issuance of create command/API call for member %s. "
                                     "Skipping TagInterfaceForMember task", m.id)
-                        return
+                        continue
                     try:
                         vlan_id = self.get_vlan_id(m.subnet_id, False)
                         self.tag_interfaces(vthunder, vlan_id)
@@ -898,7 +898,7 @@ class TagInterfaceForMember(TagInterfaceBaseTask):
                     LOG.warning("Subnet id argument was not specified during "
                                 "issuance of create command/API call for member %s. "
                                 "Skipping TagInterfaceForMember task", m.id)
-                    return
+                    continue
                 try:
                     if vthunder and vthunder.device_network_map:
                         vlan_id = self.get_vlan_id(m.subnet_id, False)

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -853,42 +853,87 @@ class TagInterfaceForMember(TagInterfaceBaseTask):
 
     @axapi_client_decorator
     def execute(self, member, vthunder):
-        if not member.subnet_id:
-            LOG.warning("Subnet id argument was not specified during "
-                        "issuance of create command/API call for member %s. "
-                        "Skipping TagInterfaceForMember task", member.id)
-            return
-        try:
-            vlan_id = self.get_vlan_id(member.subnet_id, False)
-            self.tag_interfaces(vthunder, vlan_id)
-            LOG.debug("Successfully tagged interface with VLAN id %s for member %s",
-                      str(vlan_id), member.id)
-        except (acos_errors.ACOSException, req_exceptions.ConnectionError) as e:
-            LOG.exception("Failed to tag interface with VLAN id %s for member %s",
+        # Case when batch_update_member is triggered
+        if isinstance(member, list):
+            subnet_list = []
+            for m in member:
+                if m.subnet_id not in subnet_list:
+                    if not m.subnet_id:
+                        LOG.warning("Subnet id argument was not specified during "
+                                    "issuance of create command/API call for member %s. "
+                                    "Skipping TagInterfaceForMember task", m.id)
+                        return
+                    try:
+                        vlan_id = self.get_vlan_id(m.subnet_id, False)
+                        self.tag_interfaces(vthunder, vlan_id)
+                        subnet_list.append(m.subnet_id)
+                        LOG.debug("Successfully tagged interface with VLAN id %s for member %s",
+                                  str(vlan_id), m.id)
+                    except (acos_errors.ACOSException, req_exceptions.ConnectionError) as e:
+                        LOG.exception("Failed to tag interface with VLAN id %s for member %s",
+                                      str(vlan_id), m.id)
+                        raise e
+        else:
+            if not member.subnet_id:
+                LOG.warning("Subnet id argument was not specified during "
+                            "issuance of create command/API call for member %s. "
+                            "Skipping TagInterfaceForMember task", member.id)
+                return
+            try:
+                vlan_id = self.get_vlan_id(member.subnet_id, False)
+                self.tag_interfaces(vthunder, vlan_id)
+                subnet_list.append(member.subnet_id)
+                LOG.debug("Successfully tagged interface with VLAN id %s for member %s",
                           str(vlan_id), member.id)
-            raise e
+            except (acos_errors.ACOSException, req_exceptions.ConnectionError) as e:
+                LOG.exception("Failed to tag interface with VLAN id %s for member %s",
+                              str(vlan_id), member.id)
+                raise e
 
     @axapi_client_decorator_for_revert
     def revert(self, member, vthunder, *args, **kwargs):
-        if not member.subnet_id:
-            LOG.warning("Subnet id argument was not specified during "
-                        "issuance of create command/API call for member %s. "
-                        "Skipping TagInterfaceForMember task", member.id)
-            return
-        try:
-            if vthunder and vthunder.device_network_map:
-                vlan_id = self.get_vlan_id(member.subnet_id, False)
-                if self.is_vlan_deletable():
-                    LOG.warning("Reverting tag interface for member with VLAN id %s", vlan_id)
-                    master_device_id = vthunder.device_network_map[0].vcs_device_id
-                    for device_obj in vthunder.device_network_map:
-                        self.delete_device_vlan(vlan_id, member.subnet_id, vthunder,
-                                                device_id=device_obj.vcs_device_id,
-                                                master_device_id=master_device_id)
-        except req_exceptions.ConnectionError:
-            LOG.exception("Failed to connect A10 Thunder device: %s", vthunder.ip_address)
-        except Exception as e:
-            LOG.exception("Failed to delete VLAN %s due to %s", str(vlan_id), str(e))
+        if isinstance(member, list):
+            for m in member:
+                if not m.subnet_id:
+                    LOG.warning("Subnet id argument was not specified during "
+                                "issuance of create command/API call for member %s. "
+                                "Skipping TagInterfaceForMember task", m.id)
+                    return
+                try:
+                    if vthunder and vthunder.device_network_map:
+                        vlan_id = self.get_vlan_id(m.subnet_id, False)
+                        if self.is_vlan_deletable():
+                            LOG.warning("Reverting tag interface for member "
+                                        "with VLAN id %s", vlan_id)
+                            master_device_id = vthunder.device_network_map[0].vcs_device_id
+                            for device_obj in vthunder.device_network_map:
+                                self.delete_device_vlan(vlan_id, member.subnet_id, vthunder,
+                                                        device_id=device_obj.vcs_device_id,
+                                                        master_device_id=master_device_id)
+                except req_exceptions.ConnectionError:
+                    LOG.exception("Failed to connect A10 Thunder device: %s", vthunder.ip_address)
+                except Exception as e:
+                    LOG.exception("Failed to delete VLAN %s due to %s", str(vlan_id), str(e))
+        else:
+            if not member.subnet_id:
+                LOG.warning("Subnet id argument was not specified during "
+                            "issuance of create command/API call for member %s. "
+                            "Skipping TagInterfaceForMember task", member.id)
+                return
+            try:
+                if vthunder and vthunder.device_network_map:
+                    vlan_id = self.get_vlan_id(member.subnet_id, False)
+                    if self.is_vlan_deletable():
+                        LOG.warning("Reverting tag interface for member with VLAN id %s", vlan_id)
+                        master_device_id = vthunder.device_network_map[0].vcs_device_id
+                        for device_obj in vthunder.device_network_map:
+                            self.delete_device_vlan(vlan_id, member.subnet_id, vthunder,
+                                                    device_id=device_obj.vcs_device_id,
+                                                    master_device_id=master_device_id)
+            except req_exceptions.ConnectionError:
+                LOG.exception("Failed to connect A10 Thunder device: %s", vthunder.ip_address)
+            except Exception as e:
+                LOG.exception("Failed to delete VLAN %s due to %s", str(vlan_id), str(e))
 
 
 class DeleteInterfaceTagIfNotInUseForLB(TagInterfaceBaseTask):


### PR DESCRIPTION
## Description
Added support for batch update members feature for rack flows in a10-octavia.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2932
https://a10networks.atlassian.net/browse/STACK-2900
https://a10networks.atlassian.net/browse/STACK-2901
https://a10networks.atlassian.net/browse/STACK-2926
https://a10networks.atlassian.net/browse/STACK-2927
https://a10networks.atlassian.net/browse/STACK-2943
https://a10networks.atlassian.net/browse/STACK-2928

## Technical Approach
- Implemented `member_batch_update()` API in driver.py
- Implemented `batch_update_members()` method specific to rack_flows in controller_worker.py 
- Created a flows `get_rack_vthunder_batch_update_members_flow()` in a10_member_flows for batch member update feature.
- Added tasks for handling member creation, deletion and updation upon triggering batch_update into the `get_rack_vthunder_batch_update_members_flow()` flow.
- Implemented a subflow `get_batch_update_member_snat_pool_subflow()` for handling snat_pool address allocation flows in case of batch_update_member.
- Added support for vrid creation and deletion in case of batch update member.
- Added support for tagging and untagging of interfaces in case of batch update member.

## Config Changes
N/A

## Manual Testing
Create a loadbalancer, listener, pool and members as follows:
stack@openstack-3:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 82ed78c5-ab8b-43df-83d7-c21439116c8d | lb1  | 9ef5e94c53c940239a66dbe4a1058eee | 10.0.14.209 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```

stack@openstack-3:~$ openstack loadbalancer listener list
```
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| id                                   | default_pool_id                      | name | project_id                       | protocol | protocol_port | admin_state_up |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| be62b5e3-15c5-4b7e-9872-de1afbe46c0e | 73760d0e-121f-4938-8424-52596acc7671 | l1   | 9ef5e94c53c940239a66dbe4a1058eee | HTTP     |            85 | True           |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
```

stack@openstack-3:~$ openstack loadbalancer pool list
```
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| id                                   | name | project_id                       | provisioning_status | protocol | lb_algorithm      | admin_state_up |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| 73760d0e-121f-4938-8424-52596acc7671 | p1   | 9ef5e94c53c940239a66dbe4a1058eee | ACTIVE              | HTTP     | LEAST_CONNECTIONS | True           |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
```

stack@openstack-3:~$ openstack loadbalancer member list p1
```
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address    | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| 1309c075-e159-439e-9193-df2da3b98aa0 | m1   | 9ef5e94c53c940239a66dbe4a1058eee | ACTIVE              | 10.0.13.20 |            95 | NO_MONITOR       |      5 |
| e42ebf6a-d294-4b86-83fd-09d600bda305 | m3   | 9ef5e94c53c940239a66dbe4a1058eee | ACTIVE              | 10.0.12.11 |            96 | NO_MONITOR       |      1 |
| e3f64186-99e6-4584-9dd4-08fc256ad9db | m2   | 9ef5e94c53c940239a66dbe4a1058eee | ACTIVE              | 10.0.13.24 |            94 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
```
Result on vThunder before batch update:

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 465 bytes
!Configuration last updated at 08:02:03 IST Wed Sep 15 2021
!Configuration last saved at 08:02:06 IST Wed Sep 15 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
!
interface ethernet 2
!
interface ethernet 3
!
interface ethernet 4
!
vrrp-a vrid 0
  floating-ip 10.0.14.68
  floating-ip 10.0.13.148
!
slb server 9ef5e_10_0_12_11 10.0.12.11
  port 96 tcp
!
slb server 9ef5e_10_0_13_20 10.0.13.20
  port 95 tcp
!
slb server 9ef5e_10_0_12_11 10.0.13.24
  port 94 tcp
!
slb service-group 73760d0e-121f-4938-8424-52596acc7671 tcp
  method least-connection
  member 9ef5e_10_0_12_11 96
  member 9ef5e_10_0_13_20 95
  member 9ef5e_10_0_13_24 94
!
slb virtual-server 82ed78c5-ab8b-43df-83d7-c21439116c8d 10.0.14.209
  port 85 http
    name be62b5e3-15c5-4b7e-9872-de1afbe46c0e
    extended-stats
    service-group 73760d0e-121f-4938-8424-52596acc7671
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
```

**Terraform script for batch update member:**

```
terraform {
  required_providers {
    openstack = {
      source = "terraform-provider-openstack/openstack"
      version = "1.43.0"
    }
  }
}

provider "openstack" {
  user_name = "admin"
  tenant_name = "admin"
  password = "password"
  auth_url = "http://<server_ip>/identity/v3"
  use_octavia = true
}

resource "openstack_lb_members_v2" "members_n1" {
  pool_id = "73760d0e-121f-4938-8424-52596acc7671"

  member {
    address       = "10.0.13.20"
    protocol_port = 95
    name          = "m1_update"
    weight        = 2
    subnet_id     = "0d4f7a95-d013-4a22-9b8e-6a83b22f8297"
  }
  member {
    address       = "10.0.12.11"
    protocol_port = 96
    name          = "m3_update"
    subnet_id     = "da29e3b4-c885-4834-b4ee-228d7d1bfac1"
  }
  member {
    address       = "10.0.11.10"
    protocol_port = 80
    name          = "m4"
    subnet_id     = "184910cd-74d4-4fd5-a3b2-ebad65d4cd44"
  }
  member {
    address       = "10.0.13.13"
    protocol_port = 85
    name          = "m5"
    subnet_id     = "0d4f7a95-d013-4a22-9b8e-6a83b22f8297"
  }
}
```

> Perform terraform init
> Perform terraform apply

Result after terraform apply:
stack@openstack-3:~$ journalctl -af -u a10-controller-worker.service
Sep 15 06:54:06 openstack-3 a10-octavia-worker[15482]: INFO a10_octavia.controller.queue.endpoint [-] **Batch updating members: old='[u'e3f64186-99e6-4584-9dd4-08fc256ad9db']', new='[u'0b4b0d75-3f97-47ab-a319-905dd337bdc7', u'cbba4e92-588a-4726-af92-d1fec3a95e15']', updated='[u'1309c075-e159-439e-9193-df2da3b98aa0', u'e42ebf6a-d294-4b86-83fd-09d600bda305']'...**
Sep 15 06:54:07 openstack-3 a10-octavia-worker[15482]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 10.0.0.78:shared


stack@openstack-3:~$ openstack loadbalancer member list p1
```
+--------------------------------------+-----------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| id                                   | name      | project_id                       | provisioning_status | address    | protocol_port | operating_status | weight |
+--------------------------------------+-----------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| 1309c075-e159-439e-9193-df2da3b98aa0 | m1_update | 9ef5e94c53c940239a66dbe4a1058eee | ACTIVE              | 10.0.13.20 |            95 | NO_MONITOR       |      2 |
| e42ebf6a-d294-4b86-83fd-09d600bda305 | m3_update | 9ef5e94c53c940239a66dbe4a1058eee | ACTIVE              | 10.0.12.11 |            96 | NO_MONITOR       |      1 |
| 0b4b0d75-3f97-47ab-a319-905dd337bdc7 | m4        | 9ef5e94c53c940239a66dbe4a1058eee | ACTIVE              | 10.0.11.10 |            80 | NO_MONITOR       |      1 |
| cbba4e92-588a-4726-af92-d1fec3a95e15 | m5        | 9ef5e94c53c940239a66dbe4a1058eee | ACTIVE              | 10.0.13.13 |            85 | NO_MONITOR       |      1 |
+--------------------------------------+-----------+----------------------------------+---------------------+------------+---------------+------------------+--------+
```

Result on vThunder after batch member update by the terraform script:

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 465 bytes
!Configuration last updated at 08:02:03 IST Wed Sep 15 2021
!Configuration last saved at 08:02:06 IST Wed Sep 15 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
!
interface ethernet 2
!
interface ethernet 3
!
interface ethernet 4
!
vrrp-a vrid 0
  floating-ip 10.0.14.68
  floating-ip 10.0.13.148
!
slb server 9ef5e_10_0_11_10 10.0.11.10
  port 80 tcp
!
slb server 9ef5e_10_0_12_11 10.0.12.11
  port 96 tcp
!
slb server 9ef5e_10_0_13_13 10.0.13.13
  port 85 tcp
!
slb server 9ef5e_10_0_13_20 10.0.13.20
  port 95 tcp
!
slb service-group 73760d0e-121f-4938-8424-52596acc7671 tcp
  method least-connection
  member 9ef5e_10_0_11_10 80
  member 9ef5e_10_0_12_11 96
  member 9ef5e_10_0_13_13 85
  member 9ef5e_10_0_13_20 95
!
slb virtual-server 82ed78c5-ab8b-43df-83d7-c21439116c8d 10.0.14.209
  port 85 http
    name be62b5e3-15c5-4b7e-9872-de1afbe46c0e
    extended-stats
    service-group 73760d0e-121f-4938-8424-52596acc7671
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
```



**SNAT flows testing while batch update members:**
Create a flavorprofile and a flavor for SNAT pools
stack@openstack-3:~$ openstack loadbalancer flavorprofile create --name fp_snat_list --provider a10 --flavor-data '{"nat-pool":{"pool-name":"pool1", "start-address":"10.0.11.40", "end-address":"10.0.11.41", "netmask":"/24", "gateway":"10.0.11.11"}, "nat-pool-list":[{"pool-name":"pool2", "start-address":"10.0.11.29", "end-address":"10.0.11.30", "netmask":"/24", "gateway":"10.0.11.12"}, {"pool-name":"pool3", "start-address":"10.0.11.20", "end-address":"10.0.11.21", "netmask":"/24", "gateway":"10.0.11.13"}]}'
```
+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field         | Value                                                                                                                                                                                                                                                                                                                                                                                                       |
+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| id            | ef7ae629-6507-4dd4-9bae-e52e8b5eaa03                                                                                                                                                                                                                                                                                                                                                                        |
| name          | fp_snat_list                                                                                                                                                                                                                                                                                                                                                                                                |
| provider_name | a10                                                                                                                                                                                                                                                                                                                                                                                                         |
| flavor_data   | {"nat-pool":{"pool-name":"pool1", "start-address":"10.0.11.40", "end-address":"10.0.11.41", "netmask":"/24", "gateway":"10.0.11.11"}, "nat-pool-list":[{"pool-name":"pool2", "start-address":"10.0.11.29", "end-address":"10.0.11.30", "netmask":"/24", "gateway":"10.0.11.12"}, {"pool-name":"pool3", "start-address":"10.0.11.20", "end-address":"10.0.11.21", "netmask":"/24", "gateway":"10.0.11.13"}]} |
+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

stack@openstack-3:~$ openstack loadbalancer flavor create --name f_snat_list --flavorprofile fp_snat_list --description "flaovr all test1" --enable
```
+-------------------+--------------------------------------+
| Field             | Value                                |
+-------------------+--------------------------------------+
| id                | c2946e28-958f-4e94-8cfe-b7f5866c6ed9 |
| name              | f_snat_list                          |
| flavor_profile_id | ef7ae629-6507-4dd4-9bae-e52e8b5eaa03 |
| enabled           | True                                 |
| description       | flaovr all test1                     |
+-------------------+--------------------------------------+
```

Create a loadbalancer, listener and pool:
stack@openstack-3:~$ openstack loadbalancer create --name lb1 --vip-subnet-id public-14-subnet --flavor c2946e28-958f-4e94-8cfe-b7f5866c6ed9
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-09-15T08:20:35                  |
| description         |                                      |
| flavor_id           | c2946e28-958f-4e94-8cfe-b7f5866c6ed9 |
| id                  | b96b5dee-c3d5-4d6c-a0ff-bf1b326a8af9 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 9ef5e94c53c940239a66dbe4a1058eee     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.14.243                          |
| vip_network_id      | 47552f2c-b192-435f-ab07-4494b7e0e66d |
| vip_port_id         | 5dc05cdb-8439-450b-b306-6a9c61c1c4b5 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | e01a4e76-22f8-4a56-8861-1bdbf06d40d1 |
+---------------------+--------------------------------------+
```

stack@openstack-3:~$ openstack loadbalancer listener create --name l1 --protocol http --protocol-port 85 lb1
```
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-09-15T08:21:04                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | bb27f2a3-490a-40a4-94cb-d69cf765fb76 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | b96b5dee-c3d5-4d6c-a0ff-bf1b326a8af9 |
| name                        | l1                                   |
| operating_status            | OFFLINE                              |
| project_id                  | 9ef5e94c53c940239a66dbe4a1058eee     |
| protocol                    | HTTP                                 |
| protocol_port               | 85                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
+-----------------------------+--------------------------------------+
```
stack@openstack-3:~$ openstack loadbalancer pool create --name p1 --protocol HTTP --lb-algorithm LEAST_CONNECTIONS --listener l1
```
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-09-15T08:21:15                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | 480584e5-86b5-4a98-9efd-5161a7b120e0 |
| lb_algorithm         | LEAST_CONNECTIONS                    |
| listeners            | bb27f2a3-490a-40a4-94cb-d69cf765fb76 |
| loadbalancers        | b96b5dee-c3d5-4d6c-a0ff-bf1b326a8af9 |
| members              |                                      |
| name                 | p1                                   |
| operating_status     | OFFLINE                              |
| project_id           | 9ef5e94c53c940239a66dbe4a1058eee     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
+----------------------+--------------------------------------+
```

Result on vThunder before batch update members:

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 403 bytes
!Configuration last updated at 09:21:49 IST Wed Sep 15 2021
!Configuration last saved at 09:21:52 IST Wed Sep 15 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
!
interface ethernet 2
!
interface ethernet 3
!
interface ethernet 4
!
vrrp-a vrid 0
  floating-ip 10.0.14.79
!
ip nat pool pool1 10.0.11.40 10.0.11.41 netmask /24 gateway 10.0.11.11
!
ip nat pool pool2 10.0.11.29 10.0.11.30 netmask /24 gateway 10.0.11.12
!
ip nat pool pool3 10.0.11.20 10.0.11.21 netmask /24 gateway 10.0.11.13
!
slb service-group 480584e5-86b5-4a98-9efd-5161a7b120e0 tcp
  method least-connection
!
slb virtual-server b96b5dee-c3d5-4d6c-a0ff-bf1b326a8af9 10.0.14.243
  port 85 http
    name bb27f2a3-490a-40a4-94cb-d69cf765fb76
    extended-stats
    source-nat pool pool1
    service-group 480584e5-86b5-4a98-9efd-5161a7b120e0
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
```

Write a terraform script for creating a member in same subnet as that of snat_pool address range:
```
terraform {
  required_providers {
    openstack = {
      source = "terraform-provider-openstack/openstack"
      version = "1.43.0"
    }
  }
}

provider "openstack" {
  user_name = "admin"
  tenant_name = "admin"
  password = "password"
  auth_url = "http://<server_ip> /identity/v3"
  use_octavia = true
}

resource "openstack_lb_members_v2" "members_snat" {
  pool_id = "480584e5-86b5-4a98-9efd-5161a7b120e0"

  member {
    address       = "10.0.11.60"
    protocol_port = 80
    name          = "m1"
    subnet_id     = "184910cd-74d4-4fd5-a3b2-ebad65d4cd44"
  }
}
```

>> terraform init
>> terraform apply

Result after batch update members:

stack@openstack-3:~$ openstack loadbalancer member list p1
```
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address    | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| 6cf0984a-eba5-4abf-acb1-85059b315a14 | m1   | 9ef5e94c53c940239a66dbe4a1058eee | ACTIVE              | 10.0.11.60 |            80 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
```


```
vThunder(NOLICENSE)#show running-config
!Current configuration: 403 bytes
!Configuration last updated at 09:27:24 IST Wed Sep 15 2021
!Configuration last saved at 09:27:27 IST Wed Sep 15 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
!
interface ethernet 2
!
interface ethernet 3
!
interface ethernet 4
!
vrrp-a vrid 0
  floating-ip 10.0.14.79
!
ip nat pool pool1 10.0.11.40 10.0.11.41 netmask /24 gateway 10.0.11.11
!
ip nat pool pool2 10.0.11.29 10.0.11.30 netmask /24 gateway 10.0.11.12
!
ip nat pool pool3 10.0.11.20 10.0.11.21 netmask /24 gateway 10.0.11.13
!
slb server 9ef5e_10_0_11_60 10.0.11.60
  port 80 tcp
!
slb service-group 480584e5-86b5-4a98-9efd-5161a7b120e0 tcp
  method least-connection
  member 9ef5e_10_0_11_60 80
!
slb virtual-server b96b5dee-c3d5-4d6c-a0ff-bf1b326a8af9 10.0.14.243
  port 85 http
    name bb27f2a3-490a-40a4-94cb-d69cf765fb76
    extended-stats
    source-nat pool pool1
    service-group 480584e5-86b5-4a98-9efd-5161a7b120e0
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
```


mysql> select * from ipallocations;
+--------------------------------------+---------------+--------------------------------------+--------------------------------------+
| port_id                              | ip_address    | subnet_id                            | network_id                           |
+--------------------------------------+---------------+--------------------------------------+--------------------------------------+
**| 4f56ec2a-29f5-4771-83ec-e63a00afe14f | 10.0.11.40    | 184910cd-74d4-4fd5-a3b2-ebad65d4cd44 | 6df8ee71-7519-4f9d-8300-44acfa2fe325 |
| 4f56ec2a-29f5-4771-83ec-e63a00afe14f | 10.0.11.41    | 184910cd-74d4-4fd5-a3b2-ebad65d4cd44 | 6df8ee71-7519-4f9d-8300-44acfa2fe325 |**
| 4fea8e46-8d7f-47a6-bdbe-904919aaf376 | 10.0.12.100   | dbfdac58-f176-470e-b48f-71da22949f45 | 87e1aa41-7cd8-4291-992e-7234a2665c20 |
| 52ad1d26-7dee-4e14-a4ef-e3f572dfbf21 | 10.0.12.2     | da29e3b4-c885-4834-b4ee-228d7d1bfac1 | bdeb716e-5466-42ed-b256-b088ad825790 |
| 57daa0d3-8d72-432b-8d33-0010d52b4bc8 | 192.168.0.192 | 8577d352-0b7b-461c-ba80-f55d9bfa115d | e9aa5348-950c-4db7-ae29-459344a069c5 |
| 5dc05cdb-8439-450b-b306-6a9c61c1c4b5 | 10.0.14.243   | e01a4e76-22f8-4a56-8861-1bdbf06d40d1 | 47552f2c-b192-435f-ab07-4494b7e0e66d |
| 6129be5c-771d-4edf-af6f-b655d03add7d | 10.0.14.1     | e01a4e76-22f8-4a56-8861-1bdbf06d40d1 | 47552f2c-b192-435f-ab07-4494b7e0e66d |
| 72d1cd15-3573-4585-ad37-cfe4039f57aa | 10.0.14.79    | e01a4e76-22f8-4a56-8861-1bdbf06d40d1 | 47552f2c-b192-435f-ab07-4494b7e0e66d |
| 7556523e-1a11-47e0-a925-03bd2a12189b | 192.168.0.123 | 8577d352-0b7b-461c-ba80-f55d9bfa115d | e9aa5348-950c-4db7-ae29-459344a069c5 |
| 7e72f2c3-37a8-4f6a-b0d1-e75b2b600751 | 10.0.11.100   | 4d570e46-43d4-4924-b6b7-3ee9cfddf20f | 1823c2e9-c3c2-46c7-8ac1-3f5b59172bd9 |
| 9c7f1e95-9349-45ff-a5f5-07b1d16a49a1 | 10.0.14.100   | d1652995-8110-4e3c-a953-99eb95387aca | 406ef093-5337-4272-888c-367fcb5899f7 |
| a3938146-425b-49b7-81c5-2845de9b04f2 | 192.168.0.2   | 8577d352-0b7b-461c-ba80-f55d9bfa115d | e9aa5348-950c-4db7-ae29-459344a069c5 |
| aac80cda-598f-4f72-a183-681b722506d9 | 10.0.11.2     | 184910cd-74d4-4fd5-a3b2-ebad65d4cd44 | 6df8ee71-7519-4f9d-8300-44acfa2fe325 |
| b80499d7-7910-482a-821f-e4ceab074ea4 | 172.24.4.2    | 72054180-ac06-450a-89b8-258865ae6c0f | 34cd5f8d-1b79-45fc-8fe3-12dec5ac7d7e |
| b80499d7-7910-482a-821f-e4ceab074ea4 | 2001:db8::1   | 3050504f-6165-42b3-80b3-8d091d32587b | 34cd5f8d-1b79-45fc-8fe3-12dec5ac7d7e |
| b86ea2f8-a3d5-490a-b647-1e8fda49dae2 | 192.168.0.176 | 8577d352-0b7b-461c-ba80-f55d9bfa115d | e9aa5348-950c-4db7-ae29-459344a069c5 |
+--------------------------------------+---------------+--------------------------------------+--------------------------------------+


Deletion case:
Write a terraform script for deleting the member m1 and creating member m2 in a different subnet:
```
terraform {
  required_providers {
    openstack = {
      source = "terraform-provider-openstack/openstack"
      version = "1.43.0"
    }
  }
}

provider "openstack" {
  user_name = "admin"
  tenant_name = "admin"
  password = "password"
  auth_url = "http://<server_ip>/identity/v3"
  use_octavia = true
}

resource "openstack_lb_members_v2" "members_snat" {
  pool_id = "480584e5-86b5-4a98-9efd-5161a7b120e0"

  member {
    address       = "10.0.12.50"
    protocol_port = 8080
    name          = "m2"
    subnet_id     = "da29e3b4-c885-4834-b4ee-228d7d1bfac1"
  }
}
```

> Perform terraform init
> Perform terraform apply

stack@openstack-3:~$ openstack loadbalancer member list p1
```
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address    | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| d149c01e-cdf5-491a-b9eb-4b6e0841b788 | m2   | 9ef5e94c53c940239a66dbe4a1058eee | ACTIVE              | 10.0.12.50 |          8080 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
```

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 403 bytes
!Configuration last updated at 09:34:17 IST Wed Sep 15 2021
!Configuration last saved at 09:34:20 IST Wed Sep 15 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
!
interface ethernet 2
!
interface ethernet 3
!
interface ethernet 4
!
vrrp-a vrid 0
  floating-ip 10.0.14.79
!
ip nat pool pool1 10.0.11.40 10.0.11.41 netmask /24 gateway 10.0.11.11
!
ip nat pool pool2 10.0.11.29 10.0.11.30 netmask /24 gateway 10.0.11.12
!
ip nat pool pool3 10.0.11.20 10.0.11.21 netmask /24 gateway 10.0.11.13
!
slb server 9ef5e_10_0_12_50 10.0.12.50
  port 8080 tcp
!
slb service-group 480584e5-86b5-4a98-9efd-5161a7b120e0 tcp
  method least-connection
  member 9ef5e_10_0_12_50 8080
!
slb virtual-server b96b5dee-c3d5-4d6c-a0ff-bf1b326a8af9 10.0.14.243
  port 85 http
    name bb27f2a3-490a-40a4-94cb-d69cf765fb76
    extended-stats
    source-nat pool pool1
    service-group 480584e5-86b5-4a98-9efd-5161a7b120e0
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
```

mysql> select * from ipallocations;     
```
+--------------------------------------+---------------+--------------------------------------+--------------------------------------+
| port_id                              | ip_address    | subnet_id                            | network_id                           |
+--------------------------------------+---------------+--------------------------------------+--------------------------------------+
| 4fea8e46-8d7f-47a6-bdbe-904919aaf376 | 10.0.12.100   | dbfdac58-f176-470e-b48f-71da22949f45 | 87e1aa41-7cd8-4291-992e-7234a2665c20 |
| 52ad1d26-7dee-4e14-a4ef-e3f572dfbf21 | 10.0.12.2     | da29e3b4-c885-4834-b4ee-228d7d1bfac1 | bdeb716e-5466-42ed-b256-b088ad825790 |
| 57daa0d3-8d72-432b-8d33-0010d52b4bc8 | 192.168.0.192 | 8577d352-0b7b-461c-ba80-f55d9bfa115d | e9aa5348-950c-4db7-ae29-459344a069c5 |
| 5dc05cdb-8439-450b-b306-6a9c61c1c4b5 | 10.0.14.243   | e01a4e76-22f8-4a56-8861-1bdbf06d40d1 | 47552f2c-b192-435f-ab07-4494b7e0e66d |
| 6129be5c-771d-4edf-af6f-b655d03add7d | 10.0.14.1     | e01a4e76-22f8-4a56-8861-1bdbf06d40d1 | 47552f2c-b192-435f-ab07-4494b7e0e66d |
| 72d1cd15-3573-4585-ad37-cfe4039f57aa | 10.0.14.79    | e01a4e76-22f8-4a56-8861-1bdbf06d40d1 | 47552f2c-b192-435f-ab07-4494b7e0e66d |
| 7556523e-1a11-47e0-a925-03bd2a12189b | 192.168.0.123 | 8577d352-0b7b-461c-ba80-f55d9bfa115d | e9aa5348-950c-4db7-ae29-459344a069c5 |
| 7e72f2c3-37a8-4f6a-b0d1-e75b2b600751 | 10.0.11.100   | 4d570e46-43d4-4924-b6b7-3ee9cfddf20f | 1823c2e9-c3c2-46c7-8ac1-3f5b59172bd9 |
| 9c7f1e95-9349-45ff-a5f5-07b1d16a49a1 | 10.0.14.100   | d1652995-8110-4e3c-a953-99eb95387aca | 406ef093-5337-4272-888c-367fcb5899f7 |
| a3938146-425b-49b7-81c5-2845de9b04f2 | 192.168.0.2   | 8577d352-0b7b-461c-ba80-f55d9bfa115d | e9aa5348-950c-4db7-ae29-459344a069c5 |
| aac80cda-598f-4f72-a183-681b722506d9 | 10.0.11.2     | 184910cd-74d4-4fd5-a3b2-ebad65d4cd44 | 6df8ee71-7519-4f9d-8300-44acfa2fe325 |
| b80499d7-7910-482a-821f-e4ceab074ea4 | 172.24.4.2    | 72054180-ac06-450a-89b8-258865ae6c0f | 34cd5f8d-1b79-45fc-8fe3-12dec5ac7d7e |
| b80499d7-7910-482a-821f-e4ceab074ea4 | 2001:db8::1   | 3050504f-6165-42b3-80b3-8d091d32587b | 34cd5f8d-1b79-45fc-8fe3-12dec5ac7d7e |
| b86ea2f8-a3d5-490a-b647-1e8fda49dae2 | 192.168.0.176 | 8577d352-0b7b-461c-ba80-f55d9bfa115d | e9aa5348-950c-4db7-ae29-459344a069c5 |
+--------------------------------------+---------------+--------------------------------------+--------------------------------------+
```