### PR TITLE
[BUG][STACK-3050]: Raising an exception when management network is not specified while loadbalancer creation.

### DIFF
--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -292,3 +292,9 @@ class IPAddressNotInSubnetRangeError(base.NetworkException):
                'IP {0} out of range ' +
                'for subnet {1}.').format(ip, subnet)
         super(IPAddressNotInSubnetRangeError, self).__init__(msg)
+
+
+class NetworkNotFoundToBootAmphora(base.NetworkException):
+    def __init__(self):
+        msg = ('No any management network is configured for booting the amphora')
+        super(NetworkNotFoundToBootAmphora, self).__init__(msg)

--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -296,5 +296,7 @@ class IPAddressNotInSubnetRangeError(base.NetworkException):
 
 class NetworkNotFoundToBootAmphora(base.NetworkException):
     def __init__(self):
-        msg = ('No any management network is configured for booting the amphora')
+        msg = ('No vThunder-Amphora management network has been specified in the config.'
+               ' Set `amp_mgmt_net` or add a network to `amp_boot_network_list`' 
+               ' under the [a10_controller_worker] group.')
         super(NetworkNotFoundToBootAmphora, self).__init__(msg)

--- a/a10_octavia/controller/worker/tasks/a10_compute_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_compute_tasks.py
@@ -22,6 +22,8 @@ from octavia.common import constants
 from octavia.common import exceptions
 from octavia.controller.worker.v1.tasks.compute_tasks import BaseComputeTask
 
+from a10_octavia.common import exceptions as a10_exception
+
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
 
@@ -37,6 +39,8 @@ class ComputeCreate(BaseComputeTask):
         boot_net_list = CONF.a10_controller_worker.amp_boot_network_list
         mgmt_net = CONF.a10_controller_worker.amp_mgmt_network
         mgmt_net = boot_net_list[0] if boot_net_list and not mgmt_net else mgmt_net
+        if not mgmt_net:
+            raise a10_exception.NetworkNotFoundToBootAmphora()
 
         network_ids = set(boot_net_list) if boot_net_list else set()
         if CONF.glm_license.amp_license_network:
@@ -50,8 +54,7 @@ class ComputeCreate(BaseComputeTask):
             network_ids.remove(mgmt_net)
 
         network_ids = list(network_ids)
-        if mgmt_net:
-            network_ids.insert(0, mgmt_net)
+        network_ids.insert(0, mgmt_net)
 
         LOG.debug("Compute create execute for amphora with id %s", amphora_id)
         key_name = CONF.a10_controller_worker.amp_ssh_key_name


### PR DESCRIPTION
## Description
- Severity Level: Medium
- Issue Description: An unexpected error encountered when LB is created without specifying `amp_boot_network_list` or `amp_mgmt_network` in config file.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3050

## Technical Approach
- Created a custom exception `NetworkNotFoundToBootAmphora()` which will be raised if there is no any mgmt_net specified while creating a loadbalancer.
- Raising the exception when mgmt_net is None.

## Manual Testing
Following config is used:

```
[a10_global]
network_type = 'flat'
vrid_floating_ip = "dhcp"

[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"

[glm_license]
primary_dns = 8.8.8.8
secondary_dns = 8.8.4.4
flexpool_token = A10b9c2d136d
allocate_bandwidth = 100

[a10_controller_worker]
amp_image_owner_id = 95e29d550b0643da843693f5355e5b69
amp_secgroup_list = f31b2dfa-70dd-469a-9320-028e36171e7d
amp_flavor_id = a0330f44-75b3-46b5-a913-ab8868ac6c40
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 100
amp_active_wait_sec = 2
amp_image_id = 7ec143a7-835a-439f-8fe4-3e8c1ffce818
amp_image_tag = vThp2
loadbalancer_topology = SINGLE
```

Create a loadbalancer with above config file:
stack@neha-victoria:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name lb1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-10-28T09:20:01                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 36991e46-8b85-4dd0-a439-662ff4d4b26e |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 95e29d550b0643da843693f5355e5b69     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.123                          |
| vip_network_id      | f41fca32-ef87-4125-8963-ce0ed756b3ed |
| vip_port_id         | e75fb599-6e57-42e5-a3a5-4ceb31f60ab5 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | ef039261-0b7b-4405-8bf3-78547778160d |
+---------------------+--------------------------------------+
```

Result: The exception will be raised in this case as we are not specifying management network in the config file

stack@neha-victoria:~/neha/a10-octavia$ **journalctl -af --unit a10-controller-worker.service**
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server [-] Exception during message handling: a10_octavia.common.exceptions.NetworkNotFoundToBootAmphora: No any management network is configured for booting the amphora
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server Traceback (most recent call last):
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/oslo_messaging/rpc/server.py", line 165, in _process_incoming
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server     res = self.dispatcher.dispatch(message)
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/oslo_messaging/rpc/dispatcher.py", line 309, in dispatch
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server     return self._do_dispatch(endpoint, method, ctxt, args)
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/oslo_messaging/rpc/dispatcher.py", line 229, in _do_dispatch
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server     result = func(ctxt, **new_args)
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server   File "/opt/stack/neha/a10-octavia/a10_octavia/controller/queue/endpoint.py", line 46, in create_load_balancer
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server     self.worker.create_load_balancer(load_balancer_id, flavor)
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/tenacity/__init__.py", line 329, in wrapped_f
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server     return self.call(f, *args, **kw)
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/tenacity/__init__.py", line 409, in call
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server     do = self.iter(retry_state=retry_state)
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/tenacity/__init__.py", line 356, in iter
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server     return fut.result()
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server   File "/usr/lib/python3.8/concurrent/futures/_base.py", line 437, in result
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server     return self.__get_result()
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server   File "/usr/lib/python3.8/concurrent/futures/_base.py", line 389, in __get_result
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server     raise self._exception
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/tenacity/__init__.py", line 412, in call
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server     result = fn(*args, **kwargs)
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server   File "/opt/stack/neha/a10-octavia/a10_octavia/controller/worker/controller_worker.py", line 443, in create_load_balancer
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server     create_lb_tf.run()
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/taskflow/engines/action_engine/engine.py", line 247, in run
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server     for _state in self.run_iter(timeout=timeout):
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/taskflow/engines/action_engine/engine.py", line 340, in run_iter
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server     failure.Failure.reraise_if_any(er_failures)
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/taskflow/types/failure.py", line 339, in reraise_if_any
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server     failures[0].reraise()
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/taskflow/types/failure.py", line 346, in reraise
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server     six.reraise(*self._exc_info)
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/six.py", line 703, in reraise
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server     raise value
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server     result = task.execute(**arguments)
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server   File "/opt/stack/neha/a10-octavia/a10_octavia/controller/worker/tasks/a10_compute_tasks.py", line 43, in execute
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server     raise a10_exception.NetworkNotFoundToBootAmphora()
Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: **ERROR oslo_messaging.rpc.server a10_octavia.common.exceptions.NetworkNotFoundToBootAmphora: No vThunder-Amphora management network has been specified in the config. Set `amp_mgmt_net` or add a network to `amp_boot_network_list` under the [a10_controller_worker] group.**

Oct 28 09:20:01 neha-victoria a10-octavia-worker[1562309]: ERROR oslo_messaging.rpc.server


stack@neha-victoria:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| 36991e46-8b85-4dd0-a439-662ff4d4b26e | lb1  | 95e29d550b0643da843693f5355e5b69 | 10.0.11.123 | ERROR               | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
```
