### PR TITLE
[BUG][STACK-2962]: [Rack Flow] Getting apply complete! in terraform apply when subnet_id is not define in terraform script but a10-controller-worker log shows an error

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -450,31 +450,33 @@ class GetLoadbalancersInProjectBySubnet(BaseDatabaseTask):
 class CountLoadbalancersInProjectBySubnet(BaseDatabaseTask):
 
     def execute(self, subnet, partition_project_list, use_device_flavor):
-        if not use_device_flavor and partition_project_list:
-            try:
-                return self.loadbalancer_repo.get_lb_count_by_subnet(
-                    db_apis.get_session(),
-                    project_ids=partition_project_list, subnet_id=subnet.id)
-            except Exception as e:
-                LOG.exception("Failed to get LB count for subnet %s due to %s ",
-                              subnet.id, str(e))
-                raise e
+        if subnet:
+            if not use_device_flavor and partition_project_list:
+                try:
+                    return self.loadbalancer_repo.get_lb_count_by_subnet(
+                        db_apis.get_session(),
+                        project_ids=partition_project_list, subnet_id=subnet.id)
+                except Exception as e:
+                    LOG.exception("Failed to get LB count for subnet %s due to %s ",
+                                  subnet.id, str(e))
+                    raise e
         return 0
 
 
 class CountMembersInProjectBySubnet(BaseDatabaseTask):
 
     def execute(self, subnet, partition_project_list):
-        if partition_project_list:
-            try:
-                return self.member_repo.get_member_count_by_subnet(
-                    db_apis.get_session(),
-                    project_ids=partition_project_list, subnet_id=subnet.id)
-            except Exception as e:
-                LOG.exception(
-                    "Failed to get LB member count for subnet %s due to %s",
-                    subnet.id, str(e))
-                raise e
+        if subnet:
+            if partition_project_list:
+                try:
+                    return self.member_repo.get_member_count_by_subnet(
+                        db_apis.get_session(),
+                        project_ids=partition_project_list, subnet_id=subnet.id)
+                except Exception as e:
+                    LOG.exception(
+                        "Failed to get LB member count for subnet %s due to %s",
+                        subnet.id, str(e))
+                    raise e
         return 0
 
 

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -450,33 +450,35 @@ class GetLoadbalancersInProjectBySubnet(BaseDatabaseTask):
 class CountLoadbalancersInProjectBySubnet(BaseDatabaseTask):
 
     def execute(self, subnet, partition_project_list, use_device_flavor):
-        if subnet:
-            if not use_device_flavor and partition_project_list:
-                try:
-                    return self.loadbalancer_repo.get_lb_count_by_subnet(
-                        db_apis.get_session(),
-                        project_ids=partition_project_list, subnet_id=subnet.id)
-                except Exception as e:
-                    LOG.exception("Failed to get LB count for subnet %s due to %s ",
-                                  subnet.id, str(e))
-                    raise e
+        if not subnet:
+            return 0
+        if not use_device_flavor and partition_project_list:
+            try:
+                return self.loadbalancer_repo.get_lb_count_by_subnet(
+                    db_apis.get_session(),
+                    project_ids=partition_project_list, subnet_id=subnet.id)
+            except Exception as e:
+                LOG.exception("Failed to get LB count for subnet %s due to %s ",
+                              subnet.id, str(e))
+                raise e
         return 0
 
 
 class CountMembersInProjectBySubnet(BaseDatabaseTask):
 
     def execute(self, subnet, partition_project_list):
-        if subnet:
-            if partition_project_list:
-                try:
-                    return self.member_repo.get_member_count_by_subnet(
-                        db_apis.get_session(),
-                        project_ids=partition_project_list, subnet_id=subnet.id)
-                except Exception as e:
-                    LOG.exception(
-                        "Failed to get LB member count for subnet %s due to %s",
-                        subnet.id, str(e))
-                    raise e
+        if not subnet:
+            return 0
+        if partition_project_list:
+            try:
+                return self.member_repo.get_member_count_by_subnet(
+                    db_apis.get_session(),
+                    project_ids=partition_project_list, subnet_id=subnet.id)
+            except Exception as e:
+                LOG.exception(
+                    "Failed to get LB member count for subnet %s due to %s",
+                    subnet.id, str(e))
+                raise e
         return 0
 
 

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -66,11 +66,15 @@ class CalculateAmphoraDelta(BaseNetworkTask):
         member_networks = []
         for loadbalancer in loadbalancers_list:
             for pool in loadbalancer.pools:
-                member_networks = [
-                    self.network_driver.get_subnet(member.subnet_id).network_id
-                    for member in pool.members
-                    if member.subnet_id
-                ]
+                for member in pool.members:
+                    if member.subnet_id:
+                        member_networks = [
+                            self.network_driver.get_subnet(member.subnet_id).network_id]
+                    else:
+                        LOG.warning("Subnet id argument was not specified during "
+                                    "issuance of create command/API call for member %s. "
+                                    "Skipping interface attachment", member.id)
+
                 desired_network_ids.update(member_networks)
 
         loadbalancer_networks = [
@@ -758,75 +762,76 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
         objects from DB else need update existing ones.
         """
         updated_vrid_list = []
-        if subnet:
-            vrid_value = CONF.a10_global.vrid
-            prev_vrid_value = vrid_list[0].vrid if vrid_list else None
-            updated_vrid_list = copy.copy(vrid_list)
-            if use_device_flavor:
-                if vthunder_config.vrid_floating_ip:
-                    conf_floating_ip = vthunder_config.vrid_floating_ip
-                else:
-                    conf_floating_ip = CONF.a10_global.vrid_floating_ip
+        if not subnet:
+            return updated_vrid_list
+        vrid_value = CONF.a10_global.vrid
+        prev_vrid_value = vrid_list[0].vrid if vrid_list else None
+        updated_vrid_list = copy.copy(vrid_list)
+        if use_device_flavor:
+            if vthunder_config.vrid_floating_ip:
+                conf_floating_ip = vthunder_config.vrid_floating_ip
             else:
-                conf_floating_ip = a10_utils.get_vrid_floating_ip_for_project(
-                    lb_resource.project_id)
+                conf_floating_ip = CONF.a10_global.vrid_floating_ip
+        else:
+            conf_floating_ip = a10_utils.get_vrid_floating_ip_for_project(
+                lb_resource.project_id)
 
-            if not conf_floating_ip:
-                for vrid in updated_vrid_list:
-                    self._delete_vrid_port(vrid.vrid_port_id)
-                vrid_value = prev_vrid_value if prev_vrid_value else vrid_value
-                self._remove_device_vrid_fip(vthunder.partition_name, vrid_value)
-                return []
-
-            vrid_floating_ips = []
-            update_vrid_flag = False
-            existing_fips = []
-            owner = vthunder.ip_address + "_" + vthunder.partition_name
-            self._add_vrid_to_list(updated_vrid_list, subnet, owner)
+        if not conf_floating_ip:
             for vrid in updated_vrid_list:
-                try:
-                    vrid_summary = self.axapi_client.vrrpa.get(vrid.vrid)
-                except Exception as e:
-                    vrid_summary = {}
-                    LOG.exception("Failed to get existing VRID summary due to: %s", str(e))
+                self._delete_vrid_port(vrid.vrid_port_id)
+            vrid_value = prev_vrid_value if prev_vrid_value else vrid_value
+            self._remove_device_vrid_fip(vthunder.partition_name, vrid_value)
+            return []
 
-                if vrid_summary and 'floating-ip' in vrid_summary['vrid']:
-                    vrid_fip = vrid_summary['vrid']['floating-ip']
-                    if vthunder.partition_name != 'shared':
-                        for i in range(len(vrid_fip['ip-address-part-cfg'])):
-                            existing_fips.append(
-                                vrid_fip['ip-address-part-cfg'][i]['ip-address-partition'])
-                    else:
-                        for i in range(len(vrid_fip['ip-address-cfg'])):
-                            existing_fips.append(vrid_fip['ip-address-cfg'][i]['ip-address'])
-                vrid_subnet = self.network_driver.get_subnet(vrid.subnet_id)
-                vrid.vrid = vrid_value
-                if conf_floating_ip.lower() == 'dhcp':
-                    subnet_ip, subnet_mask = a10_utils.get_net_info_from_cidr(
-                        vrid_subnet.cidr)
-                    if not a10_utils.check_ip_in_subnet_range(
-                            vrid.vrid_floating_ip, subnet_ip, subnet_mask):
-                        vrid = self._replace_vrid_port(vrid, vrid_subnet, lb_resource)
-                        update_vrid_flag = True
-                else:
-                    new_ip = a10_utils.get_patched_ip_address(
-                        conf_floating_ip, vrid_subnet.cidr)
-                    if new_ip != vrid.vrid_floating_ip:
-                        vrid = self._replace_vrid_port(vrid, vrid_subnet, lb_resource, new_ip)
-                        update_vrid_flag = True
-                if isinstance(subnet, list):
-                    subnet_ids = set([s.id for s in subnet])
-                    if vrid_subnet.id in subnet_ids or vrid.vrid_floating_ip in existing_fips:
-                        vrid_floating_ips.append(vrid.vrid_floating_ip)
-                else:
-                    if vrid_subnet.id == subnet.id or vrid.vrid_floating_ip in existing_fips:
-                        vrid_floating_ips.append(vrid.vrid_floating_ip)
+        vrid_floating_ips = []
+        update_vrid_flag = False
+        existing_fips = []
+        owner = vthunder.ip_address + "_" + vthunder.partition_name
+        self._add_vrid_to_list(updated_vrid_list, subnet, owner)
+        for vrid in updated_vrid_list:
+            try:
+                vrid_summary = self.axapi_client.vrrpa.get(vrid.vrid)
+            except Exception as e:
+                vrid_summary = {}
+                LOG.exception("Failed to get existing VRID summary due to: %s", str(e))
 
-            if (prev_vrid_value is not None) and (prev_vrid_value != vrid_value):
-                self._remove_device_vrid_fip(vthunder.partition_name, prev_vrid_value)
-                self._update_device_vrid_fip(vthunder.partition_name, vrid_floating_ips, vrid_value)
-            elif update_vrid_flag:
-                self._update_device_vrid_fip(vthunder.partition_name, vrid_floating_ips, vrid_value)
+            if vrid_summary and 'floating-ip' in vrid_summary['vrid']:
+                vrid_fip = vrid_summary['vrid']['floating-ip']
+                if vthunder.partition_name != 'shared':
+                    for i in range(len(vrid_fip['ip-address-part-cfg'])):
+                        existing_fips.append(
+                            vrid_fip['ip-address-part-cfg'][i]['ip-address-partition'])
+                else:
+                    for i in range(len(vrid_fip['ip-address-cfg'])):
+                        existing_fips.append(vrid_fip['ip-address-cfg'][i]['ip-address'])
+            vrid_subnet = self.network_driver.get_subnet(vrid.subnet_id)
+            vrid.vrid = vrid_value
+            if conf_floating_ip.lower() == 'dhcp':
+                subnet_ip, subnet_mask = a10_utils.get_net_info_from_cidr(
+                    vrid_subnet.cidr)
+                if not a10_utils.check_ip_in_subnet_range(
+                        vrid.vrid_floating_ip, subnet_ip, subnet_mask):
+                    vrid = self._replace_vrid_port(vrid, vrid_subnet, lb_resource)
+                    update_vrid_flag = True
+            else:
+                new_ip = a10_utils.get_patched_ip_address(
+                    conf_floating_ip, vrid_subnet.cidr)
+                if new_ip != vrid.vrid_floating_ip:
+                    vrid = self._replace_vrid_port(vrid, vrid_subnet, lb_resource, new_ip)
+                    update_vrid_flag = True
+            if isinstance(subnet, list):
+                subnet_ids = set([s.id for s in subnet])
+                if vrid_subnet.id in subnet_ids or vrid.vrid_floating_ip in existing_fips:
+                    vrid_floating_ips.append(vrid.vrid_floating_ip)
+            else:
+                if vrid_subnet.id == subnet.id or vrid.vrid_floating_ip in existing_fips:
+                    vrid_floating_ips.append(vrid.vrid_floating_ip)
+
+        if (prev_vrid_value is not None) and (prev_vrid_value != vrid_value):
+            self._remove_device_vrid_fip(vthunder.partition_name, prev_vrid_value)
+            self._update_device_vrid_fip(vthunder.partition_name, vrid_floating_ips, vrid_value)
+        elif update_vrid_flag:
+            self._update_device_vrid_fip(vthunder.partition_name, vrid_floating_ips, vrid_value)
 
         return updated_vrid_list
 

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -189,10 +189,11 @@ class AllowLoadbalancerForwardWithAnySource(VThunderBaseTask):
     """Task to add wildcat address in allowed_address_pair to allow any SNAT"""
 
     def execute(self, member, amphora):
-        subnet = self.network_driver.get_subnet(member.subnet_id)
-        if CONF.vthunder.slb_no_snat_support:
-            for amp in amphora:
-                self.network_driver.allow_use_any_source_ip_on_egress(subnet.network_id, amp)
+        if member.subnet_id:
+            subnet = self.network_driver.get_subnet(member.subnet_id)
+            if CONF.vthunder.slb_no_snat_support:
+                for amp in amphora:
+                    self.network_driver.allow_use_any_source_ip_on_egress(subnet.network_id, amp)
 
 
 class UpdateLoadbalancerForwardWithAnySource(VThunderBaseTask):


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description: When a member is created without specifying subnet_id into a terraform script for batch_updating members or even by a openstack command,  then terraform execution gets completed without any issue but an error is thrown on a10-octavia side in controller logs and the member goes into ERROR state.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2962

## Technical Approach
- Checking whether the member object is having subnet_id associated with it, before executing the tasks related to member's subnet_id.

## Manual Testing
1. Create a loadbalancer, listener and pool

stack@openstack-2:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-13-subnet --name vs1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-09-30T12:27:54                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 840a373c-78ab-4c7b-bf1d-660b248de304 |
| listeners           |                                      |
| name                | vs1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 6b1e0c27d80f4e5892a5c735726c657a     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.13.102                          |
| vip_network_id      | 193051f5-1c1b-4b96-b0b3-c16f9cd654f0 |
| vip_port_id         | a195a7c1-05f8-4ec7-98f1-0f36022ba386 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | dbb1d4b2-0982-4328-bcdc-ac3b3dccf9b6 |
+---------------------+--------------------------------------+
```

stack@openstack-2:~$ openstack loadbalancer listener create --name l1 --protocol http --protocol-port 85 vs1
```
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-09-30T12:28:31                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | aab964e3-2e75-4bad-bdba-0a525204ff32 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 840a373c-78ab-4c7b-bf1d-660b248de304 |
| name                        | l1                                   |
| operating_status            | OFFLINE                              |
| project_id                  | 6b1e0c27d80f4e5892a5c735726c657a     |
| protocol                    | HTTP                                 |
| protocol_port               | 85                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
+-----------------------------+--------------------------------------+
```

stack@openstack-2:~$ openstack loadbalancer pool create --name p1 --protocol HTTP --lb-algorithm LEAST_CONNECTIONS --listener l1
```
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-09-30T12:28:41                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | dee4acdf-9c0b-4f00-bf54-687580ac3541 |
| lb_algorithm         | LEAST_CONNECTIONS                    |
| listeners            | aab964e3-2e75-4bad-bdba-0a525204ff32 |
| loadbalancers        | 840a373c-78ab-4c7b-bf1d-660b248de304 |
| members              |                                      |
| name                 | p1                                   |
| operating_status     | OFFLINE                              |
| project_id           | 6b1e0c27d80f4e5892a5c735726c657a     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
+----------------------+--------------------------------------+
```

2. Create a member by a terraform script without specifying subnet_id
```
resource "openstack_lb_members_v2" "members_1" {
  pool_id = "dee4acdf-9c0b-4f00-bf54-687580ac3541"

member {
    address       = "10.0.12.121"
    protocol_port = 90
    name          = "test_member"
    weight        = 1
  }
}
```

3. Perform terraform apply
stack@openstack-2:~/neha$ terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # openstack_lb_members_v2.members_1 will be created
  + resource "openstack_lb_members_v2" "members_1" {
      + id      = (known after apply)
      + pool_id = "dee4acdf-9c0b-4f00-bf54-687580ac3541"
      + region  = (known after apply)

      + member {
          + address        = "10.0.12.121"
          + admin_state_up = true
          + id             = (known after apply)
          + name           = "test_member"
          + protocol_port  = 90
          + weight         = 1
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

openstack_lb_members_v2.members_1: Creating...
openstack_lb_members_v2.members_1: Creation complete after 3s [id=dee4acdf-9c0b-4f00-bf54-687580ac3541]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.


4. Check the a10-controller-worker logs
stack@openstack-2:~$ sudo journalctl -af --unit a10-controller-worker.service
Sep 30 13:49:18 openstack-2 a10-octavia-worker[31279]: INFO a10_octavia.controller.queue.endpoint [-] Batch updating members: old='[]', new='[u'559a8969-c383-44c9-8fb8-60d2e50699d1']', updated='[]'...
Sep 30 13:49:18 openstack-2 a10-octavia-worker[31279]: **WARNING a10_octavia.controller.worker.tasks.vthunder_tasks [-] Subnet id argument was not specified during issuance of create command/API call for member 559a8969-c383-44c9-8fb8-60d2e50699d1. Skipping TagInterfaceForMember task**

Result:
The member gets created without any error and logs a warning in the a10-controller-worker logs

stack@openstack-2:~/neha$ openstack loadbalancer member list p1
```
+--------------------------------------+-------------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| id                                   | name        | project_id                       | provisioning_status | address     | protocol_port | operating_status | weight |
+--------------------------------------+-------------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| 559a8969-c383-44c9-8fb8-60d2e50699d1 | test_member | 6b1e0c27d80f4e5892a5c735726c657a | ACTIVE              | 10.0.12.121 |            90 | NO_MONITOR       |      1 |
+--------------------------------------+-------------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
```


vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 1173 bytes
!Configuration last updated at 14:49:18 IST Thu Sep 30 2021
!Configuration last saved at 13:27:59 IST Thu Sep 30 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 10.0.0.50 255.255.255.0
!
vcs device 1
  priority 110
  interfaces management
  interfaces ethernet 1
  enable
!
vcs device 2
  priority 100
  interfaces management
  interfaces ethernet 1
  enable
!
vlan 1/12
  tagged ethernet 1
  router-interface ve 12
!
vlan 1/13
  tagged ethernet 1
  router-interface ve 13
!
vlan 2/12
  tagged ethernet 2
  router-interface ve 12
!
vlan 2/13
  tagged ethernet 2
  router-interface ve 13
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  enable
!
interface ethernet 1/2
!
interface ethernet 1/3
!
interface ethernet 1/4
!
interface ethernet 2/1
!
interface ethernet 2/2
  enable
!
interface ethernet 2/3
!
interface ethernet 2/4
!
interface ve 1/12
  ip address 10.0.12.13 255.255.255.0
!
interface ve 1/13
  ip address 10.0.13.13 255.255.255.0
!
interface ve 2/12
  ip address 10.0.12.18 255.255.255.0
!
interface ve 2/13
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.13.140
!
**slb server 6b1e0_10_0_12_121 10.0.12.121
  port 90 tcp**
!
slb service-group dee4acdf-9c0b-4f00-bf54-687580ac3541 tcp
  method least-connection
  **member 6b1e0_10_0_12_121 90**
!
slb virtual-server 840a373c-78ab-4c7b-bf1d-660b248de304 10.0.13.102
  port 85 http
    name aab964e3-2e75-4bad-bdba-0a525204ff32
    extended-stats
    service-group dee4acdf-9c0b-4f00-bf54-687580ac3541
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode



