### PR TITLE
[BUG][STACK-3129]: Nat-pool port is not getting deleted on cascade deletion of loadbalancer.

### DIFF
--- a/a10_octavia/controller/worker/tasks/l7policy_tasks.py
+++ b/a10_octavia/controller/worker/tasks/l7policy_tasks.py
@@ -118,6 +118,7 @@ class DeleteL7Policy(task.Task):
         c_pers, s_pers = utils.get_sess_pers_templates(
             listener.default_pool)
         kargs = {}
+        snat_pool = None
         if not (listener.protocol).islower():
             listener.protocol = openstack_mappings.virtual_port_protocol(
                 self.axapi_client, listener.protocol)
@@ -125,6 +126,8 @@ class DeleteL7Policy(task.Task):
             get_listener = self.axapi_client.slb.virtual_server.vport.get(
                 listener.load_balancer_id, listener.id,
                 listener.protocol, listener.protocol_port)
+            if get_listener and 'port' in get_listener and 'pool' in get_listener['port']:
+                snat_pool = get_listener['port']['pool']
             LOG.debug("Successfully fetched listener %s for l7policy %s", listener.id, l7policy.id)
         except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception("Failed to get listener %s for l7policy: %s", listener.id, l7policy.id)
@@ -143,7 +146,8 @@ class DeleteL7Policy(task.Task):
                 listener.load_balancer_id, listener.id,
                 listener.protocol, listener.protocol_port,
                 listener.default_pool_id,
-                s_pers, c_pers, 1, **kargs)
+                s_pers, c_pers, 1,
+                source_nat_pool=snat_pool, **kargs)
             LOG.debug(
                 "Successfully dissociated l7policy %s from listener %s",
                 l7policy.id,


### PR DESCRIPTION
## Description
- Severity Level: Medium
- Issue Description: When l7policy is there in the SLB tree and cascade deletion of a loadbalancer in the SLB tree is performed, then nat-pool port is not getting deleted on the cascade deletion.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3129

## Technical Approach
- Passing source nat-pool to source_nat_pool argument in the self.axapi_client.slb.virtual_server.vport.replace() call in DeleteL7Policy() task if virtual-port associated to the policy is having a source nat-pool attached to it.
- Otherwise passing None by default to the source_nat_pool.

## Config Changes
None

## Manual Testing
1. Create a loadbalancer

stack@ytsai-victoria:~$ openstack loadbalancer create --vip-subnet-id tp92 --name lb
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-11-16T05:51:04                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 6b60bd4c-4539-44f3-b8ba-cec9fab24457 |
| listeners           |                                      |
| name                | lb                                   |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | ecc2542be2644881b049636b719ca536     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.92.189                       |
| vip_network_id      | 0aab2734-6a42-4ef9-acd6-527956b3dadc |
| vip_port_id         | 64a0b130-30c7-4702-bc1a-1d470cded3ae |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 7d940d92-c8e2-48cc-89d5-74c4a4d3374c |
+---------------------+--------------------------------------+
```

2. Create a flavorprofile and flavor of nat-pool

stack@ytsai-victoria:~$ openstack loadbalancer flavorprofile create --name fp1 --provider a10 --flavor-data '{"nat-pool":{"pool-name":"pool1","start-address":"192.168.92.11","end-address":"192.168.92.12","netmask":"/24"}}'
```
+---------------+------------------------------------------------------------------------------------------------------------------+
| Field         | Value                                                                                                            |
+---------------+------------------------------------------------------------------------------------------------------------------+
| id            | 8fdc939e-66e0-4375-880b-4de18f2b5fe7                                                                             |
| name          | fp1                                                                                                              |
| provider_name | a10                                                                                                              |
| flavor_data   | {"nat-pool":{"pool-name":"pool1","start-address":"192.168.92.11","end-address":"192.168.92.12","netmask":"/24"}} |
+---------------+------------------------------------------------------------------------------------------------------------------+
```

stack@ytsai-victoria:~$ openstack loadbalancer flavor create --name f1 --flavorprofile fp1
```
+-------------------+--------------------------------------+
| Field             | Value                                |
+-------------------+--------------------------------------+
| id                | 53d95791-c882-4579-a74e-42fe0f2e3f49 |
| name              | f1                                   |
| flavor_profile_id | 8fdc939e-66e0-4375-880b-4de18f2b5fe7 |
| enabled           | True                                 |
| description       |                                      |
+-------------------+--------------------------------------+
```

3. Create second loadbalancer using the flavor.

stack@ytsai-victoria:~$ openstack loadbalancer create --vip-subnet-id tp92 --flavor f1 --name lb1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2021-11-16T05:32:14                  |
| description         |                                      |
| flavor_id           | 53d95791-c882-4579-a74e-42fe0f2e3f49 |
| id                  | ef31fe7d-9c47-463f-9c25-4b8c07e2b424 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | ecc2542be2644881b049636b719ca536     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.92.65                        |
| vip_network_id      | 0aab2734-6a42-4ef9-acd6-527956b3dadc |
| vip_port_id         | 70d65201-ee85-462a-9558-151e2d0bcd80 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 7d940d92-c8e2-48cc-89d5-74c4a4d3374c |
+---------------------+--------------------------------------+
```

stack@ytsai-victoria:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+----------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address    | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+----------------+---------------------+------------------+----------+
| ef31fe7d-9c47-463f-9c25-4b8c07e2b424 | lb1  | ecc2542be2644881b049636b719ca536 | 192.168.92.65  | ACTIVE              | OFFLINE          | a10      |
| 6b60bd4c-4539-44f3-b8ba-cec9fab24457 | lb   | ecc2542be2644881b049636b719ca536 | 192.168.92.189 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+----------------+---------------------+------------------+----------+
```

4. Create a listener, pool, member, healthmonitor, l7policy and l7rule for the second loadbalancer.

stack@ytsai-victoria:~$ openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name l1 lb1
```
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-11-16T05:45:18                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 7a1bdb0e-8104-45ed-a704-7b2497898af4 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | ef31fe7d-9c47-463f-9c25-4b8c07e2b424 |
| name                        | l1                                   |
| operating_status            | OFFLINE                              |
| project_id                  | ecc2542be2644881b049636b719ca536     |
| protocol                    | HTTP                                 |
| protocol_port               | 80                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
| allowed_cidrs               | None                                 |
| tls_ciphers                 | None                                 |
| tls_versions                | None                                 |
| alpn_protocols              | None                                 |
+-----------------------------+--------------------------------------+
```

stack@ytsai-victoria:~$ openstack loadbalancer pool create --name p1 --protocol HTTP --lb-algorithm LEAST_CONNECTIONS --listener l1
```
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-11-16T05:46:04                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | b15228e0-cba7-443e-adf0-14482b5eda33 |
| lb_algorithm         | LEAST_CONNECTIONS                    |
| listeners            | 7a1bdb0e-8104-45ed-a704-7b2497898af4 |
| loadbalancers        | ef31fe7d-9c47-463f-9c25-4b8c07e2b424 |
| members              |                                      |
| name                 | p1                                   |
| operating_status     | OFFLINE                              |
| project_id           | ecc2542be2644881b049636b719ca536     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+
```

stack@ytsai-victoria:~$ openstack loadbalancer member create --subnet-id tp92 --address 192.168.92.100 --protocol-port 95 --name m1 p1      
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 192.168.92.100                       |
| admin_state_up      | True                                 |
| created_at          | 2021-11-16T05:46:56                  |
| id                  | 98a23758-4ed3-4c97-bbc0-2b393ee146fe |
| name                | m1                                   |
| operating_status    | NO_MONITOR                           |
| project_id          | ecc2542be2644881b049636b719ca536     |
| protocol_port       | 95                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 7d940d92-c8e2-48cc-89d5-74c4a4d3374c |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
```


stack@ytsai-victoria:~$ openstack loadbalancer member list p1
```
+--------------------------------------+------+----------------------------------+---------------------+----------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address        | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+----------------+---------------+------------------+--------+
| 98a23758-4ed3-4c97-bbc0-2b393ee146fe | m1   | ecc2542be2644881b049636b719ca536 | ACTIVE              | 192.168.92.100 |            95 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+----------------+---------------+------------------+--------+
```

stack@ytsai-victoria:~$ openstack loadbalancer healthmonitor create --delay 7 --timeout 6 --max-retries 3 --http-method GET --type HTTP --name hm1 p1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| project_id          | ecc2542be2644881b049636b719ca536     |
| name                | hm1                                  |
| admin_state_up      | True                                 |
| pools               | b15228e0-cba7-443e-adf0-14482b5eda33 |
| created_at          | 2021-11-16T05:48:25                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| delay               | 7                                    |
| expected_codes      | 200                                  |
| max_retries         | 3                                    |
| http_method         | GET                                  |
| timeout             | 6                                    |
| max_retries_down    | 3                                    |
| url_path            | /                                    |
| type                | HTTP                                 |
| id                  | 72e95e5d-18cc-497a-8360-bf60d43b3e32 |
| operating_status    | OFFLINE                              |
| http_version        | None                                 |
| domain_name         | None                                 |
+---------------------+--------------------------------------+
```

stack@ytsai-victoria:~$ openstack loadbalancer l7policy create --action REDIRECT_TO_URL --redirect-url http://test1 --name ply1 l1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| listener_id         | 7a1bdb0e-8104-45ed-a704-7b2497898af4 |
| description         |                                      |
| admin_state_up      | True                                 |
| rules               |                                      |
| project_id          | ecc2542be2644881b049636b719ca536     |
| created_at          | 2021-11-16T05:48:46                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| redirect_pool_id    | None                                 |
| redirect_url        | http://test1                         |
| redirect_prefix     | None                                 |
| action              | REDIRECT_TO_URL                      |
| position            | 1                                    |
| id                  | d0e904fe-a3ee-4ccc-a83d-a38c5c3cf6a0 |
| operating_status    | OFFLINE                              |
| name                | ply1                                 |
| redirect_http_code  | 302                                  |
+---------------------+--------------------------------------+
```

stack@ytsai-victoria:~$ openstack loadbalancer l7rule create --compare-type REGEX --type FILE_TYPE --value value1 --invert ply1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| created_at          | 2021-11-16T05:48:59                  |
| compare_type        | REGEX                                |
| provisioning_status | PENDING_CREATE                       |
| invert              | True                                 |
| admin_state_up      | True                                 |
| updated_at          | None                                 |
| value               | value1                               |
| key                 | None                                 |
| project_id          | ecc2542be2644881b049636b719ca536     |
| type                | FILE_TYPE                            |
| id                  | c5b8d0db-80b1-4b28-b545-dabdefc6b3fe |
| operating_status    | OFFLINE                              |
+---------------------+--------------------------------------+
```

Output on vThunder:

amphora-2bf3aba3-ba9a-4ed1-8132(NOLICENSE)#show running-config
!Current configuration: 371 bytes
!Configuration last updated at 05:51:12 GMT Tue Nov 16 2021
!Configuration last saved at 05:51:16 GMT Tue Nov 16 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 117 (Jul-12-2021,10:12)
!
hostname amphora-2bf3aba3-ba9a-4ed1-8132
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2
  name DataPort
  enable
  ip address dhcp
!
!
ip nat pool pool1 192.168.92.11 192.168.92.12 netmask /24
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 192.168.0.164
  override-port 5550
  interval 20 timeout 3
  method udp port 5550
!
health monitor 72e95e5d-18cc-497a-8360-bf60d43b3e32
  override-port 80
  interval 7 timeout 6
  method http port 80 expect response-code 200 url GET /
!
slb server ecc25_192_168_92_100 192.168.92.100
  port 95 tcp
!
slb server octavia_health_manager_controller 192.168.0.164
  health-check octavia_health_monitor
!
slb service-group b15228e0-cba7-443e-adf0-14482b5eda33 tcp
  method least-connection
  health-check 72e95e5d-18cc-497a-8360-bf60d43b3e32
  member ecc25_192_168_92_100 95
!
slb virtual-server 6b60bd4c-4539-44f3-b8ba-cec9fab24457 192.168.92.189
!
**slb virtual-server ef31fe7d-9c47-463f-9c25-4b8c07e2b424 192.168.92.65
  port 80 http
    name 7a1bdb0e-8104-45ed-a704-7b2497898af4
    extended-stats
    aflex d0e904fe-a3ee-4ccc-a83d-a38c5c3cf6a0
    source-nat pool pool1
    service-group b15228e0-cba7-443e-adf0-14482b5eda33
!**
!
cloud-services meta-data
  enable
  provider openstack
!
end

Ports created on OpenStack side:
![final3129](https://user-images.githubusercontent.com/58077446/141932338-6f42c697-a6e4-4a61-86e8-9963fdae956e.PNG)


stack@ytsai-victoria:~$ openstack port list
+--------------------------------------+---------------------------------------------------+-------------------+----------------------------------------------------------------------------------------------------+--------+
| ID                                   | Name                                              | MAC Address       | Fixed IP Addresses                                                                                 | Status |
+--------------------------------------+---------------------------------------------------+-------------------+----------------------------------------------------------------------------------------------------+--------+
| 02737342-377b-49f8-b11c-a2f8818d645a | octavia-lb-ce0ce58a-9479-4f17-be1a-776f977ea729   | fa:16:3e:4f:eb:aa | ip_address='192.168.91.180', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                      | DOWN   |
| 027ac571-2595-457c-af87-f45b91f708b1 | octavia-health-manager-standalone-listen-port     | fa:16:3e:1e:3a:11 | ip_address='192.168.0.164', subnet_id='27ee4a0a-82c1-4722-92e8-3f8fd563661d'                       | ACTIVE |
| 0b5609fc-de8c-40f6-9bdb-009373c61e02 |                                                   | fa:16:3e:fb:52:c1 | ip_address='192.168.0.79', subnet_id='27ee4a0a-82c1-4722-92e8-3f8fd563661d'                        | ACTIVE |
| 1645df89-d3f5-47c1-9873-9beba4f7c563 |                                                   | fa:16:3e:45:20:7f | ip_address='192.168.92.131', subnet_id='7d940d92-c8e2-48cc-89d5-74c4a4d3374c'                      | ACTIVE |
| 1be372c4-d846-4cf7-86ab-e214cda6a464 |                                                   | fa:16:3e:ff:71:bb | ip_address='192.168.0.9', subnet_id='27ee4a0a-82c1-4722-92e8-3f8fd563661d'                         | ACTIVE |
**| 2c118a9d-8df3-4449-9d76-d95ce39ee677 | octavia-port-0aab2734-6a42-4ef9-acd6-527956b3dadc | fa:16:3e:ee:04:6a | ip_address='192.168.92.11', subnet_id='7d940d92-c8e2-48cc-89d5-74c4a4d3374c'                       | DOWN   |
|                                      |                                                   |                   | ip_address='192.168.92.12', subnet_id='7d940d92-c8e2-48cc-89d5-74c4a4d3374c'                       |        |**
| 32f6f9f8-1b6b-4f54-b91e-315be28106ff |                                                   | fa:16:3e:3c:8e:31 | ip_address='192.168.0.18', subnet_id='27ee4a0a-82c1-4722-92e8-3f8fd563661d'                        | ACTIVE |
| 38f4a56c-d1e0-4abf-813f-c7c1b75b7d65 | octavia-lb-4a8da528-9db2-432e-9ffc-d21fb5d6ff2c   | fa:16:3e:08:18:ec | ip_address='192.168.91.146', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                      | DOWN   |
| 464cc5c1-98e9-4a62-8e7b-eb8c76f0081c |                                                   | fa:16:3e:6d:98:4c | ip_address='10.0.0.1', subnet_id='bbc5ff49-6259-44f2-8b15-ba4b0702714b'                            | ACTIVE |
| 5092662f-635b-4056-8d4e-da41e90e7fb6 | octavia-lb-066d01db-ba73-411b-8966-2eed6aba245f   | fa:16:3e:a7:55:e9 | ip_address='192.168.91.215', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                      | DOWN   |
| 61f5e0a5-cdb0-480c-864c-d1da34b4d372 |                                                   | fa:16:3e:1c:41:af | ip_address='192.168.0.86', subnet_id='27ee4a0a-82c1-4722-92e8-3f8fd563661d'                        | ACTIVE |
| 64a0b130-30c7-4702-bc1a-1d470cded3ae | octavia-lb-6b60bd4c-4539-44f3-b8ba-cec9fab24457   | fa:16:3e:57:b8:c4 | ip_address='192.168.92.189', subnet_id='7d940d92-c8e2-48cc-89d5-74c4a4d3374c'                      | DOWN   |
| 66f56226-7f4c-4e02-b82c-a0d390dd86c6 |                                                   | fa:16:3e:83:79:19 | ip_address='192.168.92.1', subnet_id='7d940d92-c8e2-48cc-89d5-74c4a4d3374c'                        | ACTIVE |
| 6fa9845d-06b8-4322-a52a-a4d27208af59 |                                                   | fa:16:3e:bc:df:38 | ip_address='192.168.91.161', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                      | ACTIVE |
| 70d65201-ee85-462a-9558-151e2d0bcd80 | octavia-lb-ef31fe7d-9c47-463f-9c25-4b8c07e2b424   | fa:16:3e:49:40:07 | ip_address='192.168.92.65', subnet_id='7d940d92-c8e2-48cc-89d5-74c4a4d3374c'                       | DOWN   |
| 7a92428a-e1f9-4ece-bc5d-b4eb03de17f3 | octavia-lb-d5f8e3a9-f902-4ab5-83d5-d38361af415e   | fa:16:3e:e0:60:11 | ip_address='192.168.91.149', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                      | DOWN   |
| 84cb236b-969a-4b91-9ee2-04f3112c03a9 | octavia-lb-9e57c3a6-6c4f-40f1-9e60-f4c786a46763   | fa:16:3e:46:14:4f | ip_address='192.168.91.120', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                      | DOWN   |
| 8e06e7c6-dc33-4b6c-9d24-395b324da9ce |                                                   | fa:16:3e:44:59:7d | ip_address='fd37:8eda:c2f::1', subnet_id='f54606a8-1032-4d4c-b278-778901963da9'                    | ACTIVE |
| 91ac4a72-b7d7-4afb-91c4-8f70204b8957 |                                                   | fa:16:3e:aa:74:71 | ip_address='192.168.91.48', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                       | ACTIVE |
| 93e95f7b-240a-4925-a1c2-379b1ce8a517 |                                                   | fa:16:3e:51:34:e6 | ip_address='192.168.8.2', subnet_id='13428dc7-d6fd-4034-8c35-49cd7e036724'                         | ACTIVE |
| 96c6e3e1-c2df-4f1f-aec8-77e811007ce7 | octavia-lb-7ae52dd3-af51-484b-8d5d-a5dd0039e79e   | fa:16:3e:48:85:92 | ip_address='192.168.91.54', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                       | DOWN   |
| 9f10fa6e-174d-42ab-b7f7-5b7504ec63ad |                                                   | fa:16:3e:22:ad:6d | ip_address='192.168.91.156', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                      | ACTIVE |
| a00ecaa4-3269-4a20-87d2-cf19cb8cec4a |                                                   | fa:16:3e:5d:82:e8 | ip_address='192.168.91.35', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                       | ACTIVE |
| a8f4e61f-ae95-4f86-807a-2d5eb5c667d7 |                                                   | fa:16:3e:7f:a2:13 | ip_address='192.168.91.220', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                      | ACTIVE |
| b858579e-3478-4d41-a8f5-490d8a509b3a | octavia-lb-eea2b0f0-76af-4507-b3a6-e250cb8f5291   | fa:16:3e:eb:1e:ea | ip_address='192.168.91.26', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                       | DOWN   |
| b9d6ae53-f184-4c58-8b3b-6abf6b7fd196 |                                                   | fa:16:3e:64:51:90 | ip_address='192.168.0.13', subnet_id='27ee4a0a-82c1-4722-92e8-3f8fd563661d'                        | ACTIVE |
| be40a76b-82b9-4b67-8450-d31d7822f056 |                                                   | fa:16:3e:c3:2e:62 | ip_address='172.24.4.58', subnet_id='f7eb4373-46de-4270-b846-4e20574479e8'                         | ACTIVE |
|                                      |                                                   |                   | ip_address='2001:db8::3bf', subnet_id='b96bb290-1c4e-46c9-aec5-2fb2700a12cd'                       |        |
| c0c63ad2-9956-4554-9fbf-561b0d9f36a1 |                                                   | fa:16:3e:cb:cb:c8 | ip_address='192.168.8.248', subnet_id='13428dc7-d6fd-4034-8c35-49cd7e036724'                       | ACTIVE |
| ce10be63-638b-49fd-ae22-8ab460af1d81 | octavia-lb-a03a10ab-dfe9-4acc-a94e-61a9bbf6fda5   | fa:16:3e:8b:40:0a | ip_address='192.168.91.10', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                       | DOWN   |
| d12a0c59-ceaf-4b32-a9c5-c65634bac05c |                                                   | fa:16:3e:09:2b:ba | ip_address='10.0.0.2', subnet_id='bbc5ff49-6259-44f2-8b15-ba4b0702714b'                            | ACTIVE |
|                                      |                                                   |                   | ip_address='fd37:8eda:c2f:0:f816:3eff:fe09:2bba', subnet_id='f54606a8-1032-4d4c-b278-778901963da9' |        |
| d14846b8-053d-43c3-9dfe-ba9ac24999a8 |                                                   | fa:16:3e:11:f0:5b | ip_address='192.168.91.1', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                        | ACTIVE |
| da1808bb-7da2-4d60-8b2e-0696981011f0 |                                                   | fa:16:3e:77:68:05 | ip_address='192.168.90.2', subnet_id='47519092-a7a6-411b-80dd-e0cdd00fb598'                        | ACTIVE |
| dc4b74fd-5fec-44b0-8e11-baae606d60e0 | octavia-lb-63300354-fa76-4d72-9f97-82c13934b81d   | fa:16:3e:b1:e9:3f | ip_address='192.168.91.116', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                      | DOWN   |
| e6f287aa-b94c-4d40-ab50-412d649295bb |                                                   | fa:16:3e:ca:11:50 | ip_address='192.168.0.2', subnet_id='27ee4a0a-82c1-4722-92e8-3f8fd563661d'                         | ACTIVE |
| ee877759-8b30-4070-9297-8075cc6c1460 |                                                   | fa:16:3e:3c:fc:9e | ip_address='192.168.8.75', subnet_id='13428dc7-d6fd-4034-8c35-49cd7e036724'                        | ACTIVE |
| f406f2e1-59b3-44e9-a515-69a7494617e3 |                                                   | fa:16:3e:1e:6e:4e | ip_address='172.16.1.1', subnet_id='f68672e1-1cf8-4952-89d7-a49898cddc2b'                          | ACTIVE |
| faaa90d0-3d85-4bd0-bd6c-54857d58213a | octavia-lb-172b31d0-7681-4fc5-9801-be149a8d559f   | fa:16:3e:c6:a5:ed | ip_address='192.168.8.132', subnet_id='13428dc7-d6fd-4034-8c35-49cd7e036724'                       | DOWN   |
+--------------------------------------+---------------------------------------------------+-------------------+----------------------------------------------------------------------------------------------------+--------+

6. Cascade delete the second loadbalancer

stack@ytsai-victoria:~$ openstack loadbalancer delete lb1 --cascade

stack@ytsai-victoria:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+----------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address    | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+----------------+---------------------+------------------+----------+
| 6b60bd4c-4539-44f3-b8ba-cec9fab24457 | lb   | ecc2542be2644881b049636b719ca536 | 192.168.92.189 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+----------------+---------------------+------------------+----------+
```

Ouput on vThunder:

amphora-2bf3aba3-ba9a-4ed1-8132(NOLICENSE)#show running-config
!Current configuration: 312 bytes
!Configuration last updated at 05:54:06 GMT Tue Nov 16 2021
!Configuration last saved at 05:54:14 GMT Tue Nov 16 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p2, build 117 (Jul-12-2021,10:12)
!
hostname amphora-2bf3aba3-ba9a-4ed1-8132
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2
  name DataPort
  enable
  ip address dhcp
!
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 192.168.0.164
  override-port 5550
  interval 20 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 192.168.0.164
  health-check octavia_health_monitor
!
slb virtual-server 6b60bd4c-4539-44f3-b8ba-cec9fab24457 192.168.92.189
!
!
cloud-services meta-data
  enable
  provider openstack
!
end

Ports on OpenStack side:
The port associated with the LB and the nat-pool port are getting deleted
![3129_2](https://user-images.githubusercontent.com/58077446/141933058-7218abde-e371-43c5-9f0f-049964c99e91.PNG)


stack@ytsai-victoria:~$ openstack port list
```
+--------------------------------------+-------------------------------------------------+-------------------+----------------------------------------------------------------------------------------------------+--------+
| ID                                   | Name                                            | MAC Address       | Fixed IP Addresses                                                                                 | Status |
+--------------------------------------+-------------------------------------------------+-------------------+----------------------------------------------------------------------------------------------------+--------+
| 02737342-377b-49f8-b11c-a2f8818d645a | octavia-lb-ce0ce58a-9479-4f17-be1a-776f977ea729 | fa:16:3e:4f:eb:aa | ip_address='192.168.91.180', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                      | DOWN   |
| 027ac571-2595-457c-af87-f45b91f708b1 | octavia-health-manager-standalone-listen-port   | fa:16:3e:1e:3a:11 | ip_address='192.168.0.164', subnet_id='27ee4a0a-82c1-4722-92e8-3f8fd563661d'                       | ACTIVE |
| 0b5609fc-de8c-40f6-9bdb-009373c61e02 |                                                 | fa:16:3e:fb:52:c1 | ip_address='192.168.0.79', subnet_id='27ee4a0a-82c1-4722-92e8-3f8fd563661d'                        | ACTIVE |
| 1645df89-d3f5-47c1-9873-9beba4f7c563 |                                                 | fa:16:3e:45:20:7f | ip_address='192.168.92.131', subnet_id='7d940d92-c8e2-48cc-89d5-74c4a4d3374c'                      | ACTIVE |
| 1be372c4-d846-4cf7-86ab-e214cda6a464 |                                                 | fa:16:3e:ff:71:bb | ip_address='192.168.0.9', subnet_id='27ee4a0a-82c1-4722-92e8-3f8fd563661d'                         | ACTIVE |
| 32f6f9f8-1b6b-4f54-b91e-315be28106ff |                                                 | fa:16:3e:3c:8e:31 | ip_address='192.168.0.18', subnet_id='27ee4a0a-82c1-4722-92e8-3f8fd563661d'                        | ACTIVE |
| 38f4a56c-d1e0-4abf-813f-c7c1b75b7d65 | octavia-lb-4a8da528-9db2-432e-9ffc-d21fb5d6ff2c | fa:16:3e:08:18:ec | ip_address='192.168.91.146', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                      | DOWN   |
| 464cc5c1-98e9-4a62-8e7b-eb8c76f0081c |                                                 | fa:16:3e:6d:98:4c | ip_address='10.0.0.1', subnet_id='bbc5ff49-6259-44f2-8b15-ba4b0702714b'                            | ACTIVE |
| 5092662f-635b-4056-8d4e-da41e90e7fb6 | octavia-lb-066d01db-ba73-411b-8966-2eed6aba245f | fa:16:3e:a7:55:e9 | ip_address='192.168.91.215', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                      | DOWN   |
| 61f5e0a5-cdb0-480c-864c-d1da34b4d372 |                                                 | fa:16:3e:1c:41:af | ip_address='192.168.0.86', subnet_id='27ee4a0a-82c1-4722-92e8-3f8fd563661d'                        | ACTIVE |
| 64a0b130-30c7-4702-bc1a-1d470cded3ae | octavia-lb-6b60bd4c-4539-44f3-b8ba-cec9fab24457 | fa:16:3e:57:b8:c4 | ip_address='192.168.92.189', subnet_id='7d940d92-c8e2-48cc-89d5-74c4a4d3374c'                      | DOWN   |
| 66f56226-7f4c-4e02-b82c-a0d390dd86c6 |                                                 | fa:16:3e:83:79:19 | ip_address='192.168.92.1', subnet_id='7d940d92-c8e2-48cc-89d5-74c4a4d3374c'                        | ACTIVE |
| 6fa9845d-06b8-4322-a52a-a4d27208af59 |                                                 | fa:16:3e:bc:df:38 | ip_address='192.168.91.161', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                      | ACTIVE |
| 7a92428a-e1f9-4ece-bc5d-b4eb03de17f3 | octavia-lb-d5f8e3a9-f902-4ab5-83d5-d38361af415e | fa:16:3e:e0:60:11 | ip_address='192.168.91.149', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                      | DOWN   |
| 84cb236b-969a-4b91-9ee2-04f3112c03a9 | octavia-lb-9e57c3a6-6c4f-40f1-9e60-f4c786a46763 | fa:16:3e:46:14:4f | ip_address='192.168.91.120', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                      | DOWN   |
| 8e06e7c6-dc33-4b6c-9d24-395b324da9ce |                                                 | fa:16:3e:44:59:7d | ip_address='fd37:8eda:c2f::1', subnet_id='f54606a8-1032-4d4c-b278-778901963da9'                    | ACTIVE |
| 91ac4a72-b7d7-4afb-91c4-8f70204b8957 |                                                 | fa:16:3e:aa:74:71 | ip_address='192.168.91.48', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                       | ACTIVE |
| 93e95f7b-240a-4925-a1c2-379b1ce8a517 |                                                 | fa:16:3e:51:34:e6 | ip_address='192.168.8.2', subnet_id='13428dc7-d6fd-4034-8c35-49cd7e036724'                         | ACTIVE |
| 96c6e3e1-c2df-4f1f-aec8-77e811007ce7 | octavia-lb-7ae52dd3-af51-484b-8d5d-a5dd0039e79e | fa:16:3e:48:85:92 | ip_address='192.168.91.54', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                       | DOWN   |
| 9f10fa6e-174d-42ab-b7f7-5b7504ec63ad |                                                 | fa:16:3e:22:ad:6d | ip_address='192.168.91.156', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                      | ACTIVE |
| a00ecaa4-3269-4a20-87d2-cf19cb8cec4a |                                                 | fa:16:3e:5d:82:e8 | ip_address='192.168.91.35', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                       | ACTIVE |
| a8f4e61f-ae95-4f86-807a-2d5eb5c667d7 |                                                 | fa:16:3e:7f:a2:13 | ip_address='192.168.91.220', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                      | ACTIVE |
| b858579e-3478-4d41-a8f5-490d8a509b3a | octavia-lb-eea2b0f0-76af-4507-b3a6-e250cb8f5291 | fa:16:3e:eb:1e:ea | ip_address='192.168.91.26', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                       | DOWN   |
| b9d6ae53-f184-4c58-8b3b-6abf6b7fd196 |                                                 | fa:16:3e:64:51:90 | ip_address='192.168.0.13', subnet_id='27ee4a0a-82c1-4722-92e8-3f8fd563661d'                        | ACTIVE |
| be40a76b-82b9-4b67-8450-d31d7822f056 |                                                 | fa:16:3e:c3:2e:62 | ip_address='172.24.4.58', subnet_id='f7eb4373-46de-4270-b846-4e20574479e8'                         | ACTIVE |
|                                      |                                                 |                   | ip_address='2001:db8::3bf', subnet_id='b96bb290-1c4e-46c9-aec5-2fb2700a12cd'                       |        |
| c0c63ad2-9956-4554-9fbf-561b0d9f36a1 |                                                 | fa:16:3e:cb:cb:c8 | ip_address='192.168.8.248', subnet_id='13428dc7-d6fd-4034-8c35-49cd7e036724'                       | ACTIVE |
| ce10be63-638b-49fd-ae22-8ab460af1d81 | octavia-lb-a03a10ab-dfe9-4acc-a94e-61a9bbf6fda5 | fa:16:3e:8b:40:0a | ip_address='192.168.91.10', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                       | DOWN   |
| d12a0c59-ceaf-4b32-a9c5-c65634bac05c |                                                 | fa:16:3e:09:2b:ba | ip_address='10.0.0.2', subnet_id='bbc5ff49-6259-44f2-8b15-ba4b0702714b'                            | ACTIVE |
|                                      |                                                 |                   | ip_address='fd37:8eda:c2f:0:f816:3eff:fe09:2bba', subnet_id='f54606a8-1032-4d4c-b278-778901963da9' |        |
| d14846b8-053d-43c3-9dfe-ba9ac24999a8 |                                                 | fa:16:3e:11:f0:5b | ip_address='192.168.91.1', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                        | ACTIVE |
| da1808bb-7da2-4d60-8b2e-0696981011f0 |                                                 | fa:16:3e:77:68:05 | ip_address='192.168.90.2', subnet_id='47519092-a7a6-411b-80dd-e0cdd00fb598'                        | ACTIVE |
| dc4b74fd-5fec-44b0-8e11-baae606d60e0 | octavia-lb-63300354-fa76-4d72-9f97-82c13934b81d | fa:16:3e:b1:e9:3f | ip_address='192.168.91.116', subnet_id='9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65'                      | DOWN   |
| e6f287aa-b94c-4d40-ab50-412d649295bb |                                                 | fa:16:3e:ca:11:50 | ip_address='192.168.0.2', subnet_id='27ee4a0a-82c1-4722-92e8-3f8fd563661d'                         | ACTIVE |
| ee877759-8b30-4070-9297-8075cc6c1460 |                                                 | fa:16:3e:3c:fc:9e | ip_address='192.168.8.75', subnet_id='13428dc7-d6fd-4034-8c35-49cd7e036724'                        | ACTIVE |
| f406f2e1-59b3-44e9-a515-69a7494617e3 |                                                 | fa:16:3e:1e:6e:4e | ip_address='172.16.1.1', subnet_id='f68672e1-1cf8-4952-89d7-a49898cddc2b'                          | ACTIVE |
| faaa90d0-3d85-4bd0-bd6c-54857d58213a | octavia-lb-172b31d0-7681-4fc5-9801-be149a8d559f | fa:16:3e:c6:a5:ed | ip_address='192.168.8.132', subnet_id='13428dc7-d6fd-4034-8c35-49cd7e036724'                       | DOWN   |
+--------------------------------------+-------------------------------------------------+-------------------+----------------------------------------------------------------------------------------------------+--------+
```

