### PR TITLE
[STACK-3171] Health Monitor on target server ports

### DIFF
--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -85,9 +85,6 @@ A10_SLB_OPTS = [
 A10_HEALTH_MONITOR_OPTS = [
     cfg.StrOpt('post_data',
                help=_('HTTP Content for "--http-method POST" case.')),
-    cfg.BoolOpt('use_override_port',
-                default=True,
-                help=_('Allow port overriding'))
 ]
 
 A10_LISTENER_OPTS = [

--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -85,6 +85,9 @@ A10_SLB_OPTS = [
 A10_HEALTH_MONITOR_OPTS = [
     cfg.StrOpt('post_data',
                help=_('HTTP Content for "--http-method POST" case.')),
+    cfg.BoolOpt('use_override_port',
+                default=True,
+                help=_('Allow port overriding'))
 ]
 
 A10_LISTENER_OPTS = [

--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -118,8 +118,8 @@ class PoolFlows(object):
         delete_pool_flow.add(persist_tasks.DeleteSessionPersistence(
             requires=[a10constants.VTHUNDER, constants.POOL]))
         # Delete pool children
-        delete_pool_flow.add(self._get_delete_health_monitor_vthunder_subflow(health_mon))
         delete_pool_flow.add(self._get_delete_member_vthunder_subflow(members, store))
+        delete_pool_flow.add(self._get_delete_health_monitor_vthunder_subflow(health_mon))
         delete_pool_flow.add(service_group_tasks.PoolDelete(
             requires=[constants.POOL, a10constants.VTHUNDER]))
         delete_pool_flow.add(database_tasks.DeletePoolInDB(
@@ -276,8 +276,8 @@ class PoolFlows(object):
             requires=[a10constants.VTHUNDER, a10constants.USE_DEVICE_FLAVOR],
             provides=a10constants.POOLS))
         # Delete pool children
-        delete_pool_flow.add(self._get_delete_health_monitor_vthunder_subflow(health_mon, True))
         delete_pool_flow.add(self._get_delete_member_vthunder_subflow(members, store, pool_name))
+        delete_pool_flow.add(self._get_delete_health_monitor_vthunder_subflow(health_mon, True))
         delete_pool_flow.add(service_group_tasks.PoolDelete(
             name='pool_delete_' + pool_name,
             requires=[constants.POOL, a10constants.VTHUNDER],
@@ -335,8 +335,8 @@ class PoolFlows(object):
             provides=a10constants.POOLS))
 
         # Delete pool children
-        delete_pool_flow.add(self._get_delete_health_monitor_vthunder_subflow(health_mon))
         delete_pool_flow.add(self._get_delete_member_vthunder_subflow(members, store))
+        delete_pool_flow.add(self._get_delete_health_monitor_vthunder_subflow(health_mon))
         delete_pool_flow.add(service_group_tasks.PoolDelete(
             requires=[constants.POOL, a10constants.VTHUNDER]))
         delete_pool_flow.add(database_tasks.DeletePoolInDB(

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -75,18 +75,13 @@ class CreateAndAssociateHealthMonitor(task.Task):
                           "A health monitor of type {} is not supported "
                           "by A10 provider").format(health_mon.id, health_mon.type))
 
-        override_port = CONF.health_monitor.use_override_port
-        port = None
-        if override_port:
-            port = listeners[0].protocol_port
-
         try:
             post_data = CONF.health_monitor.post_data
             self.axapi_client.slb.hm.create(health_mon.id,
                                             health_mon.type,
                                             health_mon.delay, health_mon.timeout,
                                             health_mon.rise_threshold, method=method,
-                                            port=port, url=url,
+                                            port=listeners[0].protocol_port, url=url,
                                             expect_code=expect_code, post_data=post_data,
                                             **args)
             LOG.debug("Successfully created health monitor: %s", health_mon.id)

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -75,31 +75,24 @@ class CreateAndAssociateHealthMonitor(task.Task):
                           "A health monitor of type {} is not supported "
                           "by A10 provider").format(health_mon.id, health_mon.type))
 
+        override_port = CONF.health_monitor.use_override_port
+        port = None
+        if override_port:
+            port = listeners[0].protocol_port
+
         try:
             post_data = CONF.health_monitor.post_data
             self.axapi_client.slb.hm.create(health_mon.id,
                                             health_mon.type,
                                             health_mon.delay, health_mon.timeout,
                                             health_mon.rise_threshold, method=method,
-                                            port=listeners[0].protocol_port, url=url,
+                                            port=port, url=url,
                                             expect_code=expect_code, post_data=post_data,
                                             **args)
             LOG.debug("Successfully created health monitor: %s", health_mon.id)
 
         except (acos_errors.ACOSException, ConnectionError) as e:
             LOG.exception("Failed to create health monitor: %s", health_mon.id)
-            raise e
-
-        try:
-            self.axapi_client.slb.service_group.update(health_mon.pool_id,
-                                                       hm_name=health_mon.id,
-                                                       health_check_disable=0)
-            LOG.debug("Successfully associated health monitor %s to pool %s",
-                      health_mon.id, health_mon.pool_id)
-        except (acos_errors.ACOSException, ConnectionError) as e:
-            LOG.exception(
-                "Failed to associate health monitor %s to pool %s",
-                health_mon.id, health_mon.pool_id)
             raise e
 
     @axapi_client_decorator_for_revert

--- a/a10_octavia/controller/worker/tasks/server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/server_tasks.py
@@ -84,10 +84,15 @@ class MemberCreate(task.Task):
         else:
             status = True
 
+        health_check = None
+        if pool.health_monitor:
+            health_check = pool.health_monitor.id
+
         try:
             try:
                 server_name = _get_server_name(self.axapi_client, member)
                 self.axapi_client.slb.server.update(server_name, member.ip_address, status=status,
+                                                    health_check=health_check,
                                                     server_templates=server_temp,
                                                     **server_args)
                 LOG.debug("Successfully created member: %s", member.id)
@@ -95,6 +100,7 @@ class MemberCreate(task.Task):
                 server_name = '{}_{}'.format(member.project_id[:5],
                                              member.ip_address.replace('.', '_'))
                 self.axapi_client.slb.server.create(server_name, member.ip_address, status=status,
+                                                    health_check=health_check,
                                                     server_templates=server_temp,
                                                     **server_args)
                 LOG.debug("Successfully created member: %s", member.id)
@@ -192,10 +198,15 @@ class MemberUpdate(task.Task):
         else:
             status = True
 
+        health_check = None
+        if pool.health_monitor:
+            health_check = pool.health_monitor.id
+
         try:
             server_name = _get_server_name(self.axapi_client, member)
             port_list = self.axapi_client.slb.server.get(server_name)['server'].get('port-list')
             self.axapi_client.slb.server.replace(server_name, member.ip_address, status=status,
+                                                 health_check=health_check,
                                                  server_templates=server_temp,
                                                  port_list=port_list,
                                                  **server_args)

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_server_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_server_tasks.py
@@ -36,8 +36,12 @@ from a10_octavia.tests.common import a10constants
 from a10_octavia.tests.unit import base
 
 VTHUNDER = data_models.VThunder()
+HM = o_data_models.HealthMonitor(id=a10constants.MOCK_HM_ID, type='TCP',
+                                 delay=7, timeout=3,
+                                 rise_threshold=8, http_method='GET')
 POOL = o_data_models.Pool(id=a10constants.MOCK_POOL_ID,
-                          protocol=a10constants.MOCK_SERVICE_GROUP_PROTOCOL)
+                          protocol=a10constants.MOCK_SERVICE_GROUP_PROTOCOL,
+                          health_monitor=HM)
 MEMBER = o_data_models.Member(
     id=a10constants.MOCK_MEMBER_ID, protocol_port=t_constants.MOCK_PORT_ID,
     project_id=t_constants.MOCK_PROJECT_ID, ip_address=t_constants.MOCK_IP_ADDRESS,
@@ -111,7 +115,8 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
                                    member_port_count_ip, flavor)
         self.client_mock.slb.server.create.assert_called_with(
             SERVER_NAME, MEMBER.ip_address, status=mock.ANY,
-            server_templates=mock.ANY, **expect_key_args)
+            server_templates=mock.ANY, health_check='mock-hm-cd61-49ed-8508-f22a12d770c5',
+            **expect_key_args)
 
     @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
     def test_MemberCreate_execute_create_with_regex_overwrite_flavor(self, mock_server_name):
@@ -132,7 +137,8 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
                                    member_port_count_ip, flavor)
         self.client_mock.slb.server.create.assert_called_with(
             SERVER_NAME, member_obj.ip_address, status=mock.ANY,
-            server_templates=mock.ANY, **expect_key_args)
+            server_templates=mock.ANY, health_check='mock-hm-cd61-49ed-8508-f22a12d770c5',
+            **expect_key_args)
 
     @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
     def test_MemberCreate_execute_create_with_regex_flavor(self, mock_server_name):
@@ -153,7 +159,8 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
                                    member_port_count_ip, flavor)
         self.client_mock.slb.server.create.assert_called_with(
             SERVER_NAME, member_obj.ip_address, status=mock.ANY,
-            server_templates=mock.ANY, **expect_key_args)
+            server_templates=mock.ANY, health_check='mock-hm-cd61-49ed-8508-f22a12d770c5',
+            **expect_key_args)
 
     @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
     def test_MemberCreate_execute_create_flavor_override_config(self, mock_server_name):
@@ -169,7 +176,8 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
                                    member_port_count_ip, flavor)
         self.client_mock.slb.server.create.assert_called_with(
             SERVER_NAME, MEMBER.ip_address, status=mock.ANY,
-            server_templates=mock.ANY, **expect_key_args)
+            server_templates=mock.ANY, health_check='mock-hm-cd61-49ed-8508-f22a12d770c5',
+            **expect_key_args)
 
     def test_MemberCreate_revert_created_member(self):
         mock_member = task.MemberCreate()
@@ -191,7 +199,8 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
                                    member_port_count_ip)
         self.client_mock.slb.server.create.assert_called_with(
             SERVER_NAME, MEMBER.ip_address, status=mock.ANY,
-            server_templates=mock.ANY, **KEY_ARGS)
+            server_templates=mock.ANY, health_check='mock-hm-cd61-49ed-8508-f22a12d770c5',
+            **KEY_ARGS)
         self.client_mock.slb.service_group.member.create.assert_called_with(
             POOL.id, SERVER_NAME, MEMBER.protocol_port)
 
@@ -213,7 +222,8 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
         self.client_mock.slb.server.create.assert_not_called()
         self.client_mock.slb.server.update.assert_called_with(
             SERVER_NAME, MEMBER.ip_address, status=mock.ANY,
-            server_templates=mock.ANY, **KEY_ARGS)
+            server_templates=mock.ANY, health_check='mock-hm-cd61-49ed-8508-f22a12d770c5',
+            **KEY_ARGS)
         self.client_mock.slb.service_group.member.create.assert_called_with(
             POOL.id, SERVER_NAME, MEMBER.protocol_port)
 


### PR DESCRIPTION
## Description

- Moved health monitor from **service group** to **slb server** and attached listener port to health monitor 

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3171
https://a10networks.atlassian.net/browse/STACK-3172
https://a10networks.atlassian.net/browse/STACK-3173
https://a10networks.atlassian.net/browse/STACK-3174
https://a10networks.atlassian.net/browse/STACK-3175
https://a10networks.atlassian.net/browse/STACK-3176
https://a10networks.atlassian.net/browse/STACK-3169

## Technical Approach

- Removed the association between **health-monitor** and **service-group**.
- Added **health_check**  parameter in axapi call of **create** and **update** slb server operations to attach healthmonitor  to slb server.
- Modified **delete_pool_flow** to execute **self._get_delete_member_vthunder_subflow** before **self._get_delete_health_monitor_vthunder_subflow** as now health monitor is attached to slb server so we cannot delete it before deleting the server associated with it for automated flow and rack flow.
- Modified **delete_pool_flow** to execute **self._get_delete_member_vthunder_subflow** before **self._get_delete_health_monitor_vthunder_subflow** as now health monitor is attached to slb server so we cannot delete it before deleting the server associated with it for loadbalancer cascade delete operation.

## Manual Testing

1. Create a load balancer

stack@automation-1:~#openstack loadbalancer create --vip-subnet-id 172.16.0.0 --name lb1

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| created_at          | 2021-12-09T04:23:51                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 9a20812f-bc9f-46ad-8e1b-0f90de265563 |
| listeners           |                                      |
| name                | lb1                                  |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 97181a05bddd451bb00b5da4a51686ee     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 172.16.0.5                           |
| vip_network_id      | ff02c2ed-de14-44d3-81d4-0f4314b57fd4 |
| vip_port_id         | 81f104e8-e11b-40dc-9284-65a67416654e |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 76c4bb9d-a5ca-4c96-b1e1-40cc2d5b515a |
+---------------------+--------------------------------------+

stack@automation-1:~#

stack@automation-1:~#openstack server list

+--------------------------------------+----------------------------------------------+--------+-------------------------------------------------+----------------+-----------------+
| ID                                   | Name                                         | Status | Networks                                        | Image          | Flavor          |
+--------------------------------------+----------------------------------------------+--------+-------------------------------------------------+----------------+-----------------+
| 4e58269a-875c-44e7-82e9-f3e024cec11c | amphora-57243161-ba45-40f8-befa-f19ff5dc65df | ACTIVE | lb-mgmt-net=192.168.0.112; private=172.16.0.250 | vThunder.qcow2 | vThunder_flavor |
+--------------------------------------+----------------------------------------------+--------+-------------------------------------------------+----------------+-----------------+

stack@automation-1:~#

2. Create a listener

stack@automation-1:~#openstack loadbalancer listener create --protocol HTTP --protocol-port 70 --name vport1 lb1

+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2021-12-09T05:51:25                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 00f94f84-3f39-48ac-93fc-6e828e0cf0a6 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 9a20812f-bc9f-46ad-8e1b-0f90de265563 |
| name                        | vport1                               |
| operating_status            | OFFLINE                              |
| project_id                  | 97181a05bddd451bb00b5da4a51686ee     |
| protocol                    | HTTP                                 |
| protocol_port               | 70                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
+-----------------------------+--------------------------------------+
stack@automation-1:~#

3. Create a pool

stack@automation-1:~#openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener vport1 --name sg1

+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2021-12-09T05:52:02                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | 6b591f85-618c-471c-b644-a7656eb5d144 |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | 00f94f84-3f39-48ac-93fc-6e828e0cf0a6 |
| loadbalancers        | 9a20812f-bc9f-46ad-8e1b-0f90de265563 |
| members              |                                      |
| name                 | sg1                                  |
| operating_status     | OFFLINE                              |
| project_id           | 97181a05bddd451bb00b5da4a51686ee     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
+----------------------+--------------------------------------+
stack@automation-1:~#

4. Create a health monitor

stack@automation-1:~#openstack loadbalancer healthmonitor create --delay 4 --timeout 3 --max-retries 3 --type HTTP  sg1 --name hm1

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| project_id          | 97181a05bddd451bb00b5da4a51686ee     |
| name                | hm1                                  |
| admin_state_up      | True                                 |
| pools               | 6b591f85-618c-471c-b644-a7656eb5d144 |
| created_at          | 2021-12-09T05:52:48                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| delay               | 4                                    |
| expected_codes      | 200                                  |
| max_retries         | 3                                    |
| http_method         | GET                                  |
| timeout             | 3                                    |
| max_retries_down    | 3                                    |
| url_path            | /                                    |
| type                | HTTP                                 |
| id                  | 616af401-2c90-4e4a-b579-5dc3cf30a213 |
| operating_status    | OFFLINE                              |
| http_version        | None                                 |
| domain_name         | None                                 |
+---------------------+--------------------------------------+
stack@automation-1:~#

5. Create a member 

stack@automation-1:~#openstack loadbalancer member create --address 172.16.0.91 --subnet-id 172.16.0.0 --protocol-port 8001 --name srv1 sg1

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 172.16.0.91                          |
| admin_state_up      | True                                 |
| created_at          | 2021-12-09T05:53:19                  |
| id                  | 9a220906-6d81-4296-aa09-1eaeec757b7b |
| name                | srv1                                 |
| operating_status    | OFFLINE                              |
| project_id          | 97181a05bddd451bb00b5da4a51686ee     |
| protocol_port       | 8001                                 |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 76c4bb9d-a5ca-4c96-b1e1-40cc2d5b515a |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
stack@automation-1:~#

**vThunder Configuration:**

vThunder(NOLICENSE)#show running-config
!Current configuration: 99 bytes
!Configuration last updated at 05:53:23 GMT Thu Dec 9 2021
!Configuration last saved at 05:53:27 GMT Thu Dec 9 2021
!64-bit Advanced Core OS (ACOS) version 5.2.1-p1, build 56 (Feb-16-2021,19:16)
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
vrrp-a vrid 0
  floating-ip 172.16.0.110
!
health monitor 616af401-2c90-4e4a-b579-5dc3cf30a213
  interval 4 timeout 3
  **method http port 70 expect response-code 200 url GET /**
!
slb server 97181_172_16_0_91 172.16.0.91
  **health-check 616af401-2c90-4e4a-b579-5dc3cf30a213**
  port 8001 tcp
!
slb service-group 6b591f85-618c-471c-b644-a7656eb5d144 tcp
  member 97181_172_16_0_91 8001
!
slb virtual-server 9a20812f-bc9f-46ad-8e1b-0f90de265563 172.16.0.5
  **port 70 http**
    name 00f94f84-3f39-48ac-93fc-6e828e0cf0a6
    extended-stats
    service-group 6b591f85-618c-471c-b644-a7656eb5d144
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#