### PR TITLE
[STACK-3055/3056/3071/3110/3126] Various flexpool fixes

### DIFF
--- a/a10_octavia/contrib/scripts/a10_setup_provider_no_dns
+++ b/a10_octavia/contrib/scripts/a10_setup_provider_no_dns
@@ -1,0 +1,411 @@
+#!/bin/bash
+
+#
+# This script is used for setting up devstack VLAN config with provider VLAN and Openstack 
+# VLAN networks. This scripts sets up three openstack networks 
+# provider-vlan-11 (vlan id:11, subnet:10.0.11.0/24)
+# provider-vlan-12 (vlan id:12, subnet:10.0.12.0/24)
+# provider-vlan-13 (vlan id:13, subnet:10.0.13.0/24)
+# provider-vlan-14 (vlan id:14, subnet:10.0.14.0/24)
+# with which openstack instances can be launched and communicate with vthunder on provider 
+# network.
+#
+
+function usage {
+cat << EOF
+usage: $0
+
+OPTIONS:
+  --help                     prints this message
+  --setup-provider-vlan      sets up provider ovs bridge br-vlanp, neutron vlan config and
+                             openstack vlan networks.
+                             make sure to delete all non devstack entities created by user
+                             in openstack before running this command. 
+  --teardown-provider-vlan   tears down the openstack vlan networks, ovs bridge settings and
+                             removes neutron vlan config.
+                             make sure to delete all vlan entities created by user
+                             in openstack before running this command.
+EOF
+}
+
+function check_exists {
+    local cmd="${1}"
+    local pattern="${2}"
+
+    local output=$(${cmd})
+    local exists=$(echo "${output}" | grep "${pattern}")
+    if [ -z "${exists}" ]
+    then
+        echo 0
+        return
+    fi
+
+    echo 1
+}
+
+function host_install_packages {
+    echo "[+] Installing virt-manager on host"
+    sudo apt-get install -y virt-manager
+}
+
+function add_veth_pair {
+    local interface_1="${1}"
+    local interface_2="${2}"
+    local ip_address="${3}"
+
+    local exists=$(check_exists "ip link show" "${interface_1}")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Creating veth pair ${interface_1}-${interface_2} on the host"
+        sudo ip link add ${interface_1} type veth peer name ${interface_2}
+        sudo ip link set ${interface_1} up
+        sudo ip link set ${interface_2} up
+        echo "[=] Setting ${ip_address}/24 on ${interface_1}"
+        sudo ip addr add ${ip_address}/24 dev ${interface_1}
+    fi
+}
+
+function add_tap_interface {
+    local interface="${1}"
+
+    exists=$(check_exists "ip link show" "${interface}")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Creating tap interface ${interface} on the host"
+        sudo ip tuntap add mode tap ${interface}
+    fi
+}
+
+function setup_host_networking {
+    add_veth_pair veth0 veth1 10.0.0.1
+    add_veth_pair veth2 veth3 10.0.11.1
+    add_veth_pair veth4 veth5 10.0.12.1
+    add_veth_pair veth6 veth7 10.0.13.1
+    add_veth_pair veth8 veth9 10.0.14.1
+
+    add_tap_interface tap1
+    add_tap_interface tap2
+    add_tap_interface tap3
+    add_tap_interface tap4
+}
+
+function add_ovs_bridge {
+    local bridge="${1}"
+
+    local exists=$(check_exists "sudo ovs-vsctl list-br" "${bridge}")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Creating OVS bridge ${bridge}"
+        sudo ovs-vsctl add-br ${bridge}
+    fi
+}
+
+function add_port_to_bridge {
+    local bridge="${1}"
+    local port="${2}"
+    local tag="${3}"
+
+    exists=$(check_exists "sudo ovs-vsctl list-ports ${bridge}" "${port}")
+    if [[ ${exists} -ne 1 ]]; then
+        if [[ ! -z ${tag} ]]; then
+            echo "[+] Adding port ${port} to OVS bridge ${bridge} with tag ${tag}"
+            sudo ovs-vsctl add-port ${bridge} ${port} tag=${tag}
+        else
+            echo "[+] Adding port ${port} to OVS bridge ${bridge}"
+            sudo ovs-vsctl add-port ${bridge} ${port}
+        fi
+    fi
+}
+
+function setup_host_ovs_bridges {
+    add_ovs_bridge br-mgmt
+    add_port_to_bridge br-mgmt veth1 ""
+
+    add_ovs_bridge br-vlanp
+    add_port_to_bridge br-vlanp veth3 11
+    add_port_to_bridge br-vlanp veth5 12
+    add_port_to_bridge br-vlanp veth7 13
+    add_port_to_bridge br-vlanp veth9 14
+
+    add_port_to_bridge br-vlanp tap1 11
+    add_port_to_bridge br-vlanp tap2 12
+    add_port_to_bridge br-vlanp tap3 13
+    add_port_to_bridge br-vlanp tap4 14
+}
+
+function patch_conf_files {
+    echo "[+] Patching config files"
+
+    exists=$(check_exists "/bin/cat /etc/neutron/neutron.conf" "service_plugins = neutron.services.l3_router.l3_router_plugin.L3RouterPlugin")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[=] Overwriting service_plugins in /etc/neutron/neutron.conf"
+        sed -i "s/service_plugins = .*/service_plugins = /" /etc/neutron/neutron.conf
+    fi
+
+    exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "#type_drivers =")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[=] Overwriting type_drivers in /etc/neutron/plugins/ml2/ml2_conf.ini"
+        sed -i "s/#type_drivers = /type_drivers = flat,vlan/" /etc/neutron/plugins/ml2/ml2_conf.ini
+    fi
+
+    exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "mechanism_drivers = openvswitch,linuxbridge")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[=] Overwriting mechanism_drivers in /etc/neutron/plugins/ml2/ml2_conf.ini"
+        sed -i "s/mechanism_drivers = .*/mechanism_drivers = openvswitch/" /etc/neutron/plugins/ml2/ml2_conf.ini
+    fi
+
+    exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "tenant_network_types = vxlan")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[=] Overwriting tenant_network_types in /etc/neutron/plugins/ml2/ml2_conf.ini"
+        sed -i "s/tenant_network_types = .*/tenant_network_types = /" /etc/neutron/plugins/ml2/ml2_conf.ini
+    fi
+
+    exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "network_vlan_ranges = public")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[=] Overwriting network_vlan_ranges /etc/neutron/plugins/ml2/ml2_conf.ini"
+        sed -i "s/network_vlan_ranges = .*/network_vlan_ranges = provider/" /etc/neutron/plugins/ml2/ml2_conf.ini
+    fi
+
+    exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "provider:br-vlanp")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[=] Overwriting bridge_mappings in /etc/neutron/plugins/ml2/ml2_conf.ini"
+        sed -i "s/bridge_mappings = .*/bridge_mappings = public:br-ex,provider:br-vlanp/" /etc/neutron/plugins/ml2/ml2_conf.ini
+    fi
+
+    exists=$(check_exists "/bin/cat /etc/neutron/dhcp_agent.ini" "#force_metadata =")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[=] Overwriting force_metadata in /etc/neutron/dhcp_agent.ini"
+        sed -i "s/#force_metadata = .*/force_metadata = true/" /etc/neutron/dhcp_agent.ini
+    fi
+}
+
+function restart_services {
+    echo "[=] Restarting devstack@neutron-* services"
+    pushd /etc/systemd/system/
+    sudo systemctl restart devstack@q-*
+    popd
+}
+
+function create_network {
+    local vlan_id="${1}"
+    local network_name="${2}"
+    local subnet_name="${3}"
+    local subnet_range="${4}"
+    local allocation_pool="${5}"
+
+    exists=$(check_exists "openstack network list" "${network_name}")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Creating ${network_name}"
+        openstack network create --external --provider-segment ${vlan_id} --provider-network-type vlan --provider-physical-network provider --share ${network_name}
+        sleep 1
+    fi
+
+    exists=$(check_exists "openstack subnet list" "${subnet_name}")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Creating ${subnet_name}"
+        openstack subnet create --ip-version 4 --allocation-pool ${allocation_pool} --network ${network_name} --subnet-range ${subnet_range} ${subnet_name}
+        sleep 1
+    fi
+
+    local snat_rule="POSTROUTING -s ${subnet_range} ! -d ${subnet_range} -j MASQUERADE"
+    exists=$(check_exists "sudo iptables-save -t nat" "${snat_rule}")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[+] Creating SNAT rule ${snat_rule}"
+        sudo iptables -t nat -A ${snat_rule}
+    fi
+}
+
+function setup_provider_vlan {
+    host_install_packages
+    setup_host_networking
+    setup_host_ovs_bridges
+
+    patch_conf_files
+    restart_services
+    sleep 2
+
+    create_network 11 provider-vlan-11 provider-vlan-11-subnet 10.0.11.0/24 start=10.0.11.100,end=10.0.11.200
+    create_network 12 provider-vlan-12 provider-vlan-12-subnet 10.0.12.0/24 start=10.0.12.100,end=10.0.12.200
+    create_network 13 provider-vlan-13 provider-vlan-13-subnet 10.0.13.0/24 start=10.0.13.100,end=10.0.13.200
+    create_network 14 provider-vlan-14 provider-vlan-14-subnet 10.0.14.0/24 start=10.0.14.100,end=10.0.14.200
+}
+
+function delete_network {
+    local network_name="${1}"
+    local subnet_name="${2}"
+    local subnet_range="${3}"
+
+    local snat_rule="POSTROUTING -s ${subnet_range} ! -d ${subnet_range} -j MASQUERADE"
+    local exists=$(check_exists "sudo iptables-save -t nat" "${snat_rule}")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[-] Deleting SNAT rule ${snat_rule}"
+        sudo iptables -t nat -D ${snat_rule}
+    fi
+
+    exists=$(check_exists "openstack subnet list" "${subnet_name}")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[-] Deleting ${subnet_name}"
+        openstack subnet delete ${subnet_name}
+    fi
+
+    exists=$(check_exists "openstack network list" "${network_name}")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[-] Deleting ${network_name}"
+        openstack network delete ${network_name}
+    fi
+}
+
+function delete_ostack_networks {
+    delete_network provider-vlan-14 provider-vlan-14-subnet 10.0.14.0/24
+    delete_network provider-vlan-13 provider-vlan-13-subnet 10.0.13.0/24
+    delete_network provider-vlan-12 provider-vlan-12-subnet 10.0.12.0/24
+    delete_network provider-vlan-11 provider-vlan-11-subnet 10.0.11.0/24
+}
+
+function unpatch_conf_files {
+    echo "[-] Removing vlan patch in config files"
+
+    local exists=$(check_exists "/bin/cat /etc/neutron/neutron.conf" "service_plugins = neutron.services.l3_router.l3_router_plugin.L3RouterPlugin")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[=] Overwriting service_plugins in /etc/neutron/neutron.conf"
+        sed -i "s/service_plugins =/service_plugins = neutron.services.l3_router.l3_router_plugin.L3RouterPlugin/" /etc/neutron/neutron.conf
+    fi
+
+    exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "type_drivers = flat,vlan")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[=] Overwriting type_drivers in /etc/neutron/plugins/ml2/ml2_conf.ini"
+        sed -i "s/type_drivers = flat,vlan/#type_drivers = /" /etc/neutron/plugins/ml2/ml2_conf.ini
+    fi
+
+    exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "mechanism_drivers = openvswitch,linuxbridge")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[=] Overwriting mechanism_drivers in /etc/neutron/plugins/ml2/ml2_conf.ini"
+        sed -i "s/mechanism_drivers = .*/mechanism_drivers = openvswitch,linuxbridge/" /etc/neutron/plugins/ml2/ml2_conf.ini
+    fi
+
+    exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "tenant_network_types = vxlan")
+    if [[ ${exists} -ne 1 ]]; then
+        echo "[=] Overwriting tenant_network_types in /etc/neutron/plugins/ml2/ml2_conf.ini"
+        sed -i "s/tenant_network_types =/tenant_network_types = vxlan/" /etc/neutron/plugins/ml2/ml2_conf.ini
+    fi
+
+    exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "network_vlan_ranges = provider")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[=] Overwriting network_vlan_ranges /etc/neutron/plugins/ml2/ml2_conf.ini"
+        sed -i "s/network_vlan_ranges = provider/network_vlan_ranges = public/" /etc/neutron/plugins/ml2/ml2_conf.ini
+    fi
+
+    exists=$(check_exists "/bin/cat /etc/neutron/plugins/ml2/ml2_conf.ini" "provider:br-vlanp")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[=] Overwriting bridge_mappings in /etc/neutron/plugins/ml2/ml2_conf.ini"
+        sed -i "s/bridge_mappings = public:br-ex,provider:br-vlanp/bridge_mappings = public:br-ex/" /etc/neutron/plugins/ml2/ml2_conf.ini
+    fi
+}
+
+function delete_ovs_bridges {
+    local exists=$(check_exists "sudo ovs-vsctl list-br" "br-vlanp")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[-] Deleting tap ports from br-vlanp"
+        sudo ovs-vsctl del-port br-vlanp tap4
+        sudo ovs-vsctl del-port br-vlanp tap3
+        sudo ovs-vsctl del-port br-vlanp tap2
+        sudo ovs-vsctl del-port br-vlanp tap1
+
+        echo "[-] Deleting veth ports from br-vlanp"
+        sudo ovs-vsctl del-port br-vlanp veth9
+        sudo ovs-vsctl del-port br-vlanp veth7
+        sudo ovs-vsctl del-port br-vlanp veth5
+        sudo ovs-vsctl del-port br-vlanp veth3
+
+        echo "[-] Deleting OVS bridge br-vlanp"
+        sudo ovs-vsctl del-br br-vlanp
+    fi
+
+    exists=$(check_exists "sudo ovs-vsctl list-br" "br-mgmt")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[-] Deleting veth port from br-mgmt"
+        sudo ovs-vsctl del-port br-mgmt veth1
+
+        echo "[-] Deleting OVS bridge br-mgmt"
+        sudo ovs-vsctl del-br br-mgmt
+    fi
+}
+
+function delete_veth_pair {
+    local interface="${1}"
+
+    exists=$(check_exists "ip link show" "${interface}")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[-] Deleting ${interface} veth pair"
+        sudo ip link del ${interface}
+    fi
+}
+
+function delete_tap_interface {
+    local interface="${1}"
+
+    exists=$(check_exists "ip link show" "${interface}")
+    if [[ ${exists} -eq 1 ]]; then
+        echo "[-] Deleting ${interface} interface"
+        sudo ip tuntap del mode tap ${interface}
+    fi
+}
+
+function delete_host_tap_and_veth_interfaces {
+
+    delete_veth_pair veth0
+    delete_veth_pair veth2
+    delete_veth_pair veth4
+    delete_veth_pair veth6
+    delete_veth_pair veth8
+
+    delete_tap_interface tap4
+    delete_tap_interface tap3
+    delete_tap_interface tap2
+    delete_tap_interface tap1
+}
+
+function teardown_provider_vlan {
+    delete_ostack_networks
+    unpatch_conf_files
+    delete_ovs_bridges
+    delete_host_tap_and_veth_interfaces
+    restart_services
+}
+
+arg_setup_provider_vlan=false
+arg_teardown_provider_vlan=false
+
+function set_args {
+    if [[ $# -eq 0 ]] || [[ $# -gt 1 ]]; then
+        echo "Improper number of arguments. Pass only one argument."
+        usage
+        exit 0
+    fi
+    while [ "${1:-}" != "" ]; do
+        case "$1" in
+            "--help")
+                usage
+                exit 0
+                ;;
+            "--setup-provider-vlan")
+                arg_setup_provider_vlan=true
+                ;;
+            "--teardown-provider-vlan")
+                arg_teardown_provider_vlan=true
+                ;;
+            *)
+                usage
+                exit 0
+        esac
+        shift
+    done
+}
+
+function main {
+    set_args "$@"
+    if [[ $arg_setup_provider_vlan = true ]]; then
+        setup_provider_vlan
+    else
+        teardown_provider_vlan
+    fi
+}
+
+main "$@"

--- a/a10_octavia/controller/worker/tasks/glm_tasks.py
+++ b/a10_octavia/controller/worker/tasks/glm_tasks.py
@@ -12,7 +12,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from sys import _xoptions
+
 from acos_client import errors as acos_errors
 
 from requests import exceptions as req_exceptions
@@ -204,11 +204,12 @@ class ActivateFlexpoolLicense(task.Task):
                 # Must have the license on the device before enabling burst
                 self.axapi_client.glm.update(burst=burst)
         except acos_errors.LicenseOptionNotAllowed as e:
-            error_msg = "A specified configuration option is incompatible with license type provided."
+            error_msg = ("A specified configuration option is "
+                         "incompatible with license type provided.")
             if burst:
-                error_msg += ("This error can occur when the license request has "
+                error_msg += (" This error can occur when the license request has "
                               "failed due to connection issue. Please check your "
-                              "configured GLM network and dns settings")
+                              "configured GLM network and dns settings.")
             LOG.error(error_msg)
             raise e
         except acos_errors.ACOSException as e:
@@ -221,7 +222,7 @@ class ActivateFlexpoolLicense(task.Task):
             self.axapi_client.delete.glm_license.post()
         except req_exceptions.ConnectionError:
             LOG.exception("Failed to connect A10 Thunder device: %s", vthunder.ip_address)
-        except acos_errors.ACOSException as e:
+        except Exception as e:
             LOG.exception("Could not delete license for amphora %s due to: \n%s", amphora.id, e)
 
 
@@ -234,7 +235,7 @@ class RevokeFlexpoolLicense(task.Task):
             return None
         try:
             self.axapi_client.delete.glm_license.post()
-        except acos_errors.ACOSException as e:
+        except Exception as e:
             LOG.exception("Could not delete license for vthunder %s due to: \n%s", vthunder.id, e)
 
 
@@ -274,7 +275,7 @@ class ConfigureForwardProxyServer(task.Task):
             self.axapi_client.glm.proxy_server.delete()
         except req_exceptions.ConnectionError:
             LOG.exception("Failed to connect A10 Thunder device: %s", vthunder.ip_address)
-        except acos_errors.ACOSException as e:
+        except Exception as e:
             LOG.exception(
                 "Could not delete forward proxy for vthunder %s due to: \n%s",
                 vthunder.id, e)

--- a/a10_octavia/controller/worker/tasks/glm_tasks.py
+++ b/a10_octavia/controller/worker/tasks/glm_tasks.py
@@ -73,8 +73,7 @@ class DNSConfiguration(task.Task):
         if CONF.glm_license.secondary_dns:
             secondary_dns = CONF.glm_license.secondary_dns
 
-        use_network_dns = flavor and flavor.get('use-network-dns')
-
+        use_network_dns = flavor and flavor.get('glm') and flavor.get('glm').get('use-network-dns')
         if not primary_dns or use_network_dns:
             subnet_dns = license_subnet['subnet'].get('dns_nameservers', [])
             if len(subnet_dns) == 1:

--- a/a10_octavia/controller/worker/tasks/glm_tasks.py
+++ b/a10_octavia/controller/worker/tasks/glm_tasks.py
@@ -205,11 +205,10 @@ class ActivateFlexpoolLicense(task.Task):
                 self.axapi_client.glm.update(burst=burst)
         except acos_errors.LicenseOptionNotAllowed as e:
             error_msg = ("A specified configuration option is "
-                         "incompatible with license type provided.")
-            if burst:
-                error_msg += (" This error can occur when the license request has "
-                              "failed due to connection issue. Please check your "
-                              "configured GLM network and dns settings.")
+                         "incompatible with license type provided. "
+                         "This error can occur when the license request has "
+                         "failed due to connection issue. Please check your "
+                         "configured GLM network and dns settings.")
             LOG.error(error_msg)
             raise e
         except acos_errors.ACOSException as e:

--- a/a10_octavia/controller/worker/tasks/glm_tasks.py
+++ b/a10_octavia/controller/worker/tasks/glm_tasks.py
@@ -65,7 +65,7 @@ class DNSConfiguration(task.Task):
 
         primary_dns = None
         secondary_dns = None
-        subnet_dns = license_subnet.get('dns_nameservers', [])
+        subnet_dns = license_subnet['subnet'].get('dns_nameservers', [])
         if len(subnet_dns) == 1:
             primary_dns = subnet_dns[0]
         elif len(subnet_dns) >= 2:

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_glm_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_glm_tasks.py
@@ -27,6 +27,8 @@ from octavia.common import data_models as o_data_models
 from octavia.network import data_models as n_data_models
 from octavia.tests.common import constants as t_constants
 
+from acos_client import errors as acos_errors
+
 from a10_octavia.common import config_options
 from a10_octavia.common import data_models as a10_data_models
 from a10_octavia.common import exceptions as a10_ex
@@ -96,7 +98,8 @@ class TestGLMTasks(base.BaseTaskTestCase):
         vthunder = copy.deepcopy(VTHUNDER)
         dns_net = copy.deepcopy(DNS_NETWORK)
         network_driver_mock.get_network.return_value = dns_net
-        network_driver_mock.show_subnet_detailed.return_value = copy.deepcopy(DNS_SUBNET).to_dict()
+        dns_subnet = copy.deepcopy(DNS_SUBNET).to_dict()
+        network_driver_mock.show_subnet_detailed.return_value = {'subnet': dns_subnet}
 
         dns_task = task.DNSConfiguration()
         dns_task.axapi_client = self.client_mock
@@ -110,7 +113,8 @@ class TestGLMTasks(base.BaseTaskTestCase):
         vthunder = copy.deepcopy(VTHUNDER)
         dns_net = copy.deepcopy(DNS_NETWORK)
         network_driver_mock.get_network.return_value = dns_net
-        network_driver_mock.show_subnet_detailed.return_value = copy.deepcopy(DNS_SUBNET).to_dict()
+        dns_subnet = copy.deepcopy(DNS_SUBNET).to_dict()
+        network_driver_mock.show_subnet_detailed.return_value = {'subnet': dns_subnet}
 
         dns_task = task.DNSConfiguration()
         dns_task.axapi_client = self.client_mock
@@ -126,7 +130,8 @@ class TestGLMTasks(base.BaseTaskTestCase):
         vthunder = copy.deepcopy(VTHUNDER)
         dns_net = copy.deepcopy(DNS_NETWORK)
         network_driver_mock.get_network.return_value = dns_net
-        network_driver_mock.show_subnet_detailed.return_value = copy.deepcopy(DNS_SUBNET).to_dict()
+        dns_subnet = copy.deepcopy(DNS_SUBNET).to_dict()
+        network_driver_mock.show_subnet_detailed.return_value = {'subnet': dns_subnet}
 
         dns_task = task.DNSConfiguration()
         dns_task.axapi_client = self.client_mock
@@ -143,7 +148,7 @@ class TestGLMTasks(base.BaseTaskTestCase):
         dns_subnet = copy.deepcopy(DNS_SUBNET).to_dict()
         dns_subnet['dns_nameservers'] = [PRIMARY_DNS, SECONDARY_DNS]
         network_driver_mock.get_network.return_value = dns_net
-        network_driver_mock.show_subnet_detailed.return_value = dns_subnet
+        network_driver_mock.show_subnet_detailed.return_value = {'subnet': dns_subnet}
 
         dns_task = task.DNSConfiguration()
         dns_task.axapi_client = self.client_mock
@@ -160,7 +165,7 @@ class TestGLMTasks(base.BaseTaskTestCase):
         dns_subnet = copy.deepcopy(DNS_SUBNET).to_dict()
         dns_subnet['dns_nameservers'] = [PRIMARY_DNS, SECONDARY_DNS, '3.3.3.3']
         network_driver_mock.get_network.return_value = dns_net
-        network_driver_mock.show_subnet_detailed.return_value = dns_subnet
+        network_driver_mock.show_subnet_detailed.return_value = {'subnet': dns_subnet}
 
         dns_task = task.DNSConfiguration()
         dns_task.axapi_client = self.client_mock
@@ -183,7 +188,8 @@ class TestGLMTasks(base.BaseTaskTestCase):
         vthunder = copy.deepcopy(VTHUNDER)
         dns_net = copy.deepcopy(DNS_NETWORK)
         network_driver_mock.get_network.return_value = dns_net
-        network_driver_mock.show_subnet_detailed.return_value = copy.deepcopy(DNS_SUBNET).to_dict()
+        dns_subnet = copy.deepcopy(DNS_SUBNET).to_dict()
+        network_driver_mock.show_subnet_detailed.return_value = {'subnet': dns_subnet}
 
         dns_task = task.DNSConfiguration()
         dns_task.axapi_client = self.client_mock
@@ -200,7 +206,8 @@ class TestGLMTasks(base.BaseTaskTestCase):
         vthunder = copy.deepcopy(VTHUNDER)
         dns_net = copy.deepcopy(DNS_NETWORK)
         network_driver_mock.get_network.return_value = dns_net
-        network_driver_mock.show_subnet_detailed.return_value = copy.deepcopy(DNS_SUBNET).to_dict()
+        dns_subnet = copy.deepcopy(DNS_SUBNET).to_dict()
+        network_driver_mock.show_subnet_detailed.return_value = {'subnet': dns_subnet}
 
         dns_task = task.DNSConfiguration()
         dns_task.axapi_client = self.client_mock
@@ -218,7 +225,7 @@ class TestGLMTasks(base.BaseTaskTestCase):
         dns_subnet = copy.deepcopy(DNS_SUBNET).to_dict()
         dns_subnet['dns_nameservers'] = ['8.8.8.8', '8.8.4.4']
         network_driver_mock.get_network.return_value = dns_net
-        network_driver_mock.show_subnet_detailed.return_value = dns_subnet
+        network_driver_mock.show_subnet_detailed.return_value = {'subnet': dns_subnet}
 
         dns_task = task.DNSConfiguration()
         dns_task.axapi_client = self.client_mock
@@ -234,7 +241,8 @@ class TestGLMTasks(base.BaseTaskTestCase):
         vthunder = copy.deepcopy(VTHUNDER)
         dns_net = copy.deepcopy(DNS_NETWORK)
         network_driver_mock.get_network.return_value = dns_net
-        network_driver_mock.show_subnet_detailed.return_value = copy.deepcopy(DNS_SUBNET).to_dict()
+        dns_subnet = copy.deepcopy(DNS_SUBNET).to_dict()
+        network_driver_mock.show_subnet_detailed.return_value = {'subnet': dns_subnet}
 
         dns_task = task.DNSConfiguration()
         dns_task.axapi_client = self.client_mock
@@ -253,7 +261,7 @@ class TestGLMTasks(base.BaseTaskTestCase):
         dns_subnet = copy.deepcopy(DNS_SUBNET).to_dict()
         dns_subnet['dns_nameservers'] = ['8.8.8.8', '8.8.4.4']
         network_driver_mock.get_network.return_value = dns_net
-        network_driver_mock.show_subnet_detailed.return_value = dns_subnet
+        network_driver_mock.show_subnet_detailed.return_value = {'subnet': dns_subnet}
 
         dns_task = task.DNSConfiguration()
         dns_task.axapi_client = self.client_mock
@@ -269,7 +277,8 @@ class TestGLMTasks(base.BaseTaskTestCase):
         vthunder = copy.deepcopy(VTHUNDER)
         dns_net = copy.deepcopy(DNS_NETWORK)
         network_driver_mock.get_network.return_value = dns_net
-        network_driver_mock.show_subnet_detailed.return_value = copy.deepcopy(DNS_SUBNET).to_dict()
+        dns_subnet = copy.deepcopy(DNS_SUBNET).to_dict()
+        network_driver_mock.show_subnet_detailed.return_value = {'subnet': dns_subnet}
 
         dns_task = task.DNSConfiguration()
         dns_task.axapi_client = self.client_mock
@@ -283,7 +292,8 @@ class TestGLMTasks(base.BaseTaskTestCase):
         vthunder = copy.deepcopy(VTHUNDER)
         dns_net = copy.deepcopy(DNS_NETWORK)
         network_driver_mock.get_network.return_value = dns_net
-        network_driver_mock.show_subnet_detailed.return_value = copy.deepcopy(DNS_SUBNET).to_dict()
+        dns_subnet = copy.deepcopy(DNS_SUBNET).to_dict()
+        network_driver_mock.show_subnet_detailed.return_value = {'subnet': dns_subnet}
 
         dns_task = task.DNSConfiguration()
         dns_task.axapi_client = self.client_mock
@@ -298,7 +308,8 @@ class TestGLMTasks(base.BaseTaskTestCase):
         vthunder = copy.deepcopy(VTHUNDER)
         dns_net = copy.deepcopy(DNS_NETWORK)
         network_driver_mock.get_network.return_value = dns_net
-        network_driver_mock.show_subnet_detailed.return_value = copy.deepcopy(DNS_SUBNET).to_dict()
+        dns_subnet = copy.deepcopy(DNS_SUBNET).to_dict()
+        network_driver_mock.show_subnet_detailed.return_value = {'subnet': dns_subnet}
 
         dns_task = task.DNSConfiguration()
         dns_task.axapi_client = self.client_mock
@@ -318,7 +329,6 @@ class TestGLMTasks(base.BaseTaskTestCase):
     def _template_glm_call(self):
         expected_call = {
             'token': a10constants.MOCK_FLEXPOOL_TOKEN,
-            'burst': False,
             'enable_requests': True,
             'interval': None,
             'port': 443,
@@ -393,6 +403,68 @@ class TestGLMTasks(base.BaseTaskTestCase):
 
         flexpool_task.execute(vthunder, amphora)
         self.client_mock.system.action.setInterface.assert_called_with(2)
+
+    def test_ActiveFlexpoolLicense_execute_fail_LicenseOptionNotAllowed(self):
+        self.conf.config(group=a10constants.GLM_LICENSE_CONFIG_SECTION,
+                         amp_license_network=DNS_NETWORK.id,
+                         flexpool_token=a10constants.MOCK_FLEXPOOL_TOKEN)
+        vthunder = copy.deepcopy(VTHUNDER)
+        amphora = copy.deepcopy(AMPHORA)
+        interfaces = {
+            'interface': {
+                'ethernet-list': []
+            }
+        }
+
+        flexpool_task = task.ActivateFlexpoolLicense()
+        flexpool_task.axapi_client = self.client_mock
+        flexpool_task.axapi_client.interface.get_list.return_value = interfaces
+        flexpool_task.axapi_client.glm.create.side_effect = acos_errors.LicenseOptionNotAllowed()
+
+        flexpool_task.axapi_client = self.client_mock
+        task_path = "a10_octavia.controller.worker.tasks.glm_tasks"
+        log_message = ("A specified configuration option is "
+                       "incompatible with license type provided.")
+        expected_log = ["ERROR:{}:{}".format(task_path, log_message)]
+        with self.assertLogs(task_path, level='ERROR') as cm:
+            try:
+                flexpool_task.execute(vthunder, amphora)
+            except Exception:
+                pass
+            self.assertEqual(expected_log, cm.output)
+
+    def test_ActiveFlexpoolLicense_execute_fail_LicenseOptionNotAllowed_burst(self):
+        self.conf.config(group=a10constants.GLM_LICENSE_CONFIG_SECTION,
+                         amp_license_network=DNS_NETWORK.id,
+                         flexpool_token=a10constants.MOCK_FLEXPOOL_TOKEN,
+                         burst=True)
+        vthunder = copy.deepcopy(VTHUNDER)
+        amphora = copy.deepcopy(AMPHORA)
+        interfaces = {
+            'interface': {
+                'ethernet-list': []
+            }
+        }
+
+        flexpool_task = task.ActivateFlexpoolLicense()
+        flexpool_task.axapi_client = self.client_mock
+        flexpool_task.axapi_client.interface.get_list.return_value = interfaces
+        flexpool_task.axapi_client.glm.create.side_effect = acos_errors.LicenseOptionNotAllowed()
+
+        flexpool_task.axapi_client = self.client_mock
+        task_path = "a10_octavia.controller.worker.tasks.glm_tasks"
+        log_message = ("A specified configuration option is "
+                       "incompatible with license type provided. "
+                       "This error can occur when the license request has "
+                       "failed due to connection issue. Please check your "
+                       "configured GLM network and dns settings.")
+        expected_log = ["ERROR:{}:{}".format(task_path, log_message)]
+        with self.assertLogs(task_path, level='ERROR') as cm:
+            try:
+                flexpool_task.execute(vthunder, amphora)
+            except Exception:
+                pass
+            self.assertEqual(expected_log, cm.output)
 
     def test_ActivateFlexpoolLicense_revert_deactivate_license(self):
         vthunder = copy.deepcopy(VTHUNDER)


### PR DESCRIPTION
## Description

### STACK-3055/3056/3071
Severity: High

Multiple flexpool usage issues were detected due to a keyword 'subnet' not being used to access the subnet dictionary from the returned payload prior to looking up the `dns-nameserver` keyword.

### STACK-3110
Severity: Critical

Exception encountered when deleting a loadbalancer when a connection cannot be established with the GLM. This prevents loadbalancers from being deleted

### STACK-3126
Severity: Low

Error occurs when attempting to enable burst when using a burst license

## Connected PR
https://github.com/a10networks/acos-client/pull/365

## Jira Ticket
- [STACK-3055](https://a10networks.atlassian.net/browse/STACK-3055)
- [STACK-3056](https://a10networks.atlassian.net/browse/STACK-3056)
- [STACK-3071](https://a10networks.atlassian.net/browse/STACK-3071)
- [STACK-3110](https://a10networks.atlassian.net/browse/STACK-3110)
- [STACK-3126](https://a10networks.atlassian.net/browse/STACK-3126)

## Technical Approach
- Retrieved value from `subnet` key before attempting to get values from `dns-nameserver` key
- Added try-except clauses to catch general "Exception"s so that a message can be logged without triggering a revert in the case that the current code being execute is either a revert or a delete
- Improved error handling and log messages
- Added an extra `update` call to apply `burst` if it has been defined

## Config Changes
N/A

## Test Cases
- Revised `show_subnet_detailed` mock functions to return proper response
- Added test that proper error message is shown in the case that an improper license option is specified
- Added test to confirm that update is called with burst when it is enabled in the config

## Manual Testing

### STACK-3055/3056

#### Config
```
[glm_license]
amp_license_network = <network_id>
...
```

#### 1. Set network subnets
```
openstack subnet set --dns-nameserver 9.9.9.9 --dns-nameserver 149.112.112.112 --dns-nameserver 1.1.1.1 provider-vlan-13-subnet
```

#### 2. Create loadbalancer
```
openstack loadbalancer create --vip-subnet-id provider-vlan-12-subnet --name SLB1
```

#### Expected Output
![image](https://user-images.githubusercontent.com/10890376/140001243-af612673-cfa7-4eb9-8ea8-187c381fea21.png)


### STACK-3071

#### Config
```
[glm_license]
amp_license_network = <network_id>
primary_dns = 8.8.8.8
secondary_dns = 8.8.4.4
...
```

#### 1. Create flavor profile
```
openstack loadbalancer flavorprofile create --name fp1 --provider a10 --flavor-data '{"glm": {"use-network-dns": true}}'
openstack loadbalancer flavor create --name f1 --flavorprofile fp1 --enable
```

#### 2. Set network subnets
```
openstack subnet set --dns-nameserver 9.9.9.9 --dns-nameserver 149.112.112.112  provider-vlan-13-subnet
```

#### 3. Create loadbalancer
```
openstack loadbalancer create --vip-subnet-id provider-vlan-12-subnet --flavor f1 --name SLB1
```

#### Expected Output

![image](https://user-images.githubusercontent.com/10890376/140005551-148466c1-f833-4215-a28f-2a2d411bf4aa.png)


### STACK-3110

#### Config
```
[glm_license]
amp_license_network = <network_id>
primary_dns = 8.8.8.8
secondary_dns = 8.8.4.4
...
```


#### 1. Create loadbalancer
```
openstack loadbalancer create --vip-subnet-id provider-vlan-12-subnet --name SLB1
```

#### 2. Delete DNS configuration from ACOS device
```
>config
> no ip dns primary 8.8.8.8
> no ip dns secondary 8.8.4.4
```

#### 3. Delete the loadbalancer
```
openstack loadbalancer delete SLB1
```

### Expected Ouput
*Loadbalancer will be deleted successfully but the below will still show in logs*

### STACK-3126
*Requires use of a Burst Capacity Flexpool License*

#### Config
```
[glm_license]
amp_license_network = <network_id>
primary_dns = 8.8.8.8
secondary_dns = 8.8.4.4
burst=True
...
```

#### 1. Create loadbalancer
```
openstack loadbalancer create --vip-subnet-id provider-vlan-12-subnet --name SLB1
```