### PR TITLE
[BUG][STACK-3009]: Fix for validating flavor schema by changing type from bool to boolean

### DIFF
--- a/a10_octavia/api/drivers/flavor_schema.py
+++ b/a10_octavia/api/drivers/flavor_schema.py
@@ -229,7 +229,7 @@ SUPPORTED_FLAVOR_SCHEMA = {
                     "description": "Username for proxy authentication"
                 },
                 "proxy-password": {
-                    "type": "bool",
+                    "type": "boolean",
                     "description": "Password for proxy authentication"
                 },
                 "proxy-secret-string": {
@@ -243,7 +243,7 @@ SUPPORTED_FLAVOR_SCHEMA = {
             "description": "Global License Manager configuration settings",
             "properties": {
                 "use-network-dns": {
-                    "type": "bool",
+                    "type": "boolean",
                     "description": "Use the network dns nameservers instead of "
                                    "those in the config or flavor."
                 },
@@ -254,7 +254,7 @@ SUPPORTED_FLAVOR_SCHEMA = {
                     "maximum": 204800
                 },
                 "burst": {
-                    "type": "bool",
+                    "type": "boolean",
                     "description": "Enable bursting. Allows amphora to exceed allocated "
                                    "bandwidth limits. Ensures that packets never drop."
                 },
@@ -271,7 +271,7 @@ SUPPORTED_FLAVOR_SCHEMA = {
                     "maximum": 65535
                 },
                 "enable-requests": {
-                    "type": "bool",
+                    "type": "boolean",
                     "description": "Enables license retrieval from the GLM/ELM server. "
                                    "Allows license changes to be replicated automatically.",
                 },

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_compute_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_compute_tasks.py
@@ -14,7 +14,6 @@
 
 import copy
 import imp
-from json import load
 
 try:
     from unittest import mock

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_database_tasks.py
@@ -577,7 +577,6 @@ class TestA10DatabaseTasks(base.BaseTaskTestCase):
         mock_get_listener.listener_stats_repo.get_all.return_value = [LISTENER_STATS], None
         mock_get_listener.execute([LISTENER_STATS])
         mock_stats_base.assert_called_once_with([LISTENER_STATS])
-        mock_get_listener.listener_stats_repo.delete.assert_called_once()
 
     def test_GetVThunderAmphora(self):
         db_task = task.GetVThunderAmphora()


### PR DESCRIPTION
## Description
- Severity Level: Medium
- Issue Description: [FlavorProfile]: Getting error while valiating flavorrprofile

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-3009

## Technical Approach
- Changed the type from "bool" from "boolean" in flavor_schema.
- Removed unused import from test_a10_compute_tasks.py
- Updated the _test_update_listeners_stats_with_statistics_ test case as deleting of listener stats is removed from UpdateListenerStats task.

## Config Changes
- N/A

## Test Cases
- N/A

## Manual Testing
1) Create Flavor profile
```
stack@adeeb-victoria:~/adeeb/a10-octavia$ openstack loadbalancer flavorprofile create --name fp_persistcookie --provider a10 --flavor-data '{"virtual-server":{"stats-data-action":"stats-data-disable","extended-stats":1,"disable-vip-adv":1,"enable-disable-action":"disable-when-all-ports-down","arp-disable":1},"virtual-port":{"auto":1,"stats-data-action":"stats-data-disable","template-persist-cookie": "persist_cookie","conn-limit":200}}'
+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field         | Value                                                                                                                                                                                                                                                                                                      |
+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| id            | 0698ba6f-1b8c-48b4-acac-c52183be982c                                                                                                                                                                                                                                                                       |
| name          | fp_persistcookie                                                                                                                                                                                                                                                                                           |
| provider_name | a10                                                                                                                                                                                                                                                                                                        |
| flavor_data   | {"virtual-server":{"stats-data-action":"stats-data-disable","extended-stats":1,"disable-vip-adv":1,"enable-disable-action":"disable-when-all-ports-down","arp-disable":1},"virtual-port":{"auto":1,"stats-data-action":"stats-data-disable","template-persist-cookie": "persist_cookie","conn-limit":200}} |
+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
stack@adeeb-victoria:~/adeeb/a10-octavia$ openstack loadbalancer flavorprofile list
+--------------------------------------+------------------+---------------+
| id                                   | name             | provider_name |
+--------------------------------------+------------------+---------------+
| 0698ba6f-1b8c-48b4-acac-c52183be982c | fp_persistcookie | a10           |
+--------------------------------------+------------------+---------------+
stack@adeeb-victoria:~/adeeb/a10-octavia$
```
