### PR TITLE
Allow for disabling validate subnet

### DIFF
--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -52,6 +52,9 @@ A10_GLOBAL_OPTS = [
                help=_('Default flavor ID to apply globally to all users')),
     cfg.BoolOpt('handle_vrid', default=True,
                 help=_('Deletes floating ip when True.')),
+    cfg.BoolOpt('validate_subnet', default=True,
+               help=_('Allow for members and VIPs to exist in the same '
+                      ' subnet (for use with kube cloud provider)')),
 ]
 
 A10_VTHUNDER_OPTS = [

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -48,9 +48,10 @@ class MemberFlows(object):
 
         create_member_flow.add(database_tasks.MarkMemberPendingCreateInDB(
             requires=constants.MEMBER))
-        create_member_flow.add(a10_network_tasks.ValidateSubnet(
-            name='validate-subnet',
-            requires=constants.MEMBER))
+        if CONF.a10_global.validate_subnet:
+            create_member_flow.add(a10_network_tasks.ValidateSubnet(
+                name='validate-subnet',
+                requires=constants.MEMBER))
         create_member_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
@@ -612,9 +613,10 @@ class MemberFlows(object):
 
         update_member_flow.add(database_tasks.MarkMemberPendingUpdateInDB(
             requires=constants.MEMBER))
-        update_member_flow.add(a10_network_tasks.ValidateSubnet(
-            name='validate-subnet',
-            requires=constants.MEMBER))
+        if CONF.a10_global.validate_subnet:
+            update_member_flow.add(a10_network_tasks.ValidateSubnet(
+                name='validate-subnet',
+                requires=constants.MEMBER))
         update_member_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
@@ -676,9 +678,10 @@ class MemberFlows(object):
                       constants.POOL]))
         update_member_flow.add(database_tasks.MarkMemberPendingUpdateInDB(
             requires=constants.MEMBER))
-        update_member_flow.add(a10_network_tasks.ValidateSubnet(
-            name='validate-subnet',
-            requires=constants.MEMBER))
+        if CONF.a10_global.validate_subnet:
+            update_member_flow.add(a10_network_tasks.ValidateSubnet(
+                name='validate-subnet',
+                requires=constants.MEMBER))
         update_member_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
@@ -736,9 +739,10 @@ class MemberFlows(object):
                       constants.POOL]))
         create_member_flow.add(database_tasks.MarkMemberPendingCreateInDB(
             requires=constants.MEMBER))
-        create_member_flow.add(a10_network_tasks.ValidateSubnet(
-            name='validate-subnet',
-            requires=constants.MEMBER))
+        if CONF.a10_global.validate_subnet:
+            create_member_flow.add(a10_network_tasks.ValidateSubnet(
+                name='validate-subnet',
+                requires=constants.MEMBER))
         create_member_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
@@ -903,9 +907,10 @@ class MemberFlows(object):
             batch_update_members_flow.add(database_tasks.MarkMemberPendingCreateInDB(
                 name='mark-member-pending-create-in-db-' + m.id,
                 inject={constants.MEMBER: m}))
-            batch_update_members_flow.add(a10_network_tasks.ValidateSubnet(
-                name='validate-subnet' + m.id,
-                inject={constants.MEMBER: m}))
+            if CONF.a10_global.validate_subnet:
+                batch_update_members_flow.add(a10_network_tasks.ValidateSubnet(
+                    name='validate-subnet' + m.id,
+                    inject={constants.MEMBER: m}))
             batch_update_members_flow.add(a10_database_tasks.CountMembersWithIP(
                 name='count-member-with-ip-' + m.id,
                 inject={constants.MEMBER: m},
@@ -933,9 +938,10 @@ class MemberFlows(object):
             batch_update_members_flow.add(database_tasks.MarkMemberPendingUpdateInDB(
                 inject={constants.MEMBER: m},
                 name='mark-member-pending-update-in-db-' + m.id))
-            batch_update_members_flow.add(a10_network_tasks.ValidateSubnet(
-                name='validate-subnet' + m.id,
-                inject={constants.MEMBER: m}))
+            if CONF.a10_global.validate_subnet:
+                batch_update_members_flow.add(a10_network_tasks.ValidateSubnet(
+                    name='validate-subnet' + m.id,
+                    inject={constants.MEMBER: m}))
             batch_update_members_flow.add(server_tasks.MemberUpdate(
                 name='member-update-' + m.id,
                 inject={constants.MEMBER: m},
@@ -1085,9 +1091,10 @@ class MemberFlows(object):
             batch_update_members_flow.add(database_tasks.MarkMemberPendingCreateInDB(
                 name='mark-member-pending-create-in-DB' + m.id,
                 inject={constants.MEMBER: m}))
-            batch_update_members_flow.add(a10_network_tasks.ValidateSubnet(
-                name='validate-subnet' + m.id,
-                inject={constants.MEMBER: m}))
+            if CONF.a10_global.validate_subnet:
+                batch_update_members_flow.add(a10_network_tasks.ValidateSubnet(
+                    name='validate-subnet' + m.id,
+                    inject={constants.MEMBER: m}))
             batch_update_members_flow.add(a10_database_tasks.CountMembersWithIP(
                 name='count-members-with-ip' + m.id,
                 inject={constants.MEMBER: m},
@@ -1117,9 +1124,10 @@ class MemberFlows(object):
             batch_update_members_flow.add(database_tasks.MarkMemberPendingUpdateInDB(
                 inject={constants.MEMBER: m},
                 name='mark-member-pending-update-in-db-' + m.id))
-            batch_update_members_flow.add(a10_network_tasks.ValidateSubnet(
-                name='validate-subnet' + m.id,
-                inject={constants.MEMBER: m}))
+            if CONF.a10_global.validate_subnet:
+                batch_update_members_flow.add(a10_network_tasks.ValidateSubnet(
+                    name='validate-subnet' + m.id,
+                    inject={constants.MEMBER: m}))
             batch_update_members_flow.add(a10_network_tasks.GetLBResourceSubnet(
                 name='{flow}-{id}'.format(
                     id=m.id, flow=a10constants.GET_LB_RESOURCE_SUBNET),


### PR DESCRIPTION
## Description
This config option allows for an A10 Octavia operator to disable the validate subnet functionality.  This is useful in cases where developers may be using kubernetes with the legacy Openstack provider they're not able to specify a different subnet for the load balancer object and member servers. Example code: 
https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_loadbalancer.go#L448

## Technical Approach
- A boolean config option was added to allow operators to skip the validate subnet check when adding members. 

## Config Changes

<pre>
<b>    
        cfg.BoolOpt('validate_subnet', default=True,
               help=_('Allow for members and VIPs to exist in the same '
                      ' subnet (for use with kube cloud provider)')),
</b>
</pre>

