### PR TITLE
[STACK-2962]: Added a check for subnet_id in ValidateSubnet task

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -1119,8 +1119,10 @@ class GetPoolsOnThunder(BaseNetworkTask):
 class ValidateSubnet(BaseNetworkTask):
 
     def execute(self, member):
-        member_subnet = self.network_driver.get_subnet(member.subnet_id)
-        subnet_ip, subnet_mask = a10_utils.get_net_info_from_cidr(member_subnet.cidr)
-        if not a10_utils.check_ip_in_subnet_range(
-                member.ip_address, subnet_ip, subnet_mask):
-            raise exceptions.IPAddressNotInSubentRangeError(member.ip_address, member_subnet.cidr)
+        if member.subnet_id:
+            member_subnet = self.network_driver.get_subnet(member.subnet_id)
+            subnet_ip, subnet_mask = a10_utils.get_net_info_from_cidr(member_subnet.cidr)
+            if not a10_utils.check_ip_in_subnet_range(
+                    member.ip_address, subnet_ip, subnet_mask):
+                raise exceptions.IPAddressNotInSubentRangeError(
+                    member.ip_address, member_subnet.cidr)


### PR DESCRIPTION
## Description
Added a check for subnet_id in ValidateSubnet task to resolve an issue for member creation without specifying subnet_id to it.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2962

## Technical Approach
Added a check for subnet_id in ValidateSubnet task to resolve an issue for member creation without specifying subnet_id to it.

## Manual Testing
Refer PR https://github.com/a10networks/a10-octavia/pull/529