### PR TITLE
[BUG][STACK-2988][Rack Flow] when try to update member with when address and subnet id is different

### DIFF
--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -255,9 +255,9 @@ class FlavorNotFound(cfg.ConfigFileValueError):
         super(FlavorNotFound, self).__init__(msg=msg)
 
 
-class IPAddressNotInSubentRangeError(base.NetworkException):
+class IPAddressNotInSubnetRangeError(base.NetworkException):
     def __init__(self, ip, subnet):
         msg = ('Invalid IP address specified. ' +
                'IP {0} out of range ' +
                'for subnet {1}.').format(ip, subnet)
-        super(IPAddressNotInSubentRangeError, self).__init__(msg)
+        super(IPAddressNotInSubnetRangeError, self).__init__(msg)

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -609,6 +609,9 @@ class MemberFlows(object):
 
         update_member_flow.add(database_tasks.MarkMemberPendingUpdateInDB(
             requires=constants.MEMBER))
+        update_member_flow.add(a10_network_tasks.ValidateSubnet(
+            name='validate-subnet',
+            requires=constants.MEMBER))
         update_member_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
@@ -668,6 +671,9 @@ class MemberFlows(object):
                       constants.LOADBALANCER,
                       constants.POOL]))
         update_member_flow.add(database_tasks.MarkMemberPendingUpdateInDB(
+            requires=constants.MEMBER))
+        update_member_flow.add(a10_network_tasks.ValidateSubnet(
+            name='validate-subnet',
             requires=constants.MEMBER))
         update_member_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
@@ -920,6 +926,9 @@ class MemberFlows(object):
             batch_update_members_flow.add(database_tasks.MarkMemberPendingUpdateInDB(
                 inject={constants.MEMBER: m},
                 name='mark-member-pending-update-in-db-' + m.id))
+            batch_update_members_flow.add(a10_network_tasks.ValidateSubnet(
+                name='validate-subnet' + m.id,
+                inject={constants.MEMBER: m}))
             batch_update_members_flow.add(server_tasks.MemberUpdate(
                 name='member-update-' + m.id,
                 inject={constants.MEMBER: m},
@@ -1099,6 +1108,9 @@ class MemberFlows(object):
             batch_update_members_flow.add(database_tasks.MarkMemberPendingUpdateInDB(
                 inject={constants.MEMBER: m},
                 name='mark-member-pending-update-in-db-' + m.id))
+            batch_update_members_flow.add(a10_network_tasks.ValidateSubnet(
+                name='validate-subnet' + m.id,
+                inject={constants.MEMBER: m}))
             batch_update_members_flow.add(a10_network_tasks.GetLBResourceSubnet(
                 name='{flow}-{id}'.format(
                     id=m.id, flow=a10constants.GET_LB_RESOURCE_SUBNET),

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -1123,4 +1123,4 @@ class ValidateSubnet(BaseNetworkTask):
         subnet_ip, subnet_mask = a10_utils.get_net_info_from_cidr(member_subnet.cidr)
         if not a10_utils.check_ip_in_subnet_range(
                 member.ip_address, subnet_ip, subnet_mask):
-            raise exceptions.IPAddressNotInSubentRangeError(member.ip_address, member_subnet.cidr)
+            raise exceptions.IPAddressNotInSubnetRangeError(member.ip_address, member_subnet.cidr)


### PR DESCRIPTION
## Description
**Severity Level:** Medium
**Issue Description:** Able to update a member successfully though provided ip_address from one subnet and specified different subnet for the subnet_id parameter.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2988

## Technical Approach
- Added **ValidateSubnet** task in the **get_update_member_flow**, **get_rack_vthunder_update_member_flow**, **get_rack_vthunder_batch_update_members_flow** and **get_batch_update_members_flow**.


## Manual Testing

**Rack Flow:**

- Create a LB, listener and pool

```
stack@automation-1:~#openstack loadbalancer list

+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| c6e3b9f0-1f49-43ef-921d-cf8e2febe14a | lb1  | 65246d947f8543eb85382f3107110eaf | 192.168.12.86 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+

```
```
stack@automation-1:~#openstack loadbalancer listener list

+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| id                                   | default_pool_id                      | name | project_id                       | protocol | protocol_port | admin_state_up |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| a02ee8ff-193c-43b6-a3df-2e9940523a5f | b5664acb-ec45-4639-a22c-1c73c1702405 | l1   | 65246d947f8543eb85382f3107110eaf | HTTP     |            86 | True           |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
```
```
stack@automation-1:~#openstack loadbalancer pool list
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| id                                   | name | project_id                       | provisioning_status | protocol | lb_algorithm      | admin_state_up |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| b5664acb-ec45-4639-a22c-1c73c1702405 | p1   | 65246d947f8543eb85382f3107110eaf | ACTIVE              | HTTP     | LEAST_CONNECTIONS | True           |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
stack@automation-1:~#
```

```
stack@automation-1:~#openstack subnet list

+--------------------------------------+----------------+--------------------------------------+-----------------+
| ID                                   | Name           | Network                              | Subnet          |
+--------------------------------------+----------------+--------------------------------------+-----------------+
| 37fa494f-c126-412e-8596-d9b7e4022a55 | vip_subnet     | 37aad4f9-5536-42ea-9f4d-263717bde468 | 192.168.12.0/24 |
| 6753e515-8ea3-4fa8-85ec-fedc836f1527 | 172.16.0.0     | eeed88a3-4bb0-41d4-bff1-2389ea9ab44d | 172.16.0.0/24   |
| 6c19bcd0-8204-4266-b9ea-b52ec12d03d2 | member_subnet  | 68eb0628-3818-42c1-a44b-592244d2abcc | 192.168.11.0/24 |
| ba681f6a-203a-47b2-902d-61d0c0f0627b | lb-mgmt-subnet | d1dfcf8d-cd42-4b9c-90ef-6f4dad52ddc7 | 192.168.0.0/24  |
| fea07409-804f-4839-9c21-27fa4174383b | subnet1        | dc9e49e5-8211-4ae1-a2dd-24ad364f9216 | 10.0.11.0/24    |
+--------------------------------------+----------------+--------------------------------------+-----------------+
stack@automation-1:~#
```

**Terraform script:**

- Added a member with **ip_address** 192.168.13.37 and specified different **subnet_id** 37fa494f-c126-412e-8596-d9b7e4022a55 (192.168.12.0/24)

```
resource "openstack_lb_members_v2" "members_1" {

  pool_id = "b5664acb-ec45-4639-a22c-1c73c1702405"

  member {

    address       = "192.168.13.37"

    protocol_port = 87

    subnet_id     = "37fa494f-c126-412e-8596-d9b7e4022a55"

    name          = "m1"

    weight        = 60

    admin_state_up = true

  }
  member {

    address       = "192.168.12.38"

    protocol_port = 88

    subnet_id     = "37fa494f-c126-412e-8596-d9b7e4022a55"

    name          = "m2"

    weight        = 60

    admin_state_up = true

  }
```

**Result:**

```
stack@automation-1:~#openstack loadbalancer member list p1

+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address       | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
| 26c12789-d8ec-4212-87fc-c7f16c740106 | m2   | 65246d947f8543eb85382f3107110eaf | ERROR               | 192.168.12.38 |            88 | NO_MONITOR       |     60 |
| 9b5d83f5-20c2-48e5-95f9-b483e4061e76 | m1   | 65246d947f8543eb85382f3107110eaf | ERROR               | 192.168.13.37 |            87 | NO_MONITOR       |     60 |
+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
stack@automation-1:~#
```


**Journalctl logs:**

**stack@automation-1:~#journalctl -af --unit a10-controller-worker.service**

```
ERROR oslo_messaging.rpc.server [-] Exception during message handling: IPAddressNotInSubnetRangeError: Invalid IP address specified. IP 192.168.13.37 out of range for subnet 192.168.12.0/24.
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server Traceback (most recent call last):
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/server.py", line 166, in _process_incoming
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     res = self.dispatcher.dispatch(message)
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 265, in dispatch
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     return self._do_dispatch(endpoint, method, ctxt, args)
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 194, in _do_dispatch
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     result = func(ctxt, **new_args)
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/queue/endpoint.py", line 123, in batch_update_members
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     old_member_ids, new_member_ids, updated_members)
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 292, in wrapped_f
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     return self.call(f, *args, **kw)
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 358, in call
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     do = self.iter(retry_state=retry_state)
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 319, in iter
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     return fut.result()
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/concurrent/futures/_base.py", line 455, in result
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     return self.__get_result()
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 361, in call
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     result = fn(*args, **kwargs)
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/controller_worker.py", line 738, in batch_update_members
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     batch_update_members_tf.run()
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 247, in run
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     for _state in self.run_iter(timeout=timeout):
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 340, in run_iter
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     failure.Failure.reraise_if_any(er_failures)
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 339, in reraise_if_any
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     failures[0].reraise()
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 346, in reraise
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     six.reraise(*self._exc_info)
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     result = task.execute(**arguments)
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/tasks/a10_network_tasks.py", line 1126, in execute
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     raise exceptions.IPAddressNotInSubnetRangeError(member.ip_address, member_subnet.cidr)
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server IPAddressNotInSubnetRangeError: Invalid IP address specified. IP 192.168.13.37 out of range for subnet 192.168.12.0/24.
Oct 01 11:27:31 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server
```


**vThunder Configuration:**

2. Update **admin_state_up** to false in the script 

```
resource "openstack_lb_members_v2" "members_1" {

  pool_id = "b5664acb-ec45-4639-a22c-1c73c1702405"

  member {

    address       = "192.168.13.37"

    protocol_port = 87

    subnet_id     = "37fa494f-c126-412e-8596-d9b7e4022a55"

    name          = "m1"

    weight        = 60

    admin_state_up = false

  }
  member {

    address       = "192.168.12.38"

    protocol_port = 88

    subnet_id     = "37fa494f-c126-412e-8596-d9b7e4022a55"

    name          = "m2"

    weight        = 60

    admin_state_up = false

  }

}
```

**Result:**

```
stack@automation-1:~#openstack loadbalancer member list p1

+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address       | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
| 26c12789-d8ec-4212-87fc-c7f16c740106 | m2   | 65246d947f8543eb85382f3107110eaf | ERROR               | 192.168.12.38 |            88 | NO_MONITOR       |     60 |
| 9b5d83f5-20c2-48e5-95f9-b483e4061e76 | m1   | 65246d947f8543eb85382f3107110eaf | ERROR               | 192.168.13.37 |            87 | NO_MONITOR       |     60 |
+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
stack@automation-1:~#
```


**Journalctl logs:**

**stack@automation-1:~#journalctl -af --unit a10-controller-worker.service**

```
ERROR oslo_messaging.rpc.server [-] Exception during message handling: IPAddressNotInSubnetRangeError: Invalid IP address specified. IP 192.168.13.37 out of range for subnet 192.168.12.0/24.
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server Traceback (most recent call last):
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/server.py", line 166, in _process_incoming
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     res = self.dispatcher.dispatch(message)
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 265, in dispatch
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     return self._do_dispatch(endpoint, method, ctxt, args)
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 194, in _do_dispatch
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     result = func(ctxt, **new_args)
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/queue/endpoint.py", line 123, in batch_update_members
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     old_member_ids, new_member_ids, updated_members)
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 292, in wrapped_f
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     return self.call(f, *args, **kw)
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 358, in call
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     do = self.iter(retry_state=retry_state)
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 319, in iter
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     return fut.result()
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/concurrent/futures/_base.py", line 455, in result
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     return self.__get_result()
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 361, in call
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     result = fn(*args, **kwargs)
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/controller_worker.py", line 738, in batch_update_members
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     batch_update_members_tf.run()
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 247, in run
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     for _state in self.run_iter(timeout=timeout):
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 340, in run_iter
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     failure.Failure.reraise_if_any(er_failures)
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 339, in reraise_if_any
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     failures[0].reraise()
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 346, in reraise
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     six.reraise(*self._exc_info)
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     result = task.execute(**arguments)
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/tasks/a10_network_tasks.py", line 1126, in execute
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server     raise exceptions.IPAddressNotInSubnetRangeError(member.ip_address, member_subnet.cidr)
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server IPAddressNotInSubnetRangeError: Invalid IP address specified. IP 192.168.13.37 out of range for subnet 192.168.12.0/24.
Oct 01 11:32:10 automation-1 a10-octavia-worker[1897]: ERROR oslo_messaging.rpc.server
```


2. Update a member having **ip_address** of one subnet and **subnet_id** of different subnet.

```
stack@automation-1:~#openstack loadbalancer member set --enable p1 m1

stack@automation-1:~#openstack loadbalancer member list p1

+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address       | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
| 26c12789-d8ec-4212-87fc-c7f16c740106 | m2   | 65246d947f8543eb85382f3107110eaf | ERROR               | 192.168.12.38 |            88 | NO_MONITOR       |     60 |
| 9b5d83f5-20c2-48e5-95f9-b483e4061e76 | m1   | 65246d947f8543eb85382f3107110eaf | ERROR               | 192.168.13.37 |            87 | NO_MONITOR       |     60 |
+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
stack@automation-1:~#
```


**Journalctl Log:**

**stack@automation-1:~#journalctl -af --unit a10-controller-worker.service**

```
INFO a10_octavia.controller.queue.endpoint [-] Updating member '9b5d83f5-20c2-48e5-95f9-b483e4061e76'...
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'validate-subnet' (b509d783-51ca-4a0c-b880-e693c48ff964) transitioned into state 'FAILURE' from state 'RUNNING'
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: 3 predecessors (most recent first):
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]:   Atom 'octavia.controller.worker.tasks.database_tasks.MarkMemberPendingUpdateInDB' {'intention': 'EXECUTE', 'state': 'SUCCESS', 'requires': {'member': <octavia.common.data_models.Member object at 0x7fc220486fd0>}, 'provides': None}
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]:   |__Atom 'octavia.controller.worker.tasks.lifecycle_tasks.MemberToErrorOnRevertTask' {'intention': 'EXECUTE', 'state': 'SUCCESS', 'requires': {'member': <octavia.common.data_models.Member object at 0x7fc220486fd0>, 'listeners': [<octavia.common.data_models.Listener object at 0x7fc1ee936290>], 'pool': <octavia.common.data_models.Pool object at 0x7fc1eeab2110>, 'loadbalancer': <octavia.common.data_models.LoadBalancer object at 0x7fc1ee8eaf10>}, 'provides': None}
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]:      |__Flow 'octavia-update-member-flow': IPAddressNotInSubnetRangeError: Invalid IP address specified. IP 192.168.13.37 out of range for subnet 192.168.12.0/24.
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR a10_octavia.controller.worker.controller_worker Traceback (most recent call last):
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR a10_octavia.controller.worker.controller_worker   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR a10_octavia.controller.worker.controller_worker     result = task.execute(**arguments)
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR a10_octavia.controller.worker.controller_worker   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/tasks/a10_network_tasks.py", line 1126, in execute
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR a10_octavia.controller.worker.controller_worker     raise exceptions.IPAddressNotInSubnetRangeError(member.ip_address, member_subnet.cidr)
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR a10_octavia.controller.worker.controller_worker IPAddressNotInSubnetRangeError: Invalid IP address specified. IP 192.168.13.37 out of range for subnet 192.168.12.0/24.
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR a10_octavia.controller.worker.controller_worker
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'validate-subnet' (b509d783-51ca-4a0c-b880-e693c48ff964) transitioned into state 'REVERTED' from state 'REVERTING'
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: WARNING octavia.controller.worker.tasks.database_tasks [-] Reverting mark member pending update in DB for member id 9b5d83f5-20c2-48e5-95f9-b483e4061e76
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'octavia.controller.worker.tasks.database_tasks.MarkMemberPendingUpdateInDB' (ed0f4d08-a7ed-4832-9a5a-726959713f6b) transitioned into state 'REVERTED' from state 'REVERTING'
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'octavia.controller.worker.tasks.lifecycle_tasks.MemberToErrorOnRevertTask' (94b7a82e-80f8-48e7-b4fa-a76133dff26e) transitioned into state 'REVERTED' from state 'REVERTING'
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: WARNING a10_octavia.controller.worker.controller_worker [-] Flow 'octavia-update-member-flow' (af9c0bcf-e2d3-4a42-b1a8-13e6eb187ca9) transitioned into state 'REVERTED' from state 'RUNNING'
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server [-] Exception during message handling: IPAddressNotInSubnetRangeError: Invalid IP address specified. IP 192.168.13.37 out of range for subnet 192.168.12.0/24.
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server Traceback (most recent call last):
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/server.py", line 166, in _process_incoming
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server     res = self.dispatcher.dispatch(message)
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 265, in dispatch
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server     return self._do_dispatch(endpoint, method, ctxt, args)
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 194, in _do_dispatch
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server     result = func(ctxt, **new_args)
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/queue/endpoint.py", line 112, in update_member
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server     self.worker.update_member(member_id, member_updates)
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/controller_worker.py", line 800, in update_member
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server     update_member_tf.run()
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 247, in run
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server     for _state in self.run_iter(timeout=timeout):
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 340, in run_iter
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server     failure.Failure.reraise_if_any(er_failures)
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 339, in reraise_if_any
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server     failures[0].reraise()
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 346, in reraise
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server     six.reraise(*self._exc_info)
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server     result = task.execute(**arguments)
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/tasks/a10_network_tasks.py", line 1126, in execute
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server     raise exceptions.IPAddressNotInSubnetRangeError(member.ip_address, member_subnet.cidr)
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server IPAddressNotInSubnetRangeError: Invalid IP address specified. IP 192.168.13.37 out of range for subnet 192.168.12.0/24.
Oct 01 11:57:09 automation-1 a10-octavia-worker[5272]: ERROR oslo_messaging.rpc.server
```


**vThunder Configuration:**

```
vThunder-vMaster[14/1](NOLICENSE)#show running-config slb
!Section configuration: 514 bytes
!
slb template http th1
!
slb template policy tp1
!
slb template policy tp3
!
slb template port tp2
!
slb template server ts1
!
slb template tcp tt1
!
slb template udp tu1
!
slb template virtual-port tvp1
!
slb service-group b5664acb-ec45-4639-a22c-1c73c1702405 tcp
  method least-connection
!
slb virtual-server c6e3b9f0-1f49-43ef-921d-cf8e2febe14a 192.168.12.86
  port 86 http
    name a02ee8ff-193c-43b6-a3df-2e9940523a5f
    extended-stats
    service-group b5664acb-ec45-4639-a22c-1c73c1702405
!
vThunder-vMaster[14/1](NOLICENSE)#
```

**vThunder Flow**

- Create a LB, listener and pool

```
stack@automation-1:~#openstack loadbalancer list

+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
| 344d882d-3654-4a95-a2d9-8fc35d9210af | lb1  | 65246d947f8543eb85382f3107110eaf | 192.168.12.73 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+----------+
stack@automation-1:~#

```
```
stack@automation-1:~#openstack loadbalancer listener list

+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| id                                   | default_pool_id                      | name | project_id                       | protocol | protocol_port | admin_state_up |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| 8693a36b-e050-4d70-b2d0-7594331c0635 | 857f4fbe-a2ab-4fac-a020-9d7386517c6f | l1   | 65246d947f8543eb85382f3107110eaf | HTTP     |            86 | True           |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+

```
```
stack@automation-1:~#openstack loadbalancer pool list

+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| id                                   | name | project_id                       | provisioning_status | protocol | lb_algorithm      | admin_state_up |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| 857f4fbe-a2ab-4fac-a020-9d7386517c6f | p1   | 65246d947f8543eb85382f3107110eaf | ACTIVE              | HTTP     | LEAST_CONNECTIONS | True           |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
stack@automation-1:~#
```

```
stack@automation-1:~#openstack server list

+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------+----------------------+-----------------+
| ID                                   | Name                                         | Status | Networks                                             | Image                | Flavor          |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------+----------------------+-----------------+
| 97b0d1c1-e4e7-4a89-847a-7a99818c3cd6 | amphora-872b8bcf-cd2f-4ec2-89c6-f1edc565f84b | ACTIVE | lb-mgmt-net=192.168.0.112; vip_network=192.168.12.68 | vThunder_5_2_1-p1_56 | vThunder_flavor |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------+----------------------+-----------------+
stack@automation-1:~#
```

```
stack@automation-1:~#openstack subnet list

+--------------------------------------+----------------+--------------------------------------+-----------------+
| ID                                   | Name           | Network                              | Subnet          |
+--------------------------------------+----------------+--------------------------------------+-----------------+
| 37fa494f-c126-412e-8596-d9b7e4022a55 | vip_subnet     | 37aad4f9-5536-42ea-9f4d-263717bde468 | 192.168.12.0/24 |
| 6753e515-8ea3-4fa8-85ec-fedc836f1527 | 172.16.0.0     | eeed88a3-4bb0-41d4-bff1-2389ea9ab44d | 172.16.0.0/24   |
| 6c19bcd0-8204-4266-b9ea-b52ec12d03d2 | member_subnet  | 68eb0628-3818-42c1-a44b-592244d2abcc | 192.168.11.0/24 |
| ba681f6a-203a-47b2-902d-61d0c0f0627b | lb-mgmt-subnet | d1dfcf8d-cd42-4b9c-90ef-6f4dad52ddc7 | 192.168.0.0/24  |
| fea07409-804f-4839-9c21-27fa4174383b | subnet1        | dc9e49e5-8211-4ae1-a2dd-24ad364f9216 | 10.0.11.0/24    |
+--------------------------------------+----------------+--------------------------------------+-----------------+
stack@automation-1:~#
```

**Terraform script:**

- Added a member with **ip_address** 192.168.13.37 and specified different **subnet_id** 37fa494f-c126-412e-8596-d9b7e4022a55 (192.168.12.0/24)

```
resource "openstack_lb_members_v2" "members_1" {

  pool_id = "b5664acb-ec45-4639-a22c-1c73c1702405"

  member {

    address       = "192.168.13.37"

    protocol_port = 87

    subnet_id     = "37fa494f-c126-412e-8596-d9b7e4022a55"

    name          = "m1"

    weight        = 60

    admin_state_up = true

  }
  member {

    address       = "192.168.12.38"

    protocol_port = 88

    subnet_id     = "37fa494f-c126-412e-8596-d9b7e4022a55"

    name          = "m2"

    weight        = 60

    admin_state_up = true

  }
```

**Result:**

```
stack@automation-1:~#openstack loadbalancer member list p1

+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address       | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
| 102aca8c-c84f-43ae-9c12-2be8602e90a6 | m1   | 65246d947f8543eb85382f3107110eaf | ERROR               | 192.168.13.37 |            87 | NO_MONITOR       |     60 |
| f50ea625-dc3d-415e-939e-1804e3ccd971 | m2   | 65246d947f8543eb85382f3107110eaf | ERROR               | 192.168.12.38 |            88 | NO_MONITOR       |     60 |
+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
stack@automation-1:~#
```


**Journalctl logs:**

**stack@automation-1:~#journalctl -af --unit a10-controller-worker.service**
```

ERROR oslo_messaging.rpc.server [-] Exception during message handling: IPAddressNotInSubnetRangeError: Invalid IP address specified. IP 192.168.13.37 out of range for subnet 192.168.12.0/24.
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server Traceback (most recent call last):
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/server.py", line 166, in _process_incoming
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     res = self.dispatcher.dispatch(message)
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 265, in dispatch
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     return self._do_dispatch(endpoint, method, ctxt, args)
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 194, in _do_dispatch
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     result = func(ctxt, **new_args)
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/queue/endpoint.py", line 123, in batch_update_members
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     old_member_ids, new_member_ids, updated_members)
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 292, in wrapped_f
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     return self.call(f, *args, **kw)
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 358, in call
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     do = self.iter(retry_state=retry_state)
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 319, in iter
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     return fut.result()
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/concurrent/futures/_base.py", line 455, in result
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     return self.__get_result()
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 361, in call
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     result = fn(*args, **kwargs)
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/controller_worker.py", line 738, in batch_update_members
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     batch_update_members_tf.run()
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 247, in run
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     for _state in self.run_iter(timeout=timeout):
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 340, in run_iter
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     failure.Failure.reraise_if_any(er_failures)
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 339, in reraise_if_any
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     failures[0].reraise()
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 346, in reraise
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     six.reraise(*self._exc_info)
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     result = task.execute(**arguments)
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/tasks/a10_network_tasks.py", line 1126, in execute
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     raise exceptions.IPAddressNotInSubnetRangeError(member.ip_address, member_subnet.cidr)
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server IPAddressNotInSubnetRangeError: Invalid IP address specified. IP 192.168.13.37 out of range for subnet 192.168.12.0/24.
Oct 01 12:28:31 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server
```

- Update **admin_state_up** to false in the script and run the script again.

```
resource "openstack_lb_members_v2" "members_1" {

  pool_id = "b5664acb-ec45-4639-a22c-1c73c1702405"

  member {

    address       = "192.168.13.37"

    protocol_port = 87

    subnet_id     = "37fa494f-c126-412e-8596-d9b7e4022a55"

    name          = "m1"

    weight        = 60

    admin_state_up = false

  }
  member {

    address       = "192.168.12.38"

    protocol_port = 88

    subnet_id     = "37fa494f-c126-412e-8596-d9b7e4022a55"

    name          = "m2"

    weight        = 60

    admin_state_up = false

  }

}
```

**Result:**

```
stack@automation-1:~#openstack loadbalancer member list p1

+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address       | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
| 102aca8c-c84f-43ae-9c12-2be8602e90a6 | m1   | 65246d947f8543eb85382f3107110eaf | ERROR               | 192.168.13.37 |            87 | NO_MONITOR       |     60 |
| f50ea625-dc3d-415e-939e-1804e3ccd971 | m2   | 65246d947f8543eb85382f3107110eaf | ERROR               | 192.168.12.38 |            88 | NO_MONITOR       |     60 |
+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
stack@automation-1:~#
```

**Journalctl logs:**

**stack@automation-1:~#journalctl -af --unit a10-controller-worker.service**
```

 ERROR oslo_messaging.rpc.server [-] Exception during message handling: IPAddressNotInSubnetRangeError: Invalid IP address specified. IP 192.168.13.37 out of range for subnet 192.168.12.0/24.
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server Traceback (most recent call last):
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/server.py", line 166, in _process_incoming
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     res = self.dispatcher.dispatch(message)
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 265, in dispatch
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     return self._do_dispatch(endpoint, method, ctxt, args)
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 194, in _do_dispatch
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     result = func(ctxt, **new_args)
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/queue/endpoint.py", line 123, in batch_update_members
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     old_member_ids, new_member_ids, updated_members)
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 292, in wrapped_f
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     return self.call(f, *args, **kw)
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 358, in call
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     do = self.iter(retry_state=retry_state)
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 319, in iter
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     return fut.result()
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/concurrent/futures/_base.py", line 455, in result
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     return self.__get_result()
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 361, in call
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     result = fn(*args, **kwargs)
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/controller_worker.py", line 738, in batch_update_members
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     batch_update_members_tf.run()
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 247, in run
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     for _state in self.run_iter(timeout=timeout):
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 340, in run_iter
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     failure.Failure.reraise_if_any(er_failures)
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 339, in reraise_if_any
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     failures[0].reraise()
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 346, in reraise
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     six.reraise(*self._exc_info)
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     result = task.execute(**arguments)
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/tasks/a10_network_tasks.py", line 1126, in execute
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     raise exceptions.IPAddressNotInSubnetRangeError(member.ip_address, member_subnet.cidr)
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server IPAddressNotInSubnetRangeError: Invalid IP address specified. IP 192.168.13.37 out of range for subnet 192.168.12.0/24.
Oct 01 12:30:08 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server

```
- Update a member having **ip_address** of one subnet and **subnet_id** of different subnet.

```
stack@automation-1:~#openstack loadbalancer member set --enable p1 m1

stack@automation-1:~#

```

```
stack@automation-1:~#openstack loadbalancer member list p1

+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address       | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
| 102aca8c-c84f-43ae-9c12-2be8602e90a6 | m1   | 65246d947f8543eb85382f3107110eaf | ERROR               | 192.168.13.37 |            87 | NO_MONITOR       |     60 |
| f50ea625-dc3d-415e-939e-1804e3ccd971 | m2   | 65246d947f8543eb85382f3107110eaf | ERROR               | 192.168.12.38 |            88 | NO_MONITOR       |     60 |
+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
```

**Journalctl Log**

**stack@automation-1:~#journalctl -af --unit a10-controller-worker.service**

```
 INFO a10_octavia.controller.queue.endpoint [-] Updating member '102aca8c-c84f-43ae-9c12-2be8602e90a6'...
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'validate-subnet' (fe9cefcc-1f14-447b-b7b7-0f5022555a9f) transitioned into state 'FAILURE' from state 'RUNNING'
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: 4 predecessors (most recent first):
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]:   Atom 'octavia.controller.worker.tasks.database_tasks.MarkMemberPendingUpdateInDB' {'intention': 'EXECUTE', 'state': 'SUCCESS', 'requires': {'member': <octavia.common.data_models.Member object at 0x7f38f4b0acd0>}, 'provides': None}
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]:   |__Atom 'a10_octavia.controller.worker.tasks.vthunder_tasks.VthunderInstanceBusy' {'intention': 'EXECUTE', 'state': 'SUCCESS', 'requires': {'compute_busy': False}, 'provides': None}
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]:      |__Atom 'octavia.controller.worker.tasks.lifecycle_tasks.MemberToErrorOnRevertTask' {'intention': 'EXECUTE', 'state': 'SUCCESS', 'requires': {'member': <octavia.common.data_models.Member object at 0x7f38f4b0acd0>, 'listeners': [<octavia.common.data_models.Listener object at 0x7f38f40b1f90>], 'pool': <octavia.common.data_models.Pool object at 0x7f38f424ced0>, 'loadbalancer': <octavia.common.data_models.LoadBalancer object at 0x7f38f40b1610>}, 'provides': None}
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]:         |__Flow 'octavia-update-member-flow': IPAddressNotInSubnetRangeError: Invalid IP address specified. IP 192.168.13.37 out of range for subnet 192.168.12.0/24.
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR a10_octavia.controller.worker.controller_worker Traceback (most recent call last):
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR a10_octavia.controller.worker.controller_worker   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR a10_octavia.controller.worker.controller_worker     result = task.execute(**arguments)
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR a10_octavia.controller.worker.controller_worker   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/tasks/a10_network_tasks.py", line 1126, in execute
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR a10_octavia.controller.worker.controller_worker     raise exceptions.IPAddressNotInSubnetRangeError(member.ip_address, member_subnet.cidr)
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR a10_octavia.controller.worker.controller_worker IPAddressNotInSubnetRangeError: Invalid IP address specified. IP 192.168.13.37 out of range for subnet 192.168.12.0/24.
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR a10_octavia.controller.worker.controller_worker
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'validate-subnet' (fe9cefcc-1f14-447b-b7b7-0f5022555a9f) transitioned into state 'REVERTED' from state 'REVERTING'
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: WARNING octavia.controller.worker.tasks.database_tasks [-] Reverting mark member pending update in DB for member id 102aca8c-c84f-43ae-9c12-2be8602e90a6
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'octavia.controller.worker.tasks.database_tasks.MarkMemberPendingUpdateInDB' (3ac8970f-29dd-47e0-b585-ada170bdd45c) transitioned into state 'REVERTED' from state 'REVERTING'
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'a10_octavia.controller.worker.tasks.vthunder_tasks.VthunderInstanceBusy' (a4c0f2a8-52ee-4e10-808e-99e1297d88ba) transitioned into state 'REVERTED' from state 'REVERTING'
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: WARNING a10_octavia.controller.worker.controller_worker [-] Task 'octavia.controller.worker.tasks.lifecycle_tasks.MemberToErrorOnRevertTask' (fa5484b5-e31a-447f-8934-01bce888ef1b) transitioned into state 'REVERTED' from state 'REVERTING'
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: WARNING a10_octavia.controller.worker.controller_worker [-] Flow 'octavia-update-member-flow' (f75b7d5c-5f37-4f50-83af-1df7bb11252a) transitioned into state 'REVERTED' from state 'RUNNING'
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server [-] Exception during message handling: IPAddressNotInSubnetRangeError: Invalid IP address specified. IP 192.168.13.37 out of range for subnet 192.168.12.0/24.
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server Traceback (most recent call last):
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/server.py", line 166, in _process_incoming
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     res = self.dispatcher.dispatch(message)
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 265, in dispatch
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     return self._do_dispatch(endpoint, method, ctxt, args)
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 194, in _do_dispatch
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     result = func(ctxt, **new_args)
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/queue/endpoint.py", line 112, in update_member
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     self.worker.update_member(member_id, member_updates)
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/controller_worker.py", line 800, in update_member
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     update_member_tf.run()
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 247, in run
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     for _state in self.run_iter(timeout=timeout):
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 340, in run_iter
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     failure.Failure.reraise_if_any(er_failures)
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 339, in reraise_if_any
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     failures[0].reraise()
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 346, in reraise
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     six.reraise(*self._exc_info)
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     result = task.execute(**arguments)
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server   File "/opt/stack/batch_update/a10-octavia/a10_octavia/controller/worker/tasks/a10_network_tasks.py", line 1126, in execute
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server     raise exceptions.IPAddressNotInSubnetRangeError(member.ip_address, member_subnet.cidr)
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server IPAddressNotInSubnetRangeError: Invalid IP address specified. IP 192.168.13.37 out of range for subnet 192.168.12.0/24.
Oct 01 12:31:36 automation-1 a10-octavia-worker[7502]: ERROR oslo_messaging.rpc.server
```

**vThunder Configuration:**

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 186 bytes
!Configuration last updated at 13:22:41 IST Fri Oct 1 2021
!Configuration last saved at 13:22:43 IST Fri Oct 1 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
slb service-group 857f4fbe-a2ab-4fac-a020-9d7386517c6f tcp
  method least-connection
!
slb virtual-server 344d882d-3654-4a95-a2d9-8fc35d9210af 192.168.12.73
  port 86 http
    name 8693a36b-e050-4d70-b2d0-7594331c0635
    extended-stats
    service-group 857f4fbe-a2ab-4fac-a020-9d7386517c6f
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#
vThunder(NOLICENSE)#
vThunder(NOLICENSE)#
```

