### PR TITLE
[STACK-2944] Remove the logic to prevent failover on paused vThunder

### DIFF
--- a/a10_octavia/cmd/vthunder_heartbeat_udp.py
+++ b/a10_octavia/cmd/vthunder_heartbeat_udp.py
@@ -100,4 +100,6 @@ class VThunderUDPStatusGetter(object):
                         'heartbeat packet. Ignoring this packet. '
                         'Exception: %s', ex)
         else:
-            self.stats_executor.submit(cw.A10ControllerWorker().perform_vthunder_stats_update(ip))
+            if not CONF.a10_health_manager.stats_update_disable:
+                self.stats_executor.submit(
+                    cw.A10ControllerWorker().perform_vthunder_stats_update(ip))

--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -241,9 +241,6 @@ A10_HEALTH_MANAGER_OPTS = [
     cfg.IntOpt('health_update_threads',
                default=None,
                help=_('Number of processes for vthunder health update.')),
-    cfg.IntOpt('stats_update_threads',
-               default=None,
-               help=_('Number of processes for vthunder stats update.')),
     cfg.StrOpt('heartbeat_key',
                help=_('key used to validate vthunder sending'
                       'the message'), secret=True),
@@ -270,6 +267,9 @@ A10_HEALTH_MANAGER_OPTS = [
     cfg.IntOpt('stats_update_timeout',
                default=10,
                help=_('VThunder axapi timeout for Listener stats')),
+    cfg.BoolOpt('stats_update_disable',
+                default=False,
+                help=_('Disable loadbalancer listener statistics update')),
 ]
 
 A10_CONTROLLER_WORKER_OPTS = [

--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -271,12 +271,6 @@ class MissThunderForFailover(acos_errors.ACOSException):
         super(MissThunderForFailover, self).__init__(msg=msg)
 
 
-class FailoverOnPausedCompute(acos_errors.ACOSException):
-    def __init__(self):
-        msg = ('Failover on a paused compute, skipping....')
-        super(FailoverOnPausedCompute, self).__init__(msg=msg)
-
-
 class FlavorNotFound(cfg.ConfigFileValueError):
     def __init__(self, flavor):
         msg = ('Flavor {0} specified in the configuration file cannot be located,'

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -627,8 +627,6 @@ class VThunderFlows(object):
         sf_name = 'a10-house-keeper-failover-spare-vthunder'
         failover_flow = linear_flow.Flow(sf_name)
 
-        failover_flow.add(compute_tasks.FailoverPausedCompute(
-            requires=a10constants.VTHUNDER))
         failover_flow.add(a10_database_tasks.GetVThunderAmphora(
             name=sf_name + '-' + a10constants.GET_VTHUNDER_AMPHORA,
             requires=a10constants.VTHUNDER,
@@ -768,8 +766,6 @@ class VThunderFlows(object):
         sf_name = 'a10-house-keeper-failover-vcs-vthunder'
         failover_flow = linear_flow.Flow(sf_name)
 
-        failover_flow.add(compute_tasks.FailoverPausedCompute(
-            requires=a10constants.VTHUNDER))
         failover_flow.add(a10_database_tasks.GetComputeVThundersAndLoadBalancers(
             name=sf_name + '-' + a10constants.GET_LBS_BY_THUNDER,
             requires=a10constants.VTHUNDER,


### PR DESCRIPTION
## Description
If Bug Fix:
- Required: Severity Level HIGHT
- Required: Issue Description
As discussed in the meeting we will also failover on paused instance.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2944

## Technical Approach
- remove the logic to prevent failover on paused vthunder
- Also fix the issue that network list for vthunder creation is not correct in failover flow
- remove redundant configuration and add a switch to disable listener statistic update 

## Config Changes
<pre>
<b>stack@ytsai-victoria:~/source/a10-octavia$ sed -e '/^#/d' /etc/a10/a10-octavia.conf  | grep -Ev "^$"
[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
[a10_controller_worker]
amp_image_owner_id = ecc2542be2644881b049636b719ca536
amp_secgroup_list = 5a83254b-7a99-4684-a4e5-94ed75d505c9
amp_image_tag = "vthunder_5_2_1-p2"
amp_flavor_id = ba761d2f-a08c-42eb-a53e-e3a0fa646590
amp_boot_network_list = 9558e757-f279-4120-9e61-540a91be9c10
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 150
amp_active_wait_sec = 10
amp_busy_wait_sec = 0
loadbalancer_topology = ACTIVE_STANDBY
[a10_health_manager]
udp_server_ip_address = 192.168.0.164
bind_port = 5550
bind_ip = 192.168.0.164
heartbeat_interval = 20
health_check_timeout = 3
health_check_max_retries = 5
heartbeat_key = insecure
heartbeat_timeout = 30
failover_timeout = 600
health_check_interval = 10
stats_update_disable = True
[a10_house_keeping]
load_balancer_expiry_age = 3600
amphorae_expiry_age = 3600
[a10_global]
network_type = "flat"
</b>
</pre>


## Test Cases
1. Create 2 LBs in active-standby mode
2. pause one instance
3. the paused vthunder will be failover correctly.

## Manual Testing
 - openstack log
```
stack@ytsai-victoria:~/source/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+--------------------------------------------------------------------+-------------------+---------------+
| ID                                   | Name                                         | Status | Networks                                                           | Image             | Flavor        |
+--------------------------------------+----------------------------------------------+--------+--------------------------------------------------------------------+-------------------+---------------+
| 5a32836a-d4ea-4d57-8842-72144e34a205 | amphora-208938ad-d15d-4c39-b45b-4b46ba20da3f | ACTIVE | lb-mgmt-net=192.168.0.123; tp91=192.168.91.194; tp92=192.168.92.30 | vthunder_5_2_1-p2 | vthunder_4cpu |
| 6ed4c78d-c68e-41c1-8d0f-9d294e7fad95 | amphora-a5b38fe0-28b7-4f46-ba17-934a1538d8eb | ACTIVE | lb-mgmt-net=192.168.0.20; tp91=192.168.91.193; tp92=192.168.92.46  | vthunder_5_2_1-p2 | vthunder_4cpu |
+--------------------------------------+----------------------------------------------+--------+--------------------------------------------------------------------+-------------------+---------------+
stack@ytsai-victoria:~/source/a10-octavia$ openstack server pause 6ed4c78d-c68e-41c1-8d0f-9d294e7fad95
stack@ytsai-victoria:~/source/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+---------------------------------------------------------------------+-------------------+---------------+
| ID                                   | Name                                         | Status | Networks                                                            | Image             | Flavor        |
+--------------------------------------+----------------------------------------------+--------+---------------------------------------------------------------------+-------------------+---------------+
| d8e93fc3-00bb-4502-9a27-3a8194b62d40 | amphora-81eef6ae-315b-4008-8f4c-44ecd951204a | ACTIVE | lb-mgmt-net=192.168.0.172; tp91=192.168.91.178; tp92=192.168.92.206 | vthunder_5_2_1-p2 | vthunder_4cpu |
| 5a32836a-d4ea-4d57-8842-72144e34a205 | amphora-208938ad-d15d-4c39-b45b-4b46ba20da3f | ACTIVE | lb-mgmt-net=192.168.0.123; tp91=192.168.91.194; tp92=192.168.92.30  | vthunder_5_2_1-p2 | vthunder_4cpu |
| 6ed4c78d-c68e-41c1-8d0f-9d294e7fad95 | amphora-a5b38fe0-28b7-4f46-ba17-934a1538d8eb | PAUSED | lb-mgmt-net=192.168.0.20; tp91=192.168.91.193; tp92=192.168.92.46   | vthunder_5_2_1-p2 | vthunder_4cpu |
+--------------------------------------+----------------------------------------------+--------+---------------------------------------------------------------------+-------------------+---------------+
stack@ytsai-victoria:~/source/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+---------------------------------------------------------------------+-------------------+---------------+
| ID                                   | Name                                         | Status | Networks                                                            | Image             | Flavor        |
+--------------------------------------+----------------------------------------------+--------+---------------------------------------------------------------------+-------------------+---------------+
| d8e93fc3-00bb-4502-9a27-3a8194b62d40 | amphora-81eef6ae-315b-4008-8f4c-44ecd951204a | ACTIVE | lb-mgmt-net=192.168.0.172; tp91=192.168.91.178; tp92=192.168.92.206 | vthunder_5_2_1-p2 | vthunder_4cpu |
| 5a32836a-d4ea-4d57-8842-72144e34a205 | amphora-208938ad-d15d-4c39-b45b-4b46ba20da3f | ACTIVE | lb-mgmt-net=192.168.0.123; tp91=192.168.91.194; tp92=192.168.92.30  | vthunder_5_2_1-p2 | vthunder_4cpu |
+--------------------------------------+----------------------------------------------+--------+---------------------------------------------------------------------+-------------------+---------------+
```

 - in vthunder CLI
```
vThunder-Standby-vBlade[1/2](NOLICENSE)#show running-config | sec virtual-server
slb virtual-server 4fa2d6e2-692f-40e1-b24f-4ab2fb3dc293 192.168.92.147
slb virtual-server b4361952-391a-4b94-aaa1-9434b488a282 192.168.91.57
```
