### PR TITLE
[STACK-3121] Duplicate members in batch update causes pending state freeze of SLB tree

### DIFF
--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -300,3 +300,8 @@ class NetworkNotFoundToBootAmphora(base.NetworkException):
                ' Set `amp_mgmt_net` or add a network to `amp_boot_network_list`' 
                ' under the [a10_controller_worker] group.')
         super(NetworkNotFoundToBootAmphora, self).__init__(msg)
+
+
+class DuplicateMembersInBatchUpdate(base.NetworkException):
+    def __init__(self, msg):
+        super(DuplicateMembersInBatchUpdate, self).__init__(msg)

--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -303,5 +303,7 @@ class NetworkNotFoundToBootAmphora(base.NetworkException):
 
 
 class DuplicateMembersInBatchUpdate(base.NetworkException):
-    def __init__(self, msg):
+    def __init__(self):
+        msg = ('Duplicate member definition have been found during the batch update. '
+               'Please check WARNING log messages for more details.')
         super(DuplicateMembersInBatchUpdate, self).__init__(msg)

--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -297,7 +297,7 @@ class IPAddressNotInSubnetRangeError(base.NetworkException):
 class NetworkNotFoundToBootAmphora(base.NetworkException):
     def __init__(self):
         msg = ('No vThunder-Amphora management network has been specified in the config.'
-               ' Set `amp_mgmt_net` or add a network to `amp_boot_network_list`' 
+               ' Set `amp_mgmt_net` or add a network to `amp_boot_network_list`'
                ' under the [a10_controller_worker] group.')
         super(NetworkNotFoundToBootAmphora, self).__init__(msg)
 

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -13,9 +13,7 @@
 #    under the License.
 
 import json
-from logging import error
 from sqlalchemy.orm import exc as db_exceptions
-from sqlalchemy.sql.expression import update
 import tenacity
 import time
 import urllib3
@@ -664,7 +662,8 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         finally:
             self._set_vthunder_available(member.project_id, True, ctx_flags, load_balancer)
 
-    def _is_batch_valid(self, old_member_ids, new_member_ids, updated_member_ids, member_collision_map):
+    def _is_batch_valid(self, old_member_ids, new_member_ids,
+                        updated_member_ids, member_collision_map):
         valid = True
         for mem_id, member_col in member_collision_map.items():
             member, mem_cnt = member_col
@@ -688,7 +687,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         current_member_ids = set_o_ids.union(set_u_ids)
 
         current_members = [self._member_repo.get(db_apis.get_session(), id=mid)
-                            for mid in current_member_ids]
+                           for mid in current_member_ids]
 
         for mem in current_members:
             # Rollback status to prevent pending state lock
@@ -709,10 +708,10 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
         modified_members = current_members + new_members
         for mem in modified_members:
-            if mem.pool_id != None:
+            if mem.pool_id is not None:
                 self._pool_repo.update(db_apis.get_session(), mem.pool_id,
                                        provisioning_status=constants.ACTIVE)
-            if mem.pool.load_balancer_id != None:
+            if mem.pool.load_balancer_id is not None:
                 self._lb_repo.update(db_apis.get_session(),
                                      mem.pool.load_balancer_id,
                                      provisioning_status=constants.ACTIVE)
@@ -733,7 +732,6 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         new_members = [self._member_repo.get(db_apis.get_session(), id=mid)
                        for mid in new_member_ids]
 
-
         modified_members = old_members + updated_member_models + new_members
         member_collision_map = {}
         for mem in modified_members:
@@ -742,14 +740,14 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                 member_collision_map[mem_id][1] += 1
             else:
                 member_collision_map[mem_id] = [mem, 1]
-        
+
         if not self._is_batch_valid(old_member_ids, new_member_ids,
-            updated_member_ids, member_collision_map):
-            
+                                    updated_member_ids, member_collision_map):
             self._rollback_members(old_member_ids, new_member_ids, updated_member_ids)
             LOG.warning("Due to a failed batch update caused by duplicate member definitions, "
-                        "the members defined in the update are now out-of-sync with the ACOS device. "
-                        "Please update or delete the affected members.")
+                        "the members defined in the update are now out-of-sync with the "
+                        "ACOS device. Please issue a corrected update or "
+                        "delete the affected members.")
             raise a10_ex.DuplicateMembersInBatchUpdate
 
         # The API may not have commited all of the new member records yet.

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -664,8 +664,8 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         finally:
             self._set_vthunder_available(member.project_id, True, ctx_flags, load_balancer)
 
-    def _detect_batch_collision(self, old_member_ids, new_member_ids, updated_member_ids, member_collision_map):
-        error_msg = None
+    def _is_batch_valid(self, old_member_ids, new_member_ids, updated_member_ids, member_collision_map):
+        valid = True
         for mem_id, member_col in member_collision_map.items():
             member, mem_cnt = member_col
             mem_ip = member.ip_address
@@ -673,11 +673,13 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             if mem_cnt > 1:
                 if mem_id in old_member_ids:
                     error_msg = ("Duplicate members with id {} and IP {} and port {} "
-                                 " found in member database.".format(mem_id, mem_ip, mem_port))
+                                 "found in member database.".format(mem_id, mem_ip, mem_port))
                 if mem_id in new_member_ids or mem_id in updated_member_ids:
                     error_msg = ("Duplicate members with id {} and IP {} and port {} "
-                                 " found in batch update request.".format(mem_id, mem_ip, mem_port))
-        return error_msg
+                                 "found in batch update request.".format(mem_id, mem_ip, mem_port))
+                LOG.warning(error_msg)
+                valid = False
+        return valid
 
     def _rollback_members(self, old_member_ids, new_member_ids, updated_member_ids):
         set_o_ids = set(old_member_ids)
@@ -705,7 +707,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                      "slated for creation under batch update "
                      "has been deleted.".format(mem.id, mem.ip_address, mem.protocol_port))
 
-        modified_members = current_members.extend(new_members)
+        modified_members = current_members + new_members
         for mem in modified_members:
             if mem.pool_id != None:
                 self._pool_repo.update(db_apis.get_session(), mem.pool_id,
@@ -723,20 +725,16 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
     def batch_update_members(self, old_member_ids, new_member_ids,
                              updated_members_req):
 
-        import random
-        x = 4440 + random.randint(0, 9)
-        LOG.warning("PORT IS : {}".format(x))
-        import rpdb; rpdb.Rpdb(port=x).set_trace()
-
         updated_member_ids = [m.get('id') for m in updated_members_req]
-        updated_member_models = [self._member_repo.get(db_apis.get_session(), id=m.get('id'))
-                                 for m in updated_members_req]
+        updated_member_models = [self._member_repo.get(db_apis.get_session(), id=mid)
+                                 for mid in updated_member_ids]
         old_members = [self._member_repo.get(db_apis.get_session(), id=mid)
                        for mid in old_member_ids]
         new_members = [self._member_repo.get(db_apis.get_session(), id=mid)
                        for mid in new_member_ids]
 
-        modified_members = old_members.extend(updated_member_models.extend(new_members))
+
+        modified_members = old_members + updated_member_models + new_members
         member_collision_map = {}
         for mem in modified_members:
             mem_id = mem[0] if type(mem) == tuple else mem.id
@@ -744,16 +742,15 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                 member_collision_map[mem_id][1] += 1
             else:
                 member_collision_map[mem_id] = [mem, 1]
-
-        error_msg = self._detect_batch_collision(old_member_ids, new_member_ids,
-            updated_member_ids, member_collision_map)
         
-        if error_msg:
+        if not self._is_batch_valid(old_member_ids, new_member_ids,
+            updated_member_ids, member_collision_map):
+            
             self._rollback_members(old_member_ids, new_member_ids, updated_member_ids)
             LOG.warning("Due to a failed batch update caused by duplicate member definitions, "
                         "the members defined in the update are now out-of-sync with the ACOS device. "
-                        "Please issue a correct update or delete the affected members.")
-            raise a10_ex.DuplicateMembersInBatchUpdate(error_msg)
+                        "Please update or delete the affected members.")
+            raise a10_ex.DuplicateMembersInBatchUpdate
 
         # The API may not have commited all of the new member records yet.
         # Make sure we retry looking them up.

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -685,6 +685,7 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                           listeners, pool):
         set_o_ids = set(old_member_ids)
         set_u_ids = set(updated_member_ids)
+        set_n_ids = set(new_member_ids)
 
         current_member_ids = set_o_ids.union(set_u_ids)
 
@@ -700,14 +701,14 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                          mem.id, mem.ip_address, mem.protocol_port))
 
         new_members = [self._member_repo.get(db_apis.get_session(), id=mid)
-                       for mid in new_member_ids]
+                       for mid in set_n_ids]
 
         for mem in new_members:
             current_member_ids.add(mem.id)
             LOG.info("Member with id {} and ip {} and port {} "
                      "slated for creation under batch update "
                      "has been deleted.".format(mem.id, mem.ip_address, mem.protocol_port))
-        self._member_repo.delete_members(db_apis.get_session(), new_member_ids)
+        self._member_repo.delete_members(db_apis.get_session(), set_n_ids)
 
         if pool is not None:
             self._pool_repo.update(db_apis.get_session(), pool.id,

--- a/a10_octavia/controller/worker/tasks/glm_tasks.py
+++ b/a10_octavia/controller/worker/tasks/glm_tasks.py
@@ -86,7 +86,6 @@ class DNSConfiguration(task.Task):
                                 "Using %s as primary and %s as secondary.",
                                 license_subnet_id, primary_dns, secondary_dns)
 
-
             if use_network_dns:
                 if not primary_dns and not secondary_dns:
                     LOG.warning("The flavor option `use_network_dns` was defined "

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_compute_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_compute_tasks.py
@@ -29,8 +29,8 @@ from octavia.tests.common import constants as o_test_constants
 
 from a10_octavia.common import config_options
 from a10_octavia.common import data_models
-from a10_octavia.controller.worker.tasks import a10_compute_tasks as task
 from a10_octavia.common import exceptions
+from a10_octavia.controller.worker.tasks import a10_compute_tasks as task
 from a10_octavia.tests.common import a10constants
 from a10_octavia.tests.unit import base
 


### PR DESCRIPTION
## Description
Severity Level: Critical

Due to the lack of validation in the MembersController (https://github.com/openstack/octavia/blob/stable/victoria/octavia/api/v2/controllers/member.py#L319) it is possible for the driver agent and subsequently the controller worker to receive members with duplicate member ids.

This becomes problematic as it leads duplicate atoms in the flow which cause the taskflow engine to throw an irrecoverable error.

As the SLB objects (loadbalancer, pool, member) are put into PENDING_UPDATE by the MembersController, the entire SLB tree becomes "permanently" immutable. (Still possible to destroy everything in db and ACOS device and recover, but tedious).

## Limitation
Since the update to the Octavia member database table happens in the MembersController, one of the duplicates will have it's attributes override whatever is present in the database.

This cannot be corrected as the original data is lost.

## Jira Ticket
- [STACK-3121](https://a10networks.atlassian.net/browse/STACK-3121)

## Technical Approach
- Combined member definitions into hashmap with counts of member ids encountered
- Performed a check that none of the member definitions are observed more than once
- If there are duplicate member definitions, then log warnings for each duplicate based upon it being a new or old definition
- Set all members, pools, and loadbalancers that were modified back to ACTIVE state in rollback
- Deleted all newly added members that were added to the DB in the case of duplicates

## Config Changes
N/A

## Test Cases
N/A - controller test are not in place

## Manual Testing

### Pre-test Setup

Pre create objects
```
    openstack loadbalancer create --vip-subnet-id provider-vlan-14-subnet --name lb1
    openstack loadbalancer listener create --protocol HTTP --protocol-port 8080 --name l1 lb1
    sleep 8
    openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener l1 --name pool1
    sleep 8
    openstack loadbalancer member create --address 10.0.13.3 --protocol-port 80 --subnet-id provider-vlan-13-subnet --name mem1 pool1
    sleep 8
    openstack loadbalancer healthmonitor create --delay 10 --timeout 5  --max-retries 4 --type HTTP --http-method HEAD --url-path "/abc" --name hm1 --expected-codes 208 pool1
    sleep 8
    openstack loadbalancer l7policy create --action REJECT --name policy1 l1
    sleep 8
    openstack loadbalancer l7rule create --compare-type REGEX --value "abc" --type FILE_TYPE policy1
```

Define terraform provider
```
# Define required providers
terraform {
required_version = ">= 0.14.0"
  required_providers {
    openstack = {
      source  = "terraform-provider-openstack/openstack"
    }
  }
}

# Configure the OpenStack Provider
provider "openstack" {
  user_name   = "admin"
  tenant_name = "admin"
  password    = "password"
  auth_url    = "http://<host_IP>/identity"
  region      = "RegionOne"
  use_octavia = true
}
```

Execute `terraform init`

### Scenario 1: Non-duplicate entry updates

```
# Define required providers
terraform {
required_version = ">= 0.14.0"
  required_providers {
    openstack = {
      source  = "terraform-provider-openstack/openstack"
    }
  }
}

# Configure the OpenStack Provider
provider "openstack" {
  user_name   = "admin"
  tenant_name = "admin"
  password    = "password"
  auth_url    = "http://<host_IP>/identity"
  region      = "RegionOne"
  use_octavia = true
}

resource "openstack_lb_members_v2" "members_1" {
  pool_id = "8cc49327-98d1-4fef-95be-970fd3c66d88"

  member {
    address = "10.0.13.3"
    protocol_port = 80
    subnet_id = "fee3c1cd-b2ed-4fd6-bd47-55f0d8482640"
    name = "mem1"
    weight = 14
    admin_state_up = false
  }
}
```

### Scenario 2: Non-duplicate entry deletes

```
# Define required providers
terraform {
required_version = ">= 0.14.0"
  required_providers {
    openstack = {
      source  = "terraform-provider-openstack/openstack"
    }
  }
}

# Configure the OpenStack Provider
provider "openstack" {
  user_name   = "admin"
  tenant_name = "admin"
  password    = "password"
  auth_url    = "http://<host_IP>/identity"
  region      = "RegionOne"
  use_octavia = true
}

resource "openstack_lb_members_v2" "members_1" {
  pool_id = "8cc49327-98d1-4fef-95be-970fd3c66d88"
}
```


### Scenario 3: Duplicate entry updates

```
# Define required providers
terraform {
required_version = ">= 0.14.0"
  required_providers {
    openstack = {
      source  = "terraform-provider-openstack/openstack"
    }
  }
}

# Configure the OpenStack Provider
provider "openstack" {
  user_name   = "admin"
  tenant_name = "admin"
  password    = "password"
  auth_url    = "http://<host_IP>/identity"
  region      = "RegionOne"
  use_octavia = true
}

resource "openstack_lb_members_v2" "members_1" {
  pool_id = "8cc49327-98d1-4fef-95be-970fd3c66d88"

  member {
    address = "10.0.13.3"
    protocol_port = 80
    subnet_id = "fee3c1cd-b2ed-4fd6-bd47-55f0d8482640"
    name = "mem1"
    weight = 14
    admin_state_up = false
  }

  member {
    address = "10.0.13.3"
    protocol_port = 80
    subnet_id = "fee3c1cd-b2ed-4fd6-bd47-55f0d8482640"
    name = "mem3"
    weight = 100
    admin_state_up = false
  }
}
```

### Scenario 4: Duplicate entry update and a non-duplicate create

```
# Define required providers
terraform {
required_version = ">= 0.14.0"
  required_providers {
    openstack = {
      source  = "terraform-provider-openstack/openstack"
    }
  }
}

# Configure the OpenStack Provider
provider "openstack" {
  user_name   = "admin"
  tenant_name = "admin"
  password    = "password"
  auth_url    = "http://<host_IP>/identity"
  region      = "RegionOne"
  use_octavia = true
}

resource "openstack_lb_members_v2" "members_1" {
  pool_id = "8cc49327-98d1-4fef-95be-970fd3c66d88"

  member {
    address = "10.0.13.3"
    protocol_port = 80
    subnet_id = "fee3c1cd-b2ed-4fd6-bd47-55f0d8482640"
    name = "mem1"
    weight = 14
    admin_state_up = false
  }

  member {
    address = "10.0.13.3"
    protocol_port = 80
    subnet_id = "fee3c1cd-b2ed-4fd6-bd47-55f0d8482640"
    name = "mem3"
    weight = 100
    admin_state_up = false
  }

  member {
    address = "10.0.13.5"
    protocol_port = 80
    subnet_id = "fee3c1cd-b2ed-4fd6-bd47-55f0d8482640"
    name = "mem3"
    weight = 100
    admin_state_up = false
  }
}
```

### Scenario 5: Non-duplicate entry update and a duplicate create

```
# Define required providers
terraform {
required_version = ">= 0.14.0"
  required_providers {
    openstack = {
      source  = "terraform-provider-openstack/openstack"
    }
  }
}

# Configure the OpenStack Provider
provider "openstack" {
  user_name   = "admin"
  tenant_name = "admin"
  password    = "password"
  auth_url    = "http://<host_IP>/identity"
  region      = "RegionOne"
  use_octavia = true
}

resource "openstack_lb_members_v2" "members_1" {
  pool_id = "8cc49327-98d1-4fef-95be-970fd3c66d88"

  member {
    address = "10.0.13.3"
    protocol_port = 80
    subnet_id = "fee3c1cd-b2ed-4fd6-bd47-55f0d8482640"
    name = "mem1"
    weight = 14
    admin_state_up = false
  }

  member {
    address = "10.0.13.5"
    protocol_port = 80
    subnet_id = "fee3c1cd-b2ed-4fd6-bd47-55f0d8482640"
    name = "mem3"
    weight = 100
    admin_state_up = false
  }
  member {
    address = "10.0.13.5"
    protocol_port = 80
    subnet_id = "fee3c1cd-b2ed-4fd6-bd47-55f0d8482640"
    name = "mem3"
    weight = 99
    admin_state_up = false
  }
}
```

### Scenario 6: Duplicate entry update and a Duplicate create

```
# Define required providers
terraform {
required_version = ">= 0.14.0"
  required_providers {
    openstack = {
      source  = "terraform-provider-openstack/openstack"
    }
  }
}

# Configure the OpenStack Provider
provider "openstack" {
  user_name   = "admin"
  tenant_name = "admin"
  password    = "password"
  auth_url    = "http://<host_IP>/identity"
  region      = "RegionOne"
  use_octavia = true
}

resource "openstack_lb_members_v2" "members_1" {
  pool_id = "8cc49327-98d1-4fef-95be-970fd3c66d88"

  member {
    address = "10.0.13.3"
    protocol_port = 80
    subnet_id = "fee3c1cd-b2ed-4fd6-bd47-55f0d8482640"
    name = "mem1"
    weight = 14
    admin_state_up = false
  }

  member {
    address = "10.0.13.3"
    protocol_port = 80
    subnet_id = "fee3c1cd-b2ed-4fd6-bd47-55f0d8482640"
    name = "mem3"
    weight = 100
    admin_state_up = false
  }

  member {
    address = "10.0.13.5"
    protocol_port = 80
    subnet_id = "fee3c1cd-b2ed-4fd6-bd47-55f0d8482640"
    name = "mem3"
    weight = 100
    admin_state_up = false
  }
  member {
    address = "10.0.13.5"
    protocol_port = 80
    subnet_id = "fee3c1cd-b2ed-4fd6-bd47-55f0d8482640"
    name = "mem3"
    weight = 99
    admin_state_up = false
  }
}
```

### Scenario 7: Non-duplicate entry update and a non-duplicate create

```
# Define required providers
terraform {
required_version = ">= 0.14.0"
  required_providers {
    openstack = {
      source  = "terraform-provider-openstack/openstack"
    }
  }
}

# Configure the OpenStack Provider
provider "openstack" {
  user_name   = "admin"
  tenant_name = "admin"
  password    = "password"
  auth_url    = "http://<host_IP>/identity"
  region      = "RegionOne"
  use_octavia = true
}

resource "openstack_lb_members_v2" "members_1" {
  pool_id = "8cc49327-98d1-4fef-95be-970fd3c66d88"

  member {
    address = "10.0.13.3"
    protocol_port = 80
    subnet_id = "fee3c1cd-b2ed-4fd6-bd47-55f0d8482640"
    name = "mem1"
    weight = 14
    admin_state_up = false
  }

  member {
    address = "10.0.13.5"
    protocol_port = 80
    subnet_id = "fee3c1cd-b2ed-4fd6-bd47-55f0d8482640"
    name = "mem3"
    weight = 100
    admin_state_up = false
  }

}
```