### PR TITLE
[STACK-3120]: Added support for handle_vrid config option in victoria

### DIFF
--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -50,6 +50,8 @@ A10_GLOBAL_OPTS = [
                 help=_('Use shared for template')),
     cfg.StrOpt('default_flavor_id', default=None,
                help=_('Default flavor ID to apply globally to all users')),
+    cfg.BoolOpt('handle_vrid', default=True,
+                help=_('Deletes floating ip when True.')),
 ]
 
 A10_GLM_LICENSE_OPTS = [

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -187,7 +187,8 @@ class LoadBalancerFlows(object):
         post_create_lb_flow.add(database_tasks.UpdateLoadbalancerInDB(
             requires=[constants.LOADBALANCER, constants.UPDATE_DICT]))
 
-        post_create_lb_flow.add(self.handle_vrid_for_loadbalancer_subflow())
+        if CONF.a10_global.handle_vrid:
+            post_create_lb_flow.add(self.handle_vrid_for_loadbalancer_subflow())
 
         if mark_active:
             post_create_lb_flow.add(database_tasks.MarkLBActiveInDB(
@@ -304,7 +305,8 @@ class LoadBalancerFlows(object):
             a10_database_tasks.CountLoadbalancersInProjectBySubnet(
                 requires=[constants.SUBNET, a10constants.PARTITION_PROJECT_LIST],
                 provides=a10constants.LB_COUNT_SUBNET))
-        delete_LB_flow.add(self.get_delete_lb_vrid_subflow(deleteCompute))
+        if CONF.a10_global.handle_vrid:
+            delete_LB_flow.add(self.get_delete_lb_vrid_subflow(deleteCompute))
         delete_LB_flow.add(a10_network_tasks.DeallocateVIP(
             requires=[constants.LOADBALANCER, a10constants.LB_COUNT_SUBNET]))
         delete_LB_flow.add(virtual_server_tasks.DeleteVirtualServerTask(
@@ -496,7 +498,8 @@ class LoadBalancerFlows(object):
         # update_LB_flow.add(amphora_driver_tasks.ListenersUpdate(
         #    requires=[constants.LOADBALANCER, constants.LISTENERS]))
         # post_create_lb_flow.add(handle_vrid_for_loadbalancer_subflow())
-        update_LB_flow.add(self.handle_vrid_for_loadbalancer_subflow())
+        if CONF.a10_global.handle_vrid:
+            update_LB_flow.add(self.handle_vrid_for_loadbalancer_subflow())
         update_LB_flow.add(database_tasks.GetAmphoraeFromLoadbalancer(
             requires=constants.LOADBALANCER_ID,
             provides=constants.AMPHORA))
@@ -566,7 +569,8 @@ class LoadBalancerFlows(object):
             provides=a10constants.VTHUNDER))
         update_LB_flow.add(network_tasks.ApplyQos(
             requires=(constants.LOADBALANCER, constants.UPDATE_DICT)))
-        update_LB_flow.add(self.handle_vrid_for_loadbalancer_subflow())
+        if CONF.a10_global.handle_vrid:
+            update_LB_flow.add(self.handle_vrid_for_loadbalancer_subflow())
 
         update_LB_flow.add(virtual_server_tasks.UpdateVirtualServerTask(
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
@@ -695,7 +699,8 @@ class LoadBalancerFlows(object):
             a10_database_tasks.CountLoadbalancersOnThunderBySubnet(
                 requires=[a10constants.VTHUNDER, constants.SUBNET, a10constants.USE_DEVICE_FLAVOR],
                 provides=a10constants.LB_COUNT_THUNDER))
-        delete_LB_flow.add(self.get_delete_rack_lb_vrid_subflow())
+        if CONF.a10_global.handle_vrid:
+            delete_LB_flow.add(self.get_delete_rack_lb_vrid_subflow())
         delete_LB_flow.add(a10_network_tasks.DeallocateVIP(
             requires=[constants.LOADBALANCER, a10constants.LB_COUNT_SUBNET]))
         delete_LB_flow.add(virtual_server_tasks.DeleteVirtualServerTask(
@@ -771,7 +776,8 @@ class LoadBalancerFlows(object):
             post_create_lb_flow.add(vthunder_tasks.TagInterfaceForLB(
                 requires=[constants.LOADBALANCER,
                           a10constants.VTHUNDER]))
-        post_create_lb_flow.add(self.handle_vrid_for_loadbalancer_subflow())
+        if CONF.a10_global.handle_vrid:
+            post_create_lb_flow.add(self.handle_vrid_for_loadbalancer_subflow())
         if mark_active:
             post_create_lb_flow.add(database_tasks.MarkLBActiveInDB(
                 name=sf_name + '-' + constants.MARK_LB_ACTIVE_INDB,

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -31,6 +31,9 @@ from a10_octavia.controller.worker.tasks import service_group_tasks
 from a10_octavia.controller.worker.tasks import virtual_port_tasks
 from a10_octavia.controller.worker.tasks import vthunder_tasks
 
+from oslo_config import cfg
+CONF = cfg.CONF
+
 
 class PoolFlows(object):
 
@@ -176,7 +179,7 @@ class PoolFlows(object):
             member_store[member.id] = member
             delete_member_vthunder_subflow.add(
                 self.member_flow.get_delete_member_vthunder_internal_subflow(member.id, pool))
-        if members:
+        if members and CONF.a10_global.handle_vrid:
             delete_member_vthunder_subflow.add(
                 self.member_flow.get_delete_member_vrid_internal_subflow(pool, members))
         store.update(member_store)


### PR DESCRIPTION
## Description
Added support for handle_vrid config option sothat manually configured VRID FIP will not get removed on loadbalancer and member creation/deletion/updation.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3120

## Technical Approach
- Added handle_vrid config option in a10_global section with default value as True.
- Added checks for this oprion in a10_loadbalancer_flows, a10_member_flows and a10_pool_flows, wherever vrid creation and deletion is getting called.
- vrid related flows will get executed when handle_vrid option is True, otherwise they will get skipped.

## Config Changes
```
[a10_global]
handle_vrid = <True/False>
```


## Manual Testing
vThunder flows cases:

1. Create a loadbalancer without setting handle_vrid option in the config.
stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name lb1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-11-01T05:40:19                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 27a9f673-b07e-4a66-b003-b7a8aa899042 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 95e29d550b0643da843693f5355e5b69     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.187                          |
| vip_network_id      | f41fca32-ef87-4125-8963-ce0ed756b3ed |
| vip_port_id         | 2f766302-c6da-4021-9f00-7b802777055e |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | ef039261-0b7b-4405-8bf3-78547778160d |
+---------------------+--------------------------------------+
```

Result: LB gets created with configuring a VRID FIP of that subnet.

amphora-0e8e111e-44e0-47f5-b74c(NOLICENSE)#show running-config
!Current configuration: 463 bytes
!Configuration last updated at 05:45:04 GMT Mon Nov 1 2021
!Configuration last saved at 05:45:09 GMT Mon Nov 1 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 117 (Jul-12-2021,10:12)
!
ip dns primary 8.8.8.8
!
ip dns secondary 8.8.4.4
!
hostname amphora-0e8e111e-44e0-47f5-b74c
!
!
glm use-mgmt-port
glm enable-requests
glm allocate-bandwidth 100
glm token A10b9c2d136d
glm port 443
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
**vrrp-a vrid 0
  floating-ip 10.0.11.139**
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
**slb virtual-server 27a9f673-b07e-4a66-b003-b7a8aa899042 10.0.11.187**
!
!
cloud-services meta-data
  enable
  provider openstack
!
end


2. Manually configure a VRID FIP on the vThunder for provider-vlan-12-subnet

amphora-0e8e111e-44e0-47f5-b74c(config)(NOLICENSE)#vrrp-a vrid 0
amphora-0e8e111e-44e0-47f5-b74c(config-vrid:0)(NOLICENSE)#floating-ip 10.0.12.130

Result:
amphora-0e8e111e-44e0-47f5-b74c(NOLICENSE)#show running-config
!Current configuration: 463 bytes
!Configuration last updated at 05:48:35 GMT Mon Nov 1 2021
!Configuration last saved at 05:45:09 GMT Mon Nov 1 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 117 (Jul-12-2021,10:12)
!
ip dns primary 8.8.8.8
!
ip dns secondary 8.8.4.4
!
hostname amphora-0e8e111e-44e0-47f5-b74c
!
!
glm use-mgmt-port
glm enable-requests
glm allocate-bandwidth 100
glm token A10b9c2d136d
glm port 443
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.139
  **floating-ip 10.0.12.130**
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb virtual-server 27a9f673-b07e-4a66-b003-b7a8aa899042 10.0.11.187
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
671045765095

3. Create a loadbalancer in provider-vlan-12-subnet by setting **handle_vrid = False** in the config

stack@neha-victoria:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-12-subnet --name lb2
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-11-01T05:50:17                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 6c1e373f-98b2-4bc6-a166-109abf32ba46 |
| listeners           |                                      |
| name                | lb2                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 95e29d550b0643da843693f5355e5b69     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.12.165                          |
| vip_network_id      | cfecdf7d-8ffd-4e31-b4cf-20d2871737dd |
| vip_port_id         | 6549ff30-3b88-45a7-bad9-0088e5b833c4 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | c68c1d09-5694-46a2-89f5-683e4a4bc507 |
+---------------------+--------------------------------------+
```

Result: The LB gets created without removing the configured VRID FIP of provider-vlan-12-subnet.

amphora-0e8e111e-44e0-47f5-b74c(NOLICENSE)#show running-config
!Current configuration: 482 bytes
!Configuration last updated at 05:52:13 GMT Mon Nov 1 2021
!Configuration last saved at 05:52:16 GMT Mon Nov 1 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 117 (Jul-12-2021,10:12)
!
hostname amphora-0e8e111e-44e0-47f5-b74c
!
!
glm use-mgmt-port
glm enable-requests
glm allocate-bandwidth 100
glm token A10b9c2d136d
glm port 443
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.139
  **floating-ip 10.0.12.130**
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb virtual-server 27a9f673-b07e-4a66-b003-b7a8aa899042 10.0.11.187
!
**slb virtual-server 6c1e373f-98b2-4bc6-a166-109abf32ba46 10.0.12.165**
!
!
cloud-services meta-data
  enable
  provider openstack
!
end

4. Create a listener and pool for lb2.
stack@neha-victoria:~$ openstack loadbalancer listener create --name l1 --protocol http --protocol-port 85 lb1
```
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-11-01T07:21:13                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | ccae88ed-fe19-4195-bd8e-a5d5133ddab9 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 27a9f673-b07e-4a66-b003-b7a8aa899042 |
| name                        | l1                                   |
| operating_status            | OFFLINE                              |
| project_id                  | 95e29d550b0643da843693f5355e5b69     |
| protocol                    | HTTP                                 |
| protocol_port               | 85                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
| allowed_cidrs               | None                                 |
| tls_ciphers                 | None                                 |
| tls_versions                | None                                 |
| alpn_protocols              | None                                 |
+-----------------------------+--------------------------------------+
```

stack@neha-victoria:~$ openstack loadbalancer pool create --name p1 --protocol HTTP --lb-algorithm LEAST_CONNECTIONS --listener l1
```
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-11-01T07:21:22                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | 5c75ea2e-f4ba-4b33-acdf-13aa51163d39 |
| lb_algorithm         | LEAST_CONNECTIONS                    |
| listeners            | ccae88ed-fe19-4195-bd8e-a5d5133ddab9 |
| loadbalancers        | 27a9f673-b07e-4a66-b003-b7a8aa899042 |
| members              |                                      |
| name                 | p1                                   |
| operating_status     | OFFLINE                              |
| project_id           | 95e29d550b0643da843693f5355e5b69     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+
```

5. Manually configure a VRID FIP on the vThunder for provider-vlan-13-subnet and then create a member in that subnet by setting **handle_vrid = False** in the config

amphora-0e8e111e-44e0-47f5-b74c(config)(NOLICENSE)#vrrp-a vrid 0
amphora-0e8e111e-44e0-47f5-b74c(config-vrid:0)(NOLICENSE)#floating-ip 10.0.13.110

stack@neha-victoria:~$ openstack loadbalancer member create --subnet-id provider-vlan-13-subnet --address 10.0.13.20 --protocol-port 95 --name m1 p1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.13.20                           |
| admin_state_up      | True                                 |
| created_at          | 2021-11-01T07:21:48                  |
| id                  | 99e876f0-8014-41c5-9487-3b2ccada83ed |
| name                | m1                                   |
| operating_status    | NO_MONITOR                           |
| project_id          | 95e29d550b0643da843693f5355e5b69     |
| protocol_port       | 95                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | bd5aefb7-ee00-4bcf-a17d-8ab1c769d410 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
```

stack@neha-victoria:~$ openstack loadbalancer member list p1
```
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address    | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| 99e876f0-8014-41c5-9487-3b2ccada83ed | m1   | 95e29d550b0643da843693f5355e5b69 | ACTIVE              | 10.0.13.20 |            95 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
```

Result: The member will get created without removing the manually configured VRID FIP.

amphora-0e8e111e-44e0-47f5-b74c(NOLICENSE)#show running-config
!Current configuration: 413 bytes
!Configuration last updated at 07:24:48 GMT Mon Nov 1 2021
!Configuration last saved at 07:24:57 GMT Mon Nov 1 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 117 (Jul-12-2021,10:12)
!
hostname amphora-0e8e111e-44e0-47f5-b74c
!
!
glm use-mgmt-port
glm enable-requests
glm allocate-bandwidth 100
glm token A10b9c2d136d
glm port 443
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 3
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.139
  floating-ip 10.0.12.130
  **floating-ip 10.0.13.110**
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
**slb server 95e29_10_0_13_20 10.0.13.20
  port 95 tcp**
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb service-group 5c75ea2e-f4ba-4b33-acdf-13aa51163d39 tcp
  method least-connection
  member 95e29_10_0_13_20 95
!
slb virtual-server 27a9f673-b07e-4a66-b003-b7a8aa899042 10.0.11.187
  port 85 http
    name ccae88ed-fe19-4195-bd8e-a5d5133ddab9
    extended-stats
    service-group 5c75ea2e-f4ba-4b33-acdf-13aa51163d39
!
slb virtual-server 6c1e373f-98b2-4bc6-a166-109abf32ba46 10.0.12.165
!
!
cloud-services meta-data
  enable
  provider openstack
!
end

6. Delete the member by setting **handle_vrid = False** in the config

stack@neha-victoria:~$ openstack loadbalancer member delete p1 m1

stack@neha-victoria:~$ openstack loadbalancer member list p1

Result: The member will get deleted without removing the manually configured VRID FIP of that subnet.

amphora-0e8e111e-44e0-47f5-b74c(NOLICENSE)#show running-config
!Current configuration: 500 bytes
!Configuration last updated at 07:29:59 GMT Mon Nov 1 2021
!Configuration last saved at 07:30:06 GMT Mon Nov 1 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 117 (Jul-12-2021,10:12)
!
hostname amphora-0e8e111e-44e0-47f5-b74c
!
!
glm use-mgmt-port
glm enable-requests
glm allocate-bandwidth 100
glm token A10b9c2d136d
glm port 443
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.139
  floating-ip 10.0.12.130
  **floating-ip 10.0.13.110**
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb service-group 5c75ea2e-f4ba-4b33-acdf-13aa51163d39 tcp
  method least-connection
!
slb virtual-server 27a9f673-b07e-4a66-b003-b7a8aa899042 10.0.11.187
  port 85 http
    name ccae88ed-fe19-4195-bd8e-a5d5133ddab9
    extended-stats
    service-group 5c75ea2e-f4ba-4b33-acdf-13aa51163d39
!
slb virtual-server 6c1e373f-98b2-4bc6-a166-109abf32ba46 10.0.12.165
!
!
cloud-services meta-data
  enable
  provider openstack
!
end


7. Delete loadbalancer lb2.

stack@neha-victoria:~$ openstack loadbalancer delete lb2

stack@neha-victoria:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| 27a9f673-b07e-4a66-b003-b7a8aa899042 | lb1  | 95e29d550b0643da843693f5355e5b69 | 10.0.11.187 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
```

Result: The LB will get deleted without remving the manually configured VRID FIP of that subnet.

amphora-0e8e111e-44e0-47f5-b74c(NOLICENSE)#show running-config
!Current configuration: 413 bytes
!Configuration last updated at 07:42:51 GMT Mon Nov 1 2021
!Configuration last saved at 07:42:53 GMT Mon Nov 1 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 117 (Jul-12-2021,10:12)
!
hostname amphora-0e8e111e-44e0-47f5-b74c
!
!
glm use-mgmt-port
glm enable-requests
glm allocate-bandwidth 100
glm token A10b9c2d136d
glm port 443
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.139
  **floating-ip 10.0.12.130**
  floating-ip 10.0.13.110
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb virtual-server 27a9f673-b07e-4a66-b003-b7a8aa899042 10.0.11.187
!
!
cloud-services meta-data
  enable
  provider openstack
!
end



Rack flow cases:

1. Manually configure VRID FIP for provider-vlan-11-subnet and create a LB by setting **handle_vrid = False** in the config.

vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config vrrp-a
!Section configuration: 98 bytes
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
**vrrp-a vrid 0
  floating-ip 10.0.11.100**
!

stack@neha-victoria:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name lb1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-11-01T08:02:09                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 7416f185-2a85-4106-8da6-17524234a869 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 95e29d550b0643da843693f5355e5b69     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.181                          |
| vip_network_id      | f41fca32-ef87-4125-8963-ce0ed756b3ed |
| vip_port_id         | 363c6822-66c8-47e3-a280-7934ff23e341 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | ef039261-0b7b-4405-8bf3-78547778160d |
+---------------------+--------------------------------------+
```

stack@neha-victoria:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| 7416f185-2a85-4106-8da6-17524234a869 | lb1  | 95e29d550b0643da843693f5355e5b69 | 10.0.11.181 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
```


vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 827 bytes
!Configuration last updated at 08:02:33 GMT Mon Nov 1 2021
!Configuration last saved at 08:02:40 GMT Mon Nov 1 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 117 (Jul-12-2021,10:12)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 10.0.0.50 255.255.255.0
!
vcs device 1
  priority 110
  interfaces management
  interfaces ethernet 1
  enable
!
vcs device 2
  priority 100
  interfaces management
  interfaces ethernet 1
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  enable
!
interface ethernet 1/2
!
interface ethernet 1/3
!
interface ethernet 1/4
!
interface ethernet 2/1
!
interface ethernet 2/2
  enable
!
interface ethernet 2/3
!
interface ethernet 2/4
!
**vrrp-a vrid 0
  floating-ip 10.0.11.100**
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
**slb virtual-server 7416f185-2a85-4106-8da6-17524234a869 10.0.11.181**
!
!
cloud-services meta-data
  enable
  provider openstack
!
end

2. Create a listener and pool

stack@neha-victoria:~$ openstack loadbalancer listener create --name l1 --protocol http --protocol-port 85 lb1
```
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-11-01T09:09:46                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 35839719-ded7-4c13-a2f6-e6622658dc71 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 7416f185-2a85-4106-8da6-17524234a869 |
| name                        | l1                                   |
| operating_status            | OFFLINE                              |
| project_id                  | 95e29d550b0643da843693f5355e5b69     |
| protocol                    | HTTP                                 |
| protocol_port               | 85                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
| allowed_cidrs               | None                                 |
| tls_ciphers                 | None                                 |
| tls_versions                | None                                 |
| alpn_protocols              | None                                 |
+-----------------------------+--------------------------------------+
```

stack@neha-victoria:~$ openstack loadbalancer pool create --name p1 --protocol HTTP --lb-algorithm LEAST_CONNECTIONS --listener l1
```
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-11-01T09:09:58                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | 284d795d-8f78-4725-909c-aa2e5ac01c0d |
| lb_algorithm         | LEAST_CONNECTIONS                    |
| listeners            | 35839719-ded7-4c13-a2f6-e6622658dc71 |
| loadbalancers        | 7416f185-2a85-4106-8da6-17524234a869 |
| members              |                                      |
| name                 | p1                                   |
| operating_status     | OFFLINE                              |
| project_id           | 95e29d550b0643da843693f5355e5b69     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+
```

3. Manually configure VRID FIP for provider-vlan-12-subnet and create a member by setting **handle_vrid = False** in the config

vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config vrrp-a
!Section configuration: 125 bytes
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
vrrp-a vrid 0
  floating-ip 10.0.11.100
  **floating-ip 10.0.12.115**
!


stack@neha-victoria:~$ openstack loadbalancer member create --subnet-id provider-vlan-12-subnet --address 10.0.12.10 --protocol-port 95 --name m1 p1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.12.10                           |
| admin_state_up      | True                                 |
| created_at          | 2021-11-01T09:10:38                  |
| id                  | 28b8e5cb-9c09-4815-819b-cbd071c048da |
| name                | m1                                   |
| operating_status    | NO_MONITOR                           |
| project_id          | 95e29d550b0643da843693f5355e5b69     |
| protocol_port       | 95                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | c68c1d09-5694-46a2-89f5-683e4a4bc507 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
```

vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 758 bytes
!Configuration last updated at 09:10:38 GMT Mon Nov 1 2021
!Configuration last saved at 09:10:40 GMT Mon Nov 1 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 117 (Jul-12-2021,10:12)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 10.0.0.50 255.255.255.0
!
vcs device 1
  priority 110
  interfaces management
  interfaces ethernet 1
  enable
!
vcs device 2
  priority 100
  interfaces management
  interfaces ethernet 1
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  enable
!
interface ethernet 1/2
!
interface ethernet 1/3
!
interface ethernet 1/4
!
interface ethernet 2/1
!
interface ethernet 2/2
  enable
!
interface ethernet 2/3
!
interface ethernet 2/4
!
vrrp-a vrid 0
  floating-ip 10.0.11.100
  `**floating-ip 10.0.12.115**`
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
**slb server 95e29_10_0_12_10 10.0.12.10
  port 95 tcp**
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb service-group 284d795d-8f78-4725-909c-aa2e5ac01c0d tcp
  method least-connection
  member 95e29_10_0_12_10 95
!
slb virtual-server 7416f185-2a85-4106-8da6-17524234a869 10.0.11.181
  port 85 http
    name 35839719-ded7-4c13-a2f6-e6622658dc71
    extended-stats
    service-group 284d795d-8f78-4725-909c-aa2e5ac01c0d
!
!
cloud-services meta-data
  enable
  provider openstack
!
end

4. Delete the member
stack@neha-victoria:~$ openstack loadbalancer member delete p1 m1

vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 845 bytes
!Configuration last updated at 09:11:32 GMT Mon Nov 1 2021
!Configuration last saved at 09:11:40 GMT Mon Nov 1 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 117 (Jul-12-2021,10:12)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 10.0.0.50 255.255.255.0
!
vcs device 1
  priority 110
  interfaces management
  interfaces ethernet 1
  enable
!
vcs device 2
  priority 100
  interfaces management
  interfaces ethernet 1
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  enable
!
interface ethernet 1/2
!
interface ethernet 1/3
!
interface ethernet 1/4
!
interface ethernet 2/1
!
interface ethernet 2/2
  enable
!
interface ethernet 2/3
!
interface ethernet 2/4
!
vrrp-a vrid 0
  floating-ip 10.0.11.100
  **floating-ip 10.0.12.115**
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  override-port 5550
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb service-group 284d795d-8f78-4725-909c-aa2e5ac01c0d tcp
  method least-connection
!
slb virtual-server 7416f185-2a85-4106-8da6-17524234a869 10.0.11.181
  port 85 http
    name 35839719-ded7-4c13-a2f6-e6622658dc71
    extended-stats
    service-group 284d795d-8f78-4725-909c-aa2e5ac01c0d
!
!
cloud-services meta-data
  enable
  provider openstack
!
end

5. Delete the loadbalancer

stack@neha-victoria:~$ openstack loadbalancer delete lb1 --cascade

vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config
!Current configuration: 661 bytes
!Configuration last updated at 09:12:24 GMT Mon Nov 1 2021
!Configuration last saved at 09:12:26 GMT Mon Nov 1 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 117 (Jul-12-2021,10:12)
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
device-context 1
  vcs enable
!
device-context 2
  vcs enable
!
vcs floating-ip 10.0.0.50 255.255.255.0
!
vcs device 1
  priority 110
  interfaces management
  interfaces ethernet 1
  enable
!
vcs device 2
  priority 100
  interfaces management
  interfaces ethernet 1
  enable
!
!
device-context 1
  interface management
    ip address dhcp
!
device-context 2
  interface management
    ip address dhcp
!
interface ethernet 1/1
  enable
!
interface ethernet 1/2
!
interface ethernet 1/3
!
interface ethernet 1/4
!
interface ethernet 2/1
!
interface ethernet 2/2
  enable
!
interface ethernet 2/3
!
interface ethernet 2/4
!
vrrp-a vrid 0
  **floating-ip 10.0.11.100**
  floating-ip 10.0.12.115
!
!
cloud-services meta-data
  enable
  provider openstack
!
end



vThunder-Active-vMaster[1/1](NOLICENSE)#show running-config vrrp-a
!Section configuration: 125 bytes
!
vrrp-a common
  device-id 1
  set-id 1
  enable
!
**vrrp-a vrid 0
  floating-ip 10.0.11.100
  floating-ip 10.0.12.115**
!