### PR TITLE
[BUG][STACK-2758]: Updated code for removing existing persistence template

### DIFF
--- a/a10_octavia/controller/worker/tasks/persist_tasks.py
+++ b/a10_octavia/controller/worker/tasks/persist_tasks.py
@@ -34,21 +34,22 @@ class HandleSessionPersistenceDelta(task.Task):
         sess_pers = pool.session_persistence
         if pool.session_persistence and hasattr(pool.session_persistence, 'to_dict'):
             sess_pers = pool.session_persistence.to_dict()
-        if sess_pers and sess_pers['type'] in SP_OBJ_DICT:
 
-            # Remove existing persistence template if any
-            for sp_type in PERS_TYPE:
-                try:
-                    sp_template = getattr(self.axapi_client.slb.template, sp_type)
-                    sp_template.delete(pool.id)
-                    LOG.debug("Successfully deleted existing session persistence template "
-                              "for pool: %s", pool.id)
-                except acos_errors.NotFound:
-                    pass
-                except (acos_errors.ACOSException, ConnectionError) as e:
-                    LOG.exception("Failed to delete existing session persistence for pool: %s",
-                                  pool.id)
-                    raise e
+        # Remove existing persistence template if any
+        for sp_type in PERS_TYPE:
+            try:
+                sp_template = getattr(self.axapi_client.slb.template, sp_type)
+                sp_template.delete(pool.id)
+                LOG.debug("Successfully deleted existing session persistence template "
+                          "for pool: %s", pool.id)
+            except acos_errors.NotFound:
+                pass
+            except (acos_errors.ACOSException, ConnectionError) as e:
+                LOG.exception("Failed to delete existing session persistence for pool: %s",
+                              pool.id)
+                raise e
+
+        if sess_pers and sess_pers['type'] in SP_OBJ_DICT:
             sp_template = getattr(self.axapi_client.slb.template, SP_OBJ_DICT[sess_pers['type']])
 
             try:

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_persist_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_persist_tasks.py
@@ -86,14 +86,14 @@ class TestPersistTasks(BaseTaskTestCase):
         mock_session_persist.axapi_client = self.client_mock
         self.pool.session_persistence = APP_COOKIE_SESS_PERS_WITH_NO_TYPE
         mock_session_persist.execute(VTHUNDER, self.pool)
-        self.client_mock.slb.template.cookie_persistence.delete.assert_not_called()
+        self.client_mock.slb.template.cookie_persistence.delete.assert_called_with(POOL.id)
         self.client_mock.slb.template.cookie_persistence.create.assert_not_called()
 
     def test_handle_session_persistence_with_source_ip_with_no_sess_pers(self):
         mock_session_persist = persist_tasks.HandleSessionPersistenceDelta()
         mock_session_persist.axapi_client = self.client_mock
         mock_session_persist.execute(VTHUNDER, self.pool)
-        self.client_mock.slb.template.src_ip_persistence.delete.assert_not_called()
+        self.client_mock.slb.template.src_ip_persistence.delete.assert_called_with(POOL.id)
         self.client_mock.slb.template.src_ip_persistence.create.assert_not_called()
 
     def test_revert_handle_session_persistence_with_source_ip(self):
@@ -136,5 +136,5 @@ class TestPersistTasks(BaseTaskTestCase):
         mock_session_persist.axapi_client = self.client_mock
         self.pool.session_persistence = None
         mock_session_persist.execute(VTHUNDER, self.pool)
-        self.client_mock.slb.template.src_ip_persistence.delete.assert_not_called()
+        self.client_mock.slb.template.src_ip_persistence.delete.assert_called_with(POOL.id)
         self.client_mock.slb.template.src_ip_persistence.create.assert_not_called()


### PR DESCRIPTION
## Description
- Severity Level: Medium
- Issue Description :[unset pool session_persistence] slb template persist isn't removed when unset pool's session persistence

## Jira Ticket
- https://a10networks.atlassian.net/browse/STACK-2758

## Technical Approach
- Change the position of the "if statement" so that it can remove the existing persistence template.

## Config Changes
- N/A

## Test Cases
- Changed _test_handle_session_persistence_with_app_cookie_with_no_sess_pers_type_ ,  _test_handle_session_persistence_with_source_ip_with_no_sess_pers_ and _test_unset_session_persistence_.

## Manual Testing
1) Create lb, listener and pool
```
openstack loadbalancer create --name v1 --vip-subnet-id private-11-subnet
openstack loadbalancer listener create --name l80 v1 --protocol http --protocol-port 80

openstack loadbalancer pool create --name p80 --protocol http --lb-algorithm LEAST_CONNECTIONS --listener l80

stack@adeeb-victoria:~/adeeb/a10-octavia$ openstack loadbalancer pool list
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| id                                   | name | project_id                       | provisioning_status | protocol | lb_algorithm      | admin_state_up |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| 6dc27401-60c8-4a89-8c91-63b3dd3ee4e3 | p80  | dfc1c5d940834625941fe0b34202950d | ACTIVE              | HTTP     | LEAST_CONNECTIONS | True           |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
stack@adeeb-victoria:~/adeeb/a10-octavia$

Logs:
Oct 11 10:46:00 adeeb-victoria a10-octavia-worker[1486747]: INFO a10_octavia.controller.queue.endpoint [-] Creating pool '6dc27401-60c8-4a89-8c91-63b3dd3ee4e3'...
Oct 11 10:46:01 adeeb-victoria a10-octavia-worker[1486747]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.0.3:shared

vthunder:
amphora-fd7391c0-9eff-4f47-ad33-Active-vMaster[1/1](NOLICENSE)#show running-config slb
!Section configuration: 398 bytes
!
slb server octavia_health_manager_controller 192.168.0.4
  health-check octavia_health_monitor
!
slb service-group 6dc27401-60c8-4a89-8c91-63b3dd3ee4e3 tcp
  method least-connection
!
slb virtual-server 39cde409-57b4-46af-a70b-4ed4c9dd0c2c 10.0.11.163
  port 80 http
    name 289d96db-987a-4506-8c4d-b2dd768b640d
    extended-stats
    service-group 6dc27401-60c8-4a89-8c91-63b3dd3ee4e3
!
amphora-fd7391c0-9eff-4f47-ad33-Active-vMaster[1/1](NOLICENSE)#
```

2) Set the pool with session persistence
```
stack@adeeb-victoria:~/adeeb/a10-octavia$ openstack loadbalancer pool set p80 --session-persistence type=HTTP_COOKIE
stack@adeeb-victoria:~/adeeb/a10-octavia$ openstack loadbalancer pool list
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| id                                   | name | project_id                       | provisioning_status | protocol | lb_algorithm      | admin_state_up |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| 6dc27401-60c8-4a89-8c91-63b3dd3ee4e3 | p80  | dfc1c5d940834625941fe0b34202950d | ACTIVE              | HTTP     | LEAST_CONNECTIONS | True           |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
stack@adeeb-victoria:~/adeeb/a10-octavia$

Logs:
Oct 11 10:53:24 adeeb-victoria a10-octavia-worker[1486745]: INFO a10_octavia.controller.queue.endpoint [-] Updating pool '6dc27401-60c8-4a89-8c91-63b3dd3ee4e3'...
Oct 11 10:53:25 adeeb-victoria a10-octavia-worker[1486745]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.0.3:shared

vthunder:
amphora-fd7391c0-9eff-4f47-ad33-Active-vMaster[1/1](NOLICENSE)#show running-config slb
!Section configuration: 532 bytes
!
slb template persist cookie 6dc27401-60c8-4a89-8c91-63b3dd3ee4e3
!
slb server octavia_health_manager_controller 192.168.0.4
  health-check octavia_health_monitor
!
slb service-group 6dc27401-60c8-4a89-8c91-63b3dd3ee4e3 tcp
  method least-connection
!
slb virtual-server 39cde409-57b4-46af-a70b-4ed4c9dd0c2c 10.0.11.163
  port 80 http
    name 289d96db-987a-4506-8c4d-b2dd768b640d
    extended-stats
    service-group 6dc27401-60c8-4a89-8c91-63b3dd3ee4e3
    template persist cookie 6dc27401-60c8-4a89-8c91-63b3dd3ee4e3
!
amphora-fd7391c0-9eff-4f47-ad33-Active-vMaster[1/1](NOLICENSE)#
```

3) Unset the pool
```
stack@adeeb-victoria:~/adeeb/a10-octavia$ openstack loadbalancer pool unset p80 --session-persistence
stack@adeeb-victoria:~/adeeb/a10-octavia$ openstack loadbalancer pool list
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| id                                   | name | project_id                       | provisioning_status | protocol | lb_algorithm      | admin_state_up |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
| 6dc27401-60c8-4a89-8c91-63b3dd3ee4e3 | p80  | dfc1c5d940834625941fe0b34202950d | ACTIVE              | HTTP     | LEAST_CONNECTIONS | True           |
+--------------------------------------+------+----------------------------------+---------------------+----------+-------------------+----------------+
stack@adeeb-victoria:~/adeeb/a10-octavia$

Logs:
Oct 11 10:55:32 adeeb-victoria a10-octavia-worker[1486745]: INFO a10_octavia.controller.queue.endpoint [-] Updating pool '6dc27401-60c8-4a89-8c91-63b3dd3ee4e3'...
Oct 11 10:55:32 adeeb-victoria a10-octavia-worker[1486745]: INFO a10_octavia.controller.worker.tasks.vthunder_tasks [-] Performing write memory for thunder - 192.168.0.3:shared

vthunder:
amphora-fd7391c0-9eff-4f47-ad33-Active-vMaster[1/1](NOLICENSE)#show running-config slb
!Section configuration: 398 bytes
!
slb server octavia_health_manager_controller 192.168.0.4
  health-check octavia_health_monitor
!
slb service-group 6dc27401-60c8-4a89-8c91-63b3dd3ee4e3 tcp
  method least-connection
!
slb virtual-server 39cde409-57b4-46af-a70b-4ed4c9dd0c2c 10.0.11.163
  port 80 http
    name 289d96db-987a-4506-8c4d-b2dd768b640d
    extended-stats
    service-group 6dc27401-60c8-4a89-8c91-63b3dd3ee4e3
!
amphora-fd7391c0-9eff-4f47-ad33-Active-vMaster[1/1](NOLICENSE)#

``` 
