### PR TITLE
[STACK-2930] Batch Member Update Support for vthunder flow

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -1029,6 +1029,11 @@ class MemberFlows(object):
         batch_update_members_flow.add(a10_database_tasks.GetFlavorData(
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
             provides=constants.FLAVOR))
+        if topology == constants.TOPOLOGY_ACTIVE_STANDBY: 
+            batch_update_members_flow.add(vthunder_tasks.GetMasterVThunder(
+                name='get-master-vtthunder',
+                requires=a10constants.VTHUNDER,
+                provides=a10constants.VTHUNDER))
         batch_update_members_flow.add(
             lifecycle_tasks.MembersToErrorOnRevertTask(
                 inject={constants.MEMBERS: old_members},

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -974,10 +974,6 @@ class MemberFlows(object):
         """
         batch_update_members_flow = linear_flow.Flow(
             constants.BATCH_UPDATE_MEMBERS_FLOW)
-        # unordered_members_flow = unordered_flow.Flow(
-        #    constants.UNORDERED_MEMBER_UPDATES_FLOW)
-        # unordered_members_active_flow = unordered_flow.Flow(
-        #    constants.UNORDERED_MEMBER_ACTIVE_FLOW)
         batch_update_members_flow.add(vthunder_tasks.VthunderInstanceBusy(
             requires=a10constants.COMPUTE_BUSY))
         batch_update_members_flow.add(database_tasks.GetAmphoraeFromLoadbalancer(
@@ -999,14 +995,17 @@ class MemberFlows(object):
             provides=a10constants.POOLS))
         batch_update_members_flow.add(server_tasks.MemberFindNatPool(
             name='find-nat-pool-for-member',
-            requires=[a10constants.VTHUNDER,
-                      constants.POOL, constants.FLAVOR],
+            requires=[a10constants.VTHUNDER, constants.POOL, constants.FLAVOR],
             provides=a10constants.NAT_FLAVOR))
         batch_update_members_flow.add(
-            lifecycle_tasks.MembersToErrorOnRevertTask(
-                inject={constants.MEMBERS: old_members},
-                name='{flow}-deleted'.format(
-                    flow=constants.MEMBER_TO_ERROR_ON_REVERT_FLOW)))
+            a10_database_tasks.GetChildProjectsOfParentPartition(
+                name='get_child_project_of_parent_partition_',
+                rebind={a10constants.LB_RESOURCE: constants.POOL},
+                provides=a10constants.PARTITION_PROJECT_LIST))
+        batch_update_members_flow.add(lifecycle_tasks.MembersToErrorOnRevertTask(
+            inject={constants.MEMBERS: old_members},
+            name='{flow}-deleted'.format(
+                flow=constants.MEMBER_TO_ERROR_ON_REVERT_FLOW)))
         for m in old_members:
             batch_update_members_flow.add(database_tasks.MarkMemberPendingDeleteInDB(
                 name='Mark-pending-delete-in-DB' + m.id,
@@ -1018,12 +1017,11 @@ class MemberFlows(object):
                 name='Count-members-with-ip' + m.id,
                 inject={constants.MEMBER: m},
                 provides=a10constants.MEMBER_COUNT_IP))
-            batch_update_members_flow.add(
-                a10_database_tasks.CountMembersWithIPPortProtocol(
-                    name='count-member-with-ip-address' + m.id,
-                    inject={constants.MEMBER: m},
-                    requires=constants.POOL,
-                    provides=a10constants.MEMBER_COUNT_IP_PORT_PROTOCOL))
+            batch_update_members_flow.add(a10_database_tasks.CountMembersWithIPPortProtocol(
+                name='count-member-with-ip-address' + m.id,
+                inject={constants.MEMBER: m},
+                requires=constants.POOL,
+                provides=a10constants.MEMBER_COUNT_IP_PORT_PROTOCOL))
             batch_update_members_flow.add(a10_database_tasks.GetNatPoolEntry(
                 name='get-nat-pool' + m.id,
                 inject={constants.MEMBER: m},
@@ -1036,16 +1034,12 @@ class MemberFlows(object):
             batch_update_members_flow.add(a10_database_tasks.DeleteNatPoolEntry(
                 name='delete-nat-pool-entry' + m.id,
                 requires=a10constants.NAT_POOL))
-            batch_update_members_flow.add(
-                server_tasks.MemberDelete(
-                    name='member-delete' + m.id,
-                    inject={constants.MEMBER: m},
-                    requires=(
-                        constants.MEMBER,
-                        a10constants.VTHUNDER,
-                        constants.POOL,
-                        a10constants.MEMBER_COUNT_IP,
-                        a10constants.MEMBER_COUNT_IP_PORT_PROTOCOL)))
+            batch_update_members_flow.add(server_tasks.MemberDelete(
+                name='member-delete' + m.id,
+                inject={constants.MEMBER: m},
+                requires=(constants.MEMBER, a10constants.VTHUNDER,
+                          constants.POOL, a10constants.MEMBER_COUNT_IP,
+                          a10constants.MEMBER_COUNT_IP_PORT_PROTOCOL)))
             batch_update_members_flow.add(database_tasks.DeleteMemberInDB(
                 name='delete-member-in-db' + m.id,
                 inject={constants.MEMBER: m}))
@@ -1059,10 +1053,7 @@ class MemberFlows(object):
         batch_update_members_flow.add(lifecycle_tasks.MembersToErrorOnRevertTask(
             name='{flow}-created'.format(
                 flow=constants.MEMBER_TO_ERROR_ON_REVERT_FLOW),
-            inject={constants.MEMBERS: new_members},
-            requires=[constants.LISTENERS,
-                      constants.LOADBALANCER,
-                      constants.POOL]))
+            inject={constants.MEMBERS: new_members}))
         for m in new_members:
             batch_update_members_flow.add(database_tasks.MarkMemberPendingCreateInDB(
                 name='mark-member-pending-create-in-DB' + m.id,
@@ -1075,7 +1066,6 @@ class MemberFlows(object):
                 name=a10constants.ALLOW_NO_SNAT + m.id,
                 inject={constants.MEMBER: m},
                 requires=(constants.AMPHORA)))
-
             batch_update_members_flow.add(server_tasks.MemberCreate(
                 name='member-create' + m.id,
                 inject={constants.MEMBER: m},
@@ -1091,20 +1081,12 @@ class MemberFlows(object):
                 name='{flow}-updated'.format(
                     flow=constants.MEMBER_TO_ERROR_ON_REVERT_FLOW),
                 # updated_members is a list of (obj, dict), only pass `obj`
-                inject={constants.MEMBERS: [m[0] for m in updated_members]},
-                requires=[constants.LISTENERS,
-                          constants.LOADBALANCER,
-                          constants.POOL]))
+                inject={constants.MEMBERS: [m[0] for m in updated_members]}))
         for m, um in updated_members:
             um.pop('id', None)
             batch_update_members_flow.add(database_tasks.MarkMemberPendingUpdateInDB(
                 inject={constants.MEMBER: m},
                 name='mark-member-pending-update-in-db-' + m.id))
-            batch_update_members_flow.add(
-                a10_database_tasks.GetChildProjectsOfParentPartition(
-                    name='get_child_project_of_parent_partition_',
-                    rebind={a10constants.LB_RESOURCE: constants.POOL},
-                    provides=a10constants.PARTITION_PROJECT_LIST))
             batch_update_members_flow.add(a10_network_tasks.GetLBResourceSubnet(
                 name='{flow}-{id}'.format(
                     id=m.id, flow=a10constants.GET_LB_RESOURCE_SUBNET),
@@ -1147,28 +1129,21 @@ class MemberFlows(object):
             requires=constants.DELTAS, provides=constants.ADDED_PORTS))
         # managing interface additions here
         if topology == constants.TOPOLOGY_SINGLE:
-            batch_update_members_flow.add(
-                vthunder_tasks.AmphoraePostMemberNetworkPlug(
-                    requires=(
-                        constants.LOADBALANCER,
-                        constants.ADDED_PORTS,
-                        a10constants.VTHUNDER)))
+            batch_update_members_flow.add(vthunder_tasks.AmphoraePostMemberNetworkPlug(
+                requires=(constants.LOADBALANCER, constants.ADDED_PORTS,
+                          a10constants.VTHUNDER)))
             batch_update_members_flow.add(vthunder_tasks.VThunderComputeConnectivityWait(
                 name=a10constants.VTHUNDER_CONNECTIVITY_WAIT,
                 requires=(a10constants.VTHUNDER, constants.AMPHORA)))
-            batch_update_members_flow.add(
-                vthunder_tasks.EnableInterfaceForMembers(
-                    requires=[
-                        constants.ADDED_PORTS,
-                        constants.LOADBALANCER,
-                        a10constants.VTHUNDER]))
+            batch_update_members_flow.add(vthunder_tasks.EnableInterfaceForMembers(
+                requires=[constants.ADDED_PORTS, constants.LOADBALANCER,
+                          a10constants.VTHUNDER]))
         # configure member flow for HA
         if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
-            batch_update_members_flow.add(
-                a10_database_tasks.GetBackupVThunderByLoadBalancer(
-                    name="get_backup_vThunder",
-                    requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
-                    provides=a10constants.BACKUP_VTHUNDER))
+            batch_update_members_flow.add(a10_database_tasks.GetBackupVThunderByLoadBalancer(
+                name="get_backup_vThunder",
+                requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
+                provides=a10constants.BACKUP_VTHUNDER))
             batch_update_members_flow.add(vthunder_tasks.VThunderComputeConnectivityWait(
                 name="backup_compute_conn_wait_before_probe_device",
                 requires=constants.AMPHORA,
@@ -1176,17 +1151,13 @@ class MemberFlows(object):
             batch_update_members_flow.add(vthunder_tasks.VCSSyncWait(
                 name="vcs_sync_wait_before_probe_device",
                 requires=a10constants.VTHUNDER))
-            batch_update_members_flow.add(
-                vthunder_tasks.AmphoraePostMemberNetworkPlug(
-                    requires=(
-                        constants.LOADBALANCER,
-                        constants.ADDED_PORTS,
-                        a10constants.VTHUNDER)))
-            batch_update_members_flow.add(
-                vthunder_tasks.AmphoraePostMemberNetworkPlug(
-                    name="backup_amphora_network_plug", requires=[
-                        constants.ADDED_PORTS, constants.LOADBALANCER], rebind={
-                        a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
+            batch_update_members_flow.add(vthunder_tasks.AmphoraePostMemberNetworkPlug(
+                requires=(constants.LOADBALANCER, constants.ADDED_PORTS,
+                          a10constants.VTHUNDER)))
+            batch_update_members_flow.add(vthunder_tasks.AmphoraePostMemberNetworkPlug(
+                name="backup_amphora_network_plug",
+                requires=[constants.ADDED_PORTS, constants.LOADBALANCER],
+                rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
             batch_update_members_flow.add(vthunder_tasks.VThunderComputeConnectivityWait(
                 name=a10constants.MASTER_CONNECTIVITY_WAIT,
                 requires=(a10constants.VTHUNDER, constants.AMPHORA)))
@@ -1205,13 +1176,10 @@ class MemberFlows(object):
                 name="get_backup_vThunder_after_get_master",
                 requires=(constants.LOADBALANCER, a10constants.VTHUNDER),
                 provides=a10constants.BACKUP_VTHUNDER))
-            batch_update_members_flow.add(
-                vthunder_tasks.EnableInterfaceForMembers(
-                    name=a10constants.ENABLE_MASTER_VTHUNDER_INTERFACE,
-                    requires=[
-                        constants.ADDED_PORTS,
-                        constants.LOADBALANCER,
-                        a10constants.VTHUNDER]))
+            batch_update_members_flow.add(vthunder_tasks.EnableInterfaceForMembers(
+                name=a10constants.ENABLE_MASTER_VTHUNDER_INTERFACE,
+                requires=[constants.ADDED_PORTS, constants.LOADBALANCER,
+                          a10constants.VTHUNDER]))
             batch_update_members_flow.add(vthunder_tasks.AmphoraePostMemberNetworkPlug(
                 name="amphorae-post-member-network-plug-for-master",
                 requires=(constants.LOADBALANCER, constants.ADDED_PORTS,
@@ -1223,8 +1191,7 @@ class MemberFlows(object):
             batch_update_members_flow.add(
                 vthunder_tasks.VThunderComputeConnectivityWait(
                     name=a10constants.CONNECTIVITY_WAIT_FOR_BACKUP_VTHUNDER,
-                    rebind={
-                        a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
+                    rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
                     requires=constants.AMPHORA))
             batch_update_members_flow.add(vthunder_tasks.VCSSyncWait(
                 name="member_enable_interface_vcs_sync_wait",
@@ -1233,12 +1200,9 @@ class MemberFlows(object):
                 name=a10constants.GET_VTHUNDER_MASTER,
                 requires=a10constants.VTHUNDER,
                 provides=a10constants.VTHUNDER))
-            batch_update_members_flow.add(
-                vthunder_tasks.EnableInterfaceForMembers(
-                    requires=[
-                        constants.ADDED_PORTS,
-                        constants.LOADBALANCER,
-                        a10constants.VTHUNDER]))
+            batch_update_members_flow.add(vthunder_tasks.EnableInterfaceForMembers(
+                requires=[constants.ADDED_PORTS, constants.LOADBALANCER,
+                          a10constants.VTHUNDER]))
         existing_members = [m[0] for m in updated_members]
         pool_members = new_members + existing_members
         if pool_members:

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -997,6 +997,11 @@ class MemberFlows(object):
         batch_update_members_flow.add(a10_network_tasks.GetPoolsOnThunder(
             requires=[a10constants.VTHUNDER, a10constants.USE_DEVICE_FLAVOR],
             provides=a10constants.POOLS))
+        batch_update_members_flow.add(server_tasks.MemberFindNatPool(
+            name='find-nat-pool-for-member',
+            requires=[a10constants.VTHUNDER,
+                      constants.POOL, constants.FLAVOR],
+            provides=a10constants.NAT_FLAVOR))
         batch_update_members_flow.add(
             lifecycle_tasks.MembersToErrorOnRevertTask(
                 inject={constants.MEMBERS: old_members},
@@ -1019,12 +1024,6 @@ class MemberFlows(object):
                     inject={constants.MEMBER: m},
                     requires=constants.POOL,
                     provides=a10constants.MEMBER_COUNT_IP_PORT_PROTOCOL))
-            batch_update_members_flow.add(server_tasks.MemberFindNatPool(
-                name='find-nat-pool' + m.id,
-                inject={constants.MEMBER: m},
-                requires=[constants.MEMBER, a10constants.VTHUNDER,
-                          constants.POOL, constants.FLAVOR],
-                provides=a10constants.NAT_FLAVOR))
             batch_update_members_flow.add(a10_database_tasks.GetNatPoolEntry(
                 name='get-nat-pool' + m.id,
                 inject={constants.MEMBER: m},


### PR DESCRIPTION
## Description
Added basic support for batch update members feature for vthunder flows.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2925
https://a10networks.atlassian.net/browse/STACK-2902
https://a10networks.atlassian.net/browse/STACK-2903
https://a10networks.atlassian.net/browse/STACK-2904
https://a10networks.atlassian.net/browse/STACK-2917


## Technical Approach
- Added suport for **get_batch_update_members_flow** in controller_worker.py
- Created a flow **get_batch_update_members_flow** in a10_member_flows for batch member update.
- Added tasks for handling member create, delete and update operation inside  **get_batch_update_members_flow**.
- Added support for the active standby topology as well.
- Added support for VRID and NAT POOL configuration

## Manual Testing

**Single topology:**

**Create a loadbalancer, listener, pool and members:**

```
**stack@automation-1:~#openstack loadbalancer list**

+--------------------------------------+------+----------------------------------+--------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address  | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+--------------+---------------------+----------+
| fea5b69b-5a47-4beb-8321-d839943c9eb3 | lb1  | 65246d947f8543eb85382f3107110eaf | 172.16.0.253 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+--------------+---------------------+----------+

```
```
**stack@automation-1:~#openstack loadbalancer listener list**

+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| id                                   | default_pool_id                      | name | project_id                       | protocol | protocol_port | admin_state_up |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| 697eb1b1-cb89-419f-9f29-969637c33de7 | ac857d32-b9da-4af8-b916-67010a94b15f | l1   | 65246d947f8543eb85382f3107110eaf | TCP      |            90 | True           |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
```

```
**stack@automation-1:~#openstack loadbalancer pool list**

+--------------------------------------+-------+----------------------------------+---------------------+----------+--------------+----------------+
| id                                   | name  | project_id                       | provisioning_status | protocol | lb_algorithm | admin_state_up |
+--------------------------------------+-------+----------------------------------+---------------------+----------+--------------+----------------+
| ac857d32-b9da-4af8-b916-67010a94b15f | pool1 | 65246d947f8543eb85382f3107110eaf | ACTIVE              | TCP      | SOURCE_IP    | True           |
+--------------------------------------+-------+----------------------------------+---------------------+----------+--------------+----------------+
stack@automation-1:~#
```

```
**stack@automation-1:~#openstack loadbalancer member list pool1**

+--------------------------------------+---------------------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
| id                                   | name                | project_id                       | provisioning_status | address      | protocol_port | operating_status | weight |
+--------------------------------------+---------------------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
| 4d07b569-ab1e-4da8-ae79-99e689bf1e5a | test_member1_update | 65246d947f8543eb85382f3107110eaf | ACTIVE              | 172.16.0.5   |            85 | NO_MONITOR       |     40 |
| df07f739-88e2-4e65-9212-248bdcbc2a0e | test_member1_update | 65246d947f8543eb85382f3107110eaf | ACTIVE              | 192.168.11.3 |            84 | NO_MONITOR       |     10 |
| bb2512d2-49f2-4914-b0e4-7869d7704589 | test_member1_update | 65246d947f8543eb85382f3107110eaf | ACTIVE              | 192.168.11.4 |            85 | NO_MONITOR       |     10 |
+--------------------------------------+---------------------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
stack@automation-1:~#
```

**vThunder Configuration:**

vThunder(NOLICENSE)#**show running-config**
!Current configuration: 99 bytes
!Configuration last updated at 12:59:00 IST Fri Sep 17 2021
!Configuration last saved at 12:59:03 IST Fri Sep 17 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2
  name DataPort
  enable
  ip address dhcp
!
!
slb server 65246_172_16_0_5 172.16.0.5
  port 85 tcp
!
slb server 65246_192_168_11_3 192.168.11.3
  port 84 tcp
!
slb server 65246_192_168_11_4 192.168.11.4
  port 85 tcp
!
slb service-group ac857d32-b9da-4af8-b916-67010a94b15f tcp
  method src-ip-only-hash
  member 65246_172_16_0_5 85
  member 65246_192_168_11_3 84
  member 65246_192_168_11_4 85
!
slb virtual-server fea5b69b-5a47-4beb-8321-d839943c9eb3 172.16.0.253
  port 90 tcp
    name 697eb1b1-cb89-419f-9f29-969637c33de7
    extended-stats
    service-group ac857d32-b9da-4af8-b916-67010a94b15f
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#

**Terraform Script:**

```
terraform {

  required_providers {

    openstack = {

      source = "terraform-provider-openstack/openstack"

      version = "1.43.0"

    }

  }

}

provider "openstack" {

  user_name = "admin"

  tenant_name = "admin"

  password = "password"

  auth_url = "http://10.64.3.135/identity"

  use_octavia = true

}

resource "openstack_lb_members_v2" "members_1" {

  pool_id = "ac857d32-b9da-4af8-b916-67010a94b15f"

  member {

    address       = "172.16.0.5"

    protocol_port = 85

    subnet_id     = "6753e515-8ea3-4fa8-85ec-fedc836f1527"

    name          = "test_member1_update_admin_state"

    weight        = 40

    admin_state_up = false

  }
  member {

    address       = "192.168.11.3"

    protocol_port = 84

    subnet_id     = "6c19bcd0-8204-4266-b9ea-b52ec12d03d2"

    name          = "test_member1_update"

    weight        = 20

  }

  member {

    address       = "192.168.11.6"

    protocol_port = 86

    subnet_id     = "37fa494f-c126-412e-8596-d9b7e4022a55"

    name          = "test_member1_update"

    weight        = 10

  }

}
```

**stack@automation-1:~#terraform apply**
         
**Result:**

- Created a new member **192.168.11.6** with  86 port
- Updated members  **172.16.0.5** and **192.168.11.3**
- Deleted a member **192.168.11.4**

```
**stack@automation-1:~#openstack loadbalancer member list pool1**

+--------------------------------------+---------------------------------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
| id                                   | name                            | project_id                       | provisioning_status | address      | protocol_port | operating_status | weight |
+--------------------------------------+---------------------------------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
| 4d07b569-ab1e-4da8-ae79-99e689bf1e5a | test_member1_update_admin_state | 65246d947f8543eb85382f3107110eaf | ACTIVE              | 172.16.0.5   |            85 | NO_MONITOR       |     40 |
| df07f739-88e2-4e65-9212-248bdcbc2a0e | test_member1_update             | 65246d947f8543eb85382f3107110eaf | ACTIVE              | 192.168.11.3 |            84 | NO_MONITOR       |     20 |
| 484e88f2-727b-4c8b-ae64-2e6afd24ad13 | test_member1_update             | 65246d947f8543eb85382f3107110eaf | ACTIVE              | 192.168.11.6 |            86 | NO_MONITOR       |     10 |
+--------------------------------------+---------------------------------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
stack@automation-1:~#

```
**vThunder Configuration:**


vThunder(NOLICENSE)#show running-config
!Current configuration: 99 bytes
!Configuration last updated at 13:08:11 IST Fri Sep 17 2021
!Configuration last saved at 13:08:14 IST Fri Sep 17 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 3
  name DataPort
  enable
  ip address dhcp
!
!
slb server 65246_172_16_0_5 172.16.0.5
  disable
  port 85 tcp
!
slb server 65246_192_168_11_3 192.168.11.3
  port 84 tcp
!
slb server 65246_192_168_11_6 192.168.11.6
  port 86 tcp
!
slb service-group ac857d32-b9da-4af8-b916-67010a94b15f tcp
  method src-ip-only-hash
  member 65246_172_16_0_5 85
  member 65246_192_168_11_3 84
  member 65246_192_168_11_6 86
!
slb virtual-server fea5b69b-5a47-4beb-8321-d839943c9eb3 172.16.0.253
  port 90 tcp
    name 697eb1b1-cb89-419f-9f29-969637c33de7
    extended-stats
    service-group ac857d32-b9da-4af8-b916-67010a94b15f
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#


vThunder(NOLICENSE)#show json-config slb server

a10-url:/axapi/v3/slb/server
{
  "server-list": [
    {
      "name":"65246_172_16_0_5",
      "host":"172.16.0.5",
      "action":"disable",
      "uuid":"49e8d0f4-16ef-11ec-a118-fa163e7911ca",
      "port-list": [
        {
          "port-number":85,
          "protocol":"tcp",
          "uuid":"49eb8100-16ef-11ec-a118-fa163e7911ca"
        }
      ]
    }
  ]
}

**Active Standby:**
```

**stack@automation-1:~#openstack loadbalancer list**

+--------------------------------------+------+----------------------------------+--------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address  | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+--------------+---------------------+----------+
| 9ec35795-04a2-49c0-af4b-3eac7f23fcc3 | lb1  | 65246d947f8543eb85382f3107110eaf | 172.16.0.252 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+--------------+---------------------+----------+
stack@automation-1:~#
```


```
**stack@automation-1:~#openstack server list**

+--------------------------------------+----------------------------------------------+--------+-------------------------------------------------+----------------------+-----------------+
| ID                                   | Name                                         | Status | Networks                                        | Image                | Flavor          |
+--------------------------------------+----------------------------------------------+--------+-------------------------------------------------+----------------------+-----------------+
| ee127cf5-cb51-40d4-be08-6526d7ff66b4 | amphora-67f3dda7-02a6-4226-bdc3-1f3ca19f375f | ACTIVE | lb-mgmt-net=192.168.0.116; private=172.16.0.49  | vThunder_5_2_1-p1_56 | vThunder_flavor |
| ee0916fc-e755-4feb-ae69-aaf9fad5f100 | amphora-cd50f518-f052-4782-ac61-ef61c512b3b8 | ACTIVE | lb-mgmt-net=192.168.0.112; private=172.16.0.207 | vThunder_5_2_1-p1_56 | vThunder_flavor |
+--------------------------------------+----------------------------------------------+--------+-------------------------------------------------+----------------------+-----------------+
stack@automation-1:~#

```

```
**stack@automation-1:~#openstack loadbalancer listener list**

+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| id                                   | default_pool_id                      | name | project_id                       | protocol | protocol_port | admin_state_up |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| f4aa38d7-5911-492f-a551-48c523e197dc | b426a5e8-4d0d-403a-bae2-b08753b11f8a |      | 65246d947f8543eb85382f3107110eaf | HTTP     |            90 | True           |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
stack@automation-1:~#
```


```
**stack@automation-1:~#openstack loadbalancer pool list**

+--------------------------------------+------+----------------------------------+---------------------+----------+--------------+----------------+
| id                                   | name | project_id                       | provisioning_status | protocol | lb_algorithm | admin_state_up |
+--------------------------------------+------+----------------------------------+---------------------+----------+--------------+----------------+
| b426a5e8-4d0d-403a-bae2-b08753b11f8a |      | 65246d947f8543eb85382f3107110eaf | ACTIVE              | HTTP     | SOURCE_IP    | True           |
+--------------------------------------+------+----------------------------------+---------------------+----------+--------------+----------------+

```

```
**stack@automation-1:~#openstack loadbalancer member list b426a5e8-4d0d-403a-bae2-b08753b11f8a**

+--------------------------------------+---------------------------------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| id                                   | name                            | project_id                       | provisioning_status | address    | protocol_port | operating_status | weight |
+--------------------------------------+---------------------------------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| 53ffa78a-abd8-49f8-bbb3-267b30a25bb5 | test_member1_update_admin_state | 65246d947f8543eb85382f3107110eaf | ACTIVE              | 172.16.0.2 |            83 | NO_MONITOR       |     40 |
| 08dfd9c7-657f-46c4-a271-e7858e299a82 | test_member1_update_admin_state | 65246d947f8543eb85382f3107110eaf | ACTIVE              | 172.16.0.3 |            84 | NO_MONITOR       |     40 |
+--------------------------------------+---------------------------------+----------------------------------+---------------------+------------+---------------+------------------+--------+
stack@automation-1:~#
```

**Terrform script:**

```
terraform {

  required_providers {

    openstack = {

      source = "terraform-provider-openstack/openstack"

      version = "1.43.0"

    }

  }

}

provider "openstack" {

  user_name = "admin"

  tenant_name = "admin"

  password = "password"

  auth_url = "http://10.64.3.135/identity"

  use_octavia = true

}


resource "openstack_lb_members_v2" "members_1" {

  pool_id = "b426a5e8-4d0d-403a-bae2-b08753b11f8a"

  member {

    address       = "172.16.0.2"

    protocol_port = 83

    subnet_id     = "6753e515-8ea3-4fa8-85ec-fedc836f1527"

    name          = "test_member1_update_admin_state"

    weight        = 30

    admin_state_up = true
  }
  member {

    address       = "172.16.0.4"

    protocol_port = 85

    subnet_id     = "6753e515-8ea3-4fa8-85ec-fedc836f1527"

    name          = "test_member1_update_admin_state"

    weight        = 40

    admin_state_up = false
  }
}
```
            
**Result:**
 
Created a member: **172.16.0.4**
Update a member: **172.16.0.2**
Deleted a member: 172.16.0.3

```
stack@automation-1:~#openstack loadbalancer member list b426a5e8-4d0d-403a-bae2-b08753b11f8a

+--------------------------------------+---------------------------------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| id                                   | name                            | project_id                       | provisioning_status | address    | protocol_port | operating_status | weight |
+--------------------------------------+---------------------------------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| 53ffa78a-abd8-49f8-bbb3-267b30a25bb5 | test_member1_update_admin_state | 65246d947f8543eb85382f3107110eaf | ACTIVE              | 172.16.0.2 |            83 | NO_MONITOR       |     30 |
| 14fe9e98-6a77-4952-a2ae-fbd364ff6940 | test_member1_update_admin_state | 65246d947f8543eb85382f3107110eaf | ACTIVE              | 172.16.0.4 |            85 | NO_MONITOR       |     40 |
+--------------------------------------+---------------------------------+----------------------------------+---------------------+------------+---------------+------------------+--------+
stack@automation-1:~#
```


**Vthunder Configuration**

vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 601 bytes
!Configuration last updated at 13:44:54 IST Mon Sep 20 2021
!Configuration last saved at 13:44:58 IST Mon Sep 20 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.135
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server 65246_172_16_0_2 172.16.0.2
  port 83 tcp
!
slb server 65246_172_16_0_4 172.16.0.4
  disable
  port 85 tcp
!
slb server octavia_health_manager_controller 10.64.3.135
  health-check octavia_health_monitor
!
slb service-group b426a5e8-4d0d-403a-bae2-b08753b11f8a tcp
  method src-ip-only-hash
  member 65246_172_16_0_2 83
  member 65246_172_16_0_4 85
!
slb virtual-server 9ec35795-04a2-49c0-af4b-3eac7f23fcc3 172.16.0.252
  port 90 http
    name f4aa38d7-5911-492f-a551-48c523e197dc
    extended-stats
    service-group b426a5e8-4d0d-403a-bae2-b08753b11f8a
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder-Active-vMaster[1/1](NOLICENSE)#


**vBlade Configuration:**

vThunder-Standby-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 601 bytes
!Configuration last updated at 13:44:54 IST Mon Sep 20 2021
!Configuration last saved at 13:27:08 IST Mon Sep 20 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.135
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server 65246_172_16_0_2 172.16.0.2
  port 83 tcp
!
slb server 65246_172_16_0_4 172.16.0.4
  disable
  port 85 tcp
!
slb server octavia_health_manager_controller 10.64.3.135
  health-check octavia_health_monitor
!
slb service-group b426a5e8-4d0d-403a-bae2-b08753b11f8a tcp
  method src-ip-only-hash
  member 65246_172_16_0_2 83
  member 65246_172_16_0_4 85
!
slb virtual-server 9ec35795-04a2-49c0-af4b-3eac7f23fcc3 172.16.0.252
  port 90 http
    name f4aa38d7-5911-492f-a551-48c523e197dc
    extended-stats
    service-group b426a5e8-4d0d-403a-bae2-b08753b11f8a
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder-Standby-vBlade[1/2](NOLICENSE)#


**VRID configuration**

**TOPOLOGY:**   SINGLE

```
**stack@automation-1:~#openstack loadbalancer list**

+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| a2bee6f2-99c7-4667-aa89-2d3d111d1f0b | lb1  | 65246d947f8543eb85382f3107110eaf | 172.16.0.15 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
stack@automation-1:~#
```

```
**stack@automation-1:~#openstack loadbalancer listener list**

+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| id                                   | default_pool_id                      | name | project_id                       | protocol | protocol_port | admin_state_up |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| 96cacc1c-fb1d-44d4-bf82-6a86c8862b0a | 6dece87d-c26f-417f-9461-09090a14cd43 |      | 65246d947f8543eb85382f3107110eaf | HTTP     |            90 | True           |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
stack@automation-1:~#
```

```
**stack@automation-1:~#openstack loadbalancer pool list**

+--------------------------------------+-------+----------------------------------+---------------------+----------+--------------+----------------+
| id                                   | name  | project_id                       | provisioning_status | protocol | lb_algorithm | admin_state_up |
+--------------------------------------+-------+----------------------------------+---------------------+----------+--------------+----------------+
| 6dece87d-c26f-417f-9461-09090a14cd43 | pool1 | 65246d947f8543eb85382f3107110eaf | ACTIVE              | HTTP     | SOURCE_IP    | True           |
+--------------------------------------+-------+----------------------------------+---------------------+----------+--------------+----------------+
stack@automation-1:~#
```

```
**stack@automation-1:~#openstack loadbalancer member list pool1**

+--------------------------------------+---------------------------------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
| id                                   | name                            | project_id                       | provisioning_status | address      | protocol_port | operating_status | weight |
+--------------------------------------+---------------------------------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
| 2e67066a-f26a-4c79-9e9a-93deaa9085c4 | test_member1_update_admin_state | 65246d947f8543eb85382f3107110eaf | ACTIVE              | 172.16.0.3   |            83 | NO_MONITOR       |     30 |
+--------------------------------------+---------------------------------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
```


**Terraform Script:**

```
terraform {

  required_providers {

    openstack = {

      source = "terraform-provider-openstack/openstack"

      version = "1.43.0"

    }

  }

}

provider "openstack" {

  user_name = "admin"

  tenant_name = "admin"

  password = "password"

  auth_url = "http://10.64.3.135/identity"

  use_octavia = true

}

resource "openstack_lb_members_v2" "members_1" {

  pool_id = "6dece87d-c26f-417f-9461-09090a14cd43"

  member {

    address       = "172.16.0.3"

    protocol_port = 83

    subnet_id     = "6753e515-8ea3-4fa8-85ec-fedc836f1527"

    name          = "member1_update_admin_state"

    weight        = 30

    admin_state_up = true
  }
  member {

    address       = "192.168.11.3"

    protocol_port = 84

    subnet_id     = "6c19bcd0-8204-4266-b9ea-b52ec12d03d2"

    name          = "test_member1_update"

    weight        = 10

  }

```
**Result:**

**Updated Member:** 172.16.0.3
**Created New member:** 192.168.11.3 and with creation vrid floating ip also got configured

**stack@automation-1:~#openstack loadbalancer member list pool1**

+--------------------------------------+---------------------------------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
| id                                   | name                            | project_id                       | provisioning_status | address      | protocol_port | operating_status | weight |
+--------------------------------------+---------------------------------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
| 2e67066a-f26a-4c79-9e9a-93deaa9085c4 | test_member1_update_admin_state | 65246d947f8543eb85382f3107110eaf | ACTIVE              | 172.16.0.3   |            83 | NO_MONITOR       |     30 |
| 5d89556c-b936-46b9-a105-afddace6a0e2 | test_member1_update             | 65246d947f8543eb85382f3107110eaf | ACTIVE              | 192.168.11.3 |            84 | NO_MONITOR       |     10 |
+--------------------------------------+---------------------------------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
stack@automation-1:~#


**vThunder Configuration:**

vThunder(NOLICENSE)#show running-config
!Current configuration: 99 bytes
!Configuration last updated at 08:48:21 IST Wed Sep 22 2021
!Configuration last saved at 08:48:24 IST Wed Sep 22 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2
  name DataPort
  enable
  ip address dhcp
!
**vrrp-a vrid 0
  floating-ip 172.16.0.20
  floating-ip 192.168.11.245**
!
slb server 65246_172_16_0_3 172.16.0.3
  port 83 tcp
!
slb server 65246_192_168_11_3 192.168.11.3
  port 84 tcp
!
slb service-group 6dece87d-c26f-417f-9461-09090a14cd43 tcp
  method src-ip-only-hash
  member 65246_172_16_0_3 83
  member 65246_192_168_11_3 84
!
slb virtual-server a2bee6f2-99c7-4667-aa89-2d3d111d1f0b 172.16.0.15
  port 90 http
    name 96cacc1c-fb1d-44d4-bf82-6a86c8862b0a
    extended-stats
    service-group 6dece87d-c26f-417f-9461-09090a14cd43
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#


**Terraform Script:**

```
terraform {

  required_providers {

    openstack = {

      source = "terraform-provider-openstack/openstack"

      version = "1.43.0"

    }

  }

}

provider "openstack" {

  user_name = "admin"

  tenant_name = "admin"

  password = "password"

  auth_url = "http://10.64.3.135/identity"

  use_octavia = true

}

resource "openstack_lb_members_v2" "members_1" {

  pool_id = "6dece87d-c26f-417f-9461-09090a14cd43"

  member {

    address       = "172.16.0.3"

    protocol_port = 83

    subnet_id     = "6753e515-8ea3-4fa8-85ec-fedc836f1527"

    name          = "test_member1_update_admin_state"

    weight        = 30

    admin_state_up = true
  }

}
```
**Result:**

**Updated Member:** 172.16.0.3
**Deleted member:** 192.168.11.3 and with deletion vrid floating ip also got removed
  
**Openstack:**

```
**stack@automation-1:~#openstack loadbalancer member list pool1**

+--------------------------------------+---------------------------------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| id                                   | name                            | project_id                       | provisioning_status | address    | protocol_port | operating_status | weight |
+--------------------------------------+---------------------------------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| 2e67066a-f26a-4c79-9e9a-93deaa9085c4 | test_member1_update_admin_state | 65246d947f8543eb85382f3107110eaf | ACTIVE              | 172.16.0.3 |            83 | NO_MONITOR       |     30 |
+--------------------------------------+---------------------------------+----------------------------------+---------------------+------------+---------------+------------------+--------+
stack@automation-1:~#
```

  
**Vthunder Configuration:**

vThunder(NOLICENSE)#show running-config
!Current configuration: 99 bytes
!Configuration last updated at 08:55:48 IST Wed Sep 22 2021
!Configuration last saved at 08:55:51 IST Wed Sep 22 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
**vrrp-a vrid 0
  floating-ip 172.16.0.20
!**
slb server 65246_172_16_0_3 172.16.0.3
  port 83 tcp
!
slb service-group 6dece87d-c26f-417f-9461-09090a14cd43 tcp
  method src-ip-only-hash
  member 65246_172_16_0_3 83
!
slb virtual-server a2bee6f2-99c7-4667-aa89-2d3d111d1f0b 172.16.0.15
  port 90 http
    name 96cacc1c-fb1d-44d4-bf82-6a86c8862b0a
    extended-stats
    service-group 6dece87d-c26f-417f-9461-09090a14cd43
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#


**Topology: ACTIVE STANDBY**

```
stack@automation-1:~#openstack loadbalancer create --name lb1 --vip-subnet-id vip_subnet

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-09-22T12:40:14                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 9ce4ebae-7e42-45be-af2a-f4139dd164e3 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 65246d947f8543eb85382f3107110eaf     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.12.111                       |
| vip_network_id      | 37aad4f9-5536-42ea-9f4d-263717bde468 |
| vip_port_id         | 8aa616c8-49db-4d8f-8b9c-c1d0d3540063 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 37fa494f-c126-412e-8596-d9b7e4022a55 |
+---------------------+--------------------------------------+
stack@automation-1:~#
```

```
**stack@automation-1:~#openstack loadbalancer listener create --name l1 --protocol http --protocol-port 85 lb1**

+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-09-22T12:49:45                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 92b2540c-c66d-4635-9ff8-9b9cc3e0f398 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 9ce4ebae-7e42-45be-af2a-f4139dd164e3 |
| name                        | l1                                   |
| operating_status            | OFFLINE                              |
| project_id                  | 65246d947f8543eb85382f3107110eaf     |
| protocol                    | HTTP                                 |
| protocol_port               | 85                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
+-----------------------------+--------------------------------------+
stack@automation-1:~#
```


```
**stack@automation-1:~#openstack loadbalancer pool create --name p1 --protocol HTTP --lb-algorithm LEAST_CONNECTIONS --listener l1**

+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-09-22T12:50:37                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | 0100a117-6c72-4226-a188-dae30822e969 |
| lb_algorithm         | LEAST_CONNECTIONS                    |
| listeners            | 92b2540c-c66d-4635-9ff8-9b9cc3e0f398 |
| loadbalancers        | 9ce4ebae-7e42-45be-af2a-f4139dd164e3 |
| members              |                                      |
| name                 | p1                                   |
| operating_status     | OFFLINE                              |
| project_id           | 65246d947f8543eb85382f3107110eaf     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
+----------------------+--------------------------------------+
stack@automation-1:~#
```


**vThunder Configuration:**

vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 688 bytes
!Configuration last updated at 13:50:37 IST Wed Sep 22 2021
!Configuration last saved at 13:50:39 IST Wed Sep 22 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 192.168.12.17
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.135
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.135
  health-check octavia_health_monitor
!
slb service-group 0100a117-6c72-4226-a188-dae30822e969 tcp
  method least-connection
!
slb virtual-server 9ce4ebae-7e42-45be-af2a-f4139dd164e3 192.168.12.111
  port 85 http
    name 92b2540c-c66d-4635-9ff8-9b9cc3e0f398
    extended-stats
    service-group 0100a117-6c72-4226-a188-dae30822e969
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder-Active-vMaster[1/1](NOLICENSE)#


vThunder-Standby-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 688 bytes
!Configuration last updated at 13:50:36 IST Wed Sep 22 2021
!Configuration last saved at 13:44:25 IST Wed Sep 22 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
**vrrp-a vrid 0
  floating-ip 192.168.12.17**
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.135
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.135
  health-check octavia_health_monitor
!
slb service-group 0100a117-6c72-4226-a188-dae30822e969 tcp
  method least-connection
!
slb virtual-server 9ce4ebae-7e42-45be-af2a-f4139dd164e3 192.168.12.111
  port 85 http
    name 92b2540c-c66d-4635-9ff8-9b9cc3e0f398
    extended-stats
    service-group 0100a117-6c72-4226-a188-dae30822e969
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder-Standby-vBlade[1/2](NOLICENSE)#


**Terraform script:**

```
terraform {

  required_providers {

    openstack = {

      source = "terraform-provider-openstack/openstack"

      version = "1.43.0"

    }

  }

}



provider "openstack" {

  user_name = "admin"

  tenant_name = "admin"

  password = "password"

  auth_url = "http://10.64.3.135/identity"

  use_octavia = true

}

resource "openstack_lb_members_v2" "members_1" {

  pool_id = "0100a117-6c72-4226-a188-dae30822e969"

  member {

    address       = "192.168.11.5"

    protocol_port = 85

    subnet_id     = "6c19bcd0-8204-4266-b9ea-b52ec12d03d2"

    name          = "m1"

    weight        = 10

  }
  member {

    address       = "10.0.11.4"

    protocol_port = 84

    subnet_id     = "fea07409-804f-4839-9c21-27fa4174383b"

    name          = "m1"

    weight        = 10

  }

}
```

**Result:**

Created New members: **192.168.11.5** and **10.0.11.4** with creation vrid floating ip also got configured respectively for both 

```
**stack@automation-1:~#openstack loadbalancer member list p1**

+--------------------------------------+------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address      | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
| 515658aa-ba11-4c8c-8896-6652c9515edb | m1   | 65246d947f8543eb85382f3107110eaf | ACTIVE              | 192.168.11.5 |            85 | NO_MONITOR       |     10 |
| 1da62826-62ae-4ade-8b2f-fcaa8a5660cd | m1   | 65246d947f8543eb85382f3107110eaf | ACTIVE              | 10.0.11.4    |            84 | NO_MONITOR       |     10 |
+--------------------------------------+------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
stack@automation-1:~#

```

**vThunder Configuration:**

**vMaster Configuration:**

vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 601 bytes
!Configuration last updated at 14:22:08 IST Wed Sep 22 2021
!Configuration last saved at 14:22:11 IST Wed Sep 22 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
**vrrp-a vrid 0
  floating-ip 192.168.12.17
  floating-ip 10.0.11.200
  floating-ip 192.168.11.178**
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.135
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server 65246_10_0_11_4 10.0.11.4
  port 84 tcp
!
slb server 65246_192_168_11_5 192.168.11.5
  port 85 tcp
!
slb server octavia_health_manager_controller 10.64.3.135
  health-check octavia_health_monitor
!
slb service-group 0100a117-6c72-4226-a188-dae30822e969 tcp
  method least-connection
  member 65246_10_0_11_4 84
  member 65246_192_168_11_5 85
!
slb virtual-server 9ce4ebae-7e42-45be-af2a-f4139dd164e3 192.168.12.111
  port 85 http
    name 92b2540c-c66d-4635-9ff8-9b9cc3e0f398
    extended-stats
    service-group 0100a117-6c72-4226-a188-dae30822e969
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder-Active-vMaster[1/1](NOLICENSE)#

**vBlade Configuration:**

vThunder-Standby-vBlade[1/2](NOLICENSE)#show running-config
!Current configuration: 601 bytes
!Configuration last updated at 14:22:08 IST Wed Sep 22 2021
!Configuration last saved at 14:19:11 IST Wed Sep 22 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/3
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/3
  name DataPort
  enable
  ip address dhcp
!
**vrrp-a vrid 0
  floating-ip 192.168.12.17
  floating-ip 10.0.11.200
  floating-ip 192.168.11.178
!**
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.135
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server 65246_10_0_11_4 10.0.11.4
  port 84 tcp
!
slb server 65246_192_168_11_5 192.168.11.5
  port 85 tcp
!
slb server octavia_health_manager_controller 10.64.3.135
  health-check octavia_health_monitor
!
slb service-group 0100a117-6c72-4226-a188-dae30822e969 tcp
  method least-connection
  member 65246_10_0_11_4 84
  member 65246_192_168_11_5 85
!
slb virtual-server 9ce4ebae-7e42-45be-af2a-f4139dd164e3 192.168.12.111
  port 85 http
    name 92b2540c-c66d-4635-9ff8-9b9cc3e0f398
    extended-stats
    service-group 0100a117-6c72-4226-a188-dae30822e969
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder-Standby-vBlade[1/2](NOLICENSE)#


**Terraform Script:**

```
terraform {

  required_providers {

    openstack = {

      source = "terraform-provider-openstack/openstack"

      version = "1.43.0"

    }

  }

}

provider "openstack" {

  user_name = "admin"

  tenant_name = "admin"

  password = "password"

  auth_url = "http://10.64.3.135/identity"

  use_octavia = true

}

resource "openstack_lb_members_v2" "members_1" {

  pool_id = "0100a117-6c72-4226-a188-dae30822e969"

  member {

    address       = "192.168.11.5"

    protocol_port = 85

    subnet_id     = "6c19bcd0-8204-4266-b9ea-b52ec12d03d2"

    name          = "m1"

    weight        = 10

  }

}
```
**Result:**

**Updated Member:** 192.168.11.5
**Deleted member:** 10.0.11.4 and with deletion vrid floating ip also got removed


**Openstack:**

```
**stack@automation-1:~#openstack loadbalancer member list p1**

+--------------------------------------+------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address      | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
| 515658aa-ba11-4c8c-8896-6652c9515edb | m1   | 65246d947f8543eb85382f3107110eaf | ACTIVE              | 192.168.11.5 |            85 | NO_MONITOR       |     10 |
+--------------------------------------+------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
stack@automation-1:~#
```

**vMaster Configuration:**

vThunder-Active-vBlade[1/1](NOLICENSE)#show running-config
!Current configuration: 601 bytes
!Configuration last updated at 14:36:32 IST Wed Sep 22 2021
!Configuration last saved at 14:33:36 IST Wed Sep 22 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
**vrrp-a vrid 0
  floating-ip 192.168.12.17
  floating-ip 192.168.11.178**
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.135
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server 65246_192_168_11_5 192.168.11.5
  port 85 tcp
!
slb server octavia_health_manager_controller 10.64.3.135
  health-check octavia_health_monitor
!
slb service-group 0100a117-6c72-4226-a188-dae30822e969 tcp
  method least-connection
  member 65246_192_168_11_5 85
!
slb virtual-server 9ce4ebae-7e42-45be-af2a-f4139dd164e3 192.168.12.111
  port 85 http
    name 92b2540c-c66d-4635-9ff8-9b9cc3e0f398
    extended-stats
    service-group 0100a117-6c72-4226-a188-dae30822e969
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder-Active-vBlade[1/1](NOLICENSE)#

**vBlade Configuration:**

vThunder-Standby-vMaster[1/2](NOLICENSE)#show running-config
!Current configuration: 601 bytes
!Configuration last updated at 14:36:31 IST Wed Sep 22 2021
!Configuration last saved at 14:36:34 IST Wed Sep 22 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
vrrp-a common
  device-id 2
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 192.168.0.100 255.255.255.0
vcs failure-retry-count forever
!
vcs device 1
  priority 200
  interfaces management
  enable
!
vcs device 2
  priority 100
  interfaces management
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
!
**vrrp-a vrid 0
  floating-ip 192.168.12.17
  floating-ip 192.168.11.178**
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.135
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server 65246_192_168_11_5 192.168.11.5
  port 85 tcp
!
slb server octavia_health_manager_controller 10.64.3.135
  health-check octavia_health_monitor
!
slb service-group 0100a117-6c72-4226-a188-dae30822e969 tcp
  method least-connection
  member 65246_192_168_11_5 85
!
slb virtual-server 9ce4ebae-7e42-45be-af2a-f4139dd164e3 192.168.12.111
  port 85 http
    name 92b2540c-c66d-4635-9ff8-9b9cc3e0f398
    extended-stats
    service-group 0100a117-6c72-4226-a188-dae30822e969
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder-Standby-vMaster[1/2](NOLICENSE)#exit


**NAT POOL Configuration:**

```
stack@automation-1:~#**openstack loadbalancer flavorprofile create --name fp_snat_list --provider a10 --flavor-data '{"nat-pool":{"pool-name":"pool1", "start-address":"10.0.11.40", "end-address":"10.0.11.41", "netmask":"/24", "gateway":"10.0.11.11"}, "nat-pool-list":[{"pool-name":"pool2", "start-address":"10.0.11.29", "end-address":"10.0.11.30", "netmask":"/24", "gateway":"10.0.11.12"}, {"pool-name":"pool3", "start-address":"10.0.11.20", "end-address":"10.0.11.21", "netmask":"/24", "gateway":"10.0.11.13"}]}'**

+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field         | Value                                                                                                                                                                                                                                                                                                                                                                                                       |
+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| id            | 687c3415-7a39-47b5-bffe-171a68927cf0                                                                                                                                                                                                                                                                                                                                                                        |
| name          | fp_snat_list                                                                                                                                                                                                                                                                                                                                                                                                |
| provider_name | a10                                                                                                                                                                                                                                                                                                                                                                                                         |
| flavor_data   | {"nat-pool":{"pool-name":"pool1", "start-address":"10.0.11.40", "end-address":"10.0.11.41", "netmask":"/24", "gateway":"10.0.11.11"}, "nat-pool-list":[{"pool-name":"pool2", "start-address":"10.0.11.29", "end-address":"10.0.11.30", "netmask":"/24", "gateway":"10.0.11.12"}, {"pool-name":"pool3", "start-address":"10.0.11.20", "end-address":"10.0.11.21", "netmask":"/24", "gateway":"10.0.11.13"}]} |
+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
stack@automation-1:~#
```

```
stack@automation-1:~#**openstack loadbalancer flavor create --name f_snat_list --flavorprofile fp_snat_list --description "flaovr all test1" --enable**

+-------------------+--------------------------------------+
| Field             | Value                                |
+-------------------+--------------------------------------+
| id                | 490c3e01-0b09-4bf6-b24d-d6be904cd723 |
| name              | f_snat_list                          |
| flavor_profile_id | 687c3415-7a39-47b5-bffe-171a68927cf0 |
| enabled           | True                                 |
| description       | flaovr all test1                     |
+-------------------+--------------------------------------+
stack@automation-1:~#
```

```
**stack@automation-1:~#openstack loadbalancer create --name lb1 --vip-subnet-id vip_subnet --flavor 490c3e01-0b09-4bf6-b24d-d6be904cd723**

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-09-22T08:58:42                  |
| description         |                                      |
| flavor_id           | 490c3e01-0b09-4bf6-b24d-d6be904cd723 |
| id                  | 590a0d7e-5aa8-4ca2-b67b-f470540f5c94 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 65246d947f8543eb85382f3107110eaf     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.12.116                       |
| vip_network_id      | 37aad4f9-5536-42ea-9f4d-263717bde468 |
| vip_port_id         | fd082eca-222f-45e4-8652-b07805f50d16 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 37fa494f-c126-412e-8596-d9b7e4022a55 |
+---------------------+--------------------------------------+
stack@automation-1:~#
```

```
**stack@automation-1:~#openstack loadbalancer listener create --name l1 --protocol http --protocol-port 85 lb1**

+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-09-22T09:03:29                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | ae8d7f6c-64e5-46c7-b637-b4c3d5bf7c46 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 590a0d7e-5aa8-4ca2-b67b-f470540f5c94 |
| name                        | l1                                   |
| operating_status            | OFFLINE                              |
| project_id                  | 65246d947f8543eb85382f3107110eaf     |
| protocol                    | HTTP                                 |
| protocol_port               | 85                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
+-----------------------------+--------------------------------------+
stack@automation-1:~#
```

```
**stack@automation-1:~#openstack loadbalancer pool create --name p1 --protocol HTTP --lb-algorithm LEAST_CONNECTIONS --listener l1**

+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-09-22T09:04:16                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | 3c319487-a97d-437e-b637-c97ee3fcac6a |
| lb_algorithm         | LEAST_CONNECTIONS                    |
| listeners            | ae8d7f6c-64e5-46c7-b637-b4c3d5bf7c46 |
| loadbalancers        | 590a0d7e-5aa8-4ca2-b67b-f470540f5c94 |
| members              |                                      |
| name                 | p1                                   |
| operating_status     | OFFLINE                              |
| project_id           | 65246d947f8543eb85382f3107110eaf     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
+----------------------+--------------------------------------+
stack@automation-1:~#
```

**vThunder Configuration:**

vThunder(NOLICENSE)#show running-config
!Current configuration: 402 bytes
!Configuration last updated at 10:04:15 IST Wed Sep 22 2021
!Configuration last saved at 10:04:17 IST Wed Sep 22 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 192.168.12.26
!
**ip nat pool pool1 10.0.11.40 10.0.11.41 netmask /24 gateway 10.0.11.11
!
ip nat pool pool2 10.0.11.29 10.0.11.30 netmask /24 gateway 10.0.11.12
!
ip nat pool pool3 10.0.11.20 10.0.11.21 netmask /24 gateway 10.0.11.13
!**
slb service-group 3c319487-a97d-437e-b637-c97ee3fcac6a tcp
  method least-connection
!
slb virtual-server 590a0d7e-5aa8-4ca2-b67b-f470540f5c94 192.168.12.116
  port 85 http
    name ae8d7f6c-64e5-46c7-b637-b4c3d5bf7c46
    extended-stats
    **source-nat pool pool1**
    service-group 3c319487-a97d-437e-b637-c97ee3fcac6a
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#


**Terraform script:**

```
terraform {

  required_providers {

    openstack = {

      source = "terraform-provider-openstack/openstack"

      version = "1.43.0"

    }

  }

}



provider "openstack" {

  user_name = "admin"

  tenant_name = "admin"

  password = "password"

  auth_url = "http://10.64.3.135/identity"

  use_octavia = true

}

resource "openstack_lb_members_v2" "members_1" {

  pool_id = "3c319487-a97d-437e-b637-c97ee3fcac6a"

  member {

    address       = "192.168.11.3"

    protocol_port = 84

    subnet_id     = "fea07409-804f-4839-9c21-27fa4174383b"

    name          = "m1"

    weight        = 10

  }

}
```
**Result:**

Created a member 192.168.11.3 and checked IP Allocation table for 10.0.11.40 and 10.0.11.41 entries.  

```
**stack@automation-1:~#openstack loadbalancer member list p1**

+--------------------------------------+------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address      | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
| 755a1cbc-da48-4089-b06b-f4f3caf51aa2 | m1   | 65246d947f8543eb85382f3107110eaf | ACTIVE              | 192.168.11.3 |            84 | NO_MONITOR       |     10 |
+--------------------------------------+------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
stack@automation-1:~#
```

**vThunder Configuration:**
	 
vThunder(NOLICENSE)#show running-config
!Current configuration: 315 bytes
!Configuration last updated at 10:11:43 IST Wed Sep 22 2021
!Configuration last saved at 10:11:48 IST Wed Sep 22 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 192.168.12.26
  floating-ip 10.0.11.168
!
**ip nat pool pool1 10.0.11.40 10.0.11.41 netmask /24 gateway 10.0.11.11
!
ip nat pool pool2 10.0.11.29 10.0.11.30 netmask /24 gateway 10.0.11.12
!
ip nat pool pool3 10.0.11.20 10.0.11.21 netmask /24 gateway 10.0.11.13**
!
slb server 65246_192_168_11_3 192.168.11.3
  port 84 tcp
!
slb service-group 3c319487-a97d-437e-b637-c97ee3fcac6a tcp
  method least-connection
  member 65246_192_168_11_3 84
!
slb virtual-server 590a0d7e-5aa8-4ca2-b67b-f470540f5c94 192.168.12.116
  port 85 http
    name ae8d7f6c-64e5-46c7-b637-b4c3d5bf7c46
    extended-stats
    **source-nat pool pool1**
    service-group 3c319487-a97d-437e-b637-c97ee3fcac6a
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#



**mysql> select * from ipallocations;**                                                                                                          

+--------------------------------------+----------------+--------------------------------------+--------------------------------------+
| port_id                              | ip_address     | subnet_id                            | network_id                           |
+--------------------------------------+----------------+--------------------------------------+--------------------------------------+
| 1208aa4c-abdb-47ce-9b91-b2591bfba51f | 10.0.11.23     | fea07409-804f-4839-9c21-27fa4174383b | dc9e49e5-8211-4ae1-a2dd-24ad364f9216 |
| 2abfdb27-4ec1-411c-980f-94241a2c50a8 | 192.168.11.96  | 6c19bcd0-8204-4266-b9ea-b52ec12d03d2 | 68eb0628-3818-42c1-a44b-592244d2abcc |
| 318fa274-dd32-4a8d-8b98-b8be46abe31d | 10.0.11.168    | fea07409-804f-4839-9c21-27fa4174383b | dc9e49e5-8211-4ae1-a2dd-24ad364f9216 |
| 5dba278a-e154-4063-9991-e8b7e5a04bf5 | 192.168.0.112  | ba681f6a-203a-47b2-902d-61d0c0f0627b | d1dfcf8d-cd42-4b9c-90ef-6f4dad52ddc7 |
| 71c26ae0-6444-4eed-9f5d-3b4cc94b5b7b | 172.16.0.1     | 6753e515-8ea3-4fa8-85ec-fedc836f1527 | eeed88a3-4bb0-41d4-bff1-2389ea9ab44d |
| 812e1c59-200b-4780-b0bc-7db08614eb87 | 192.168.12.26  | 37fa494f-c126-412e-8596-d9b7e4022a55 | 37aad4f9-5536-42ea-9f4d-263717bde468 |
| 8e806c00-ac38-4d5f-89df-8d371bcd9412 | 192.168.0.1    | ba681f6a-203a-47b2-902d-61d0c0f0627b | d1dfcf8d-cd42-4b9c-90ef-6f4dad52ddc7 |
| 9ed8acef-3173-4d0b-b119-6e178e123dd7 | 192.168.12.31  | 37fa494f-c126-412e-8596-d9b7e4022a55 | 37aad4f9-5536-42ea-9f4d-263717bde468 |
| a0b72d8a-5042-4612-bd8f-96b3a7da78a1 | 192.168.11.146 | 6c19bcd0-8204-4266-b9ea-b52ec12d03d2 | 68eb0628-3818-42c1-a44b-592244d2abcc |
| b1b553c9-86a1-4b24-a8af-29b8fb0d8385 | 192.168.0.254  | ba681f6a-203a-47b2-902d-61d0c0f0627b | d1dfcf8d-cd42-4b9c-90ef-6f4dad52ddc7 |
| b1dc7b47-d93c-4aa9-ae89-9e60df437b00 | 192.168.11.243 | 6c19bcd0-8204-4266-b9ea-b52ec12d03d2 | 68eb0628-3818-42c1-a44b-592244d2abcc |
**| ba42f27e-fd8b-44af-ab1b-a820990e2554 | 10.0.11.40     | fea07409-804f-4839-9c21-27fa4174383b | dc9e49e5-8211-4ae1-a2dd-24ad364f9216 |
| ba42f27e-fd8b-44af-ab1b-a820990e2554 | 10.0.11.41     | fea07409-804f-4839-9c21-27fa4174383b | dc9e49e5-8211-4ae1-a2dd-24ad364f9216 |**
| be9f7cd0-536e-4db5-94ec-e0d586321a19 | 10.0.11.2      | fea07409-804f-4839-9c21-27fa4174383b | dc9e49e5-8211-4ae1-a2dd-24ad364f9216 |
| dd84d1db-4147-4fa3-94de-85d7ae15e0d3 | 192.168.11.2   | 6c19bcd0-8204-4266-b9ea-b52ec12d03d2 | 68eb0628-3818-42c1-a44b-592244d2abcc |
| fd082eca-222f-45e4-8652-b07805f50d16 | 192.168.12.116 | 37fa494f-c126-412e-8596-d9b7e4022a55 | 37aad4f9-5536-42ea-9f4d-263717bde468 |
| fd42a037-438c-48be-8efb-7a72be98a98f | 192.168.12.2   | 37fa494f-c126-412e-8596-d9b7e4022a55 | 37aad4f9-5536-42ea-9f4d-263717bde468 |
+--------------------------------------+----------------+--------------------------------------+--------------------------------------+
17 rows in set (0.00 sec)

mysql>
 
**Terraform Script:**

```
terraform {

  required_providers {

    openstack = {

      source = "terraform-provider-openstack/openstack"

      version = "1.43.0"

    }

  }

}

provider "openstack" {

  user_name = "admin"

  tenant_name = "admin"

  password = "password"

  auth_url = "http://10.64.3.135/identity"

  use_octavia = true

}

resource "openstack_lb_members_v2" "members_1" {

  pool_id = "3c319487-a97d-437e-b637-c97ee3fcac6a"

  member {

    address       = "192.168.11.4"

    protocol_port = 85

    subnet_id     = "6c19bcd0-8204-4266-b9ea-b52ec12d03d2"

    name          = "m1"

    weight        = 10

  }

}
```
**Result:**

192.168.11.4

- Created 192.168.11.4  with different subnet
- Deleted 192.168.11.3  and validated the entries for 10.0.11.40 and 10.0.11.41 in **ipallocation** table 

```
stack@automation-1:~#openstack loadbalancer member list p1

+--------------------------------------+------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address      | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
| a3a92f08-b922-4a8c-974d-9f7d7d5b607a | m1   | 65246d947f8543eb85382f3107110eaf | ACTIVE              | 192.168.11.4 |            85 | NO_MONITOR       |     10 |
+--------------------------------------+------+----------------------------------+---------------------+--------------+---------------+------------------+--------+
stack@automation-1:~#
```

**vThunder Configuration:**

vThunder(NOLICENSE)#show running-config
!Current configuration: 315 bytes
!Configuration last updated at 10:28:06 IST Wed Sep 22 2021
!Configuration last saved at 10:28:08 IST Wed Sep 22 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 192.168.12.26
  floating-ip 192.168.11.16
!
**ip nat pool pool1 10.0.11.40 10.0.11.41 netmask /24 gateway 10.0.11.11
!
ip nat pool pool2 10.0.11.29 10.0.11.30 netmask /24 gateway 10.0.11.12
!
ip nat pool pool3 10.0.11.20 10.0.11.21 netmask /24 gateway 10.0.11.13**
!
slb server 65246_192_168_11_4 192.168.11.4
  port 85 tcp
!
slb service-group 3c319487-a97d-437e-b637-c97ee3fcac6a tcp
  method least-connection
  member 65246_192_168_11_4 85
!
slb virtual-server 590a0d7e-5aa8-4ca2-b67b-f470540f5c94 192.168.12.116
  port 85 http
    name ae8d7f6c-64e5-46c7-b637-b4c3d5bf7c46
    extended-stats
    **source-nat pool pool1**
    service-group 3c319487-a97d-437e-b637-c97ee3fcac6a
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#

**Database:**

```
**mysql> select * from ipallocations;**       
                                                                                                   
+--------------------------------------+----------------+--------------------------------------+--------------------------------------+
| port_id                              | ip_address     | subnet_id                            | network_id                           |
+--------------------------------------+----------------+--------------------------------------+--------------------------------------+
| 29a543d5-166f-4e5a-a504-90a2091020bb | 192.168.11.222 | 6c19bcd0-8204-4266-b9ea-b52ec12d03d2 | 68eb0628-3818-42c1-a44b-592244d2abcc |
| 2abfdb27-4ec1-411c-980f-94241a2c50a8 | 192.168.11.96  | 6c19bcd0-8204-4266-b9ea-b52ec12d03d2 | 68eb0628-3818-42c1-a44b-592244d2abcc |
| 46b89091-72c9-406c-b115-7e8caa481970 | 192.168.11.16  | 6c19bcd0-8204-4266-b9ea-b52ec12d03d2 | 68eb0628-3818-42c1-a44b-592244d2abcc |
| 5dba278a-e154-4063-9991-e8b7e5a04bf5 | 192.168.0.112  | ba681f6a-203a-47b2-902d-61d0c0f0627b | d1dfcf8d-cd42-4b9c-90ef-6f4dad52ddc7 |
| 71c26ae0-6444-4eed-9f5d-3b4cc94b5b7b | 172.16.0.1     | 6753e515-8ea3-4fa8-85ec-fedc836f1527 | eeed88a3-4bb0-41d4-bff1-2389ea9ab44d |
| 812e1c59-200b-4780-b0bc-7db08614eb87 | 192.168.12.26  | 37fa494f-c126-412e-8596-d9b7e4022a55 | 37aad4f9-5536-42ea-9f4d-263717bde468 |
| 8e806c00-ac38-4d5f-89df-8d371bcd9412 | 192.168.0.1    | ba681f6a-203a-47b2-902d-61d0c0f0627b | d1dfcf8d-cd42-4b9c-90ef-6f4dad52ddc7 |
| 9ed8acef-3173-4d0b-b119-6e178e123dd7 | 192.168.12.31  | 37fa494f-c126-412e-8596-d9b7e4022a55 | 37aad4f9-5536-42ea-9f4d-263717bde468 |
| a0b72d8a-5042-4612-bd8f-96b3a7da78a1 | 192.168.11.146 | 6c19bcd0-8204-4266-b9ea-b52ec12d03d2 | 68eb0628-3818-42c1-a44b-592244d2abcc |
| b1b553c9-86a1-4b24-a8af-29b8fb0d8385 | 192.168.0.254  | ba681f6a-203a-47b2-902d-61d0c0f0627b | d1dfcf8d-cd42-4b9c-90ef-6f4dad52ddc7 |
| b1dc7b47-d93c-4aa9-ae89-9e60df437b00 | 192.168.11.243 | 6c19bcd0-8204-4266-b9ea-b52ec12d03d2 | 68eb0628-3818-42c1-a44b-592244d2abcc |
| be9f7cd0-536e-4db5-94ec-e0d586321a19 | 10.0.11.2      | fea07409-804f-4839-9c21-27fa4174383b | dc9e49e5-8211-4ae1-a2dd-24ad364f9216 |
| dd84d1db-4147-4fa3-94de-85d7ae15e0d3 | 192.168.11.2   | 6c19bcd0-8204-4266-b9ea-b52ec12d03d2 | 68eb0628-3818-42c1-a44b-592244d2abcc |
| fd082eca-222f-45e4-8652-b07805f50d16 | 192.168.12.116 | 37fa494f-c126-412e-8596-d9b7e4022a55 | 37aad4f9-5536-42ea-9f4d-263717bde468 |
| fd42a037-438c-48be-8efb-7a72be98a98f | 192.168.12.2   | 37fa494f-c126-412e-8596-d9b7e4022a55 | 37aad4f9-5536-42ea-9f4d-263717bde468 |
+--------------------------------------+----------------+--------------------------------------+--------------------------------------+
15 rows in set (0.00 sec)

mysql>
```
Removed entries for 10.0.11.40 and 10.0.11.41 
 
      



