### PR TITLE
[BUG][STACK-2937][Loadbalancer statistics][Automated Flow] Loadbalancer statistics for the vBlade device is not present in MYSQL 

### DIFF
--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -1246,9 +1246,9 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         store = {}
         try:
-            thunders = self._vthunder_repo.get_vthunders_by_ip_address(db_apis.get_session(),
-                                                                       ip_address=ip,
-                                                                       vthunders=True)
+            thunders = self._vthunder_repo.get_vthunders_by_ip_address_statistics(
+                db_apis.get_session(),
+                ip_address=ip)
             for vthunder in thunders:
                 vthunder_stats_tf = self.taskflow_load(
                     self._listener_flows.get_listener_stats_flow(vthunder, store),

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -1246,7 +1246,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         store = {}
         try:
-            thunders = self._vthunder_repo.get_vthunders_by_ip_address_statistics(
+            thunders = self._vthunder_repo.get_all_vthunder_by_address(
                 db_apis.get_session(),
                 ip_address=ip)
             for vthunder in thunders:

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -298,16 +298,6 @@ class VThunderRepository(BaseRepository):
             model_list = model_list.options(noload('*'))
             return model_list.all()
 
-    def get_vthunders_by_ip_address_statistics(self, session, ip_address):
-        model_list = session.query(self.model_class).filter(
-            self.model_class.ip_address == ip_address).filter(
-            and_(self.model_class.status == "ACTIVE",
-                 or_(self.model_class.role == "STANDALONE",
-                     self.model_class.role == "MASTER",
-                     self.model_class.role == "BACKUP")))
-        model_list = model_list.options(noload('*'))
-        return model_list.all()
-
     def get_all_vthunder_by_address(self, session, ip_address):
         model_list = session.query(self.model_class).filter(
             self.model_class.ip_address == ip_address).filter(

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -298,6 +298,16 @@ class VThunderRepository(BaseRepository):
             model_list = model_list.options(noload('*'))
             return model_list.all()
 
+    def get_vthunders_by_ip_address_statistics(self, session, ip_address):
+        model_list = session.query(self.model_class).filter(
+            self.model_class.ip_address == ip_address).filter(
+            and_(self.model_class.status == "ACTIVE",
+                 or_(self.model_class.role == "STANDALONE",
+                     self.model_class.role == "MASTER",
+                     self.model_class.role == "BACKUP")))
+        model_list = model_list.options(noload('*'))
+        return model_list.all()
+
     def get_all_vthunder_by_address(self, session, ip_address):
         model_list = session.query(self.model_class).filter(
             self.model_class.ip_address == ip_address).filter(


### PR DESCRIPTION
## Description
- Severity Level : High
- Issue Description: Only entry for the vMaster device is present in listener_statistics table and entry for the vBlade device is not present 

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2937

## Technical Approach
- Previously we use to ignore blade device while fetching vthunders, used query which fetches all vthunder devices. 

## Manual Testing
```
stack@rahul:~/rahul/a10-octavia$ openstack loadbalancer listener list
+--------------------------------------+-----------------+-----------+----------------------------------+----------+---------------+----------------+
| id                                   | default_pool_id | name      | project_id                       | protocol | protocol_port | admin_state_up |
+--------------------------------------+-----------------+-----------+----------------------------------+----------+---------------+----------------+
| b028378b-251d-4e51-a657-1f9bb4c9e925 | None            | listener1 | b88132daae604a36b5eb988a65f43f9e | HTTP     |            80 | True           |
+--------------------------------------+-----------------+-----------+----------------------------------+----------+---------------+----------------+

```


```
mysql> select * from listener_statistics;
+--------------------------------------+----------+-----------+--------------------+-------------------+--------------------------------------+----------------+
| listener_id                          | bytes_in | bytes_out | active_connections | total_connections | amphora_id                           | request_errors |
+--------------------------------------+----------+-----------+--------------------+-------------------+--------------------------------------+----------------+
| b028378b-251d-4e51-a657-1f9bb4c9e925 |        0 |         0 |                  0 |                 0 | 0111faf6-0b2a-4ed7-ac2d-c90d594812c4 |              0 |
| b028378b-251d-4e51-a657-1f9bb4c9e925 |        0 |         0 |                  0 |                 0 | f105b720-ee95-4fce-bffa-1b65b954b6da |              0 |
+--------------------------------------+----------+-----------+--------------------+-------------------+--------------------------------------+----------------+
2 rows in set (0.00 sec)

```

```
mysql> select * from amphora;
+--------------------------------------+--------------------------------------+-----------+--------------------------------------+---------------+---------+-------+--------------+------------+--------+-----------------+-----------+----------------+---------+---------------+-------------+---------------------+---------------------+--------------------------------------+--------------------------------------+
| id                                   | compute_id                           | status    | load_balancer_id                     | lb_network_ip | vrrp_ip | ha_ip | vrrp_port_id | ha_port_id | role   | cert_expiration | cert_busy | vrrp_interface | vrrp_id | vrrp_priority | cached_zone | created_at          | updated_at          | image_id                             | compute_flavor                       |
+--------------------------------------+--------------------------------------+-----------+--------------------------------------+---------------+---------+-------+--------------+------------+--------+-----------------+-----------+----------------+---------+---------------+-------------+---------------------+---------------------+--------------------------------------+--------------------------------------+
| 0111faf6-0b2a-4ed7-ac2d-c90d594812c4 | bf1a01aa-d568-4ecc-ab61-c6d463dca66a | ALLOCATED | 507e90d9-2318-4e43-ad65-4a6bed557970 | 192.168.0.16  | NULL    | NULL  | NULL         | NULL       | BACKUP | NULL            |         0 | NULL           |    NULL |            90 | nova        | 2021-09-30 14:17:58 | 2021-09-30 14:20:51 | 1f16a115-3ede-4358-8a8d-82825fd91b82 | 4276bc45-ea5f-4b89-a553-a9c14b43c730 |
| f105b720-ee95-4fce-bffa-1b65b954b6da | 21bc4cf6-8805-4e27-8ee0-844f01ab3fb7 | ALLOCATED | 507e90d9-2318-4e43-ad65-4a6bed557970 | 192.168.0.166 | NULL    | NULL  | NULL         | NULL       | MASTER | NULL            |         0 | NULL           |    NULL |           100 | nova        | 2021-09-30 14:17:58 | 2021-09-30 14:20:51 | 1f16a115-3ede-4358-8a8d-82825fd91b82 | 4276bc45-ea5f-4b89-a553-a9c14b43c730 |
+--------------------------------------+--------------------------------------+-----------+--------------------------------------+---------------+---------+-------+--------------+------------+--------+-----------------+-----------+----------------+---------+---------------+-------------+---------------------+---------------------+--------------------------------------+--------------------------------------+
2 rows in set (0.00 sec)
```

**Note:  This change will not work will current version of redundant listener statistics removal code,  @mohdadeebkhan is changing the code for removal of redundant statistics rows.** 