### PR TITLE
[STACK-2944] Fix failover for paused vthunder

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_compute_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_compute_tasks.py
@@ -164,6 +164,8 @@ class FailoverPausedCompute(BaseComputeTask):
                         db_apis.get_session(), vthunder.id, amp.status)
                     LOG.info("The vThunder instance is paused, skipping the failover...")
                     raise a10_exceptions.FailoverOnPausedCompute()
+            except a10_exceptions.FailoverOnPausedCompute as e:
+                raise e
             except Exception as e:
                 LOG.exception("Failed to find compute %s du to: %s",
                               vthunder.compute_id, str(e))


### PR DESCRIPTION
## Description
If Bug Fix:
- Required: Severity Level High
- Required: Issue Description
For paused vthunder, health manager will still failover for it.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2944

## Technical Approach
The try/except was added for the task, but it will cause the a10_exceptions.FailoverOnPausedCompute() exception be ignore. So, for a10_exceptions.FailoverOnPausedCompute raise it to stop the failover for paused vthunder.

## Config Changes
<pre>
<b>[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
[a10_controller_worker]
amp_image_owner_id = 4b670176da5046e188aa0a503fd4cebb
amp_image_tag = "vthunder_5_2_1-p2"
amp_secgroup_list = d93900d4-44b5-4ac1-a80b-a80901595b54
amp_flavor_id = 1d0915fe-76e4-486f-a9b0-185ed0a57a47
amp_boot_network_list = 7a723117-6a5d-44a0-b0cc-30460def9efa, e02e1e75-9b6d-4eaf-b06e-e17c702b9c41, d83d4eed-b469-455b-a192-49ab0995ad2b, 20313f25-49eb-4787-a05b-554873f9217f
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 150
amp_active_wait_sec = 10
amp_busy_wait_sec = 0
loadbalancer_topology = ACTIVE_STANDBY
[a10_health_manager]
udp_server_ip_address = 192.168.0.200
bind_port = 5550
bind_ip = 192.168.0.200
heartbeat_interval = 20
health_check_timeout = 3
health_check_max_retries = 5
heartbeat_key = insecure
heartbeat_timeout = 30
failover_timeout = 600
health_check_interval = 10
[a10_house_keeping]
load_balancer_expiry_age = 3600
amphorae_expiry_age = 3600
spare_amphora_pool_size = 1
[a10_global]
network_type = "flat"
</b>
</pre>

## Test Cases
Steps:
1. pause vthunder
2. wait failover timeout
3. check vthunder will not be deleted after failover skipped.

## Manual Testing
```
stack@ytsai-victoria1:~/source/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+---------------------------------------------------------------------------------------+-------------------+---------------+
| ID                                   | Name                                         | Status | Networks                                                                              | Image             | Flavor        |
+--------------------------------------+----------------------------------------------+--------+---------------------------------------------------------------------------------------+-------------------+---------------+
| bb1d6b33-1e7f-4f96-9c6b-e38181ed3250 | amphora-87d18304-7a92-4182-8cf0-fd4cf0af8e6c | ACTIVE | lb-mgmt-net=192.168.0.91; tp90=192.168.90.27; tp91=192.168.91.75; tp92=192.168.92.237 | vthunder_5_2_1-p2 | vthunder_4cpu |
+--------------------------------------+----------------------------------------------+--------+---------------------------------------------------------------------------------------+-------------------+---------------+
stack@ytsai-victoria1:~/source/a10-octavia$ openstack server pause bb1d6b33-1e7f-4f96-9c6b-e38181ed3250
stack@ytsai-victoria1:~/source/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+---------------------------------------------------------------------------------------+-------------------+---------------+
| ID                                   | Name                                         | Status | Networks                                                                              | Image             | Flavor        |
+--------------------------------------+----------------------------------------------+--------+---------------------------------------------------------------------------------------+-------------------+---------------+
| bb1d6b33-1e7f-4f96-9c6b-e38181ed3250 | amphora-87d18304-7a92-4182-8cf0-fd4cf0af8e6c | PAUSED | lb-mgmt-net=192.168.0.91; tp90=192.168.90.27; tp91=192.168.91.75; tp92=192.168.92.237 | vthunder_5_2_1-p2 | vthunder_4cpu |
+--------------------------------------+----------------------------------------------+--------+---------------------------------------------------------------------------------------+-------------------+---------------+
```


```
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]: INFO a10_octavia.controller.healthmanager.a10_health_manager [-] Stale vThunder's id is: 1718bb32-f8f9-4607-800c-dc60885b6fc1
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]: INFO a10_octavia.controller.worker.controller_worker [-] Starting Failover process on 192.168.0.91
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]: DEBUG a10_octavia.controller.worker.controller_worker [-] Flow 'a10-house-keeper-failover-spare-vthunder' (8fbb6da8-ae98-40cc-ae54-f92278a477c3) transitioned into state 'RUNNING' from state 'PENDING' {{(pid=2030496) _flow_receiver /usr/local/lib/python3.8/dist-packages/taskflow/listeners/logging.py:141}}
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]: DEBUG a10_octavia.controller.worker.controller_worker [-] Task 'a10_octavia.controller.worker.tasks.a10_compute_tasks.FailoverPausedCompute' (8dab9fe3-a29c-4ab5-9835-12acb145e847) transitioned into state 'RUNNING' from state 'PENDING' {{(pid=2030496) _task_receiver /usr/local/lib/python3.8/dist-packages/taskflow/listeners/logging.py:190}}
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]: INFO a10_octavia.controller.healthmanager.a10_health_manager [-] Waiting for 1 failovers to finish
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]: INFO a10_octavia.controller.worker.tasks.a10_compute_tasks [-] The vThunder instance is paused, skipping the failover...
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'a10_octavia.controller.worker.tasks.a10_compute_tasks.FailoverPausedCompute' (8dab9fe3-a29c-4ab5-9835-12acb145e847) transitioned into state 'FAILURE' from state 'RUNNING'
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]: 1 predecessors (most recent first):
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]:   Flow 'a10-house-keeper-failover-spare-vthunder': a10_octavia.common.exceptions.FailoverOnPausedCompute: 1 Failover on a paused compute, skipping....
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]: ERROR a10_octavia.controller.worker.controller_worker Traceback (most recent call last):
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]: ERROR a10_octavia.controller.worker.controller_worker   File "/usr/local/lib/python3.8/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]: ERROR a10_octavia.controller.worker.controller_worker     result = task.execute(**arguments)
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]: ERROR a10_octavia.controller.worker.controller_worker   File "/opt/stack/source/a10-octavia/a10_octavia/controller/worker/tasks/a10_compute_tasks.py", line 168, in execute
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]: ERROR a10_octavia.controller.worker.controller_worker     raise e
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]: ERROR a10_octavia.controller.worker.controller_worker   File "/opt/stack/source/a10-octavia/a10_octavia/controller/worker/tasks/a10_compute_tasks.py", line 166, in execute
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]: ERROR a10_octavia.controller.worker.controller_worker     raise a10_exceptions.FailoverOnPausedCompute()
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]: ERROR a10_octavia.controller.worker.controller_worker a10_octavia.common.exceptions.FailoverOnPausedCompute: 1 Failover on a paused compute, skipping....
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]: ERROR a10_octavia.controller.worker.controller_worker
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]: DEBUG a10_octavia.controller.worker.controller_worker [-] Task 'a10_octavia.controller.worker.tasks.a10_compute_tasks.FailoverPausedCompute' (8dab9fe3-a29c-4ab5-9835-12acb145e847) transitioned into state 'REVERTING' from state 'FAILURE' {{(pid=2030496) _task_receiver /usr/local/lib/python3.8/dist-packages/taskflow/listeners/logging.py:190}}
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'a10_octavia.controller.worker.tasks.a10_compute_tasks.FailoverPausedCompute' (8dab9fe3-a29c-4ab5-9835-12acb145e847) transitioned into state 'REVERTED' from state 'REVERTING' with result 'None'
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]: WARNING a10_octavia.controller.worker.controller_worker [-] Flow 'a10-house-keeper-failover-spare-vthunder' (8fbb6da8-ae98-40cc-ae54-f92278a477c3) transitioned into state 'REVERTED' from state 'RUNNING'
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]: ERROR a10_octavia.controller.worker.controller_worker [-] vThunder 1718bb32-f8f9-4607-800c-dc60885b6fc1 topology SPARE failover exception: 1 Failover on a paused compute, skipping....: a10_octavia.common.exceptions.FailoverOnPausedCompute: 1 Failover on a paused compute, skipping....
Sep 23 08:22:00 ytsai-victoria1 a10-health-manager[2030496]: INFO a10_octavia.controller.healthmanager.a10_health_manager [-] Successfully completed failover for VThunders.
```