### PR TITLE
changed config option stats_update_thread to stats_update_threads

### DIFF
--- a/a10_octavia/cmd/vthunder_heartbeat_udp.py
+++ b/a10_octavia/cmd/vthunder_heartbeat_udp.py
@@ -45,7 +45,7 @@ class VThunderUDPStatusGetter(object):
         self.update(self.key, self.ip, self.port)
         self.vthunder_repo = a10repo.VThunderRepository()
         self.stats_executor = futures.ProcessPoolExecutor(
-            max_workers=CONF.a10_health_manager.stats_update_thread)
+            max_workers=CONF.a10_health_manager.stats_update_threads)
 
     def update(self, key, ip, port):
         """Update the running config for the udp socket server

--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -242,7 +242,7 @@ A10_HEALTH_MANAGER_OPTS = [
                default=None,
                help=_('Number of processes for vthunder health update.')),
     cfg.IntOpt('stats_update_threads',
-               default=None,
+               default=4,
                help=_('Number of processes for vthunder stats update.')),
     cfg.StrOpt('heartbeat_key',
                help=_('key used to validate vthunder sending'
@@ -264,9 +264,6 @@ A10_HEALTH_MANAGER_OPTS = [
     cfg.IntOpt('heartbeat_interval',
                default=10,
                help=_('Sleep time between sending heartbeats.')),
-    cfg.IntOpt('stats_update_thread',
-               default=4,
-               help=_('Number of processes for thunder stats update')),
     cfg.IntOpt('stats_update_timeout',
                default=10,
                help=_('VThunder axapi timeout for Listener stats')),


### PR DESCRIPTION
## Description
To have config option similar to Octavia code, change the stats_update_thread to stats_update_threads in config_options.py

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-3011

## Technical Approach
- Changed "stats_update_thread" to "stats_update_threads" in config_options.py and vthunder_heartbeat_udp.py

## Config Changes

<pre>
[a10_health_manager]
udp_server_ip_address = 192.168.0.4
bind_port = 5550
bind_ip = 192.168.0.4
<b>stats_update_threads = 4</b>
</pre>

## Test Cases
- N/A 

## Manual Testing
1) Create lb and listener.
```
stack@adeeb-victoria:~/adeeb/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| 39cde409-57b4-46af-a70b-4ed4c9dd0c2c | v1   | dfc1c5d940834625941fe0b34202950d | 10.0.11.163 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
stack@adeeb-victoria:~/adeeb/a10-octavia$ openstack loadbalancer listener list
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| id                                   | default_pool_id                      | name | project_id                       | protocol | protocol_port | admin_state_up |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
| 289d96db-987a-4506-8c4d-b2dd768b640d | 6ce4d301-acda-4824-b536-36ed8c236d01 | l80  | dfc1c5d940834625941fe0b34202950d | HTTP     |            80 | True           |
+--------------------------------------+--------------------------------------+------+----------------------------------+----------+---------------+----------------+
stack@adeeb-victoria:~/adeeb/a10-octavia$
```

2)Restart the health manager service
logs:
```
Oct 07 08:09:06 adeeb-victoria systemd[1]: Started Devstack a10-health-manager.service.
Oct 07 08:09:09 adeeb-victoria a10-health-manager[540114]: INFO a10_octavia.common.config_options [-] Logging enabled!
Oct 07 08:09:09 adeeb-victoria a10-health-manager[540114]: INFO a10_octavia.common.config_options [-] /usr/local/bin/a10-health-manager version 7.1.2.dev33
Oct 07 08:09:09 adeeb-victoria a10-health-manager[540114]: INFO a10_octavia.cmd.a10_health_manager [-] A10 Health Manager listener process starts:
Oct 07 08:09:09 adeeb-victoria a10-health-manager[540114]: INFO a10_octavia.cmd.a10_health_manager [-] A10 Health manager check process starts:
Oct 07 08:09:09 adeeb-victoria a10-health-manager[540145]: INFO a10_octavia.cmd.vthunder_heartbeat_udp [-] attempting to listen on 192.168.0.4 port 5550
Oct 07 08:09:09 adeeb-victoria a10-health-manager[540146]: WARNING a10_octavia.cmd.a10_health_manager [-] Pausing before starting health check
Oct 07 08:09:15 adeeb-victoria a10-health-manager[540145]: INFO a10_octavia.cmd.vthunder_heartbeat_udp [-] Received packet from 192.168.0.64
Oct 07 08:09:16 adeeb-victoria a10-health-manager[540145]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Listener 289d96db-987a-4506-8c4d-b2dd768b640d / Amphora b10695b2-a0f5-4cbb-b223-0e63e8713b93 stats: {'bytes_in': 0, 'bytes_out': 0, 'active_connections': 0, 'total_connections': 0, 'request_errors': 0}
Oct 07 08:09:16 adeeb-victoria a10-health-manager[540145]: INFO a10_octavia.controller.worker.tasks.a10_database_tasks [-] Updated the listeners statistics
Oct 07 08:09:17 adeeb-victoria a10-health-manager[540145]: INFO a10_octavia.cmd.vthunder_heartbeat_udp [-] Received packet from 192.168.0.3
Oct 07 08:09:17 adeeb-victoria a10-health-manager[540145]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Listener 289d96db-987a-4506-8c4d-b2dd768b640d / Amphora fd7391c0-9eff-4f47-ad33-b7e98a592dc9 stats: {'bytes_in': 0, 'bytes_out': 0, 'active_connections': 0, 'total_connections': 0, 'request_errors': 0}
Oct 07 08:09:17 adeeb-victoria a10-health-manager[540145]: INFO a10_octavia.controller.worker.tasks.a10_database_tasks [-] Updated the listeners statistics
Oct 07 08:09:25 adeeb-victoria a10-health-manager[540145]: INFO a10_octavia.cmd.vthunder_heartbeat_udp [-] Received packet from 192.168.0.64
Oct 07 08:09:25 adeeb-victoria a10-health-manager[540145]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Listener 289d96db-987a-4506-8c4d-b2dd768b640d / Amphora b10695b2-a0f5-4cbb-b223-0e63e8713b93 stats: {'bytes_in': 0, 'bytes_out': 0, 'active_connections': 0, 'total_connections': 0, 'request_errors': 0}
Oct 07 08:09:25 adeeb-victoria a10-health-manager[540145]: INFO a10_octavia.controller.worker.tasks.a10_database_tasks [-] Updated the listeners statistics
```

