### PR TITLE
[BUG][STACK-3122]: Resolved issues for member creation/updation when subnet_id is not specified during member_batch_update.

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -473,6 +473,8 @@ class UpdateVRIDForLoadbalancerResource(BaseDatabaseTask):
 class GetLoadbalancersInProjectBySubnet(BaseDatabaseTask):
 
     def execute(self, subnet, partition_project_list):
+        if not subnet:
+            return 0
         if partition_project_list:
             try:
                 return self.loadbalancer_repo.get_lbs_by_subnet(
@@ -763,19 +765,20 @@ class GetFlavorData(BaseDatabaseTask):
 class CheckForL2DSRFlavor(BaseDatabaseTask):
 
     def execute(self, lb_resource):
-        for lb in lb_resource:
-            flavor_id = a10_task_utils.attribute_search(lb, 'flavor_id')
-            if flavor_id:
-                flavor = self.flavor_repo.get(db_apis.get_session(), id=flavor_id)
-                if flavor and flavor.flavor_profile_id:
-                    flavor_profile = self.flavor_profile_repo.get(
-                        db_apis.get_session(),
-                        id=flavor.flavor_profile_id)
-                    flavor_data = json.loads(flavor_profile.flavor_data)
-                    deployment = flavor_data.get('deployment')
-                    if deployment and 'dsr_type' in deployment and \
-                            deployment['dsr_type'] == "l2dsr_transparent":
-                        return True
+        if lb_resource:
+            for lb in lb_resource:
+                flavor_id = a10_task_utils.attribute_search(lb, 'flavor_id')
+                if flavor_id:
+                    flavor = self.flavor_repo.get(db_apis.get_session(), id=flavor_id)
+                    if flavor and flavor.flavor_profile_id:
+                        flavor_profile = self.flavor_profile_repo.get(
+                            db_apis.get_session(),
+                            id=flavor.flavor_profile_id)
+                        flavor_data = json.loads(flavor_profile.flavor_data)
+                        deployment = flavor_data.get('deployment')
+                        if deployment and 'dsr_type' in deployment and \
+                                deployment['dsr_type'] == "l2dsr_transparent":
+                            return True
         return False
 
 

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -241,7 +241,8 @@ class UpdateLoadbalancerForwardWithAnySource(VThunderBaseTask):
                     if (CONF.vthunder.l2dsr_support and lb_count_subnet < 1) or \
                             not CONF.vthunder.l2dsr_support:
                         for amp in amphora:
-                            self.network_driver.remove_any_source_ip_on_egress(subnet.network_id, amp)
+                            self.network_driver.remove_any_source_ip_on_egress(
+                                subnet.network_id, amp)
 
 
 class AmphoraePostMemberNetworkPlug(VThunderBaseTask):

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -232,15 +232,16 @@ class UpdateLoadbalancerForwardWithAnySource(VThunderBaseTask):
     """Task to update wildcat address in allowed_address_pair to allow any SNAT"""
 
     def execute(self, subnet, amphora, lb_count_subnet, l2dsr_flavor):
-        if CONF.vthunder.slb_no_snat_support:
-            for amp in amphora:
-                self.network_driver.allow_use_any_source_ip_on_egress(subnet.network_id, amp)
-        else:
-            if not l2dsr_flavor:
-                if (CONF.vthunder.l2dsr_support and lb_count_subnet < 1) or \
-                        not CONF.vthunder.l2dsr_support:
-                    for amp in amphora:
-                        self.network_driver.remove_any_source_ip_on_egress(subnet.network_id, amp)
+        if subnet:
+            if CONF.vthunder.slb_no_snat_support:
+                for amp in amphora:
+                    self.network_driver.allow_use_any_source_ip_on_egress(subnet.network_id, amp)
+            else:
+                if not l2dsr_flavor:
+                    if (CONF.vthunder.l2dsr_support and lb_count_subnet < 1) or \
+                            not CONF.vthunder.l2dsr_support:
+                        for amp in amphora:
+                            self.network_driver.remove_any_source_ip_on_egress(subnet.network_id, amp)
 
 
 class AmphoraePostMemberNetworkPlug(VThunderBaseTask):


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description: Getting an error when creating/updating a member without specifying subnet_id by member_batch_update script.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3122

## Technical Approach
- Added checks for member's subnet_id wherever required.

## Config Changes
N/A

## Manual Testing
1. Create a loadbalancer, listener and pool.
stack@neha-victoria:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name lb1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-10-29T11:42:26                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 3a9f1362-58dc-48b7-8a14-3c564f3cd13e |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 95e29d550b0643da843693f5355e5b69     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.147                          |
| vip_network_id      | f41fca32-ef87-4125-8963-ce0ed756b3ed |
| vip_port_id         | 37d33f76-fa6c-4101-998e-41b4a0c7b026 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | ef039261-0b7b-4405-8bf3-78547778160d |
+---------------------+--------------------------------------+
```

stack@neha-victoria:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| 3a9f1362-58dc-48b7-8a14-3c564f3cd13e | lb1  | 95e29d550b0643da843693f5355e5b69 | 10.0.11.147 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
```

stack@neha-victoria:~$ openstack loadbalancer listener create --name l1 --protocol http --protocol-port 85 lb1
```
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-10-29T11:54:08                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 8f6c0e56-6cec-48d5-ba20-7eb77f735f93 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 3a9f1362-58dc-48b7-8a14-3c564f3cd13e |
| name                        | l1                                   |
| operating_status            | OFFLINE                              |
| project_id                  | 95e29d550b0643da843693f5355e5b69     |
| protocol                    | HTTP                                 |
| protocol_port               | 85                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
| allowed_cidrs               | None                                 |
| tls_ciphers                 | None                                 |
| tls_versions                | None                                 |
| alpn_protocols              | None                                 |
+-----------------------------+--------------------------------------+
```

stack@neha-victoria:~$ openstack loadbalancer pool create --name p1 --protocol HTTP --lb-algorithm LEAST_CONNECTIONS --listener l1
```
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-10-29T11:54:17                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | 4be18ea9-a953-4fb0-8122-67c11488c029 |
| lb_algorithm         | LEAST_CONNECTIONS                    |
| listeners            | 8f6c0e56-6cec-48d5-ba20-7eb77f735f93 |
| loadbalancers        | 3a9f1362-58dc-48b7-8a14-3c564f3cd13e |
| members              |                                      |
| name                 | p1                                   |
| operating_status     | OFFLINE                              |
| project_id           | 95e29d550b0643da843693f5355e5b69     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+
```


2. Create a member using below member_batch_update script
```
resource "openstack_lb_members_v2" "members_1" {
  pool_id = "4be18ea9-a953-4fb0-8122-67c11488c029"

  member {
    address       = "10.0.12.110"
    protocol_port = 80
    name          = "test_member"
    weight        = 14
    admin_state_up = false
    backup = false
  }

}

```
stack@neha-victoria:~/neha$ terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # openstack_lb_members_v2.members_1 will be created
  + resource "openstack_lb_members_v2" "members_1" {
      + id      = (known after apply)
      + pool_id = "4be18ea9-a953-4fb0-8122-67c11488c029"
      + region  = (known after apply)

      + member {
          + address        = "10.0.12.110"
          + admin_state_up = false
          + backup         = false
          + id             = (known after apply)
          + name           = "test_member"
          + protocol_port  = 80
          + weight         = 14
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

openstack_lb_members_v2.members_1: Creating...
openstack_lb_members_v2.members_1: Creation complete after 4s [id=4be18ea9-a953-4fb0-8122-67c11488c029]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.


stack@neha-victoria:~$ openstack loadbalancer member list p1
```
+--------------------------------------+-------------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| id                                   | name        | project_id                       | provisioning_status | address     | protocol_port | operating_status | weight |
+--------------------------------------+-------------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| 98a23c00-f7b8-49d7-9994-4cd49d3a152c | test_member | 95e29d550b0643da843693f5355e5b69 | ACTIVE              | 10.0.12.110 |            80 | NO_MONITOR       |     14 |
+--------------------------------------+-------------+----------------------------------+---------------------+-------------+---------------+------------------+--------+

```

3. Update the member using below member_batch_update script:
```
resource "openstack_lb_members_v2" "members_1" {
  pool_id = "4be18ea9-a953-4fb0-8122-67c11488c029"

  member {
    address       = "10.0.12.110"
    protocol_port = 80
    name          = "test_member_update"
    weight        = 20
    admin_state_up = true
    backup = true
  }

}

```

stack@neha-victoria:~/neha$ openstack loadbalancer member list p1
```
+--------------------------------------+--------------------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| id                                   | name               | project_id                       | provisioning_status | address     | protocol_port | operating_status | weight |
+--------------------------------------+--------------------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| 98a23c00-f7b8-49d7-9994-4cd49d3a152c | test_member_update | 95e29d550b0643da843693f5355e5b69 | ACTIVE              | 10.0.12.110 |            80 | NO_MONITOR       |     20 |
+--------------------------------------+--------------------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
```
