### PR TITLE
[STACK-2961]: Fixed missing dependency error

### DIFF
--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -478,6 +478,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                               constants.VIP: lb.vip,
                               constants.SERVER_GROUP_ID: lb.server_group_id,
                               constants.LOADBALANCER_ID: lb.id,
+                              a10constants.MASTER_AMPHORA_STATUS: True,
                               a10constants.VTHUNDER_CONFIG: None,
                               a10constants.USE_DEVICE_FLAVOR: False,
                               a10constants.LB_COUNT_THUNDER: None,

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -206,8 +206,7 @@ class LoadBalancerFlows(object):
             requires=a10constants.COMPUTE_BUSY))
 
         delete_LB_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
-            requires=constants.LOADBALANCER,
-            inject={a10constants.MASTER_AMPHORA_STATUS: True},
+            requires=(constants.LOADBALANCER, a10constants.MASTER_AMPHORA_STATUS),
             provides=a10constants.VTHUNDER))
         if lb.topology == constants.TOPOLOGY_ACTIVE_STANDBY:
             delete_LB_flow.add(a10_compute_tasks.CheckAmphoraStatus(


### PR DESCRIPTION
## Description
- Severity Level: Medium
- Issue Description: Missing Dependency error on deleting lb which is in Error state

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-2961

## Technical Approach 
- Added a10constants.MASTER_AMPHORA_STATUS with default value in controller_worker.py

## Config Changes
- N/A

## Test Cases
- N/A

## Manual Testing
- Similar to QA
1) Delete the lb which is in Error state

```
stack@victoria:~/addeb2/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| 4457e6b6-f014-4bd0-8c58-077e5881f6c5 | vsw  | 5b7d0ed761dc480993a602ddc79c7c70 | 10.0.11.121 | ERROR               | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
stack@victoria:~/addeb2/a10-octavia$ openstack server list
stack@victoria:~/addeb2/a10-octavia$
stack@victoria:~/addeb2/a10-octavia$ openstack loadbalancer delete vsw
stack@victoria:~/addeb2/a10-octavia$

Logs:
Sep 27 04:07:09 victoria a10-octavia-worker[1416221]: INFO a10_octavia.common.config_options [-] Logging enabled!
Sep 27 04:07:09 victoria a10-octavia-worker[1416221]: INFO a10_octavia.common.config_options [-] /usr/local/bin/a10-octavia-worker version 7.1.2.dev25
Sep 27 04:07:10 victoria a10-octavia-worker[1416242]: INFO a10_octavia.controller.queue.consumer [-] Starting consumer...
Sep 27 04:07:10 victoria a10-octavia-worker[1416247]: INFO a10_octavia.controller.queue.consumer [-] Starting consumer...
Sep 27 04:08:30 victoria a10-octavia-worker[1416242]: INFO a10_octavia.controller.queue.endpoint [-] Deleting load balancer '4457e6b6-f014-4bd0-8c58-077e5881f6c5'...
```


