### PR TITLE
global option to use neutron lbaas member names

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ this provider driver uses a "Thunder per Tenant" architecture. Therefore, each t
 
 ## Project Resources
 
-Installation and usage information is available at https://documentation.a10networks.com/Install/Software/A10_ACOS_Install/pdf/Thunder_openstack_octavia_install_guide.pdf
+Installation and usage information is available at https://documentation.a10networks.com/Install/Software/A10_ACOS_Install/pdf/A10_OCTAVIA_INSTALL.pdf
 
-Release notes are available at https://documentation.a10networks.com/Install/Software/A10_ACOS_Install/pdf/Thunder_openstack_octavia_RN.pdf
+Release notes are available at https://documentation.a10networks.com/Install/Software/A10_ACOS_Install/pdf/A10_OCTAVIA_RN.pdf
 
 ## Issues and Inquiries
 For all issues, please send an email to support@a10networks.com 

--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -52,6 +52,8 @@ A10_GLOBAL_OPTS = [
                help=_('Default flavor ID to apply globally to all users')),
     cfg.BoolOpt('handle_vrid', default=True,
                 help=_('Deletes floating ip when True.')),
+    cfg.BoolOpt('nlbaas_member_names', default=False,
+                help=_('Use neutron lbaas member names in a10 config.')),
 ]
 
 A10_VTHUNDER_OPTS = [

--- a/a10_octavia/controller/worker/tasks/server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/server_tasks.py
@@ -92,8 +92,14 @@ class MemberCreate(task.Task):
                                                     **server_args)
                 LOG.debug("Successfully created member: %s", member.id)
             except acos_errors.NotFound:
-                server_name = '{}_{}'.format(member.project_id[:5],
-                                             member.ip_address.replace('.', '_'))
+                if CONF.a10_global.nlbaas_member_names:
+                    server_name = '_{}_{}_neutron'.format(
+                        member.project_id[:5],
+                        member.ip_address.replace('.', '_'))
+                else:
+                    server_name = '{}_{}'.format(
+                        member.project_id[:5],
+                        member.ip_address.replace('.', '_'))                
                 self.axapi_client.slb.server.create(server_name, member.ip_address, status=status,
                                                     server_templates=server_temp,
                                                     **server_args)


### PR DESCRIPTION
This change adds a global option which causes new loadbalancer members to be created with the same nomenclature used by the neutron a10 driver. This is useful if using neutron lbaas and octavia concurrently since octavia members created with the alternative nomenclature can't be reused as neutron members.