### PR TITLE
[STACK-3113] Fix interface lost when failover master vthunder

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -1157,11 +1157,13 @@ class GetVThunderNetworkList(BaseNetworkTask):
 
             # in case the compute is deleted by some reason
             if not nics:
-                if vthunder.role == constants.ROLE_MASTER:
+                # Since stale vthunder will switch to backup, so peer is current master
+                peer = self.vthunder_repo.get_vthunder_from_lb(
+                    db_apis.get_session(), vthunder.loadbalancer_id)
+
+                # in case role switch failed
+                if peer.compute_id == vthunder.compute_id:
                     peer = self.vthunder_repo.get_backup_vthunder_from_lb(
-                        db_apis.get_session(), vthunder.loadbalancer_id)
-                else:
-                    peer = self.vthunder_repo.get_vthunder_from_lb(
                         db_apis.get_session(), vthunder.loadbalancer_id)
                 nics = self.network_driver.get_plugged_networks(peer.compute_id)
 


### PR DESCRIPTION
## Description
If Bug Fix:
- Required: Severity Level: HIGH
- Required: Issue Description
Failover for deleted master vthunder case failed.
This is caused by the master will be switch as backup when a10-health-monitor find it is dead. But later in GetVThunderNetworkList() we still use backup to get peer compute (which is it-self now). Then if failed to get the network list.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3113

## Technical Approach
Since the stale vthunder will switch to backup, so the peer vthunder will always be master. So, we just need to get master vthunder as peer in GetVThunderNetworkList.

## Config Changes
<pre>
<b>default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"

[a10_controller_worker]
amp_image_owner_id = 0cb3ab3a534b4b6e9e2504c3589d8e7e
amp_secgroup_list = 60235647-2889-4a7e-9775-45c0c9f2e292
amp_image_tag = "vthunder_5_2_1-p2"
amp_flavor_id = 58ac2aec-d261-4c3d-9421-ef4a3df7d4fd
amp_boot_network_list = 31f3823c-62af-4b43-baa1-3d7e05a0d69b, e78942d5-9e48-4b9c-9b32-bfa0b08ec230
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 150
amp_active_wait_sec = 10
amp_busy_wait_sec = 0

loadbalancer_topology = ACTIVE_STANDBY

[a10_health_manager]
udp_server_ip_address = 192.168.0.140
bind_port = 5550
bind_ip = 192.168.0.140
heartbeat_interval = 5
health_check_timeout = 10
health_check_max_retries = 2
heartbeat_key = insecure
heartbeat_timeout = 30
failover_timeout = 300
health_check_interval = 15

[a10_house_keeping]
load_balancer_expiry_age = 3600
amphorae_expiry_age = 3600
spare_amphora_pool_size = 0
spare_check_interval = 10

[a10_global]
network_type = "flat"
vrid_floating_ip = ".111"

[listener]
autosnat=True</b>
</pre>

## Test Cases
1- Keep amp_boot_network_list = management_subnet, LB_subnet in config file.
2- Create an LB with topology active_standby
3- Create listener, pool and member
4- delete active device and wait for failover

## Manual Testing
LOG:
```
stack@ytsai-victoria:~/source/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+-------------------------------------------------------------------+-------------------+---------------+
| ID                                   | Name                                         | Status | Networks                                                          | Image             | Flavor        |
+--------------------------------------+----------------------------------------------+--------+-------------------------------------------------------------------+-------------------+---------------+
| dc3a23c9-51d8-4570-ac1d-2aa81329da4b | amphora-39fd0c2b-3233-4904-98da-4437f2501427 | ACTIVE | lb-mgmt-net=192.168.0.138; tp90=192.168.90.60; tp91=192.168.91.82 | vthunder_5_2_1-p2 | vthunder_4cpu |
| 44691521-470d-411a-ab3c-c977f83b2240 | amphora-e46220ab-9675-477a-9014-6d6cd5a4abbb | ACTIVE | lb-mgmt-net=192.168.0.99; tp90=192.168.90.99; tp91=192.168.91.77  | vthunder_5_2_1-p2 | vthunder_4cpu |
+--------------------------------------+----------------------------------------------+--------+-------------------------------------------------------------------+-------------------+---------------+
stack@ytsai-victoria:~/source/a10-octavia$ openstack server delete 44691521-470d-411a-ab3c-c977f83b2240
stack@ytsai-victoria:~/source/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+-------------------------------------------------------------------+-------------------+---------------+
| ID                                   | Name                                         | Status | Networks                                                          | Image             | Flavor        |
+--------------------------------------+----------------------------------------------+--------+-------------------------------------------------------------------+-------------------+---------------+
| 410d6b1a-8f5c-4363-9948-8b2470d5db3d | amphora-0dac975b-4202-4ed7-a79a-ec335d15c659 | BUILD  |                                                                   | vthunder_5_2_1-p2 | vthunder_4cpu |
| dc3a23c9-51d8-4570-ac1d-2aa81329da4b | amphora-39fd0c2b-3233-4904-98da-4437f2501427 | ACTIVE | lb-mgmt-net=192.168.0.138; tp90=192.168.90.60; tp91=192.168.91.82 | vthunder_5_2_1-p2 | vthunder_4cpu |
+--------------------------------------+----------------------------------------------+--------+-------------------------------------------------------------------+-------------------+---------------+
stack@ytsai-victoria:~/source/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+--------------------------------------------------------------------+-------------------+---------------+
| ID                                   | Name                                         | Status | Networks                                                           | Image             | Flavor        |
+--------------------------------------+----------------------------------------------+--------+--------------------------------------------------------------------+-------------------+---------------+
| 410d6b1a-8f5c-4363-9948-8b2470d5db3d | amphora-0dac975b-4202-4ed7-a79a-ec335d15c659 | ACTIVE | lb-mgmt-net=192.168.0.160; tp90=192.168.90.106; tp91=192.168.91.80 | vthunder_5_2_1-p2 | vthunder_4cpu |
| dc3a23c9-51d8-4570-ac1d-2aa81329da4b | amphora-39fd0c2b-3233-4904-98da-4437f2501427 | ACTIVE | lb-mgmt-net=192.168.0.138; tp90=192.168.90.60; tp91=192.168.91.82  | vthunder_5_2_1-p2 | vthunder_4cpu |
+--------------------------------------+----------------------------------------------+--------+--------------------------------------------------------------------+-------------------+---------------+
```

- interfaces in new vthunder
```
vThunder-Active-vBlade[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3e6d.1eb2  192.168.0.160/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3edd.4966  192.168.90.106/24     1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e99.a7ad  192.168.91.80/24      1  DataPort
```
