### PR TITLE
[BUG][STACK-2973][Rack Flow] Can able to create member when address and subnet_id are conflict

### DIFF
--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -253,3 +253,11 @@ class FlavorNotFound(cfg.ConfigFileValueError):
         msg = ('Flavor {0} specified in the configuration file cannot be located,'
                ' Please create the flavor in advance.').format(flavor)
         super(FlavorNotFound, self).__init__(msg=msg)
+
+
+class IPAddressNotInSubentRangeError(base.NetworkException):
+    def __init__(self, ip, subnet):
+        msg = ('Invalid IP address specified. ' +
+               'IP {0} out of range ' +
+               'for subnet {1}.').format(ip, subnet)
+        super(IPAddressNotInSubentRangeError, self).__init__(msg)

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -48,6 +48,9 @@ class MemberFlows(object):
 
         create_member_flow.add(database_tasks.MarkMemberPendingCreateInDB(
             requires=constants.MEMBER))
+        create_member_flow.add(a10_network_tasks.ValidateSubnet(
+            name='validate-subnet',
+            requires=constants.MEMBER))
         create_member_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
@@ -722,6 +725,9 @@ class MemberFlows(object):
                       constants.POOL]))
         create_member_flow.add(database_tasks.MarkMemberPendingCreateInDB(
             requires=constants.MEMBER))
+        create_member_flow.add(a10_network_tasks.ValidateSubnet(
+            name='validate-subnet',
+            requires=constants.MEMBER))
         create_member_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
@@ -883,6 +889,9 @@ class MemberFlows(object):
         for m in new_members:
             batch_update_members_flow.add(database_tasks.MarkMemberPendingCreateInDB(
                 name='mark-member-pending-create-in-db-' + m.id,
+                inject={constants.MEMBER: m}))
+            batch_update_members_flow.add(a10_network_tasks.ValidateSubnet(
+                name='validate-subnet' + m.id,
                 inject={constants.MEMBER: m}))
             batch_update_members_flow.add(a10_database_tasks.CountMembersWithIP(
                 name='count-member-with-ip-' + m.id,
@@ -1057,6 +1066,9 @@ class MemberFlows(object):
         for m in new_members:
             batch_update_members_flow.add(database_tasks.MarkMemberPendingCreateInDB(
                 name='mark-member-pending-create-in-DB' + m.id,
+                inject={constants.MEMBER: m}))
+            batch_update_members_flow.add(a10_network_tasks.ValidateSubnet(
+                name='validate-subnet' + m.id,
                 inject={constants.MEMBER: m}))
             batch_update_members_flow.add(a10_database_tasks.CountMembersWithIP(
                 name='count-members-with-ip' + m.id,

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -30,6 +30,7 @@ from octavia.network import data_models as n_data_models
 
 from a10_octavia.common import a10constants
 from a10_octavia.common import data_models
+from a10_octavia.common import exceptions
 from a10_octavia.common import utils as a10_utils
 from a10_octavia.controller.worker.tasks.decorators import axapi_client_decorator
 from a10_octavia.controller.worker.tasks import utils as a10_task_utils
@@ -1101,3 +1102,13 @@ class GetPoolsOnThunder(BaseNetworkTask):
                 raise e
         else:
             return
+
+
+class ValidateSubnet(BaseNetworkTask):
+
+    def execute(self, member):
+        member_subnet = self.network_driver.get_subnet(member.subnet_id)
+        subnet_ip, subnet_mask = a10_utils.get_net_info_from_cidr(member_subnet.cidr)
+        if not a10_utils.check_ip_in_subnet_range(
+                member.ip_address, subnet_ip, subnet_mask):
+            raise exceptions.IPAddressNotInSubentRangeError(member.ip_address, member_subnet.cidr)


### PR DESCRIPTION
## Description
- Severity Level: Medium 
- Issue Description: Able to create a member successfully though provided **ip_address** from one subnet and specified different subnet for the **subnet_id** parameter.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2973

## Technical Approach
- Added a task **ValidateSubnet** for validating the **ip_address** belongs to a specified **subnet** or not
- If IP is not in the range of specified subnet raised a custom exception **IPAddressNotInSubentRangeError**.
- Added **ValidateSubnet** task in the **get_create_member_flow**, **get_rack_vthunder_create_member_flow**, **get_rack_vthunder_batch_update_members_flow** and **get_batch_update_members_flow**

## Manual Testing

**Rack Flow:**

```
stack@automation-1:~#openstack loadbalancer list

+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| c4da9e31-c683-45dd-8d87-e47b2817fba0 | lb1  | 65246d947f8543eb85382f3107110eaf | 192.168.12.24 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+

```
```
stack@automation-1:~#openstack loadbalancer listener list

+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| id                                   | default_pool_id                      | name | project_id                       | protocol | protocol_port | admin_state_up |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| c2dbc254-806c-4c65-ba27-e55781466b88 | a855c873-2ce0-4ffa-84d1-838aa809498a | l1   | 65246d947f8543eb85382f3107110eaf | HTTP     |            86 | True           |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
```

```
stack@automation-1:~#openstack loadbalancer  pool list

+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| id                                   | name | project_id                       | provisioning_status | protocol | lb_algorithm      | admin_state_up |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| 89dc5178-f401-4c16-8b6e-6261c0d20774 | p1   | 65246d947f8543eb85382f3107110eaf | ACTIVE              | HTTP     | LEAST_CONNECTIONS | True           |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
stack@automation-1:~#
```

**vThunder Configuration:**

```
vThunder-vMaster[14/1](NOLICENSE)#show running-config slb
!Section configuration: 514 bytes
!
slb template http th1
!
slb template policy tp1
!
slb template policy tp3
!
slb template port tp2
!
slb template server ts1
!
slb template tcp tt1
!
slb template udp tu1
!
slb template virtual-port tvp1
!
slb service-group 89dc5178-f401-4c16-8b6e-6261c0d20774 tcp
  method least-connection
!
slb virtual-server c4da9e31-c683-45dd-8d87-e47b2817fba0 192.168.12.24
  port 86 http
    name c2dbc254-806c-4c65-ba27-e55781466b88
    extended-stats
    service-group 89dc5178-f401-4c16-8b6e-6261c0d20774
!
vThunder-vMaster[14/1](NOLICENSE)#
vThunder-vMaster[14/1](NOLICENSE)#
```

```
stack@automation-1:~#openstack subnet list

+--------------------------------------+----------------+--------------------------------------+-----------------+
| ID                                   | Name           | Network                              | Subnet          |
+--------------------------------------+----------------+--------------------------------------+-----------------+
| 37fa494f-c126-412e-8596-d9b7e4022a55 | vip_subnet     | 37aad4f9-5536-42ea-9f4d-263717bde468 | 192.168.12.0/24 |
| 6753e515-8ea3-4fa8-85ec-fedc836f1527 | 172.16.0.0     | eeed88a3-4bb0-41d4-bff1-2389ea9ab44d | 172.16.0.0/24   |
| 6c19bcd0-8204-4266-b9ea-b52ec12d03d2 | member_subnet  | 68eb0628-3818-42c1-a44b-592244d2abcc | 192.168.11.0/24 |
| ba681f6a-203a-47b2-902d-61d0c0f0627b | lb-mgmt-subnet | d1dfcf8d-cd42-4b9c-90ef-6f4dad52ddc7 | 192.168.0.0/24  |
| fea07409-804f-4839-9c21-27fa4174383b | subnet1        | dc9e49e5-8211-4ae1-a2dd-24ad364f9216 | 10.0.11.0/24    |
+--------------------------------------+----------------+--------------------------------------+-----------------+
stack@automation-1:~#
```

**Terraform script:**

1.  Added a member with **ip_address** 192.168.13.37  and specified different **subnet_id**   37fa494f-c126-412e-8596-d9b7e4022a55 (192.168.12.0/24)

```
resource "openstack_lb_members_v2" "members_1" {

  pool_id = "89dc5178-f401-4c16-8b6e-6261c0d20774"

  member {

    address       = "192.168.13.37"

    protocol_port = 87

    subnet_id     = "37fa494f-c126-412e-8596-d9b7e4022a55"

    name          = "m1"

    weight        = 60

    admin_state_up = true

  }
  member {

    address       = "192.168.12.38"

    protocol_port = 88

    subnet_id     = "37fa494f-c126-412e-8596-d9b7e4022a55"

    name          = "m2"

    weight        = 60

    admin_state_up = true

  }

}

```

```
stack@automation-1:~#openstack loadbalancer member list p1

+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address       | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
| 0e604128-10cd-4391-a8a8-1e49a5eec022 | m2   | 65246d947f8543eb85382f3107110eaf | ERROR               | 192.168.12.38 |            88 | NO_MONITOR       |     60 |
| 140ded7e-afa5-42f2-87b3-0152ea9ec073 | m1   | 65246d947f8543eb85382f3107110eaf | ERROR               | 192.168.13.37 |            87 | NO_MONITOR       |     60 |
+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
```

**Journalctl logs:**

**stack@automation-1:~#journalctl -af --unit a10-controller-worker.service**

```
ERROR oslo_messaging.rpc.server [-] Exception during message handling: IPAddressNotInSubentRangeError: Invalid IP address specified. IP 192.168.13.37 out of range for subnet 192.168.12.0/24.
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server Traceback (most recent call last):
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/server.py", line 166, in _process_incoming
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     res = self.dispatcher.dispatch(message)
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 265, in dispatch
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     return self._do_dispatch(endpoint, method, ctxt, args)
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 194, in _do_dispatch
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     result = func(ctxt, **new_args)
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/queue/endpoint.py", line 123, in batch_update_members
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     old_member_ids, new_member_ids, updated_members)
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 292, in wrapped_f
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     return self.call(f, *args, **kw)
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 358, in call
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     do = self.iter(retry_state=retry_state)
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 319, in iter
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     return fut.result()
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/concurrent/futures/_base.py", line 455, in result
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     return self.__get_result()
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 361, in call
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     result = fn(*args, **kwargs)
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/controller_worker.py", line 733, in batch_update_members
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     batch_update_members_tf.run()
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 247, in run
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     for _state in self.run_iter(timeout=timeout):
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 340, in run_iter
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     failure.Failure.reraise_if_any(er_failures)
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 339, in reraise_if_any
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     failures[0].reraise()
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 346, in reraise
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     six.reraise(*self._exc_info)
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     result = task.execute(**arguments)
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/tasks/a10_network_tasks.py", line 1114, in execute
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     raise exceptions.IPAddressNotInSubentRangeError(member.ip_address, member_subnet.cidr)
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server IPAddressNotInSubentRangeError: Invalid IP address specified. IP 192.168.13.37 out of range for subnet 192.168.12.0/24.
Sep 30 07:27:08 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server

```
**Result:**

- Raised  "IPAddressNotInSubentRangeError:  as ip address doesn't belong to specified subnet 192.168.12.0/24."

```

2. Create a member with ip address from one subnet and provide different subnet_id for  subnet_id  parameter.

stack@automation-1:~#openstack loadbalancer member create --address 192.163.13.12 --subnet-id 37fa494f-c126-412e-8596-d9b7e4022a55 --protocol-port 82 p1 --name m2

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 192.163.13.12                        |
| admin_state_up      | True                                 |
| created_at          | 2021-09-30T07:28:18                  |
| id                  | 5850deb2-d90a-4b17-8cfa-e78324aa9cc7 |
| name                | m2                                   |
| operating_status    | NO_MONITOR                           |
| project_id          | 65246d947f8543eb85382f3107110eaf     |
| protocol_port       | 82                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 37fa494f-c126-412e-8596-d9b7e4022a55 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
stack@automation-1:~#
```

```
stack@automation-1:~#openstack loadbalancer member list p1

+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address       | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
| 0e604128-10cd-4391-a8a8-1e49a5eec022 | m2   | 65246d947f8543eb85382f3107110eaf | ERROR               | 192.168.12.38 |            88 | NO_MONITOR       |     60 |
| 140ded7e-afa5-42f2-87b3-0152ea9ec073 | m1   | 65246d947f8543eb85382f3107110eaf | ERROR               | 192.168.13.37 |            87 | NO_MONITOR       |     60 |
| 5850deb2-d90a-4b17-8cfa-e78324aa9cc7 | m2   | 65246d947f8543eb85382f3107110eaf | ERROR               | 192.163.13.12 |            82 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
stack@automation-1:~#
```

**Journalctl logs:**

**stack@automation-1:~#journalctl -af --unit a10-controller-worker.service**

```
INFO a10_octavia.controller.queue.endpoint [-] Creating member '5850deb2-d90a-4b17-8cfa-e78324aa9cc7'...
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'validate-subnet' (0c575161-baec-44f1-a9df-4bd3c032b527) transitioned into state 'FAILURE' from state 'RUNNING'
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: 3 predecessors (most recent first):
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]:   Atom 'octavia.controller.worker.tasks.database_tasks.MarkMemberPendingCreateInDB' {'intention': 'EXECUTE', 'state': 'SUCCESS', 'requires': {'member': <octavia.common.data_models.Member object at 0x7ff5dfac0cd0>}, 'provides': None}
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]:   |__Atom 'octavia.controller.worker.tasks.lifecycle_tasks.MemberToErrorOnRevertTask' {'intention': 'EXECUTE', 'state': 'SUCCESS', 'requires': {'member': <octavia.common.data_models.Member object at 0x7ff5dfac0cd0>, 'listeners': [<octavia.common.data_models.Listener object at 0x7ff5a69da6d0>], 'pool': <octavia.common.data_models.Pool object at 0x7ff5a5db6250>, 'loadbalancer': <octavia.common.data_models.LoadBalancer object at 0x7ff5a5dd87d0>}, 'provides': None}
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]:      |__Flow 'octavia-create-member-flow': IPAddressNotInSubentRangeError: Invalid IP address specified. IP 192.163.13.12 out of range for subnet 192.168.12.0/24.
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR a10_octavia.controller.worker.controller_worker Traceback (most recent call last):
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR a10_octavia.controller.worker.controller_worker   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR a10_octavia.controller.worker.controller_worker     result = task.execute(**arguments)
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR a10_octavia.controller.worker.controller_worker   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/tasks/a10_network_tasks.py", line 1114, in execute
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR a10_octavia.controller.worker.controller_worker     raise exceptions.IPAddressNotInSubentRangeError(member.ip_address, member_subnet.cidr)
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR a10_octavia.controller.worker.controller_worker IPAddressNotInSubentRangeError: Invalid IP address specified. IP 192.163.13.12 out of range for subnet 192.168.12.0/24.
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR a10_octavia.controller.worker.controller_worker
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'validate-subnet' (0c575161-baec-44f1-a9df-4bd3c032b527) transitioned into state 'REVERTED' from state 'REVERTING'
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: WARNING octavia.controller.worker.tasks.database_tasks [-] Reverting mark member pending create in DB for member id 5850deb2-d90a-4b17-8cfa-e78324aa9cc7
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'octavia.controller.worker.tasks.database_tasks.MarkMemberPendingCreateInDB' (6b189236-38f8-43fb-86c0-aa6b47c1aace) transitioned into state 'REVERTED' from state 'REVERTING'
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'octavia.controller.worker.tasks.lifecycle_tasks.MemberToErrorOnRevertTask' (b0212b67-c952-4bdd-907a-b4567f990934) transitioned into state 'REVERTED' from state 'REVERTING'
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: WARNING a10_octavia.controller.worker.controller_worker [-] Flow 'octavia-create-member-flow' (f317b004-250e-4e8e-99d0-07928a25323a) transitioned into state 'REVERTED' from state 'RUNNING'
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server [-] Exception during message handling: IPAddressNotInSubentRangeError: Invalid IP address specified. IP 192.163.13.12 out of range for subnet 192.168.12.0/24.
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server Traceback (most recent call last):
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/server.py", line 166, in _process_incoming
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     res = self.dispatcher.dispatch(message)
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 265, in dispatch
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     return self._do_dispatch(endpoint, method, ctxt, args)
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 194, in _do_dispatch
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     result = func(ctxt, **new_args)
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/queue/endpoint.py", line 108, in create_member
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     self.worker.create_member(member_id)
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 292, in wrapped_f
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     return self.call(f, *args, **kw)
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 358, in call
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     do = self.iter(retry_state=retry_state)
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 319, in iter
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     return fut.result()
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/concurrent/futures/_base.py", line 455, in result
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     return self.__get_result()
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 361, in call
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     result = fn(*args, **kwargs)
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/controller_worker.py", line 617, in create_member
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     create_member_tf.run()
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 247, in run
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     for _state in self.run_iter(timeout=timeout):
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 340, in run_iter
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     failure.Failure.reraise_if_any(er_failures)
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 339, in reraise_if_any
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     failures[0].reraise()
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 346, in reraise
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     six.reraise(*self._exc_info)
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     result = task.execute(**arguments)
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/tasks/a10_network_tasks.py", line 1114, in execute
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server     raise exceptions.IPAddressNotInSubentRangeError(member.ip_address, member_subnet.cidr)
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server IPAddressNotInSubentRangeError: Invalid IP address specified. IP 192.163.13.12 out of range for subnet 192.168.12.0/24.
Sep 30 07:28:18 automation-1 a10-octavia-worker[2362]: ERROR oslo_messaging.rpc.server
```

**Result:**

- Raised  "IPAddressNotInSubentRangeError:  as ip address doesn't belong to specified subnet 192.168.12.0/24."

**Automated flow:** 


```
stack@automation-1:~#openstack loadbalancer list

+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address    | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
| 065a2d6d-f642-45b8-947a-2fc4838d137b | lb1  | 65246d947f8543eb85382f3107110eaf | 192.168.12.235 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+----------------+---------------------+----------+
```

```
stack@automation-1:~#openstack server list

+--------------------------------------+----------------------------------------------+--------+-------------------------------------------------------+----------------------+-----------------+
| ID                                   | Name                                         | Status | Networks                                              | Image                | Flavor          |
+--------------------------------------+----------------------------------------------+--------+-------------------------------------------------------+----------------------+-----------------+
| 626d47b9-4dbb-4e67-8d0f-9bd1fbee6c45 | amphora-548589d2-00ab-44e3-9c40-8b9f50d526ff | ACTIVE | lb-mgmt-net=192.168.0.112; vip_network=192.168.12.129 | vThunder_5_2_1-p1_56 | vThunder_flavor |
+--------------------------------------+----------------------------------------------+--------+-------------------------------------------------------+----------------------+-----------------+
stack@automation-1:~#

```
```
stack@automation-1:~#openstack loadbalancer listener list

+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| id                                   | default_pool_id                      | name | project_id                       | protocol | protocol_port | admin_state_up |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| 897a8b45-3acb-45af-8960-94c1b52dcd61 | 92bbc8fe-f986-4a63-bc93-8b6e078c851a | l1   | 65246d947f8543eb85382f3107110eaf | HTTP     |            86 | True           |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
```

```
stack@automation-1:~#openstack loadbalancer pool list

+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| id                                   | name | project_id                       | provisioning_status | protocol | lb_algorithm      | admin_state_up |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| 92bbc8fe-f986-4a63-bc93-8b6e078c851a | p1   | 65246d947f8543eb85382f3107110eaf | ACTIVE              | HTTP     | LEAST_CONNECTIONS | True           |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
stack@automation-1:~#
```

```
stack@automation-1:~#openstack loadbalancer member list p1

stack@automation-1:~#
```

**vThunder Configuration:**

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 186 bytes
!Configuration last updated at 07:16:16 IST Thu Sep 30 2021
!Configuration last saved at 07:11:23 IST Thu Sep 30 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 192.168.12.43
!
slb service-group 92bbc8fe-f986-4a63-bc93-8b6e078c851a tcp
  method least-connection
!
slb virtual-server 065a2d6d-f642-45b8-947a-2fc4838d137b 192.168.12.235
  port 86 http
    name 897a8b45-3acb-45af-8960-94c1b52dcd61
    extended-stats
    service-group 92bbc8fe-f986-4a63-bc93-8b6e078c851a
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#

```
```
stack@automation-1:~#openstack subnet list

+--------------------------------------+----------------+--------------------------------------+-----------------+
| ID                                   | Name           | Network                              | Subnet          |
+--------------------------------------+----------------+--------------------------------------+-----------------+
| 37fa494f-c126-412e-8596-d9b7e4022a55 | vip_subnet     | 37aad4f9-5536-42ea-9f4d-263717bde468 | 192.168.12.0/24 |
| 6753e515-8ea3-4fa8-85ec-fedc836f1527 | 172.16.0.0     | eeed88a3-4bb0-41d4-bff1-2389ea9ab44d | 172.16.0.0/24   |
| 6c19bcd0-8204-4266-b9ea-b52ec12d03d2 | member_subnet  | 68eb0628-3818-42c1-a44b-592244d2abcc | 192.168.11.0/24 |
| ba681f6a-203a-47b2-902d-61d0c0f0627b | lb-mgmt-subnet | d1dfcf8d-cd42-4b9c-90ef-6f4dad52ddc7 | 192.168.0.0/24  |
| fea07409-804f-4839-9c21-27fa4174383b | subnet1        | dc9e49e5-8211-4ae1-a2dd-24ad364f9216 | 10.0.11.0/24    |
+--------------------------------------+----------------+--------------------------------------+-----------------+
stack@automation-1:~#

```

**Terraform Script:**

1.  Added a member with **ip_address** 192.168.13.31  and specified different **subnet_id**   37fa494f-c126-412e-8596-d9b7e4022a55 (192.168.12.0/24)

```
resource "openstack_lb_members_v2" "members_1" {

  pool_id = "92bbc8fe-f986-4a63-bc93-8b6e078c851a"

  member {

    address       = "192.168.13.31"

    protocol_port = 81

    subnet_id     = "37fa494f-c126-412e-8596-d9b7e4022a55"

    name          = "m1"

    weight        = 60

    admin_state_up = true

  }
  member {

    address       = "192.168.12.32"

    protocol_port = 82

    subnet_id     = "37fa494f-c126-412e-8596-d9b7e4022a55"

    name          = "m1"

    weight        = 60

    admin_state_up = true

  }

}

```

```
stack@automation-1:~#openstack loadbalancer member list p1

+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address       | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
| 261e0302-b94c-4173-9150-b09fc857ea03 | m1   | 65246d947f8543eb85382f3107110eaf | ERROR               | 192.168.13.31 |            81 | NO_MONITOR       |     60 |
| f78a43d6-513b-4798-ba87-cd93a4cbc875 | m1   | 65246d947f8543eb85382f3107110eaf | ERROR               | 192.168.12.32 |            82 | NO_MONITOR       |     60 |
+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
stack@automation-1:~#
```

**stack@automation-1:~#journalctl -af --unit a10-controller-worker.service**

```
ERROR oslo_messaging.rpc.server [-] Exception during message handling: IPAddressNotInSubentRangeError: Invalid IP address specified. IP 192.168.13.31 out of range for subnet 192.168.12.0/24.
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server Traceback (most recent call last):
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/server.py", line 166, in _process_incoming
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server     res = self.dispatcher.dispatch(message)
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 265, in dispatch
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server     return self._do_dispatch(endpoint, method, ctxt, args)
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 194, in _do_dispatch
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server     result = func(ctxt, **new_args)
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/queue/endpoint.py", line 123, in batch_update_members
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server     old_member_ids, new_member_ids, updated_members)
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 292, in wrapped_f
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server     return self.call(f, *args, **kw)
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 358, in call
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server     do = self.iter(retry_state=retry_state)
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 319, in iter
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server     return fut.result()
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/concurrent/futures/_base.py", line 455, in result
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server     return self.__get_result()
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 361, in call
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server     result = fn(*args, **kwargs)
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/controller_worker.py", line 733, in batch_update_members
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server     batch_update_members_tf.run()
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 247, in run
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server     for _state in self.run_iter(timeout=timeout):
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 340, in run_iter
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server     failure.Failure.reraise_if_any(er_failures)
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 339, in reraise_if_any
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server     failures[0].reraise()
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 346, in reraise
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server     six.reraise(*self._exc_info)
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server     result = task.execute(**arguments)
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/tasks/a10_network_tasks.py", line 1114, in execute
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server     raise exceptions.IPAddressNotInSubentRangeError(member.ip_address, member_subnet.cidr)
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server IPAddressNotInSubentRangeError: Invalid IP address specified. IP 192.168.13.31 out of range for subnet 192.168.12.0/24.
Sep 30 06:16:17 automation-1 a10-octavia-worker[27796]: ERROR oslo_messaging.rpc.server

```

**Result:**

- Raised  "IPAddressNotInSubentRangeError:  as ip address doesn't belong to specified subnet 192.168.12.0/24."


2. Create a member with **ip_address** from one subnet and provide different **subnet_id** for  subnet_id  parameter.

```
stack@automation-1:~#openstack loadbalancer member create --address 192.163.13.12 --subnet-id 37fa494f-c126-412e-8596-d9b7e4022a55 --protocol-port 80 p1 --name m1

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 192.163.13.12                        |
| admin_state_up      | True                                 |
| created_at          | 2021-09-30T06:39:09                  |
| id                  | 674a245d-a06f-4a83-bca5-1e74a9d1b610 |
| name                | m1                                   |
| operating_status    | NO_MONITOR                           |
| project_id          | 65246d947f8543eb85382f3107110eaf     |
| protocol_port       | 80                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 37fa494f-c126-412e-8596-d9b7e4022a55 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
stack@automation-1:~#

```

**Journalctl logs:**

**stack@automation-1:~#journalctl -af --unit a10-controller-worker.service**

```
Sep 30 06:39:08 automation-1 a10-octavia-worker[30523]: INFO a10_octavia.controller.queue.endpoint [-] Creating member '674a245d-a06f-4a83-bca5-1e74a9d1b610'...
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'validate-subnet' (fa6dbeaf-b474-43eb-a687-81fdb4b446a4) transitioned into state 'FAILURE' from state 'RUNNING'
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: 4 predecessors (most recent first):
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]:   Atom 'octavia.controller.worker.tasks.database_tasks.MarkMemberPendingCreateInDB' {'intention': 'EXECUTE', 'state': 'SUCCESS', 'requires': {'member': <octavia.common.data_models.Member object at 0x7f6bb6ff4310>}, 'provides': None}
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]:   |__Atom 'a10_octavia.controller.worker.tasks.vthunder_tasks.VthunderInstanceBusy' {'intention': 'EXECUTE', 'state': 'SUCCESS', 'requires': {'compute_busy': False}, 'provides': None}
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]:      |__Atom 'octavia.controller.worker.tasks.lifecycle_tasks.MemberToErrorOnRevertTask' {'intention': 'EXECUTE', 'state': 'SUCCESS', 'requires': {'member': <octavia.common.data_models.Member object at 0x7f6bb6ff4310>, 'listeners': [<octavia.common.data_models.Listener object at 0x7f6bb708c310>], 'pool': <octavia.common.data_models.Pool object at 0x7f6bb7443050>, 'loadbalancer': <octavia.common.data_models.LoadBalancer object at 0x7f6bb7336690>}, 'provides': None}
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]:         |__Flow 'octavia-create-member-flow': IPAddressNotInSubentRangeError: Invalid IP address specified. IP 192.163.13.12 out of range for subnet 192.168.12.0/24.
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR a10_octavia.controller.worker.controller_worker Traceback (most recent call last):
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR a10_octavia.controller.worker.controller_worker   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR a10_octavia.controller.worker.controller_worker     result = task.execute(**arguments)
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR a10_octavia.controller.worker.controller_worker   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/tasks/a10_network_tasks.py", line 1114, in execute
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR a10_octavia.controller.worker.controller_worker     raise exceptions.IPAddressNotInSubentRangeError(member.ip_address, member_subnet.cidr)
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR a10_octavia.controller.worker.controller_worker IPAddressNotInSubentRangeError: Invalid IP address specified. IP 192.163.13.12 out of range for subnet 192.168.12.0/24.
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR a10_octavia.controller.worker.controller_worker
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'validate-subnet' (fa6dbeaf-b474-43eb-a687-81fdb4b446a4) transitioned into state 'REVERTED' from state 'REVERTING'
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: WARNING octavia.controller.worker.tasks.database_tasks [-] Reverting mark member pending create in DB for member id 674a245d-a06f-4a83-bca5-1e74a9d1b610
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'octavia.controller.worker.tasks.database_tasks.MarkMemberPendingCreateInDB' (5101b0e9-a11b-4ed1-8086-2563a65d0b46) transitioned into state 'REVERTED' from state 'REVERTING'
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'a10_octavia.controller.worker.tasks.vthunder_tasks.VthunderInstanceBusy' (9cafc0d8-8c35-483c-b829-c07eca5e5959) transitioned into state 'REVERTED' from state 'REVERTING'
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'octavia.controller.worker.tasks.lifecycle_tasks.MemberToErrorOnRevertTask' (3059ac0c-080c-462d-ab7c-89cac34cd737) transitioned into state 'REVERTED' from state 'REVERTING'
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: WARNING a10_octavia.controller.worker.controller_worker [-] Flow 'octavia-create-member-flow' (1935ed2e-cffb-49d7-9273-7e110d068e1c) transitioned into state 'REVERTED' from state 'RUNNING'
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server [-] Exception during message handling: IPAddressNotInSubentRangeError: Invalid IP address specified. IP 192.163.13.12 out of range for subnet 192.168.12.0/24.
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server Traceback (most recent call last):
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/server.py", line 166, in _process_incoming
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server     res = self.dispatcher.dispatch(message)
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 265, in dispatch
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server     return self._do_dispatch(endpoint, method, ctxt, args)
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 194, in _do_dispatch
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server     result = func(ctxt, **new_args)
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/queue/endpoint.py", line 108, in create_member
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server     self.worker.create_member(member_id)
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 292, in wrapped_f
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server     return self.call(f, *args, **kw)
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 358, in call
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server     do = self.iter(retry_state=retry_state)
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 319, in iter
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server     return fut.result()
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/concurrent/futures/_base.py", line 455, in result
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server     return self.__get_result()
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 361, in call
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server     result = fn(*args, **kwargs)
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/controller_worker.py", line 617, in create_member
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server     create_member_tf.run()
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 247, in run
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server     for _state in self.run_iter(timeout=timeout):
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 340, in run_iter
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server     failure.Failure.reraise_if_any(er_failures)
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 339, in reraise_if_any
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server     failures[0].reraise()
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 346, in reraise
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server     six.reraise(*self._exc_info)
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server     result = task.execute(**arguments)
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/tasks/a10_network_tasks.py", line 1114, in execute
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server     raise exceptions.IPAddressNotInSubentRangeError(member.ip_address, member_subnet.cidr)
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server **IPAddressNotInSubentRangeError: Invalid IP address specified. IP 192.163.13.12 out of range for subnet 192.168.12.0/24.**
Sep 30 06:39:09 automation-1 a10-octavia-worker[30523]: ERROR oslo_messaging.rpc.server
```

**Result:**

- Raised  "IPAddressNotInSubentRangeError:  as ip address doesn't belong to specified subnet 192.168.12.0/24."


