### PR TITLE
[STACK-3007] Prevent failover on pending state vthunder

### DIFF
--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -367,15 +367,32 @@ class VThunderFlows(object):
             vthunder_for_amphora_subflow.add(database_tasks.MarkAmphoraMasterInDB(
                 name=sf_name + '-' + constants.MARK_AMP_MASTER_INDB,
                 requires=constants.AMPHORA))
+            vthunder_for_amphora_subflow.add(
+                vthunder_tasks.UpdateAcosVersionInVthunderEntry(
+                    name=sf_name + '-' + a10constants.UPDATE_ACOS_VERSION_FOR_BACKUP_VTHUNDER,
+                    requires=(a10constants.VTHUNDER)))
         elif role == constants.ROLE_BACKUP:
             vthunder_for_amphora_subflow.add(database_tasks.MarkAmphoraBackupInDB(
                 name=sf_name + '-' + constants.MARK_AMP_BACKUP_INDB,
                 requires=constants.AMPHORA))
+            vthunder_for_amphora_subflow.add(
+                a10_database_tasks.GetBackupVThunderByLoadBalancer(
+                    name=sf_name + '-' + a10constants.BACKUP_VTHUNDER,
+                    requires=constants.LOADBALANCER,
+                    provides=a10constants.BACKUP_VTHUNDER))
+            vthunder_for_amphora_subflow.add(
+                vthunder_tasks.UpdateAcosVersionInVthunderEntry(
+                    name=sf_name + '-' + a10constants.UPDATE_ACOS_VERSION_FOR_BACKUP_VTHUNDER,
+                    rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER}))
         elif role == constants.ROLE_STANDALONE:
             vthunder_for_amphora_subflow.add(
                 database_tasks.MarkAmphoraStandAloneInDB(
                     name=sf_name + '-' + constants.MARK_AMP_STANDALONE_INDB,
                     requires=constants.AMPHORA))
+            vthunder_for_amphora_subflow.add(
+                vthunder_tasks.UpdateAcosVersionInVthunderEntry(
+                    name=sf_name + '-' + a10constants.UPDATE_ACOS_VERSION_FOR_BACKUP_VTHUNDER,
+                    requires=(a10constants.VTHUNDER)))
 
         # If spare vThunder is used, remove spare vThunder the database
         vthunder_for_amphora_subflow.add(a10_database_tasks.DeleteStaleSpareVThunder(

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_compute_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_compute_tasks.py
@@ -14,7 +14,6 @@
 
 import copy
 import imp
-from json import load
 
 try:
     from unittest import mock


### PR DESCRIPTION
## Description
If Bug Fix:
- Required: Severity Level Critical
- Required: Issue Description
The root cause is the second loadbalancer creation for vThunder flow will failed.
And then the loadbalancer change state to error. And failover starts.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3007

## Technical Approach
1. Fix the second loadbalancer creation failed by get the acos version for it. (This is caused by we move the task for get acos version, and missing this case. And vthunder don't have acos version and interface attachment failed)
2. For Failover, move the vThunder status to Down when health monitor find it not update udp after heartbeat_timeout. So, health monitor will not keep checking it in loop.

## Config Changes
<pre>
<b>[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
[a10_controller_worker]
amp_image_owner_id = ecc2542be2644881b049636b719ca536
amp_secgroup_list = 5a83254b-7a99-4684-a4e5-94ed75d505c9
amp_image_tag = "vthunder_5_2_1-p2"
amp_flavor_id = ba761d2f-a08c-42eb-a53e-e3a0fa646590
amp_boot_network_list = 9558e757-f279-4120-9e61-540a91be9c10
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 150
amp_active_wait_sec = 10
amp_busy_wait_sec = 0
loadbalancer_topology = ACTIVE_STANDBY
[a10_health_manager]
udp_server_ip_address = 192.168.0.164
bind_port = 5550
bind_ip = 192.168.0.164
heartbeat_interval = 5
health_check_timeout = 3
health_check_max_retries = 5
heartbeat_key = insecure
heartbeat_timeout = 30
failover_timeout = 600
health_check_interval = 10
[a10_house_keeping]
load_balancer_expiry_age = 3600
amphorae_expiry_age = 3600
[a10_global]
network_type = "flat"
</b>
</pre>

## Test Cases
create 2 lb on a vThunder

## Manual Testing
```
stack@ytsai-victoria:~/source/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+----------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address    | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+----------------+---------------------+------------------+----------+
| b4361952-391a-4b94-aaa1-9434b488a282 | vip1 | ecc2542be2644881b049636b719ca536 | 192.168.91.57  | ACTIVE              | OFFLINE          | a10      |
| 4fa2d6e2-692f-40e1-b24f-4ab2fb3dc293 | vip2 | ecc2542be2644881b049636b719ca536 | 192.168.92.147 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+----------------+---------------------+------------------+----------+

```