### PR TITLE
[STACK-3242] Fix a10-octavia failed with IPv6 subnet in network

### DIFF
--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -307,3 +307,9 @@ class DuplicateMembersInBatchUpdate(base.NetworkException):
         msg = ('Duplicate member definition have been found during the batch update. '
                'Please check WARNING log messages for more details.')
         super(DuplicateMembersInBatchUpdate, self).__init__(msg)
+
+
+class IpVersionNotSupport(base.NetworkException):
+    def __init__(self, version):
+        msg = ('Unsupported IP Version {0}').format(version)
+        super(IpVersionNotSupport, self).__init__(msg)


### PR DESCRIPTION
## Description

If Bug Fix:
- Required: Severity Level Critical
- Required: Issue Description
In hardware thunder flow, a10-octavia create loadbalancer failed if the vlan network configure an IPv6 Subnet (and this subnet is the first one i.e.  network.subnets[0]).

## Jira Ticket
- Required: Add links to tickets closed here](https://a10networks.atlassian.net/browse/STACK-3242)

## Technical Approach
- a10-octavia didn't support IPv6 for now. So, when select subnet for specified vlan_id only select the IPv6 subnet.


## Config Changes

<pre>
<b>[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"

[a10_controller_worker]
amp_image_owner_id = ecc2542be2644881b049636b719ca536
amp_secgroup_list = 5a83254b-7a99-4684-a4e5-94ed75d505c9
amp_image_tag = "vthunder_5_2_1-p2"
amp_flavor_id = ba761d2f-a08c-42eb-a53e-e3a0fa646590
amp_boot_network_list = 9558e757-f279-4120-9e61-540a91be9c10, f7c66e14-6eb1-456b-a677-65ce525d175e, 338ab9a6-520e-4804-8225-dc17c4db442d
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 150
amp_active_wait_sec = 10
amp_busy_wait_sec = 0
loadbalancer_topology = SINGLE

[a10_health_manager]
udp_server_ip_address = 192.168.0.164
bind_port = 5550
bind_ip = 192.168.0.164

# ACOS slb server health monitor parameters
heartbeat_interval = 20
health_check_timeout = 3
health_check_max_retries = 5

# a10-octavia failover parameters
heartbeat_key = insecure
#  failover after heartbeat missing heartbeat_timeout seconds
heartbeat_timeout = 30
#  vthunder is build but no heartbeat after failover_timeout seconds -> failover
failover_timeout = 600
health_check_interval = 10

stats_update_disable = True

[a10_house_keeping]
load_balancer_expiry_age = 3600
amphorae_expiry_age = 3600

[a10_global]
network_type = "vlan"
[hardware_thunder]
devices = [
                    {
                     "project_id": "ecc2542be2644881b049636b719ca536",
                     "ip_address": "10.64.26.105",
                     "username": "admin",
                     "password": "a10",
                     "device_name": "dev2",
                     "interface_vlan_map": {
                        "device_1": {
                          "vcs_device_id"      : 1,
                          "mgmt_ip_address"    : "10.64.26.105",
                          "ethernet_interfaces": [
                              {
                                  "interface_num": 1,
                                  "vlan_map"     : [
                                      {
                                          "vlan_id": 621,
                                          "ve_ip"  : ".4"
                                      }
                                  ]
                              }
                          ]
                        }
                     }
                    },
                    {
                     "ip_address": "192.168.90.45",
                     "username": "admin",
                     "password": "a10",
                     "device_name": "dev1"
                    }
             ]


</b>
</pre>

## Test Cases
1. create loadbalancer with vlan network has ipv6 subnet (as the first entry)

## Manual Testing

 - create vip successfully

```
stack@ytsai-victoria:~/source/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+------------------+----------+
| 8ac4800f-556d-494d-9ff0-642c93c8c633 | vip1 | ecc2542be2644881b049636b719ca536 | 192.168.90.35 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+------------------+----------+
```


```
slb virtual-server 8ac4800f-556d-494d-9ff0-642c93c8c633 192.168.90.35
!

```