### PR TITLE
[STACK-3365] add default valuss for post_data option

### DIFF
--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -140,6 +140,7 @@ A10_SLB_OPTS = [
 
 A10_HEALTH_MONITOR_OPTS = [
     cfg.StrOpt('post_data',
+               default="0123456789",
                help=_('HTTP Content for "--http-method POST" case.')),
 ]
 


### PR DESCRIPTION
## Description

If Bug Fix:
Severity Level: Low,
Issue Description: 
The post_data option is required when POST health monitor is used. But we can add a default value to prevent user forget to provide the post_data.


## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3365

## Technical Approach
Provide a default value to prevent user forget to provide the post_data.

## Config Changes

<pre>
<b>N/A</b>
</pre>


## Test Cases
 - run the script below:
```
#!/bin/sh

set -e

subnet_id=$(openstack subnet show tp91 -c id -f value)

TOKEN=$(openstack token issue -f value -c id)
OCTAVIA_BASE_URL=$(openstack endpoint list --service load-balancer --interface public -c URL -f value)

cat <<EOF > tree.json
{
    "loadbalancer": {
        "name": "vip1",
        "vip_subnet_id": "$subnet_id",
        "provider": "a10",
        "listeners": [
            {
                "name": "vport1",
                "protocol": "TCP",
                "protocol_port": 80,
                "default_pool": {
                    "name": "pool1",
                    "protocol": "TCP",
                    "lb_algorithm": "ROUND_ROBIN",
                    "healthmonitor": {
                        "name": "hm1",
                        "type": "HTTP",
                        "delay": "3",
                        "max_retries": 2,
                        "timeout": 1,
                        "http_method": "GET",
                        "expected_codes": "200",
                        "url_path": "/ab/cd/ef"
                    }
                }
            },
            {
                "name": "vport2",
                "protocol": "HTTP",
                "protocol_port": 8047,
                "default_pool": {
                    "name": "pool2",
                    "protocol": "HTTP",
                    "lb_algorithm": "ROUND_ROBIN",
                    "healthmonitor": {
                        "name": "hm2",
                        "type": "HTTP",
                        "delay": "3",
                        "max_retries": 2,
                        "timeout": 1,
                        "http_method": "POST",
                        "expected_codes": "200",
                        "url_path" : "/ab/cd/ef"
                    }
                }
            },
            {
                "name": "vport3",
                "protocol": "HTTPS",
                "protocol_port": 82,
                "default_pool": {
                    "name": "pool3",
                    "protocol": "HTTPS",
                    "lb_algorithm": "ROUND_ROBIN",
                    "healthmonitor": {
                        "type": "HTTP",
                        "delay": "3",
                        "max_retries": 2,
                        "timeout": 1,
                        "http_method": "HEAD",
                        "expected_codes": "200",
                        "url_path" : "/ab/cd/ef"
                    }
                }
            }
        ]

    }
}
EOF

echo curl -X POST -H "Content-Type: application/json" -H "X-Auth-Token: $TOKEN" -d @tree.json ${OCTAVIA_BASE_URL}/v2.0/lbaas/loadbalancers
echo "........."
echo ""

curl -X POST \
    -H "Content-Type: application/json" \
    -H "X-Auth-Token: $TOKEN" \
    -d @tree.json \
    ${OCTAVIA_BASE_URL}/v2.0/lbaas/loadbalancers

echo ""

```

## Manual Testing

```
stack@ytsai-victoria:~/ytsai/scripts/fully-populated$ ./stack-3365.sh
curl -X POST -H Content-Type: application/json -H X-Auth-Token: gAAAAABi3gutlkL29lMD2VuOHjhDQYJA5pOkTatqRX61cM0_tY-bvMVok6BWIINPWzrJILKcfTUJEKVsniF1DhOa62jY60Zin7CatIUlA9LTiLYkrM4Jclf76rdVpUiZnUZbV3Qf7Eg_2KI_QDQg7uRVE8vlzFOVGamEr8jhVYMm4lL9KkgQZPQ -d @tree.json http://10.64.3.104/load-balancer/v2.0/lbaas/loadbalancers
.........

{"loadbalancer": {"listeners": [{"l7policies": [], "id": "5ae6aaeb-a3cc-41b1-8dee-de4abda93f6e", "name": "vport2", "description": "", "provisioning_status": "PENDING_CREATE", "operating_status": "OFFLINE", "admin_state_up": true, "protocol": "HTTP", "protocol_port": 8047, "connection_limit": -1, "default_tls_container_ref": null, "sni_container_refs": [], "project_id": "ecc2542be2644881b049636b719ca536", "default_pool_id": "9cdbcb9f-648c-4a71-b39a-46a6e1c92489", "insert_headers": {}, "created_at": "2022-07-25T03:19:12", "updated_at": "2022-07-25T03:19:12", "timeout_client_data": 50000, "timeout_member_connect": 5000, "timeout_member_data": 50000, "timeout_tcp_inspect": 0, "tags": [], "client_ca_tls_container_ref": null, "client_authentication": "NONE", "client_crl_container_ref": null, "allowed_cidrs": null, "tls_ciphers": null, "tls_versions": null, "alpn_protocols": null, "tenant_id": "ecc2542be2644881b049636b719ca536"}, {"l7policies": [], "id": "6dd0ed3b-4ce4-40fe-bc40-9e6bb383ea85", "name": "vport3", "description": "", "provisioning_status": "PENDING_CREATE", "operating_status": "OFFLINE", "admin_state_up": true, "protocol": "HTTPS", "protocol_port": 82, "connection_limit": -1, "default_tls_container_ref": null, "sni_container_refs": [], "project_id": "ecc2542be2644881b049636b719ca536", "default_pool_id": "5e8f89eb-9fea-4460-b6bd-d41a06e7b5b2", "insert_headers": {}, "created_at": "2022-07-25T03:19:12", "updated_at": "2022-07-25T03:19:12", "timeout_client_data": 50000, "timeout_member_connect": 5000, "timeout_member_data": 50000, "timeout_tcp_inspect": 0, "tags": [], "client_ca_tls_container_ref": null, "client_authentication": "NONE", "client_crl_container_ref": null, "allowed_cidrs": null, "tls_ciphers": null, "tls_versions": null, "alpn_protocols": null, "tenant_id": "ecc2542be2644881b049636b719ca536"}, {"l7policies": [], "id": "7c09f3b1-1606-459c-b822-6aa4be5c6cb4", "name": "vport1", "description": "", "provisioning_status": "PENDING_CREATE", "operating_status": "OFFLINE", "admin_state_up": true, "protocol": "TCP", "protocol_port": 80, "connection_limit": -1, "default_tls_container_ref": null, "sni_container_refs": [], "project_id": "ecc2542be2644881b049636b719ca536", "default_pool_id": "44e1bc7c-b16d-435d-b28d-1d6cf1404e00", "insert_headers": {}, "created_at": "2022-07-25T03:19:12", "updated_at": "2022-07-25T03:19:12", "timeout_client_data": 50000, "timeout_member_connect": 5000, "timeout_member_data": 50000, "timeout_tcp_inspect": 0, "tags": [], "client_ca_tls_container_ref": null, "client_authentication": "NONE", "client_crl_container_ref": null, "allowed_cidrs": null, "tls_ciphers": null, "tls_versions": null, "alpn_protocols": null, "tenant_id": "ecc2542be2644881b049636b719ca536"}], "pools": [{"members": [], "healthmonitor": null, "id": "44e1bc7c-b16d-435d-b28d-1d6cf1404e00", "name": "pool1", "description": "", "provisioning_status": "PENDING_CREATE", "operating_status": "OFFLINE", "admin_state_up": true, "protocol": "TCP", "lb_algorithm": "ROUND_ROBIN", "session_persistence": null, "project_id": "ecc2542be2644881b049636b719ca536", "listeners": [{"id": "7c09f3b1-1606-459c-b822-6aa4be5c6cb4"}], "created_at": "2022-07-25T03:19:12", "updated_at": null, "tags": [], "tls_container_ref": null, "ca_tls_container_ref": null, "crl_container_ref": null, "tls_enabled": false, "tls_ciphers": null, "tls_versions": null, "tenant_id": "ecc2542be2644881b049636b719ca536"}, {"members": [], "healthmonitor": null, "id": "5e8f89eb-9fea-4460-b6bd-d41a06e7b5b2", "name": "pool3", "description": "", "provisioning_status": "PENDING_CREATE", "operating_status": "OFFLINE", "admin_state_up": true, "protocol": "HTTPS", "lb_algorithm": "ROUND_ROBIN", "session_persistence": null, "project_id": "ecc2542be2644881b049636b719ca536", "listeners": [{"id": "6dd0ed3b-4ce4-40fe-bc40-9e6bb383ea85"}], "created_at": "2022-07-25T03:19:12", "updated_at": null, "tags": [], "tls_container_ref": null, "ca_tls_container_ref": null, "crl_container_ref": null, "tls_enabled": false, "tls_ciphers": null, "tls_versions": null, "tenant_id": "ecc2542be2644881b049636b719ca536"}, {"members": [], "healthmonitor": null, "id": "9cdbcb9f-648c-4a71-b39a-46a6e1c92489", "name": "pool2", "description": "", "provisioning_status": "PENDING_CREATE", "operating_status": "OFFLINE", "admin_state_up": true, "protocol": "HTTP", "lb_algorithm": "ROUND_ROBIN", "session_persistence": null, "project_id": "ecc2542be2644881b049636b719ca536", "listeners": [{"id": "5ae6aaeb-a3cc-41b1-8dee-de4abda93f6e"}], "created_at": "2022-07-25T03:19:12", "updated_at": null, "tags": [], "tls_container_ref": null, "ca_tls_container_ref": null, "crl_container_ref": null, "tls_enabled": false, "tls_ciphers": null, "tls_versions": null, "tenant_id": "ecc2542be2644881b049636b719ca536"}], "id": "331d66fe-6499-4e57-a2a1-315a9fa7dc2f", "name": "vip1", "description": "", "provisioning_status": "PENDING_CREATE", "operating_status": "OFFLINE", "admin_state_up": true, "project_id": "ecc2542be2644881b049636b719ca536", "created_at": "2022-07-25T03:19:11", "updated_at": null, "vip_address": "192.168.91.51", "vip_port_id": "00f2040b-8c56-46ff-9965-7cf0e90e0d25", "vip_subnet_id": "9f8ca3e8-6fe9-43c2-b22f-b4d8e59beb65", "vip_network_id": "f7c66e14-6eb1-456b-a677-65ce525d175e", "provider": "a10", "flavor_id": null, "vip_qos_policy_id": null, "tags": [], "availability_zone": null, "tenant_id": "ecc2542be2644881b049636b719ca536"}}
```

```
stack@ytsai-victoria:~/source/a10-octavia/STACK-3363/a10-octavia$ openstack loadbalancer pool list
+--------------------------------------+-------+----------------------------------+---------------------+----------+--------------+----------------+
| id                                   | name  | project_id                       | provisioning_status | protocol | lb_algorithm | admin_state_up |
+--------------------------------------+-------+----------------------------------+---------------------+----------+--------------+----------------+
| 44e1bc7c-b16d-435d-b28d-1d6cf1404e00 | pool1 | ecc2542be2644881b049636b719ca536 | ACTIVE              | TCP      | ROUND_ROBIN  | True           |
| 5e8f89eb-9fea-4460-b6bd-d41a06e7b5b2 | pool3 | ecc2542be2644881b049636b719ca536 | ACTIVE              | HTTPS    | ROUND_ROBIN  | True           |
| 9cdbcb9f-648c-4a71-b39a-46a6e1c92489 | pool2 | ecc2542be2644881b049636b719ca536 | ACTIVE              | HTTP     | ROUND_ROBIN  | True           |
+--------------------------------------+-------+----------------------------------+---------------------+----------+--------------+----------------+
```

```
health monitor 5ce4f97d-8e89-468a-8c94-f8657af96249
  retry 2
  interval 3 timeout 1
  method http port 80 expect response-code 200 url GET /ab/cd/ef
!
health monitor 85f714b8-72ff-4526-8804-f982e1395392
  retry 2
  interval 3 timeout 1
  method http port 80 expect response-code 200 url HEAD /ab/cd/ef
!
health monitor 33f5e66c-c808-4589-bd4e-d5815dfa48ce
  retry 2
  interval 3 timeout 1
  method http port 80 expect response-code 200 url POST /ab/cd/ef postdata 0123456789
!
slb service-group 44e1bc7c-b16d-435d-b28d-1d6cf1404e00 tcp
!
slb service-group 5e8f89eb-9fea-4460-b6bd-d41a06e7b5b2 tcp
!
slb service-group 9cdbcb9f-648c-4a71-b39a-46a6e1c92489 tcp
!
slb virtual-server 331d66fe-6499-4e57-a2a1-315a9fa7dc2f 192.168.91.51
  port 80 tcp
    name 7c09f3b1-1606-459c-b822-6aa4be5c6cb4
    extended-stats
    source-nat auto
    service-group 44e1bc7c-b16d-435d-b28d-1d6cf1404e00
  port 82 tcp
    name 6dd0ed3b-4ce4-40fe-bc40-9e6bb383ea85
    extended-stats
    source-nat auto
    service-group 5e8f89eb-9fea-4460-b6bd-d41a06e7b5b2
  port 8047 http
    name 5ae6aaeb-a3cc-41b1-8dee-de4abda93f6e
    extended-stats
    source-nat auto
    service-group 9cdbcb9f-648c-4a71-b39a-46a6e1c92489
!
```
