### PR TITLE
[STACK-2920] Prevent failover process hardware thunder

### DIFF
--- a/a10_octavia/controller/healthmanager/a10_health_manager.py
+++ b/a10_octavia/controller/healthmanager/a10_health_manager.py
@@ -73,6 +73,11 @@ class A10HealthManager(health_manager.HealthManager):
                     self.vthunder_repo.set_vthunder_health_state(
                         lock_session, vthunder.id, 'DOWN')
 
+                    if not vthunder.amphora_id:
+                        LOG.info("Hardware vthunder %s heartbeat timeout", vthunder.vthunder_id)
+                        lock_session.commit()
+                        continue
+
                 lock_session.commit()
 
             except db_exc.DBDeadlock:

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -320,6 +320,7 @@ class VThunderRepository(BaseRepository):
 
     def get_vthunder_from_src_addr(self, session, srcaddr):
         model = session.query(self.model_class).filter(
+            self.model_class.status != "DELETED").filter(
             self.model_class.ip_address == srcaddr).first()
 
         if not model:


### PR DESCRIPTION
## Description
If Bug Fix:
- Required: Severity Level High
- Required: Issue Description
Prevent failover process running on hardware thunders

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2920

## Technical Approach
For hardware thunder, the amphora_id will be NULL in vthunders table. So, we can use this difference to prevent failover on hardware thunders.

## Config Changes
<pre>
<b>stack@ytsai-victoria1:~/source/a10-octavia$ sed -e '/^#/d' /etc/a10/a10-octavia.conf  | grep -Ev "^$"
[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
[a10_controller_worker]
amp_image_owner_id = 4b670176da5046e188aa0a503fd4cebb
amp_image_tag = "vthunder_5_2_1-p2"
amp_secgroup_list = d93900d4-44b5-4ac1-a80b-a80901595b54
amp_flavor_id = 1d0915fe-76e4-486f-a9b0-185ed0a57a47
amp_boot_network_list = 7a723117-6a5d-44a0-b0cc-30460def9efa, e02e1e75-9b6d-4eaf-b06e-e17c702b9c41, d83d4eed-b469-455b-a192-49ab0995ad2b, 20313f25-49eb-4787-a05b-554873f9217f
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 150
amp_active_wait_sec = 10
amp_busy_wait_sec = 0
loadbalancer_topology = SINGLE
[a10_health_manager]
udp_server_ip_address = 10.64.3.104
bind_port = 5550
bind_ip = 10.64.3.104
heartbeat_interval = 20
health_check_timeout = 3
health_check_max_retries = 5
heartbeat_key = insecure
heartbeat_timeout = 30
failover_timeout = 600
health_check_interval = 10
[a10_house_keeping]
load_balancer_expiry_age = 3600
amphorae_expiry_age = 3600
[a10_global]
network_type = "flat"
[hardware_thunder]
devices = [
                    {
                     "project_id": "4b670176da5046e188aa0a503fd4cebb",
                     "ip_address": "192.168.90.46",
                     "username": "admin",
                     "password": "a10",
                     "device_name": "dev2"
                     }
             ]
</b>
</pre>

## Test Cases
- Setup hardware thunder with health monitor udp heartbeat
- Disable health check on thunder
- Failover will not process on the device

## Manual Testing

```
Sep 23 13:05:20 ytsai-victoria1 a10-health-manager[2069321]: DEBUG futurist.periodics [-] Submitting periodic callback 'a10_octavia.cmd.a10_health_manager.hm_health_check.<locals>.periodic_health_check' {{(pid=2069321) _process_scheduled /usr/local/lib/python3.8/dist-packages/futurist/periodics.py:641}}
Sep 23 13:05:20 ytsai-victoria1 a10-health-manager[2069321]: DEBUG a10_octavia.controller.healthmanager.a10_health_manager [-] health_check() starting... {{(pid=2069321) health_check /opt/stack/source/a10-octavia/a10_octavia/controller/healthmanager/a10_health_manager.py:49}}
Sep 23 13:05:30 ytsai-victoria1 a10-health-manager[2069321]: DEBUG futurist.periodics [-] Submitting periodic callback 'a10_octavia.cmd.a10_health_manager.hm_health_check.<locals>.periodic_health_check' {{(pid=2069321) _process_scheduled /usr/local/lib/python3.8/dist-packages/futurist/periodics.py:641}}
Sep 23 13:05:30 ytsai-victoria1 a10-health-manager[2069321]: DEBUG a10_octavia.controller.healthmanager.a10_health_manager [-] health_check() starting... {{(pid=2069321) health_check /opt/stack/source/a10-octavia/a10_octavia/controller/healthmanager/a10_health_manager.py:49}}
Sep 23 13:05:30 ytsai-victoria1 a10-health-manager[2069321]: INFO a10_octavia.controller.healthmanager.a10_health_manager [-] Hardware vthunder 2a6867cf-9322-49b0-823a-05baf94107fd heartbeat timeout
Sep 23 13:05:40 ytsai-victoria1 a10-health-manager[2069321]: DEBUG futurist.periodics [-] Submitting periodic callback 'a10_octavia.cmd.a10_health_manager.hm_health_check.<locals>.periodic_health_check' {{(pid=2069321) _process_scheduled /usr/local/lib/python3.8/dist-packages/futurist/periodics.py:641}}
Sep 23 13:05:40 ytsai-victoria1 a10-health-manager[2069321]: DEBUG a10_octavia.controller.healthmanager.a10_health_manager [-] health_check() starting... {{(pid=2069321) health_check /opt/stack/source/a10-octavia/a10_octavia/controller/healthmanager/a10_health_manager.py:49}}
Sep 23 13:05:50 ytsai-victoria1 a10-health-manager[2069321]: DEBUG futurist.periodics [-] Submitting periodic callback 'a10_octavia.cmd.a10_health_manager.hm_health_check.<locals>.periodic_health_check' {{(pid=2069321) _process_scheduled /usr/local/lib/python3.8/dist-packages/futurist/periodics.py:641}}
Sep 23 13:05:50 ytsai-victoria1 a10-health-manager[2069321]: DEBUG a10_octavia.controller.healthmanager.a10_health_manager [-] health_check() starting... {{(pid=2069321) health_check /opt/stack/source/a10-octavia/a10_octavia/controller/healthmanager/a10_health_manager.py:49}}
Sep 23 13:06:00 ytsai-victoria1 a10-health-manager[2069321]: DEBUG futurist.periodics [-] Submitting periodic callback 'a10_octavia.cmd.a10_health_manager.hm_health_check.<locals>.periodic_health_check' {{(pid=2069321) _process_scheduled /usr/local/lib/python3.8/dist-packages/futurist/periodics.py:641}}
Sep 23 13:06:00 ytsai-victoria1 a10-health-manager[2069321]: DEBUG a10_octavia.controller.healthmanager.a10_health_manager [-] health_check() starting... {{(pid=2069321) health_check /opt/stack/source/a10-octavia/a10_octavia/controller/healthmanager/a10_health_manager.py:49}}
```


```
mysql> select * from vthunders;
+----+--------------------------------------+------------+-------------+---------------+----------+----------+---------------+------------+--------------------------------------+----------------------------------+------------+------------+--------+---------------------+---------+---------------------+---------------------+----------------+---------------------------+----------------+--------------+--------------+
| id | vthunder_id                          | amphora_id | device_name | ip_address    | username | password | axapi_version | undercloud | loadbalancer_id                      | project_id                       | compute_id | topology   | role   | last_udp_update     | status  | created_at          | updated_at          | partition_name | hierarchical_multitenancy | last_write_mem | acos_version | health_state |
+----+--------------------------------------+------------+-------------+---------------+----------+----------+---------------+------------+--------------------------------------+----------------------------------+------------+------------+--------+---------------------+---------+---------------------+---------------------+----------------+---------------------------+----------------+--------------+--------------+
| 65 | 424a1a85-5294-4815-8a97-75d777d3ce36 | NULL       | dev2        | 192.168.90.46 | admin    | a10      |            30 |          1 | de59354d-d570-4bdd-bb6c-a9146d0e2b10 | 4b670176da5046e188aa0a503fd4cebb | NULL       | STANDALONE | MASTER | 2021-09-23 12:58:30 | DELETED | 2021-09-23 08:41:35 | 2021-09-23 08:43:09 | shared         | disable                   | NULL           | NULL         | UP           |
| 66 | 2a6867cf-9322-49b0-823a-05baf94107fd | NULL       | dev2        | 192.168.90.46 | admin    | a10      |            30 |          1 | fd6c4beb-90a1-4f83-ac4d-646952cfb872 | 4b670176da5046e188aa0a503fd4cebb | NULL       | STANDALONE | MASTER | 2021-09-23 13:04:57 | ACTIVE  | 2021-09-23 08:55:13 | 2021-09-23 09:55:43 | shared         | disable                   | NULL           | NULL         | UP           |
+----+--------------------------------------+------------+-------------+---------------+----------+----------+---------------+------------+--------------------------------------+----------------------------------+------------+------------+--------+---------------------+---------+---------------------+---------------------+----------------+---------------------------+----------------+--------------+--------------+
2 rows in set (0.00 sec)

mysql> select * from vthunders;
+----+--------------------------------------+------------+-------------+---------------+----------+----------+---------------+------------+--------------------------------------+----------------------------------+------------+------------+--------+---------------------+---------+---------------------+---------------------+----------------+---------------------------+----------------+--------------+--------------+
| id | vthunder_id                          | amphora_id | device_name | ip_address    | username | password | axapi_version | undercloud | loadbalancer_id                      | project_id                       | compute_id | topology   | role   | last_udp_update     | status  | created_at          | updated_at          | partition_name | hierarchical_multitenancy | last_write_mem | acos_version | health_state |
+----+--------------------------------------+------------+-------------+---------------+----------+----------+---------------+------------+--------------------------------------+----------------------------------+------------+------------+--------+---------------------+---------+---------------------+---------------------+----------------+---------------------------+----------------+--------------+--------------+
| 65 | 424a1a85-5294-4815-8a97-75d777d3ce36 | NULL       | dev2        | 192.168.90.46 | admin    | a10      |            30 |          1 | de59354d-d570-4bdd-bb6c-a9146d0e2b10 | 4b670176da5046e188aa0a503fd4cebb | NULL       | STANDALONE | MASTER | 2021-09-23 12:58:30 | DELETED | 2021-09-23 08:41:35 | 2021-09-23 08:43:09 | shared         | disable                   | NULL           | NULL         | UP           |
| 66 | 2a6867cf-9322-49b0-823a-05baf94107fd | NULL       | dev2        | 192.168.90.46 | admin    | a10      |            30 |          1 | fd6c4beb-90a1-4f83-ac4d-646952cfb872 | 4b670176da5046e188aa0a503fd4cebb | NULL       | STANDALONE | MASTER | 2021-09-23 13:04:57 | ACTIVE  | 2021-09-23 08:55:13 | 2021-09-23 09:55:43 | shared         | disable                   | NULL           | NULL         | DOWN         |
+----+--------------------------------------+------------+-------------+---------------+----------+----------+---------------+------------+--------------------------------------+----------------------------------+------------+------------+--------+---------------------+---------+---------------------+---------------------+----------------+---------------------------+----------------+--------------+--------------+
```
