### PR TITLE
Add use_override_port option

### DIFF
--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -141,6 +141,9 @@ A10_SLB_OPTS = [
 A10_HEALTH_MONITOR_OPTS = [
     cfg.StrOpt('post_data',
                help=_('HTTP Content for "--http-method POST" case.')),
+    cfg.BoolOpt('use_override_port', default=True,
+                help=_('True causes the monitor to check members on the '
+                       'listener port.')),
 ]
 
 A10_LISTENER_OPTS = [

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -75,13 +75,18 @@ class CreateAndAssociateHealthMonitor(task.Task):
                           "A health monitor of type {} is not supported "
                           "by A10 provider").format(health_mon.id, health_mon.type))
 
+
+        port = None
+        if CONF.health_monitor.use_override_port:
+            if listeners:
+                port = listeners[0].protocol_port
         try:
             post_data = CONF.health_monitor.post_data
             self.axapi_client.slb.hm.create(health_mon.id,
                                             health_mon.type,
                                             health_mon.delay, health_mon.timeout,
                                             health_mon.rise_threshold, method=method,
-                                            port=listeners[0].protocol_port, url=url,
+                                            port=port, url=url,
                                             expect_code=expect_code, post_data=post_data,
                                             **args)
             LOG.debug("Successfully created health monitor: %s", health_mon.id)


### PR DESCRIPTION
use_override_port option, as the default behavior, will always set the override port to the port of the listener associated with a health monitor, if any. Setting this to false ensures that the health monitor will monitor the members on their configured ports unless an override port is configured via flavorprofile.