### PR TITLE
[STACK-3165]: [v1.3.3] Porting STACK-3121 and STACK-3129 to a10_octavia_1_3_3-d branch

### DIFF
--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -261,3 +261,10 @@ class IPAddressNotInSubnetRangeError(base.NetworkException):
                'IP {0} out of range ' +
                'for subnet {1}.').format(ip, subnet)
         super(IPAddressNotInSubnetRangeError, self).__init__(msg)
+
+
+class DuplicateMembersInBatchUpdate(base.NetworkException):
+    def __init__(self):
+        msg = ('Duplicate member definition have been found during the batch update. '
+               'Please check WARNING log messages for more details.')
+        super(DuplicateMembersInBatchUpdate, self).__init__(msg)

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -30,6 +30,7 @@ from octavia.db import api as db_apis
 from octavia.db import repositories as repo
 
 from a10_octavia.common import a10constants
+from a10_octavia.common import exceptions as a10_ex
 from a10_octavia.common import utils
 from a10_octavia.controller.worker.flows import a10_health_monitor_flows
 from a10_octavia.controller.worker.flows import a10_l7policy_flows
@@ -667,16 +668,115 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
         finally:
             self._set_vthunder_available(member.project_id, True, ctx_flags, load_balancer)
 
+    def _is_batch_valid(self, old_member_ids, new_member_ids,
+                        updated_member_ids, member_collision_map):
+        valid = True
+        for mem_id, member_col in member_collision_map.items():
+            member, mem_cnt = member_col
+            mem_ip = member.ip_address
+            mem_port = member.protocol_port
+            if mem_cnt > 1:
+                if mem_id in old_member_ids:
+                    error_msg = ("Duplicate members with id {} and IP {} and port {} "
+                                 "found in member database.".format(mem_id, mem_ip, mem_port))
+                if mem_id in new_member_ids or mem_id in updated_member_ids:
+                    error_msg = ("Duplicate members with id {} and IP {} and port {} "
+                                 "found in batch update request.".format(mem_id, mem_ip, mem_port))
+                LOG.warning(error_msg)
+                valid = False
+        return valid
+
+    def _rollback_members(self, old_member_ids, new_member_ids,
+                          updated_member_ids, load_balancer,
+                          listeners, pool):
+        set_o_ids = set(old_member_ids)
+        set_u_ids = set(updated_member_ids)
+        set_n_ids = set(new_member_ids)
+
+        current_member_ids = set_o_ids.union(set_u_ids)
+
+        current_members = [self._member_repo.get(db_apis.get_session(), id=mid)
+                           for mid in current_member_ids]
+
+        for mem in current_members:
+            # Rollback status to prevent pending state lock
+            self._member_repo.update(db_apis.get_session(), mem.id,
+                                     provisioning_status=constants.ACTIVE)
+            LOG.info("Member with id {} and ip {} and port {} slated for "
+                     "batch update have been set to ACTIVE state.".format(
+                         mem.id, mem.ip_address, mem.protocol_port))
+
+        new_members = [self._member_repo.get(db_apis.get_session(), id=mid)
+                       for mid in set_n_ids]
+
+        for mem in new_members:
+            current_member_ids.add(mem.id)
+            LOG.info("Member with id {} and ip {} and port {} "
+                     "slated for creation under batch update "
+                     "has been deleted.".format(mem.id, mem.ip_address, mem.protocol_port))
+        self._member_repo.delete_members(db_apis.get_session(), set_n_ids)
+
+        if pool is not None:
+            self._pool_repo.update(db_apis.get_session(), pool.id,
+                                   provisioning_status=constants.ACTIVE)
+        if listeners is not None:
+            for listener in listeners:
+                self._listener_repo.update(db_apis.get_session(),
+                                           listener.id,
+                                           provisioning_status=constants.ACTIVE)
+        if load_balancer is not None:
+            self._lb_repo.update(db_apis.get_session(),
+                                 load_balancer.id,
+                                 provisioning_status=constants.ACTIVE)
+
     @tenacity.retry(
         retry=tenacity.retry_if_exception_type(db_exceptions.NoResultFound),
         wait=tenacity.wait_incrementing(
             RETRY_INITIAL_DELAY, RETRY_BACKOFF, RETRY_MAX),
         stop=tenacity.stop_after_attempt(RETRY_ATTEMPTS))
     def batch_update_members(self, old_member_ids, new_member_ids,
-                             updated_members):
+                             updated_members_req):
+
+        updated_member_ids = [m.get('id') for m in updated_members_req]
+        updated_member_models = [self._member_repo.get(db_apis.get_session(), id=mid)
+                                 for mid in updated_member_ids]
+
+        old_members = [self._member_repo.get(db_apis.get_session(), id=mid)
+                       for mid in old_member_ids]
 
         new_members = [self._member_repo.get(db_apis.get_session(), id=mid)
                        for mid in new_member_ids]
+
+        if old_members:
+            pool = old_members[0].pool
+        elif new_members:
+            pool = new_members[0].pool
+        else:
+            pool = updated_member_models[0].pool
+
+        load_balancer = pool.load_balancer
+        listeners = pool.listeners
+
+        modified_members = old_members + updated_member_models + new_members
+        member_collision_map = {}
+        for mem in modified_members:
+            mem_id = mem[0] if type(mem) == tuple else mem.id
+            if member_collision_map.get(mem_id):
+                member_collision_map[mem_id][1] += 1
+            else:
+                member_collision_map[mem_id] = [mem, 1]
+
+        if not self._is_batch_valid(old_member_ids, new_member_ids,
+                                    updated_member_ids, member_collision_map):
+            self._rollback_members(old_member_ids, new_member_ids,
+                                   updated_member_ids, load_balancer,
+                                   listeners, pool)
+            LOG.warning("Due to a failed batch update caused by duplicate member definitions, "
+                        "the members defined in the update are now out-of-sync with the "
+                        "ACOS device. Please issue a corrected update or "
+                        "delete the affected members.")
+            raise a10_ex.DuplicateMembersInBatchUpdate
+
         # The API may not have commited all of the new member records yet.
         # Make sure we retry looking them up.
         if None in new_members or len(new_members) != len(new_member_ids):
@@ -684,22 +784,9 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                         'Retrying for up to 60 seconds.')
             raise db_exceptions.NoResultFound
 
-        old_members = [self._member_repo.get(db_apis.get_session(), id=mid)
-                       for mid in old_member_ids]
-
-        updated_members = [(self._member_repo.get(
-                            db_apis.get_session(), id=m.get('id')), m)
-                           for m in updated_members]
-
-        if old_members:
-            pool = old_members[0].pool
-        elif new_members:
-            pool = new_members[0].pool
-        else:
-            pool = updated_members[0][0].pool
-
-        load_balancer = pool.load_balancer
-        listeners = pool.listeners
+        updated_members = []
+        for i in range(len(updated_members_req)):
+            updated_members.append((updated_member_models[i], updated_members_req[i]))
 
         ctx_flags = [False]
         try:

--- a/a10_octavia/controller/worker/tasks/l7policy_tasks.py
+++ b/a10_octavia/controller/worker/tasks/l7policy_tasks.py
@@ -118,6 +118,7 @@ class DeleteL7Policy(task.Task):
         c_pers, s_pers = utils.get_sess_pers_templates(
             listener.default_pool)
         kargs = {}
+        snat_pool = None
         if not (listener.protocol).islower():
             listener.protocol = openstack_mappings.virtual_port_protocol(
                 self.axapi_client, listener.protocol)
@@ -125,6 +126,8 @@ class DeleteL7Policy(task.Task):
             get_listener = self.axapi_client.slb.virtual_server.vport.get(
                 listener.load_balancer_id, listener.id,
                 listener.protocol, listener.protocol_port)
+            if get_listener and 'port' in get_listener and 'pool' in get_listener['port']:
+                snat_pool = get_listener['port']['pool']
             LOG.debug("Successfully fetched listener %s for l7policy %s", listener.id, l7policy.id)
         except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception("Failed to get listener %s for l7policy: %s", listener.id, l7policy.id)
@@ -143,7 +146,8 @@ class DeleteL7Policy(task.Task):
                 listener.load_balancer_id, listener.id,
                 listener.protocol, listener.protocol_port,
                 listener.default_pool_id,
-                s_pers, c_pers, 1, **kargs)
+                s_pers, c_pers, 1,
+                source_nat_pool=snat_pool, **kargs)
             LOG.debug(
                 "Successfully dissociated l7policy %s from listener %s",
                 l7policy.id,

--- a/a10_octavia/controller/worker/tasks/l7policy_tasks.py
+++ b/a10_octavia/controller/worker/tasks/l7policy_tasks.py
@@ -36,7 +36,7 @@ class L7PolicyParent(object):
         size = len(script.encode('utf-8'))
         listener = listeners[0]
         c_pers, s_pers = utils.get_sess_pers_templates(listener.default_pool)
-        kargs = {}
+        kwargs = {}
         listener.protocol = openstack_mappings.virtual_port_protocol(self.axapi_client,
                                                                      listener.protocol)
         try:
@@ -61,14 +61,14 @@ class L7PolicyParent(object):
             aflex_scripts.append({"aflex": filename})
         else:
             aflex_scripts = [{"aflex": filename}]
-        kargs["aflex_scripts"] = aflex_scripts
+        kwargs["aflex_scripts"] = aflex_scripts
 
         try:
             self.axapi_client.slb.virtual_server.vport.update(
                 listener.load_balancer_id, listener.id,
                 listener.protocol, listener.protocol_port,
                 listener.default_pool_id, s_pers,
-                c_pers, 1, **kargs)
+                c_pers, 1, **kwargs)
             LOG.debug(
                 "Successfully associated l7policy %s to listener %s",
                 l7policy.id,
@@ -117,7 +117,7 @@ class DeleteL7Policy(task.Task):
         listener = l7policy.listener
         c_pers, s_pers = utils.get_sess_pers_templates(
             listener.default_pool)
-        kargs = {}
+        kwargs = {}
         snat_pool = None
         if not (listener.protocol).islower():
             listener.protocol = openstack_mappings.virtual_port_protocol(
@@ -139,7 +139,7 @@ class DeleteL7Policy(task.Task):
             for aflex in aflex_scripts:
                 if aflex['aflex'] != l7policy.id:
                     new_aflex_scripts.append(aflex)
-        kargs["aflex_scripts"] = new_aflex_scripts
+        kwargs["aflex_scripts"] = new_aflex_scripts
 
         try:
             self.axapi_client.slb.virtual_server.vport.replace(
@@ -147,7 +147,7 @@ class DeleteL7Policy(task.Task):
                 listener.protocol, listener.protocol_port,
                 listener.default_pool_id,
                 s_pers, c_pers, 1,
-                source_nat_pool=snat_pool, **kargs)
+                source_nat_pool=snat_pool, **kwargs)
             LOG.debug(
                 "Successfully dissociated l7policy %s from listener %s",
                 l7policy.id,


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description:
1. When l7policy is there in the SLB tree and cascade deletion of a loadbalancer in the SLB tree is performed, then nat-pool port is not getting deleted on the cascade deletion.
2. Duplicate members in batch update causes pending state freeze of SLB tree

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3165

## Technical Approach
- Passing source nat-pool to source_nat_pool argument in the self.axapi_client.slb.virtual_server.vport.replace() call in DeleteL7Policy() task if virtual-port associated to the policy is having a source nat-pool attached to it.
- Otherwise passing None by default to the source_nat_pool.

- Combined member definitions into hashmap with counts of member ids encountered
- Performed a check that none of the member definitions are observed more than once
- If there are duplicate member definitions, then log warnings for each duplicate based upon it being a new or old definition
- Set all members, pools, and loadbalancers that were modified back to ACTIVE state in rollback
- Deleted all newly added members that were added to the DB in the case of duplicates


## Config Changes
N/A

## Manual Testing
**For STACK-3129:**

1. Create 1st loadbalancer
stack@openstack-3:~$ openstack loadbalancer create --name lb1 --vip-subnet-id public-11-subnet
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-11-17T09:16:37                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 72859b1f-e202-4c31-b9ad-c0db38d1d599 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 9ef5e94c53c940239a66dbe4a1058eee     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.42                           |
| vip_network_id      | 6df8ee71-7519-4f9d-8300-44acfa2fe325 |
| vip_port_id         | 14cc305c-917f-452b-a723-afe2afe16793 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 184910cd-74d4-4fd5-a3b2-ebad65d4cd44 |
+---------------------+--------------------------------------+
```


vThunder(NOLICENSE)#show running-config
!Current configuration: 167 bytes
!Configuration last updated at 09:20:20 GMT Wed Nov 17 2021
!Configuration last saved at 09:20:22 GMT Wed Nov 17 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.243
!
**slb virtual-server 72859b1f-e202-4c31-b9ad-c0db38d1d599 10.0.11.42**
!
!
cloud-services meta-data
  enable
  provider openstack
!
end

2. Create a flavorprofile, flavor and a loadbalancer using that flavor

stack@openstack-3:~/neha/a10-octavia$ openstack loadbalancer flavorprofile create --name fpn --provider a10 --flavor-data '{"nat-pool":{"pool-name":"pool1","start-address":"10.0.11.11","end-address":"10.0.11.12","netmask":"/24"}}'
```
+---------------+------------------------------------------------------------------------------------------------------------+
| Field         | Value                                                                                                      |
+---------------+------------------------------------------------------------------------------------------------------------+
| id            | 8b4fe0e4-add5-4132-8f55-7c8e1dc0be76                                                                       |
| name          | fpn                                                                                                        |
| provider_name | a10                                                                                                        |
| flavor_data   | {"nat-pool":{"pool-name":"pool1","start-address":"10.0.11.11","end-address":"10.0.11.12","netmask":"/24"}} |
+---------------+------------------------------------------------------------------------------------------------------------+
```

stack@openstack-3:~/neha/a10-octavia$ openstack loadbalancer flavor create --name fn --flavorprofile fpn
```
+-------------------+--------------------------------------+
| Field             | Value                                |
+-------------------+--------------------------------------+
| id                | 2435b076-c46f-4ee6-b6e7-f9eaf31a170e |
| name              | fn                                   |
| flavor_profile_id | 8b4fe0e4-add5-4132-8f55-7c8e1dc0be76 |
| enabled           | True                                 |
| description       |                                      |
+-------------------+--------------------------------------+
```

stack@openstack-3:~/neha/a10-octavia$ openstack loadbalancer create --name lb2 --vip-subnet-id public-11-subnet --flavor fn
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-11-17T09:34:58                  |
| description         |                                      |
| flavor_id           | 2435b076-c46f-4ee6-b6e7-f9eaf31a170e |
| id                  | 15d1a014-1f10-4c24-876c-0d0bcf4b6aff |
| listeners           |                                      |
| name                | lb2                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 9ef5e94c53c940239a66dbe4a1058eee     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.221                          |
| vip_network_id      | 6df8ee71-7519-4f9d-8300-44acfa2fe325 |
| vip_port_id         | eba04019-9162-4060-ac41-bd1d5aafc411 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 184910cd-74d4-4fd5-a3b2-ebad65d4cd44 |
+---------------------+--------------------------------------+
```


stack@openstack-3:~/neha/a10-octavia$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 72859b1f-e202-4c31-b9ad-c0db38d1d599 | lb1  | 9ef5e94c53c940239a66dbe4a1058eee | 10.0.11.42  | ACTIVE              | a10      |
| 15d1a014-1f10-4c24-876c-0d0bcf4b6aff | lb2  | 9ef5e94c53c940239a66dbe4a1058eee | 10.0.11.221 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```

3. Create a SLB tree for 2nd loadbalancer till l7rule

stack@openstack-3:~$ openstack loadbalancer listener create --name l2 --protocol http --protocol-port 85 lb2
```
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-11-17T09:36:09                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 8a9938bc-1671-43a1-8019-9ae6db4d886d |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 15d1a014-1f10-4c24-876c-0d0bcf4b6aff |
| name                        | l2                                   |
| operating_status            | OFFLINE                              |
| project_id                  | 9ef5e94c53c940239a66dbe4a1058eee     |
| protocol                    | HTTP                                 |
| protocol_port               | 85                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
+-----------------------------+--------------------------------------+
```

stack@openstack-3:~$ openstack loadbalancer pool create --name p2 --protocol HTTP --lb-algorithm LEAST_CONNECTIONS --listener l2
```
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-11-17T09:36:22                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | fbb0bf08-c6cc-4468-ba79-146128451c75 |
| lb_algorithm         | LEAST_CONNECTIONS                    |
| listeners            | 8a9938bc-1671-43a1-8019-9ae6db4d886d |
| loadbalancers        | 15d1a014-1f10-4c24-876c-0d0bcf4b6aff |
| members              |                                      |
| name                 | p2                                   |
| operating_status     | OFFLINE                              |
| project_id           | 9ef5e94c53c940239a66dbe4a1058eee     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
+----------------------+--------------------------------------+
```

stack@openstack-3:~$ openstack loadbalancer member create --address 10.0.11.8 --subnet-id public-11-subnet --protocol-port 95 --name m2 p2
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.11.8                            |
| admin_state_up      | True                                 |
| created_at          | 2021-11-17T09:36:39                  |
| id                  | 2bba6a97-8275-4105-981d-780e1a7f26b3 |
| name                | m2                                   |
| operating_status    | NO_MONITOR                           |
| project_id          | 9ef5e94c53c940239a66dbe4a1058eee     |
| protocol_port       | 95                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 184910cd-74d4-4fd5-a3b2-ebad65d4cd44 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
```

stack@openstack-3:~$ openstack loadbalancer healthmonitor create --delay 7 --timeout 6 --max-retries 3 --http-method GET --type HTTP --name hm2 p2
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| project_id          | 9ef5e94c53c940239a66dbe4a1058eee     |
| name                | hm2                                  |
| admin_state_up      | True                                 |
| pools               | fbb0bf08-c6cc-4468-ba79-146128451c75 |
| created_at          | 2021-11-17T09:43:40                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| delay               | 7                                    |
| expected_codes      | 200                                  |
| max_retries         | 3                                    |
| http_method         | GET                                  |
| timeout             | 6                                    |
| max_retries_down    | 3                                    |
| url_path            | /                                    |
| type                | HTTP                                 |
| id                  | 0973f3cd-7229-41eb-a707-a80e3c553b9e |
| operating_status    | OFFLINE                              |
| http_version        | None                                 |
| domain_name         | None                                 |
+---------------------+--------------------------------------+
```

stack@openstack-3:~$ openstack loadbalancer l7policy create --action REDIRECT_TO_URL --redirect-url http://test1 --name ply2 l2
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| listener_id         | 8a9938bc-1671-43a1-8019-9ae6db4d886d |
| description         |                                      |
| admin_state_up      | True                                 |
| rules               |                                      |
| project_id          | 9ef5e94c53c940239a66dbe4a1058eee     |
| created_at          | 2021-11-17T09:43:56                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| redirect_pool_id    | None                                 |
| redirect_url        | http://test1                         |
| redirect_prefix     | None                                 |
| action              | REDIRECT_TO_URL                      |
| position            | 1                                    |
| id                  | 8d767744-b683-451a-8fbe-b75c6f70b9d6 |
| operating_status    | OFFLINE                              |
| name                | ply2                                 |
| redirect_http_code  | 302                                  |
+---------------------+--------------------------------------+
```

stack@openstack-3:~$ openstack loadbalancer l7rule create --compare-type REGEX --type FILE_TYPE --value value1 --invert ply2
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| created_at          | 2021-11-17T09:44:12                  |
| compare_type        | REGEX                                |
| provisioning_status | PENDING_CREATE                       |
| invert              | True                                 |
| admin_state_up      | True                                 |
| updated_at          | None                                 |
| value               | value1                               |
| key                 | None                                 |
| project_id          | 9ef5e94c53c940239a66dbe4a1058eee     |
| type                | FILE_TYPE                            |
| id                  | 5c80d373-201e-4a91-9d41-85fd8893b136 |
| operating_status    | OFFLINE                              |
+---------------------+--------------------------------------+
```

vThunder(NOLICENSE)#show running-config
!Current configuration: 220 bytes
!Configuration last updated at 09:44:11 GMT Wed Nov 17 2021
!Configuration last saved at 09:44:14 GMT Wed Nov 17 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.243
!
ip nat pool pool1 10.0.11.11 10.0.11.12 netmask /24
!
health monitor 0973f3cd-7229-41eb-a707-a80e3c553b9e
  override-port 85
  interval 7 timeout 6
  method http port 85 expect response-code 200 url GET /
!
slb server 9ef5e_10_0_11_8 10.0.11.8
  port 95 tcp
!
slb service-group fbb0bf08-c6cc-4468-ba79-146128451c75 tcp
  method least-connection
  health-check 0973f3cd-7229-41eb-a707-a80e3c553b9e
  member 9ef5e_10_0_11_8 95
!
slb virtual-server 15d1a014-1f10-4c24-876c-0d0bcf4b6aff 10.0.11.221
  port 85 http
    name 8a9938bc-1671-43a1-8019-9ae6db4d886d
    extended-stats
    aflex 8d767744-b683-451a-8fbe-b75c6f70b9d6
    source-nat pool pool1
    service-group fbb0bf08-c6cc-4468-ba79-146128451c75
!
slb virtual-server 72859b1f-e202-4c31-b9ad-c0db38d1d599 10.0.11.42
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode


Ports created on OpenStack side:

![stack-3165-1](https://user-images.githubusercontent.com/58077446/142417205-5084d34a-5196-44a1-a2aa-a6b871b128c7.PNG)


4.  Cascade delete the 2nd loadbalancer

stack@openstack-3:~$ openstack loadbalancer delete lb2 --cascade

stack@openstack-3:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 72859b1f-e202-4c31-b9ad-c0db38d1d599 | lb1  | 9ef5e94c53c940239a66dbe4a1058eee | 10.0.11.42  | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```

vThunder(NOLICENSE)#show running-config
!Current configuration: 167 bytes
!Configuration last updated at 09:51:04 GMT Wed Nov 17 2021
!Configuration last saved at 09:51:09 GMT Wed Nov 17 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.243
!
slb virtual-server 72859b1f-e202-4c31-b9ad-c0db38d1d599 10.0.11.42
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode

Ports remaining on the OpenStack side:
**Port associated to nat-pool is deleted**

![stack-3165-2](https://user-images.githubusercontent.com/58077446/142417664-77732c69-edf5-4db5-8e5b-e434d4b40c9e.PNG)


**For STACK-3121:**

1. Create a loadbalancer, listener and pool

stack@openstack-3:~$ openstack loadbalancer create --name lb1 --vip-subnet-id public-11-subnet
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-11-18T04:31:42                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 75f1be2a-4d79-4c5f-91aa-ef820d4777fc |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 9ef5e94c53c940239a66dbe4a1058eee     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.131                          |
| vip_network_id      | 6df8ee71-7519-4f9d-8300-44acfa2fe325 |
| vip_port_id         | c7eb3551-2600-4cd9-9039-e292ba115f10 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 184910cd-74d4-4fd5-a3b2-ebad65d4cd44 |
+---------------------+--------------------------------------+
```

stack@openstack-3:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 75f1be2a-4d79-4c5f-91aa-ef820d4777fc | lb1  | 9ef5e94c53c940239a66dbe4a1058eee | 10.0.11.131 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```

stack@openstack-3:~$ openstack loadbalancer listener create --name l1 --protocol http --protocol-port 85 lb1
```
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-11-18T04:37:20                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 1193fd19-56a8-42d6-9d9e-58d60766c861 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 75f1be2a-4d79-4c5f-91aa-ef820d4777fc |
| name                        | l1                                   |
| operating_status            | OFFLINE                              |
| project_id                  | 9ef5e94c53c940239a66dbe4a1058eee     |
| protocol                    | HTTP                                 |
| protocol_port               | 85                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
+-----------------------------+--------------------------------------+
```

stack@openstack-3:~$ openstack loadbalancer pool create --name p1 --protocol HTTP --lb-algorithm LEAST_CONNECTIONS --listener l1
```
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-11-18T04:37:30                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | 817599a2-0ae2-4e0a-b7e6-5f032bb2f60e |
| lb_algorithm         | LEAST_CONNECTIONS                    |
| listeners            | 1193fd19-56a8-42d6-9d9e-58d60766c861 |
| loadbalancers        | 75f1be2a-4d79-4c5f-91aa-ef820d4777fc |
| members              |                                      |
| name                 | p1                                   |
| operating_status     | OFFLINE                              |
| project_id           | 9ef5e94c53c940239a66dbe4a1058eee     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
+----------------------+--------------------------------------+
```

2. Run the terraform script to create 2 members:

```
resource "openstack_lb_members_v2" "members_1" {
  pool_id = "817599a2-0ae2-4e0a-b7e6-5f032bb2f60e"

  member {
    address       = "10.0.13.20"
    subnet_id     = "0d4f7a95-d013-4a22-9b8e-6a83b22f8297"
    protocol_port = 94
    name          = "m1"
    weight        = 5
  }

  member {
    address       = "10.0.13.21"
    subnet_id     = "0d4f7a95-d013-4a22-9b8e-6a83b22f8297"
    protocol_port = 95
    name          = "m2"
    weight        = 15
  }
}

```

stack@openstack-3:~/neha$ **terraform apply**

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # openstack_lb_members_v2.members_1 will be created
  + resource "openstack_lb_members_v2" "members_1" {
      + id      = (known after apply)
      + pool_id = "817599a2-0ae2-4e0a-b7e6-5f032bb2f60e"
      + region  = (known after apply)

      + member {
          + address        = "10.0.13.20"
          + admin_state_up = true
          + id             = (known after apply)
          + name           = "m1"
          + protocol_port  = 94
          + subnet_id      = "0d4f7a95-d013-4a22-9b8e-6a83b22f8297"
          + weight         = 5
        }
      + member {
          + address        = "10.0.13.21"
          + admin_state_up = true
          + id             = (known after apply)
          + name           = "m2"
          + protocol_port  = 95
          + subnet_id      = "0d4f7a95-d013-4a22-9b8e-6a83b22f8297"
          + weight         = 15
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

openstack_lb_members_v2.members_1: Creating...
openstack_lb_members_v2.members_1: Still creating... [10s elapsed]
openstack_lb_members_v2.members_1: Still creating... [20s elapsed]
openstack_lb_members_v2.members_1: Still creating... [30s elapsed]
openstack_lb_members_v2.members_1: Still creating... [40s elapsed]
openstack_lb_members_v2.members_1: Still creating... [50s elapsed]
openstack_lb_members_v2.members_1: Still creating... [1m0s elapsed]
openstack_lb_members_v2.members_1: Still creating... [1m10s elapsed]
openstack_lb_members_v2.members_1: Still creating... [1m20s elapsed]
openstack_lb_members_v2.members_1: Still creating... [1m30s elapsed]
openstack_lb_members_v2.members_1: Still creating... [1m40s elapsed]
openstack_lb_members_v2.members_1: Still creating... [1m50s elapsed]
openstack_lb_members_v2.members_1: Still creating... [2m0s elapsed]
openstack_lb_members_v2.members_1: Still creating... [2m10s elapsed]
openstack_lb_members_v2.members_1: Creation complete after 2m11s [id=817599a2-0ae2-4e0a-b7e6-5f032bb2f60e]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

stack@openstack-3:~/neha$ openstack loadbalancer member list p1
```
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address    | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| 95c8b26a-2670-4f55-8f2a-a7dff54b64ac | m2   | 9ef5e94c53c940239a66dbe4a1058eee | ACTIVE              | 10.0.13.21 |            95 | NO_MONITOR       |     15 |
| ceac4a61-ba77-4b3a-8a93-eb80b68541b3 | m1   | 9ef5e94c53c940239a66dbe4a1058eee | ACTIVE              | 10.0.13.20 |            94 | NO_MONITOR       |      5 |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
```


vThunder(NOLICENSE)#show running-config
!Current configuration: 99 bytes
!Configuration last updated at 04:42:01 GMT Thu Nov 18 2021
!Configuration last saved at 04:42:05 GMT Thu Nov 18 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,22:03)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 10.0.11.228
  floating-ip 10.0.13.234
!
**slb server 9ef5e_10_0_13_20 10.0.13.20
  port 94 tcp
!
slb server 9ef5e_10_0_13_21 10.0.13.21
  port 95 tcp
!**
slb service-group 817599a2-0ae2-4e0a-b7e6-5f032bb2f60e tcp
  method least-connection
  member 9ef5e_10_0_13_20 94
  member 9ef5e_10_0_13_21 95
!
slb virtual-server 75f1be2a-4d79-4c5f-91aa-ef820d4777fc 10.0.11.131
  port 85 http
    name 1193fd19-56a8-42d6-9d9e-58d60766c861
    extended-stats
    service-group 817599a2-0ae2-4e0a-b7e6-5f032bb2f60e
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode

3. Modify the terraform script sothat it holds 2 member blocks with same required parameters and different optional parameters.

```
resource "openstack_lb_members_v2" "members_1" {
  pool_id = "817599a2-0ae2-4e0a-b7e6-5f032bb2f60e"

  member {
    address       = "10.0.13.20"
    subnet_id     = "0d4f7a95-d013-4a22-9b8e-6a83b22f8297"
    protocol_port = 94
    name          = "m1"
    weight        = 5
  }

  member {
    address       = "10.0.13.21"
    subnet_id     = "0d4f7a95-d013-4a22-9b8e-6a83b22f8297"
    protocol_port = 95
    name          = "m2"
    weight        = 15
  }

  member {
    address       = "10.0.13.21"
    subnet_id     = "0d4f7a95-d013-4a22-9b8e-6a83b22f8297"
    protocol_port = 95
    name          = "m2_update"
    weight        = 20
  }
}
```

stack@openstack-3:~/neha$ terraform apply
openstack_lb_members_v2.members_1: Refreshing state... [id=817599a2-0ae2-4e0a-b7e6-5f032bb2f60e]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # openstack_lb_members_v2.members_1 will be updated in-place
  ~ resource "openstack_lb_members_v2" "members_1" {
        id      = "817599a2-0ae2-4e0a-b7e6-5f032bb2f60e"
        # (1 unchanged attribute hidden)

      - member {
          - address        = "10.0.13.20" -> null
          - admin_state_up = true -> null
          - backup         = false -> null
          - id             = "ceac4a61-ba77-4b3a-8a93-eb80b68541b3" -> null
          - name           = "m1" -> null
          - protocol_port  = 94 -> null
          - subnet_id      = "0d4f7a95-d013-4a22-9b8e-6a83b22f8297" -> null
          - weight         = 5 -> null
        }
      + member {
          + address        = "10.0.13.20"
          + admin_state_up = true
          + id             = "ceac4a61-ba77-4b3a-8a93-eb80b68541b3"
          + name           = "m1"
          + protocol_port  = 94
          + subnet_id      = "0d4f7a95-d013-4a22-9b8e-6a83b22f8297"
          + weight         = 5
        }
      - member {
          - address        = "10.0.13.21" -> null
          - admin_state_up = true -> null
          - backup         = false -> null
          - id             = "95c8b26a-2670-4f55-8f2a-a7dff54b64ac" -> null
          - name           = "m2" -> null
          - protocol_port  = 95 -> null
          - subnet_id      = "0d4f7a95-d013-4a22-9b8e-6a83b22f8297" -> null
          - weight         = 15 -> null
        }
      + member {
          + address        = "10.0.13.21"
          + admin_state_up = true
          + id             = "95c8b26a-2670-4f55-8f2a-a7dff54b64ac"
          + name           = "m2"
          + protocol_port  = 95
          + subnet_id      = "0d4f7a95-d013-4a22-9b8e-6a83b22f8297"
          + weight         = 15
        }
      + member {
          + address        = "10.0.13.21"
          + admin_state_up = true
          + id             = (known after apply)
          + name           = "m2_update"
          + protocol_port  = 95
          + subnet_id      = "0d4f7a95-d013-4a22-9b8e-6a83b22f8297"
          + weight         = 20
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

openstack_lb_members_v2.members_1: Modifying... [id=817599a2-0ae2-4e0a-b7e6-5f032bb2f60e]
openstack_lb_members_v2.members_1: Modifications complete after 4s [id=817599a2-0ae2-4e0a-b7e6-5f032bb2f60e]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.


stack@openstack-3:~$ journalctl -af -u a10-controller-worker.service
Nov 18 04:58:47 openstack-3 a10-octavia-worker[4358]: INFO a10_octavia.controller.queue.endpoint [-] Batch updating members: old='[]', new='[]', updated='[u'ceac4a61-ba77-4b3a-8a93-eb80b68541b3', u'95c8b26a-2670-4f55-8f2a-a7dff54b64ac', u'95c8b26a-2670-4f55-8f2a-a7dff54b64ac']'...
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: **WARNING a10_octavia.controller.worker.controller_worker [-] Duplicate members with id 95c8b26a-2670-4f55-8f2a-a7dff54b64ac and IP 10.0.13.21 and port 95 found in batch update request.**
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: INFO a10_octavia.controller.worker.controller_worker [-] Member with id 95c8b26a-2670-4f55-8f2a-a7dff54b64ac and ip 10.0.13.21 and port 95 slated for batch update have been set to ACTIVE state.
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: INFO a10_octavia.controller.worker.controller_worker [-] Member with id ceac4a61-ba77-4b3a-8a93-eb80b68541b3 and ip 10.0.13.20 and port 94 slated for batch update have been set to ACTIVE state.
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: **WARNING a10_octavia.controller.worker.controller_worker [-] Due to a failed batch update caused by duplicate member definitions, the members defined in the update are now out-of-sync with the ACOS device. Please issue a corrected update or delete the affected members.**
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server [-] Exception during message handling: DuplicateMembersInBatchUpdate: Duplicate member definition have been found during the batch update. Please check WARNING log messages for more details.
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server Traceback (most recent call last):
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/server.py", line 166, in _process_incoming
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server     res = self.dispatcher.dispatch(message)
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 265, in dispatch
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server     return self._do_dispatch(endpoint, method, ctxt, args)
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 194, in _do_dispatch
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server     result = func(ctxt, **new_args)
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server   File "/opt/stack/neha/a10-octavia/a10_octavia/controller/queue/endpoint.py", line 123, in batch_update_members
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server     old_member_ids, new_member_ids, updated_members)
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 292, in wrapped_f
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server     return self.call(f, *args, **kw)
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 358, in call
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server     do = self.iter(retry_state=retry_state)
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 319, in iter
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server     return fut.result()
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/concurrent/futures/_base.py", line 455, in result
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server     return self.__get_result()
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 361, in call
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server     result = fn(*args, **kwargs)
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server   File "/opt/stack/neha/a10-octavia/a10_octavia/controller/worker/controller_worker.py", line 778, in batch_update_members
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server     raise a10_ex.DuplicateMembersInBatchUpdate
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: **ERROR oslo_messaging.rpc.server DuplicateMembersInBatchUpdate: Duplicate member definition have been found during the batch update. Please check WARNING log messages for more details.
Nov 18 04:58:48 openstack-3 a10-octavia-worker[4358]: ERROR oslo_messaging.rpc.server**


stack@openstack-3:~/neha$ openstack loadbalancer member list p1
```
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address    | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| 95c8b26a-2670-4f55-8f2a-a7dff54b64ac | m2   | 9ef5e94c53c940239a66dbe4a1058eee | ACTIVE              | 10.0.13.21 |            95 | NO_MONITOR       |     15 |
| ceac4a61-ba77-4b3a-8a93-eb80b68541b3 | m1   | 9ef5e94c53c940239a66dbe4a1058eee | ACTIVE              | 10.0.13.20 |            94 | NO_MONITOR       |      5 |
+--------------------------------------+------+----------------------------------+---------------------+------------+---------------+------------------+--------+
```