### PR TITLE
[STACK-3091] Enlarge default failover timeout

### DIFF
--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -248,7 +248,7 @@ A10_HEALTH_MANAGER_OPTS = [
                help=_('key used to validate vthunder sending'
                       'the message'), secret=True),
     cfg.IntOpt('heartbeat_timeout',
-               default=90,
+               default=180,
                help=_('Interval(in seconds) to wait before failing over a '
                       'vthunder.')),
     cfg.IntOpt('health_check_interval',


### PR DESCRIPTION
## Description
For vthunder flow, instance will be reloaded for attach/deattach interfaces. And if the default failover timeout is too short, a10-health-manager may think the instance is down.
This should be fine because we don't do failover for pending LB instance, but enlarge this to prevent problems and false-positive failover.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3091

## Technical Approach
Enlarge default failover timeout

## Config Changes
<pre>
<b>N/A</b>
</pre>

## Test Cases
N/A

## Manual Testing
N/A
