### PR TITLE
[STACK-2941] Prevent create LB in booting spare vthunder

### DIFF
--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -235,3 +235,4 @@ POST_FAILOVER_DB_UPDATE = 'post-failover-db-update'
 
 OCTAVIA_OWNER = 'Octavia'
 TOPOLOGY_SPARE = 'SPARE'
+READY = "READY"

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -88,6 +88,10 @@ class VThunderFlows(object):
             vthunder_tasks.CreateHealthMonitorOnVThunder(
                 name=sf_name + '-' + a10constants.CREATE_HEALTH_MONITOR_ON_SPARE,
                 requires=(a10constants.VTHUNDER)))
+
+        create_vthunder_flow.add(a10_database_tasks.MarkVThunderStatusInDB(
+            requires=(a10constants.VTHUNDER),
+            inject={"status": a10constants.READY}))
         return create_vthunder_flow
 
     def get_vthunder_for_lb_subflow(
@@ -624,6 +628,9 @@ class VThunderFlows(object):
                 name=sf_name + '-' + constants.AMP_COMPUTE_CONNECTIVITY_WAIT,
                 requires=constants.AMPHORA,
                 rebind={a10constants.VTHUNDER: a10constants.SPARE_VTHUNDER}))
+        create_amp_flow.add(a10_database_tasks.MarkVThunderStatusInDB(
+            rebind={a10constants.VTHUNDER: a10constants.SPARE_VTHUNDER},
+            inject={"status": a10constants.READY}))
         create_amp_flow.add(
             vthunder_tasks.UpdateAcosVersionInVthunderEntry(
                 name=sf_name + '-' + a10constants.UPDATE_ACOS_VERSION_IN_VTHUNDER_ENTRY,

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -356,7 +356,7 @@ class CreateSpareVThunderEntry(BaseDatabaseTask):
             compute_id=amphora.compute_id,
             topology=a10constants.TOPOLOGY_SPARE,
             role="MASTER",
-            status="READY",
+            status="BOOTING",
             created_at=datetime.utcnow(),
             last_udp_update=datetime.utcnow(),
             updated_at=datetime.utcnow())


### PR DESCRIPTION
If Bug Fix:
- Required: Severity Level High
- Required: Issue Description
Loadbalancer becomes pending_update after created. 


## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2941

## Technical Approach
This should be happen because a10-octavia using the spare vthunder that is not ready yet.
So, for spare vthunder creation. a10-octavia will set the status to booting intead now. And set to ready until the creation flow is finished.

## Config Changes
<pre>
<b>stack@ytsai-victoria1:~/source/a10-octavia$ sed -e '/^#/d' /etc/a10/a10-octavia.conf  | grep -Ev "^$"
[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
[a10_controller_worker]
amp_image_owner_id = 4b670176da5046e188aa0a503fd4cebb
amp_image_tag = "vthunder_5_2_1-p2"
amp_secgroup_list = d93900d4-44b5-4ac1-a80b-a80901595b54
amp_flavor_id = 1d0915fe-76e4-486f-a9b0-185ed0a57a47
amp_boot_network_list = 7a723117-6a5d-44a0-b0cc-30460def9efa, e02e1e75-9b6d-4eaf-b06e-e17c702b9c41, d83d4eed-b469-455b-a192-49ab0995ad2b, 20313f25-49eb-4787-a05b-554873f9217f
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 150
amp_active_wait_sec = 10
amp_busy_wait_sec = 0
loadbalancer_topology = ACTIVE_STANDBY
[a10_health_manager]
udp_server_ip_address = 192.168.0.200
bind_port = 5550
bind_ip = 192.168.0.200
heartbeat_interval = 20
health_check_timeout = 3
health_check_max_retries = 5
heartbeat_key = insecure
heartbeat_timeout = 30
failover_timeout = 600
health_check_interval = 10
[a10_house_keeping]
load_balancer_expiry_age = 3600
amphorae_expiry_age = 3600
[a10_global]
network_type = "flat"
</b>
</pre>

## Test Cases
1.  create LB while spare vthunder is booting
2. Test failover with new vthunder case

## Manual Testing
1.  create LB while spare vthunder is booting
```
stack@ytsai-victoria1:~/source/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+------------------+----------+
| 2c46a2c5-aac3-4c20-8b15-37b57e0fa6a2 | vip1 | 4b670176da5046e188aa0a503fd4cebb | 192.168.91.25 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+------------------+----------+
stack@ytsai-victoria1:~/source/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------------------------------------------+-------------------+---------------+
| ID                                   | Name                                         | Status | Networks                                                                                | Image             | Flavor        |
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------------------------------------------+-------------------+---------------+
| 37beddca-ed1d-4be5-b64d-abfb813b6ac5 | amphora-1a17db3f-d4cf-4638-a468-4cdf2b5c849e | ACTIVE | lb-mgmt-net=192.168.0.172; tp90=192.168.90.99; tp91=192.168.91.41; tp92=192.168.92.184  | vthunder_5_2_1-p2 | vthunder_4cpu |
| 5fd047e7-a7ac-4ed7-aa08-c998ab6bb1a8 | amphora-a8c9b018-fed8-497f-88d7-30e1ae4bafd2 | ACTIVE | lb-mgmt-net=192.168.0.56; tp90=192.168.90.211; tp91=192.168.91.47; tp92=192.168.92.183  | vthunder_5_2_1-p2 | vthunder_4cpu |
| 40997c14-ce30-49ce-9bce-87522ccb5bc5 | amphora-a946697a-79b2-4965-8a5a-b5bb3dffea45 | ACTIVE | lb-mgmt-net=192.168.0.128; tp90=192.168.90.148; tp91=192.168.91.65; tp92=192.168.92.186 | vthunder_5_2_1-p2 | vthunder_4cpu |
+--------------------------------------+----------------------------------------------+--------+-----------------------------------------------------------------------------------------+-------------------+---------------+
```

2. Test failover with new vthunder case
After failover:
```
stack@ytsai-victoria1:~/source/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------------------+-------------------+---------------+
| ID                                   | Name                                         | Status | Networks                                                                                 | Image             | Flavor        |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------------------+-------------------+---------------+
| b11d2a52-5257-46a5-8021-1765af6c9907 | amphora-b6d56912-2fd9-48db-b216-791a274533d0 | ACTIVE | lb-mgmt-net=192.168.0.155; tp90=192.168.90.109; tp91=192.168.91.152; tp92=192.168.92.206 | vthunder_5_2_1-p2 | vthunder_4cpu |
| 80a2048b-2067-4516-85cc-eb7af3e2e25c | amphora-6c713971-53a5-4696-b3c3-fb8963b59b6e | ACTIVE | lb-mgmt-net=192.168.0.169; tp90=192.168.90.23; tp91=192.168.91.247; tp92=192.168.92.177  | vthunder_5_2_1-p2 | vthunder_4cpu |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------------------+-------------------+---------------+
stack@ytsai-victoria1:~/source/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+----------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address    | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+----------------+---------------------+------------------+----------+
| 88b6c604-261d-4c0b-8713-e3094fb1b57e | vip1 | 4b670176da5046e188aa0a503fd4cebb | 192.168.91.150 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+----------------+---------------------+------------------+----------+
```