### PR TITLE
[BUG] Update driver rpc to singleton

### DIFF
--- a/a10_octavia/api/drivers/driver.py
+++ b/a10_octavia/api/drivers/driver.py
@@ -19,6 +19,7 @@ from oslo_log import log as logging
 import oslo_messaging as messaging
 
 from octavia.common import constants
+from octavia.common import rpc
 from octavia.db import api as db_apis
 from octavia.db import repositories
 from octavia_lib.api.drivers import exceptions
@@ -35,14 +36,11 @@ LOG = logging.getLogger(__name__)
 class A10ProviderDriver(driver_base.ProviderDriver):
     def __init__(self):
         super(A10ProviderDriver, self).__init__()
-        self._args = {}
-        self.transport = messaging.get_rpc_transport(cfg.CONF)
-        self._args['fanout'] = False
-        self._args['namespace'] = constants.RPC_NAMESPACE_CONTROLLER_AGENT
-        self._args['topic'] = "a10_octavia"
-        self._args['version'] = '1.0'
-        self.target = messaging.Target(**self._args)
-        self.client = messaging.RPCClient(self.transport, target=self.target)
+        self.target = messaging.Target(
+            namespace=constants.RPC_NAMESPACE_CONTROLLER_AGENT,
+            topic='a10_octavia', version='1.0', fanout=False
+        )
+        self.client = rpc.get_client(self.target)
         self.repositories = repositories.Repositories()
 
     # Load Balancer


### PR DESCRIPTION
## Description
The previous rpc call can open multiple connections to rabbitMQ causing a runaway socket descriptor issue, where the socket descriptor limit is hit quickly in a large environment.  This update uses octavia.common.rpc to change the driver behavior to a singleton. 

Bug Fix:
Severity Level: High

## Technical Approach
This change calls the octavia.common.rpc function built into openstack/octavia to use a singleton as documented here: https://review.opendev.org/c/openstack/octavia/+/636428/12/octavia/common/rpc.py#65
This fixes the connection leaking issue seen in the a10-octavia/api/drivers/driver.py functionality. 

## Config Changes
```
 from octavia.common import rpc

        self.target = messaging.Target(
            namespace=constants.RPC_NAMESPACE_CONTROLLER_AGENT,
            topic='a10_octavia', version='1.0', fanout=False
        )
        self.client = rpc.get_client(self.target)
```

<pre>
 **REMOVED/UPDATED**
        self._args = {}
        self.transport = messaging.get_rpc_transport(cfg.CONF)
        self._args['fanout'] = False
        self._args['namespace'] = constants.RPC_NAMESPACE_CONTROLLER_AGENT
        self._args['topic'] = "a10_octavia"
        self._args['version'] = '1.0'
        self.target = messaging.Target(**self._args)
        self.client = messaging.RPCClient(self.transport, target=self.target)
</pre>

## Manual Testing
- Blizzard Entertainment has tested this in our lab environment and reduced the socket descriptors used in our rabbitmq environment.  
- For checking the connection count before and after a quick one line command can achieve this: 
` for i in $(ps -ef | grep octavia-api.ini | awk '{print $2}'); do netstat -np | grep 5672 | grep $i | wc -l; done`
