### PR TITLE
[STACK-3375] Fix health monitor missing when HM configured after member

### DIFF
--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -100,11 +100,13 @@ class CreateAndAssociateHealthMonitor(task.Task):
         if health_mon.pool is not None and health_mon.pool.members is not None:
             for member in health_mon.pool.members:
                 try:
-                    server_name = utils.get_member_server_name(self.axapi_client, member)
-                    self.axapi_client.slb.server.update(server_name, member.ip_address,
-                                                        health_check=health_mon.id)
-                    LOG.debug("Successfully associated health monitor %s to member %s",
-                              health_mon.id, member.id)
+                    server_name = utils.get_member_server_name(self.axapi_client, member,
+                                                               rasie_not_found=False)
+                    if self.axapi_client.slb.server.exists(server_name):
+                        self.axapi_client.slb.server.update(server_name, member.ip_address,
+                                                            health_check=health_mon.id)
+                        LOG.debug("Successfully associated health monitor %s to member %s",
+                                  health_mon.id, member.id)
                 except (acos_errors.ACOSException, ConnectionError) as e:
                     LOG.exception(
                         "Failed to associate health monitor %s to member %s",

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -97,6 +97,19 @@ class CreateAndAssociateHealthMonitor(task.Task):
             LOG.exception("Failed to create health monitor: %s", health_mon.id)
             raise e
 
+        for member in health_mon.pool.members:
+            try:
+                server_name = utils.get_member_server_name(self.axapi_client, member)
+                self.axapi_client.slb.server.update(server_name, member.ip_address,
+                                                    health_check=health_mon.id)
+                LOG.debug("Successfully associated health monitor %s to member %s",
+                          health_mon.id, member.id)
+            except (acos_errors.ACOSException, ConnectionError) as e:
+                LOG.exception(
+                    "Failed to associate health monitor %s to member %s",
+                    health_mon.id, member.id)
+                raise e
+
     @axapi_client_decorator_for_revert
     def revert(self, listeners, health_mon, vthunder, *args, **kwargs):
         try:

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -101,7 +101,7 @@ class CreateAndAssociateHealthMonitor(task.Task):
             for member in health_mon.pool.members:
                 try:
                     server_name = utils.get_member_server_name(self.axapi_client, member,
-                                                               rasie_not_found=False)
+                                                               raise_not_found=False)
                     if self.axapi_client.slb.server.exists(server_name):
                         self.axapi_client.slb.server.update(server_name, member.ip_address,
                                                             health_check=health_mon.id)

--- a/a10_octavia/controller/worker/tasks/utils.py
+++ b/a10_octavia/controller/worker/tasks/utils.py
@@ -183,8 +183,9 @@ def attribute_search(lb_resource, attr_name):
     return None
 
 
-def get_member_server_name(axapi_client, member):
-    server_name = '{}_{}'.format(member.project_id[:5], member.ip_address.replace('.', '_'))
+def get_member_server_name(axapi_client, member, rasie_not_found=True):
+    default_name = '{}_{}'.format(member.project_id[:5], member.ip_address.replace('.', '_'))
+    server_name = default_name
     try:
         server_name = axapi_client.slb.server.get(server_name)
     except (acos_errors.NotFound):
@@ -198,7 +199,17 @@ def get_member_server_name(axapi_client, member):
             except (acos_errors.NotFound):
                 server_name = '_{}_{}_neutron'.format(member.project_id[:5],
                                                       member.ip_address.replace('.', '_'))
-                server_name = axapi_client.slb.server.get(server_name)
+                try:
+                    server_name = axapi_client.slb.server.get(server_name)
+                except (acos_errors.NotFound) as e:
+                    if rasie_not_found:
+                        raise e
+                    return default_name
         else:
-            server_name = axapi_client.slb.server.get('_{}_{}'.format(server_name, 'neutron'))
+            try:
+                server_name = axapi_client.slb.server.get('_{}_{}'.format(server_name, 'neutron'))
+            except (acos_errors.NotFound) as e:
+                if rasie_not_found:
+                    raise e
+                return default_name
     return server_name['server']['name']

--- a/a10_octavia/controller/worker/tasks/utils.py
+++ b/a10_octavia/controller/worker/tasks/utils.py
@@ -183,7 +183,7 @@ def attribute_search(lb_resource, attr_name):
     return None
 
 
-def get_member_server_name(axapi_client, member, rasie_not_found=True):
+def get_member_server_name(axapi_client, member, raise_not_found=True):
     default_name = '{}_{}'.format(member.project_id[:5], member.ip_address.replace('.', '_'))
     server_name = default_name
     try:
@@ -202,14 +202,14 @@ def get_member_server_name(axapi_client, member, rasie_not_found=True):
                 try:
                     server_name = axapi_client.slb.server.get(server_name)
                 except (acos_errors.NotFound) as e:
-                    if rasie_not_found:
+                    if raise_not_found:
                         raise e
                     return default_name
         else:
             try:
                 server_name = axapi_client.slb.server.get('_{}_{}'.format(server_name, 'neutron'))
             except (acos_errors.NotFound) as e:
-                if rasie_not_found:
+                if raise_not_found:
                     raise e
                 return default_name
     return server_name['server']['name']

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_health_monitor_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_health_monitor_tasks.py
@@ -62,6 +62,8 @@ FLAVOR_WITH_REGEX_ARGS = {
     }
 }
 
+DEF_POST_DATA = '0123456789'
+
 
 class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
 
@@ -86,7 +88,7 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
                                                           mock_hm.delay, mock_hm.timeout,
                                                           mock_hm.rise_threshold, method=None,
                                                           port=mock.ANY, url=None,
-                                                          expect_code=None, post_data=None,
+                                                          expect_code=None, post_data=DEF_POST_DATA,
                                                           **ARGS)
         self.conf.config(group=a10constants.HEALTH_MONITOR_SECTION,
                          post_data='abc=1')
@@ -121,7 +123,8 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
                                                           self.client_mock.slb.hm.TCP,
                                                           mock_hm.delay, mock_hm.timeout,
                                                           mock_hm.rise_threshold, method=None,
-                                                          port=mock.ANY, url=None, post_data=None,
+                                                          port=mock.ANY, url=None,
+                                                          post_data=DEF_POST_DATA,
                                                           expect_code=None, **FLAVOR_ARGS)
 
     def test_health_monitor_create_with_flavor_and_config(self):
@@ -185,7 +188,8 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
                                                           mock_hm.delay, mock_hm.timeout,
                                                           mock_hm.rise_threshold, method=None,
                                                           port=mock.ANY, url=None,
-                                                          expect_code=None, post_data=None,
+                                                          expect_code=None,
+                                                          post_data=DEF_POST_DATA,
                                                           **FLAVOR_WITH_REGEX_ARGS)
 
     def test_health_monitor_create_with_regex_overwrite_flavor_task(self):
@@ -224,7 +228,7 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
                                                           mock_hm.delay, mock_hm.timeout,
                                                           mock_hm.rise_threshold, method=None,
                                                           port=mock.ANY, url=None,
-                                                          expect_code=None, post_data=None,
+                                                          expect_code=None, post_data=DEF_POST_DATA,
                                                           **FLAVOR_WITH_REGEX_ARGS)
 
     def test_get_hm_name(self):
@@ -268,7 +272,7 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
                                                           mock_hm.delay, mock_hm.timeout,
                                                           mock_hm.rise_threshold, method=None,
                                                           port=mock.ANY, url=None,
-                                                          expect_code=None, post_data=None,
+                                                          expect_code=None, post_data=DEF_POST_DATA,
                                                           **ARGS)
         self.conf.config(group=a10constants.HEALTH_MONITOR_SECTION,
                          post_data='abc=1')
@@ -334,7 +338,8 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
                                                           self.client_mock.slb.hm.TCP,
                                                           mock_hm.delay, mock_hm.timeout,
                                                           mock_hm.rise_threshold, method=None,
-                                                          port=mock.ANY, url=None, post_data=None,
+                                                          port=mock.ANY, url=None,
+                                                          post_data=DEF_POST_DATA,
                                                           expect_code=None, **FLAVOR_ARGS)
 
     @mock.patch('a10_octavia.controller.worker.tasks.health_monitor_tasks._get_hm_name')
@@ -375,7 +380,7 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
                                                           mock_hm.delay, mock_hm.timeout,
                                                           mock_hm.rise_threshold, method=None,
                                                           port=mock.ANY, url=None,
-                                                          expect_code=None, post_data=None,
+                                                          expect_code=None, post_data=DEF_POST_DATA,
                                                           **FLAVOR_WITH_REGEX_ARGS)
 
     @mock.patch('a10_octavia.controller.worker.tasks.health_monitor_tasks._get_hm_name')
@@ -417,7 +422,7 @@ class TestHandlerHealthMonitorTasks(BaseTaskTestCase):
                                                           mock_hm.delay, mock_hm.timeout,
                                                           mock_hm.rise_threshold, method=None,
                                                           port=mock.ANY, url=None,
-                                                          expect_code=None, post_data=None,
+                                                          expect_code=None, post_data=DEF_POST_DATA,
                                                           **FLAVOR_WITH_REGEX_ARGS)
 
     @mock.patch('a10_octavia.controller.worker.tasks.health_monitor_tasks._get_hm_name')

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_server_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_server_tasks.py
@@ -73,7 +73,7 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
         member_task.CONF = self.conf
         return member_task
 
-    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.get_member_server_name')
     def test_MemberCreate_execute_create_with_server_template(self, mock_server_name):
         mock_server_name.side_effect = acos_errors.NotFound()
         member_port_count_ip = 1
@@ -83,7 +83,7 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
         self.assertIn('template-server', kwargs['server_templates'])
         self.assertEqual(kwargs['server_templates']['template-server'], 'my_server_template')
 
-    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.get_member_server_name')
     def test_MemberCreate_execute_create_with_shared_template_log_warning(self, mock_server_name):
         mock_server_name.side_effect = acos_errors.NotFound()
         member_port_count_ip = 1
@@ -98,7 +98,7 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
             member_task.execute(MEMBER, VTHUNDER, POOL, member_port_count_ip)
             self.assertEqual(expected_log, cm.output)
 
-    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.get_member_server_name')
     def test_MemberCreate_execute_create_with_flavor(self, mock_server_name):
         mock_server_name.side_effect = acos_errors.NotFound()
         mock_create_member = task.MemberCreate()
@@ -113,7 +113,7 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
             SERVER_NAME, MEMBER.ip_address, status=mock.ANY,
             health_check=mock.ANY, server_templates=mock.ANY, **expect_key_args)
 
-    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.get_member_server_name')
     def test_MemberCreate_execute_create_with_regex_overwrite_flavor(self, mock_server_name):
         mock_server_name.side_effect = acos_errors.NotFound()
         mock_create_member = task.MemberCreate()
@@ -134,7 +134,7 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
             SERVER_NAME, member_obj.ip_address, status=mock.ANY,
             health_check=mock.ANY, server_templates=mock.ANY, **expect_key_args)
 
-    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.get_member_server_name')
     def test_MemberCreate_execute_create_with_regex_flavor(self, mock_server_name):
         mock_server_name.side_effect = acos_errors.NotFound()
         mock_create_member = task.MemberCreate()
@@ -155,7 +155,7 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
             SERVER_NAME, member_obj.ip_address, status=mock.ANY,
             health_check=mock.ANY, server_templates=mock.ANY, **expect_key_args)
 
-    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.get_member_server_name')
     def test_MemberCreate_execute_create_flavor_override_config(self, mock_server_name):
         mock_server_name.side_effect = acos_errors.NotFound()
         self.conf.config(group=a10constants.SERVER_CONF_SECTION, conn_resume=300)
@@ -180,7 +180,7 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
         self.client_mock.slb.server.delete.assert_called_with(
             SERVER_NAME)
 
-    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.get_member_server_name')
     def test_create_member_task(self, mock_server_name):
         mock_server_name.side_effect = acos_errors.NotFound()
         mock_create_member = task.MemberCreate()
@@ -202,7 +202,7 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
         mock_member.revert(MEMBER, VTHUNDER, POOL, member_port_count_ip)
         self.client_mock.slb.server.delete.assert_not_called()
 
-    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.get_member_server_name')
     def test_create_member_task_multi_port(self, mock_server_name):
         mock_server_name.return_value = SERVER_NAME
         mock_create_member = task.MemberCreate()
@@ -217,7 +217,7 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
         self.client_mock.slb.service_group.member.create.assert_called_with(
             POOL.id, SERVER_NAME, MEMBER.protocol_port)
 
-    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.get_member_server_name')
     def test_delete_member_task_single_no_port(self, mock_server_name):
         mock_server_name.return_value = SERVER_NAME
         mock_delete_member = task.MemberDelete()
@@ -227,7 +227,7 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
             POOL.id, SERVER_NAME, MEMBER.protocol_port)
         self.client_mock.slb.server.delete.assert_called_with(SERVER_NAME)
 
-    @mock.patch('a10_octavia.controller.worker.tasks.server_tasks._get_server_name')
+    @mock.patch('a10_octavia.controller.worker.tasks.utils.get_member_server_name')
     def test_delete_member_task_multi_port(self, mock_server_name):
         mock_server_name.return_value = SERVER_NAME
         member_port_count_ip = 2
@@ -250,7 +250,7 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
             }
         }
         self.client_mock.slb.server.get.return_value = server_name
-        server_name = task._get_server_name(self.client_mock, MEMBER)
+        server_name = utils.get_member_server_name(self.client_mock, MEMBER)
         self.assertEqual(SERVER_NAME, server_name)
 
     def test_get_server_name_backwards_compat(self):
@@ -260,13 +260,13 @@ class TestHandlerServerTasks(base.BaseTaskTestCase):
             }
         }
         self.client_mock.slb.server.get.return_value = server_name
-        server_name = task._get_server_name(self.client_mock, MEMBER)
+        server_name = utils.get_member_server_name(self.client_mock, MEMBER)
         self.assertEqual('_{}_neutron'.format(SERVER_NAME), server_name)
 
     def test_get_server_name_raise_notfound(self):
         self.client_mock.slb.server.get.side_effect = acos_errors.NotFound
 
         expected_error = acos_errors.NotFound
-        module_func = task._get_server_name
+        module_func = utils.get_member_server_name
         func_args = [self.client_mock, MEMBER]
         self.assertRaises(expected_error, module_func, *func_args)


### PR DESCRIPTION
## Description
- Required: Severity Level: Critical
- Required: Issue Description:
Health Monitor will not configured on slb servers if Health Monitor creation command is after the member creation commands.
This is introduced after: https://github.com/a10networks/a10-octavia/pull/560/files
Previously we have logic to update service-group health monitor. But when move hm from service-group to slb server. We didn't implement the logic for membre.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3375

## Technical Approach
For CreateAndAssociateHealthMonitor(), we need to update members in the pool with the health monitor.

## Config Changes


<pre>
<b>N/A</b>
</pre>


## Test Cases
- verify commands:
```
openstack loadbalancer create --vip-subnet-id tp91 --name vip1
openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name vport1 vip1
openstack loadbalancer pool create --protocol HTTP --lb-algorithm SOURCE_IP_PORT --listener vport1 --name pool1
openstack loadbalancer member create --address 192.168.90.18 --protocol-port 8080 pool1
openstack loadbalancer healthmonitor create --delay 30 --timeout 3 --max-retries 3 --type HTTP pool1 --name hm1
openstack loadbalancer member create --address 192.168.90.19 --protocol-port 8080 pool1
```

## Manual Testing

- result:
```
health monitor 6a499b2b-f2de-45d0-b5c6-d6e108ff5cb6
  override-port 80
  interval 30 timeout 3
  method http port 80 expect response-code 200 url GET /
!
slb server ecc25_192_168_90_18 192.168.90.18
  health-check 6a499b2b-f2de-45d0-b5c6-d6e108ff5cb6
  port 8080 tcp
!
slb server ecc25_192_168_90_19 192.168.90.19
  health-check 6a499b2b-f2de-45d0-b5c6-d6e108ff5cb6
  port 8080 tcp
!
slb service-group a10fc2c3-c321-4c73-8416-e7777e490f91 tcp
  method src-ip-hash
  member ecc25_192_168_90_18 8080
  member ecc25_192_168_90_19 8080
!
slb virtual-server 36cb4911-8546-4ff0-bd7b-f482318b2d22 192.168.91.78
  port 80 http
    name 5c3932b2-edba-4b16-b110-b77e8dd20b81
    extended-stats
    source-nat auto
    service-group a10fc2c3-c321-4c73-8416-e7777e490f91
```
