### PR TITLE
[STACK-2999] GLM tasks aren't ignored during second loadbalancer create

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -88,10 +88,10 @@ class LoadBalancerFlows(object):
         # Attaching vThunder to LB in database
         if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
             lb_create_flow.add(*self._create_active_standby_topology())
-            LOG.info("TOPOLOGY ===" + str(topology))
+            LOG.info("TOPOLOGY === " + str(topology))
         elif topology == constants.TOPOLOGY_SINGLE:
             lb_create_flow.add(*self._create_single_topology())
-            LOG.info("TOPOLOGY ===" + str(topology))
+            LOG.info("TOPOLOGY === " + str(topology))
         else:
             LOG.error("Unknown topology: %s.  Unable to build load balancer.",
                       topology)

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -84,7 +84,7 @@ class VThunderFlows(object):
                 name=sf_name + '-' + a10constants.MARK_AMPHORA_READY_INDB,
                 requires=(constants.AMPHORA)))
         create_vthunder_flow.add(self.get_glm_license_subflow(
-            prefix=a10constants.SPARE_VTHUNDER_CREATE))
+            prefix=a10constants.SPARE_VTHUNDER_CREATE, role=a10constants.SPARE_VTHUNDER))
         create_vthunder_flow.add(
             vthunder_tasks.CreateHealthMonitorOnVThunder(
                 name=sf_name + '-' + a10constants.CREATE_HEALTH_MONITOR_ON_SPARE,
@@ -215,7 +215,7 @@ class VThunderFlows(object):
                     requires=(a10constants.VTHUNDER, constants.AMPHORA)))
         # License the vThunder-Amphora
         create_amp_for_lb_subflow.add(
-            self.get_glm_license_subflow(prefix + '-' + role, role))
+            *self.get_glm_license_subflow(prefix + '-' + role, role))
         create_amp_for_lb_subflow.add(
             database_tasks.MarkAmphoraAllocatedInDB(
                 name=sf_name + '-' + constants.MARK_AMPHORA_ALLOCATED_INDB,
@@ -389,40 +389,40 @@ class VThunderFlows(object):
 
         if role == constants.ROLE_BACKUP:
             glm_license_subflow.add(vthunder_tasks.SetVThunderHostname(
-                name=role + '-' + a10constants.SET_VTHUNDER_HOSTNAME,
+                name=sf_name + '-' + a10constants.SET_VTHUNDER_HOSTNAME,
                 requires=constants.AMPHORA,
                 rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}
             ))
             glm_license_subflow.add(glm_tasks.ConfigureForwardProxyServer(
-                name=role + '-' + a10constants.CONFIGURE_PROXY_SERVER,
+                name=sf_name + '-' + a10constants.CONFIGURE_PROXY_SERVER,
                 requires=constants.FLAVOR,
                 rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}
             ))
             glm_license_subflow.add(glm_tasks.DNSConfiguration(
-                name=role + '-' + a10constants.CONFIGURE_DNS_NAMESERVERS,
+                name=sf_name + '-' + a10constants.CONFIGURE_DNS_NAMESERVERS,
                 requires=constants.FLAVOR,
                 rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
             ))
             glm_license_subflow.add(glm_tasks.ActivateFlexpoolLicense(
-                name=role + '-' + a10constants.ACTIVATE_FLEXPOOL_LICENSE,
+                name=sf_name + '-' + a10constants.ACTIVATE_FLEXPOOL_LICENSE,
                 requires=(constants.AMPHORA, constants.FLAVOR),
                 rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
             ))
         else:
             glm_license_subflow.add(vthunder_tasks.SetVThunderHostname(
-                name=role + '-' + a10constants.SET_VTHUNDER_HOSTNAME,
+                name=sf_name + '-' + a10constants.SET_VTHUNDER_HOSTNAME,
                 requires=(constants.AMPHORA, a10constants.VTHUNDER)
             ))
             glm_license_subflow.add(glm_tasks.ConfigureForwardProxyServer(
-                name=role + '-' + a10constants.CONFIGURE_PROXY_SERVER,
+                name=sf_name + '-' + a10constants.CONFIGURE_PROXY_SERVER,
                 requires=(constants.FLAVOR, a10constants.VTHUNDER)
             ))
             glm_license_subflow.add(glm_tasks.DNSConfiguration(
-                name=role + '-' + a10constants.CONFIGURE_DNS_NAMESERVERS,
+                name=sf_name + '-' + a10constants.CONFIGURE_DNS_NAMESERVERS,
                 requires=(constants.FLAVOR, a10constants.VTHUNDER)
             ))
             glm_license_subflow.add(glm_tasks.ActivateFlexpoolLicense(
-                name=role + '-' + a10constants.ACTIVATE_FLEXPOOL_LICENSE,
+                name=sf_name + '-' + a10constants.ACTIVATE_FLEXPOOL_LICENSE,
                 requires=(constants.AMPHORA, a10constants.VTHUNDER, constants.FLAVOR),
             ))
         return glm_license_subflow


### PR DESCRIPTION
## Description
Severity Level: Critical

When a second loadbalancer is created in the same project, the glm tasks are not ignored. This occurs because the glm tasks are not added directly to the create amphora flow which the decider is controlling. The decider is set to the flow level so any subsequent flows will not be ignored.

```
        # Setup the decider for the path if we can map vThunder
        amp_for_lb_flow.link(allocate_and_associate_amp, map_lb_to_vthunder,
                             decider=self._allocate_amp_to_lb_decider,
                             decider_depth='flow')
        # Setup the decider to create a vThunder
        amp_for_lb_flow.link(allocate_and_associate_amp, create_amp,
                             decider=self._create_new_amp_for_lb_decider,
                             decider_depth='flow')

```

## Jira Ticket
- [STACK-2999](https://a10networks.atlassian.net/browse/STACK-2999?focusedCommentId=493386)

## Technical Approach
- Used the splat operator to add the list of tasks from the linear flow directly to the create amphora flow

## Config Changes
N/A

## Test Cases
N/A

## Manual Testing
**GLM config omitted**

Steps:
1. openstack loadbalancer create --vip-subnet-id provider-vlan-12-subnet --name vip1
2. openstack loadbalancer create --vip-subnet-id provider-vlan-12-subnet --name vip2
3. openstack loadbalancer create --vip-subnet-id provider-vlan-12-subnet --name vip3

Expected Result:
3 vips created within a licensed device