### PR TITLE
[STACK-3372] Fix cascade delete failed with multiple listeners

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_listener_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_listener_flows.py
@@ -183,7 +183,7 @@ class ListenerFlows(object):
             requires=a10constants.VTHUNDER))
         return delete_listener_flow
 
-    def get_cascade_delete_listener_internal_flow(self, listener, listener_name, compute_flag):
+    def get_cascade_delete_listener_internal_flow(self, listener, listener_name):
         """Create a flow to delete a listener
            (will skip deletion on the amp and marking LB active)
         :returns: The flow for deleting a listener
@@ -191,10 +191,6 @@ class ListenerFlows(object):
         delete_listener_flow = linear_flow.Flow(constants.DELETE_LISTENER_FLOW)
         delete_listener_flow.add(self.handle_ssl_cert_flow(
             flow_type='delete', listener=listener))
-        if compute_flag:
-            delete_listener_flow.add(network_tasks.UpdateVIPForDelete(
-                name='delete_update_vip_' + listener_name,
-                requires=constants.LOADBALANCER))
         delete_listener_flow.add(database_tasks.DeleteListenerInDB(
             name='delete_listener_in_db_' + listener_name,
             requires=constants.LISTENER,

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -1002,6 +1002,9 @@ class LoadBalancerFlows(object):
         # move UpdateVIPForDelete() out from unordered_flow loop, call it multiple time at the
         # same time will add/del same rules at the same time and causing error from neutron.
         if lb.amphorae:
+            pools_listeners_delete_flow.add(a10_database_tasks.GetLatestLoadBalancer(
+                requires=constants.LOADBALANCER,
+                provides=constants.LOADBALANCER))
             pools_listeners_delete_flow.add(network_tasks.UpdateVIPForDelete(
                 requires=constants.LOADBALANCER))
 

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -1065,6 +1065,17 @@ class GetLoadBalancerListForDeletion(BaseDatabaseTask):
                           'due to: {}'.format(str(e)))
 
 
+class GetLatestLoadBalancer(BaseDatabaseTask):
+
+    def execute(self, loadbalancer):
+        try:
+            lb = self.loadbalancer_repo.get(db_apis.get_session(), id=loadbalancer.id)
+            return lb
+        except Exception as e:
+            LOG.exception("Failed to get latest loadbalancer: %s", str(e))
+            return loadbalancer
+
+
 class CheckExistingVthunderTopology(BaseDatabaseTask):
     """This task only meant to use with vthunder flow[amphora]"""
 

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -532,7 +532,10 @@ class UpdateVIPForDelete(BaseNetworkTask):
         LOG.debug("Updating VIP for listener delete on load_balancer %s.",
                   loadbalancer.id)
 
-        self.network_driver.update_vip(loadbalancer, for_delete=True)
+        try:
+            self.network_driver.update_vip(loadbalancer, for_delete=True)
+        except Exception as e:
+            LOG.error("Failed to update vip error: %s", str(e))
 
 
 class GetAmphoraNetworkConfigs(BaseNetworkTask):

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -97,6 +97,22 @@ class CreateAndAssociateHealthMonitor(task.Task):
             LOG.exception("Failed to create health monitor: %s", health_mon.id)
             raise e
 
+        if health_mon.pool is not None and health_mon.pool.members is not None:
+            for member in health_mon.pool.members:
+                try:
+                    server_name = utils.get_member_server_name(self.axapi_client, member,
+                                                               raise_not_found=False)
+                    if self.axapi_client.slb.server.exists(server_name):
+                        self.axapi_client.slb.server.update(server_name, member.ip_address,
+                                                            health_check=health_mon.id)
+                        LOG.debug("Successfully associated health monitor %s to member %s",
+                                  health_mon.id, member.id)
+                except (acos_errors.ACOSException, ConnectionError) as e:
+                    LOG.exception(
+                        "Failed to associate health monitor %s to member %s",
+                        health_mon.id, member.id)
+                    raise e
+
     @axapi_client_decorator_for_revert
     def revert(self, listeners, health_mon, vthunder, *args, **kwargs):
         try:

--- a/a10_octavia/controller/worker/tasks/utils.py
+++ b/a10_octavia/controller/worker/tasks/utils.py
@@ -18,11 +18,14 @@ import re
 
 from oslo_config import cfg
 
+import acos_client.errors as acos_errors
+
 from octavia.common import constants
 from octavia_lib.common import constants as lib_consts
 
 from a10_octavia.common import a10constants
 from a10_octavia.common.data_models import Certificate
+from a10_octavia.common import utils as a10_utils
 
 
 CONF = cfg.CONF
@@ -178,3 +181,35 @@ def attribute_search(lb_resource, attr_name):
     elif hasattr(lb_resource, 'load_balancer'):
         return attribute_search(lb_resource.load_balancer, attr_name)
     return None
+
+
+def get_member_server_name(axapi_client, member, raise_not_found=True):
+    default_name = '{}_{}'.format(member.project_id[:5], member.ip_address.replace('.', '_'))
+    server_name = default_name
+    try:
+        server_name = axapi_client.slb.server.get(server_name)
+    except (acos_errors.NotFound):
+        # Backwards compatability with a10-neutron-lbaas
+        if CONF.a10_global.use_parent_partition:
+            try:
+                parent_project_id = a10_utils.get_parent_project(member.project_id)
+                server_name = '_{}_{}_neutron'.format(parent_project_id[:5],
+                                                      member.ip_address.replace('.', '_'))
+                server_name = axapi_client.slb.server.get(server_name)
+            except (acos_errors.NotFound):
+                server_name = '_{}_{}_neutron'.format(member.project_id[:5],
+                                                      member.ip_address.replace('.', '_'))
+                try:
+                    server_name = axapi_client.slb.server.get(server_name)
+                except (acos_errors.NotFound) as e:
+                    if raise_not_found:
+                        raise e
+                    return default_name
+        else:
+            try:
+                server_name = axapi_client.slb.server.get('_{}_{}'.format(server_name, 'neutron'))
+            except (acos_errors.NotFound) as e:
+                if raise_not_found:
+                    raise e
+                return default_name
+    return server_name['server']['name']

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_health_monitor_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_health_monitor_tasks.py
@@ -62,6 +62,8 @@ FLAVOR_WITH_REGEX_ARGS = {
     }
 }
 
+DEF_POST_DATA = '0123456789'
+
 
 class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
 
@@ -86,7 +88,7 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
                                                           mock_hm.delay, mock_hm.timeout,
                                                           mock_hm.rise_threshold, method=None,
                                                           port=mock.ANY, url=None,
-                                                          expect_code=None, post_data=None,
+                                                          expect_code=None, post_data=DEF_POST_DATA,
                                                           **ARGS)
         self.conf.config(group=a10constants.HEALTH_MONITOR_SECTION,
                          post_data='abc=1')
@@ -121,7 +123,8 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
                                                           self.client_mock.slb.hm.TCP,
                                                           mock_hm.delay, mock_hm.timeout,
                                                           mock_hm.rise_threshold, method=None,
-                                                          port=mock.ANY, url=None, post_data=None,
+                                                          port=mock.ANY, url=None,
+                                                          post_data=DEF_POST_DATA,
                                                           expect_code=None, **FLAVOR_ARGS)
 
     def test_health_monitor_create_with_flavor_and_config(self):
@@ -185,7 +188,8 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
                                                           mock_hm.delay, mock_hm.timeout,
                                                           mock_hm.rise_threshold, method=None,
                                                           port=mock.ANY, url=None,
-                                                          expect_code=None, post_data=None,
+                                                          expect_code=None,
+                                                          post_data=DEF_POST_DATA,
                                                           **FLAVOR_WITH_REGEX_ARGS)
 
     def test_health_monitor_create_with_regex_overwrite_flavor_task(self):
@@ -224,7 +228,7 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
                                                           mock_hm.delay, mock_hm.timeout,
                                                           mock_hm.rise_threshold, method=None,
                                                           port=mock.ANY, url=None,
-                                                          expect_code=None, post_data=None,
+                                                          expect_code=None, post_data=DEF_POST_DATA,
                                                           **FLAVOR_WITH_REGEX_ARGS)
 
     def test_get_hm_name(self):
@@ -268,7 +272,7 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
                                                           mock_hm.delay, mock_hm.timeout,
                                                           mock_hm.rise_threshold, method=None,
                                                           port=mock.ANY, url=None,
-                                                          expect_code=None, post_data=None,
+                                                          expect_code=None, post_data=DEF_POST_DATA,
                                                           **ARGS)
         self.conf.config(group=a10constants.HEALTH_MONITOR_SECTION,
                          post_data='abc=1')
@@ -334,7 +338,8 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
                                                           self.client_mock.slb.hm.TCP,
                                                           mock_hm.delay, mock_hm.timeout,
                                                           mock_hm.rise_threshold, method=None,
-                                                          port=mock.ANY, url=None, post_data=None,
+                                                          port=mock.ANY, url=None,
+                                                          post_data=DEF_POST_DATA,
                                                           expect_code=None, **FLAVOR_ARGS)
 
     @mock.patch('a10_octavia.controller.worker.tasks.health_monitor_tasks._get_hm_name')
@@ -375,7 +380,7 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
                                                           mock_hm.delay, mock_hm.timeout,
                                                           mock_hm.rise_threshold, method=None,
                                                           port=mock.ANY, url=None,
-                                                          expect_code=None, post_data=None,
+                                                          expect_code=None, post_data=DEF_POST_DATA,
                                                           **FLAVOR_WITH_REGEX_ARGS)
 
     @mock.patch('a10_octavia.controller.worker.tasks.health_monitor_tasks._get_hm_name')
@@ -417,7 +422,7 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
                                                           mock_hm.delay, mock_hm.timeout,
                                                           mock_hm.rise_threshold, method=None,
                                                           port=mock.ANY, url=None,
-                                                          expect_code=None, post_data=None,
+                                                          expect_code=None, post_data=DEF_POST_DATA,
                                                           **FLAVOR_WITH_REGEX_ARGS)
 
     @mock.patch('a10_octavia.controller.worker.tasks.health_monitor_tasks._get_hm_name')

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_server_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_server_tasks.py
@@ -73,7 +73,7 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
         member_task.CONF = self.conf
         return member_task
 
-    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.get_member_server_name')
     def test_MemberCreate_execute_create_with_server_template(self, mock_server_name):
         mock_server_name.side_effect = acos_errors.NotFound()
         member_port_count_ip = 1
@@ -83,7 +83,7 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
         self.assertIn('template-server', kwargs['server_templates'])
         self.assertEqual(kwargs['server_templates']['template-server'], 'my_server_template')
 
-    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.get_member_server_name')
     def test_MemberCreate_execute_create_with_shared_template_log_warning(self, mock_server_name):
         mock_server_name.side_effect = acos_errors.NotFound()
         member_port_count_ip = 1
@@ -98,7 +98,7 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
             member_task.execute(MEMBER, VTHUNDER, POOL, member_port_count_ip)
             self.assertEqual(expected_log, cm.output)
 
-    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.get_member_server_name')
     def test_MemberCreate_execute_create_with_flavor(self, mock_server_name):
         mock_server_name.side_effect = acos_errors.NotFound()
         mock_create_member = task.MemberCreate()
@@ -113,7 +113,7 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
             SERVER_NAME, MEMBER.ip_address, status=mock.ANY,
             health_check=mock.ANY, server_templates=mock.ANY, **expect_key_args)
 
-    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.get_member_server_name')
     def test_MemberCreate_execute_create_with_regex_overwrite_flavor(self, mock_server_name):
         mock_server_name.side_effect = acos_errors.NotFound()
         mock_create_member = task.MemberCreate()
@@ -134,7 +134,7 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
             SERVER_NAME, member_obj.ip_address, status=mock.ANY,
             health_check=mock.ANY, server_templates=mock.ANY, **expect_key_args)
 
-    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.get_member_server_name')
     def test_MemberCreate_execute_create_with_regex_flavor(self, mock_server_name):
         mock_server_name.side_effect = acos_errors.NotFound()
         mock_create_member = task.MemberCreate()
@@ -155,7 +155,7 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
             SERVER_NAME, member_obj.ip_address, status=mock.ANY,
             health_check=mock.ANY, server_templates=mock.ANY, **expect_key_args)
 
-    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.get_member_server_name')
     def test_MemberCreate_execute_create_flavor_override_config(self, mock_server_name):
         mock_server_name.side_effect = acos_errors.NotFound()
         self.conf.config(group=a10constants.SERVER_CONF_SECTION, conn_resume=300)
@@ -180,7 +180,7 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
         self.client_mock.slb.server.delete.assert_called_with(
             SERVER_NAME)
 
-    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.get_member_server_name')
     def test_create_member_task(self, mock_server_name):
         mock_server_name.side_effect = acos_errors.NotFound()
         mock_create_member = task.MemberCreate()
@@ -202,7 +202,7 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
         mock_member.revert(MEMBER, VTHUNDER, POOL, member_port_count_ip)
         self.client_mock.slb.server.delete.assert_not_called()
 
-    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.get_member_server_name')
     def test_create_member_task_multi_port(self, mock_server_name):
         mock_server_name.return_value = SERVER_NAME
         mock_create_member = task.MemberCreate()
@@ -217,7 +217,7 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
         self.client_mock.slb.service_group.member.create.assert_called_with(
             POOL.id, SERVER_NAME, MEMBER.protocol_port)
 
-    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.get_member_server_name')
     def test_delete_member_task_single_no_port(self, mock_server_name):
         mock_server_name.return_value = SERVER_NAME
         mock_delete_member = task.MemberDelete()
@@ -227,7 +227,7 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
             POOL.id, SERVER_NAME, MEMBER.protocol_port)
         self.client_mock.slb.server.delete.assert_called_with(SERVER_NAME)
 
-    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.get_member_server_name')
     def test_delete_member_task_multi_port(self, mock_server_name):
         mock_server_name.return_value = SERVER_NAME
         member_port_count_ip = 2
@@ -250,7 +250,7 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
             }
         }
         self.client_mock.slb.server.get.return_value = server_name
-        server_name = task._get_server_name(self.client_mock, MEMBER)
+        server_name = utils.get_member_server_name(self.client_mock, MEMBER)
         self.assertEqual(SERVER_NAME, server_name)
 
     def test_get_server_name_backwards_compat(self):
@@ -260,13 +260,13 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
             }
         }
         self.client_mock.slb.server.get.return_value = server_name
-        server_name = task._get_server_name(self.client_mock, MEMBER)
+        server_name = utils.get_member_server_name(self.client_mock, MEMBER)
         self.assertEqual('_{}_neutron'.format(SERVER_NAME), server_name)
 
     def test_get_server_name_raise_notfound(self):
         self.client_mock.slb.server.get.side_effect = acos_errors.NotFound
 
         expected_error = acos_errors.NotFound
-        module_func = task._get_server_name
+        module_func = utils.get_member_server_name
         func_args = [self.client_mock, MEMBER]
         self.assertRaises(expected_error, module_func, *func_args)


### PR DESCRIPTION
## Description
- Severity Level: High
- Description:
vthunder flow cascade deletion failed for octavia failed to update security group rule at:
https://github.com/openstack/octavia/blob/stable/victoria/octavia/network/drivers/neutron/allowed_address_pairs.py#L219

- Root Cause:
  - In _get_cascade_delete_pools_listeners_flow(), listeners_delete_flow is an unordered flow so multiple listener are deleting and calling UpdateVIPForDelete() at the same time.
  - But the loadbalancer (and loadbalancer.listener) parameter didn't updated and sync with database. So, it always generate the same add/del rules. And neutron return failed for rule already existed.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3372

## Technical Approach
1. update loadbalancer before calling UpdateVIPForDelete()
2. we only need  to call UpdateVIPforDelete() to update security group rules, no need to do it every time in the loop. Move it out from the loop for performance.

## Config Changes

<pre>
<b>#!/bin/sh
set -e
subnet_id=$(openstack subnet show tp91 -c id -f value)
#container_ref = $(openstack secret container list | awk /'\ mytls1 / {print $2}\')
container_ref=$(openstack secret container list -c 'Container href' -f value)
echo "container reference $container_ref"
TOKEN=$(openstack token issue -f value -c id)
OCTAVIA_BASE_URL=$(openstack endpoint list --service load-balancer --interface public -c URL -f value)
cat <<EOF > all_pools_session_per.json
{
    "loadbalancer": {
        "name": "lb1",
        "vip_subnet_id": "$subnet_id",
        "provider": "a10",
        "listeners": [
            {
                "name": "vport1",
                "protocol": "TCP",
                "connection_limit": "600",
                "protocol_port": 80,
                "default_pool": {
                    "name": "pool1",
                    "protocol": "TCP",
                    "lb_algorithm": "ROUND_ROBIN",
                    "session_persistence": {
                        "type": "SOURCE_IP"
                    }
                }
            },
            {
                "name": "vport2",
                "protocol": "UDP",
                "connection_limit": "600",
                "protocol_port": 81,
                "default_pool": {
                    "name": "pool2",
                    "protocol": "UDP",
                    "lb_algorithm": "SOURCE_IP_PORT",
                    "session_persistence": {
                        "type": "SOURCE_IP"
                    }
                }
            },
            {
                "name": "vport3",
                "protocol": "HTTP",
                "connection_limit": "600",
                "protocol_port": 82,
                "default_pool": {
                    "name": "pool3",
                    "protocol": "HTTP",
                    "lb_algorithm": "LEAST_CONNECTIONS",
                    "session_persistence": {
                        "type": "APP_COOKIE",
                        "cookie_name": "cookie1"
                    }
                }
            },
            {
                "name": "vport5",
                "protocol": "TERMINATED_HTTPS",
                "default_tls_container_ref": "$container_ref",
                "connection_limit": "600",
                "protocol_port": 83,
                "default_pool": {
                    "name": "pool5",
                    "protocol": "HTTP",
                    "lb_algorithm": "ROUND_ROBIN",
                    "session_persistence": {
                        "type": "HTTP_COOKIE"
                    }
                }
            }
        ]
    }
}
EOF
echo curl -X POST -H "Content-Type: application/json" -H "X-Auth-Token: $TOKEN" -d @all_pools_session_per.json ${OCTAVIA_BASE_URL}/v2.0/lbaas/loadbalancers
echo "........."
echo ""
curl -v -X POST -H "Content-Type: application/json" -H "X-Auth-Token: $TOKEN" -d @all_pools_session_per.json ${OCTAVIA_BASE_URL}/v2.0/lbaas/loadbalancers</b>
</pre>


## Test Cases
1. run the script as the ticket and cascade delete the loadbalancer

## Manual Testing
log:
```
stack@ytsai-victoria:~/source/a10-octavia/latest/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+----------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address    | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+----------------+---------------------+------------------+----------+
| 07b0e3ad-b345-4ef7-ac76-eb3be5932df5 | lb1  | ecc2542be2644881b049636b719ca536 | 192.168.91.182 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+----------------+---------------------+------------------+----------+
stack@ytsai-victoria:~/source/a10-octavia/latest/a10-octavia$ openstack loadbalancer delete lb1 --cascade
stack@ytsai-victoria:~/source/a10-octavia/latest/a10-octavia$ openstack server list

stack@ytsai-victoria:~/source/a10-octavia/latest/a10-octavia$ 
```
