### PR TITLE
[STACK-3022] Set LBs to ERROR when failover failed

### DIFF
--- a/a10_octavia/common/a10constants.py
+++ b/a10_octavia/common/a10constants.py
@@ -236,6 +236,7 @@ PLUG_VIP_NETWORK_ON_SPARE = 'plusg-vip-network-on-spare'
 POST_SPARE_PLUG_NETWORK = 'post-failover-plug-network'
 GET_VCS_DEVICE_ID = 'get-vcs-device-id'
 POST_FAILOVER_DB_UPDATE = 'post-failover-db-update'
+MARK_LB_LIST_ERROR_ON_REVERT = 'mark-lb-list-error-on-revert'
 
 # ======================
 # Non-Taskflow Constants

--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -774,6 +774,9 @@ class VThunderFlows(object):
         failover_flow.add(a10_database_tasks.SetVThunderToStandby(
             name=sf_name + '-' + a10constants.SET_VTHUNDER_TO_STANDBY,
             requires=a10constants.VTHUNDER_LIST))
+        failover_flow.add(a10_database_tasks.LoadBalancerListToErrorOnRevertTask(
+            name=sf_name + '-' + a10constants.MARK_LB_LIST_ERROR_ON_REVERT,
+            requires=a10constants.LOADBALANCERS_LIST))
         failover_flow.add(a10_database_tasks.MarkLoadBalancersPendingUpdateInDB(
             name=sf_name + '-' + a10constants.MARK_LB_PENIND_UPDATE_IN_DB,
             requires=a10constants.LOADBALANCERS_LIST))

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -26,6 +26,7 @@ from taskflow.types import failure
 
 from octavia.common import constants
 from octavia.common import exceptions as octavia_exceptions
+from octavia.controller.worker import task_utils as task_utilities
 from octavia.db import api as db_apis
 from octavia.db import repositories as repo
 from octavia.statistics import stats_base
@@ -56,6 +57,7 @@ class BaseDatabaseTask(task.Task):
         self.flavor_profile_repo = repo.FlavorProfileRepository()
         self.nat_pool_repo = a10_repo.NatPoolRepository()
         self.vrrp_set_repo = a10_repo.VrrpSetRepository()
+        self.task_utils = task_utilities.TaskUtils()
         super(BaseDatabaseTask, self).__init__(**kwargs)
 
 
@@ -1353,3 +1355,14 @@ class CountLBThunderPartition(BaseDatabaseTask):
         return self.vthunder_repo.get_lb_count_vthunder_partition(db_apis.get_session(),
                                                                   vthunder.ip_address,
                                                                   vthunder.partition_name)
+
+
+class LoadBalancerListToErrorOnRevertTask(BaseDatabaseTask):
+    """Task to set Loadbalancers to ERROR on revert"""
+
+    def execute(self, loadbalancers_list):
+        pass
+
+    def revert(self, loadbalancers_list, *args, **kwargs):
+        for lb in loadbalancers_list:
+            self.task_utils.mark_loadbalancer_prov_status_error(lb.id)


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description
Loadbalancers will stay in pending update when failover is failed.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3022

## Technical Approach
Set the loadbalancers in loadbalancer list to ERROR state in revert flow

## Config Changes
<pre>
<b>stack@ytsai-victoria:~/source/a10-octavia$ sed -e '/^#/d' /etc/a10/a10-octavia.conf  | grep -Ev "^$"
[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"
[a10_controller_worker]
amp_image_owner_id = ecc2542be2644881b049636b719ca536
amp_secgroup_list = 5a83254b-7a99-4684-a4e5-94ed75d505c9
amp_image_tag = "vthunder_5_2_1-p2"
amp_flavor_id = ba761d2f-a08c-42eb-a53e-e3a0fa646590
amp_boot_network_list = 9558e757-f279-4120-9e61-540a91be9c10, 0aab2734-6a42-4ef9-acd6-527956b3dadc
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 150
amp_active_wait_sec = 10
amp_busy_wait_sec = 0
loadbalancer_topology = ACTIVE_STANDBY
[a10_health_manager]
udp_server_ip_address = 192.168.0.164
bind_port = 5550
bind_ip = 192.168.0.164
heartbeat_interval = 20
health_check_timeout = 3
health_check_max_retries = 5
heartbeat_key = insecure
heartbeat_timeout = 30
failover_timeout = 600
health_check_interval = 10
stats_update_disable = True
[a10_house_keeping]
load_balancer_expiry_age = 3600
amphorae_expiry_age = 3600
[a10_global]
network_type = "flat"
</b>
</pre>

## Test Cases
 - Test failover, loadbalancer status will be change to ERROR

## Manual Testing

```
stack@ytsai-victoria:~/source/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+--------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address  | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+--------------+---------------------+------------------+----------+
| bb4003a9-cf88-4779-832b-3544eca8f45a | vip1 | ecc2542be2644881b049636b719ca536 | 192.168.91.7 | ERROR               | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+--------------+---------------------+------------------+----------+
```
