### PR TITLE
[STACK-3392] Fix listener update SSL failed

### DIFF
--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -365,6 +365,8 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                         constants.PENDING_UPDATE)
             listener = e.last_attempt.result()
 
+        LOG.warning('listener update ssl: %s !!!!!!!!!!!!!!!', listener.tls_certificate_id)
+
         load_balancer = listener.load_balancer
 
         topology = CONF.a10_controller_worker.loadbalancer_topology

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -365,8 +365,6 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
                         constants.PENDING_UPDATE)
             listener = e.last_attempt.result()
 
-        LOG.warning('listener update ssl: %s !!!!!!!!!!!!!!!', listener.tls_certificate_id)
-
         load_balancer = listener.load_balancer
 
         topology = CONF.a10_controller_worker.loadbalancer_topology

--- a/a10_octavia/controller/worker/tasks/cert_tasks.py
+++ b/a10_octavia/controller/worker/tasks/cert_tasks.py
@@ -220,9 +220,13 @@ class ClientSSLTemplateUpdate(task.Task):
 
                 try:
                     if 'cert' in old['client-ssl'].keys() and 'key' in old['client-ssl'].keys():
-                        self.axapi_client.file.ssl_cert.delete(private_key=old['client-ssl']['key'],
-                                                               cert_name=old['client-ssl']['cert'])
-                        self.axapi_client.file.ssl_key.delete(private_key=old['client-ssl']['key'])
+                        if old['client-ssl']['cert'] != cert_data.cert_filename:
+                            self.axapi_client.file.ssl_cert.delete(
+                                private_key=old['client-ssl']['key'],
+                                cert_name=old['client-ssl']['cert'])
+                        if old['client-ssl']['key'] != cert_data.key_filename:
+                            self.axapi_client.file.ssl_key.delete(
+                                private_key=old['client-ssl']['key'])
                 except Exception as e:
                     LOG.warning("Clean up old cert/key files failed. error:%s", str(e))
                     # clean up with best effort, don't raise here


### PR DESCRIPTION
## Description
- Required: Severity Level: High
- Required: Issue Description
For openstack loadbalancer listener set command, if the --default-tls-container-ref is not changed do not delete the secret.

## Jira Ticket
[**This is optional if you are an external contributor**
- Required: Add links to tickets closed here](https://a10networks.atlassian.net/browse/STACK-3392)

## Technical Approach
In ClientSSLTemplateUpdate task, if the cert/key is not changed. Do not delete then in ACOS side.

## Config Changes
<pre>
<b>N/A</b>
</pre>


## Test Cases

1. configure loadbalancer and listener with secret
2. use same secret to update listener
```
openstack loadbalancer create --vip-subnet-id tp91 --vip-address 192.168.91.56 --name vip1
openstack loadbalancer listener create --protocol TERMINATED_HTTPS --protocol-port 443 --default-tls-container-ref="$(openstack secret container list | awk '/ srv1 / {print $2}')" --name vport1 vip1
openstack loadbalancer listener set  --default-tls-container-ref="$(openstack secret container list | awk '/ srv2 / {print $2}')" vport1
openstack loadbalancer listener set  --default-tls-container-ref="$(openstack secret container list | awk '/ srv2 / {print $2}')" vport1
openstack loadbalancer listener set  --default-tls-container-ref="$(openstack secret container list | awk '/ srv2 / {print $2}')" vport1

```

## Manual Testing

in audit log we should not see any cert/key deletion errors:
```
vThunder(NOLICENSE)#show audit
Dec 12 2022 02:38:01  [admin] cli: [192.168.120.8:64006] show audit
Dec 12 2022 02:37:58  [admin] axapi: [15:10.64.3.104:33178] RESP HTTP status 200 OK
Dec 12 2022 02:37:58  Session[15] closed
Dec 12 2022 02:37:58  [admin] axapi: [15:10.64.3.104:33178] POST: /axapi/v3/logoff
Dec 12 2022 02:37:58  [admin] axapi: [15:10.64.3.104:33176] RESP HTTP status 200 OK
Dec 12 2022 02:37:58  [admin] cli: [10.64.3.104] write memory partition shared
Dec 12 2022 02:37:56  [admin] axapi: [15:10.64.3.104:33176] payload section 1
{"memory": {"destination": null, "partition": "shared"}}
Dec 12 2022 02:37:56  [admin] axapi: [15:10.64.3.104:33176] POST: /axapi/v3/write/memory/
Dec 12 2022 02:37:56  [admin] axapi: [15:10.64.3.104:33174] RESP HTTP status 200 OK
Dec 12 2022 02:37:56  [admin] axapi: [15:10.64.3.104:33174] POST: /axapi/v3/auth
Dec 12 2022 02:37:56  A aXAPI session[15] opened,  username: admin, remote host: 10.64.3.104
Dec 12 2022 02:37:56  [admin] axapi: [14:10.64.3.104:33172] RESP HTTP status 200 OK
Dec 12 2022 02:37:56  Session[14] closed
Dec 12 2022 02:37:56  [admin] axapi: [14:10.64.3.104:33172] POST: /axapi/v3/logoff
Dec 12 2022 02:37:56  [admin] axapi: [14:10.64.3.104:33170] RESP HTTP status 200 OK
Dec 12 2022 02:37:56  [admin] axapi: [14:10.64.3.104:33170] payload section 1
{"port": {"name": "7966ef69-bbba-464e-a555-84662e5de842", "protocol": "https", "port-number": 443, "template-persist-source-ip": null, "template-persist-cookie": null, "template-tcp-proxy": null, "extended-stats": 1, "auto": 1, "ipinip": 0, "use-rcv-hop-for-resp": 0, "template-client-ssl": "7966ef69-bbba-464e-a555-84662e5de842", "no-dest-nat": 0, "conn-limit": 64000000}}
Dec 12 2022 02:37:56  [admin] axapi: [14:10.64.3.104:33170] PUT: /axapi/v3/slb/virtual-server/1d4e4ed8-d219-4939-b71d-968f8f4edf30/port/443+https
Dec 12 2022 02:37:56  [admin] axapi: [14:10.64.3.104:33168] RESP HTTP status 200 OK
Dec 12 2022 02:37:56  [admin] axapi: [14:10.64.3.104:33168] GET: /axapi/v3/slb/virtual-server/1d4e4ed8-d219-4939-b71d-968f8f4edf30/port/443+https
Dec 12 2022 02:37:56  [admin] axapi: [14:10.64.3.104:33166] RESP HTTP status 200 OK
Dec 12 2022 02:37:56  [admin] axapi: [14:10.64.3.104:33166] GET: /axapi/v3/slb/template/
Dec 12 2022 02:37:56  [admin] axapi: [14:10.64.3.104:33164] RESP HTTP status 200 OK
Dec 12 2022 02:37:56  [admin] axapi: [14:10.64.3.104:33164] POST: /axapi/v3/auth
Dec 12 2022 02:37:56  A aXAPI session[14] opened,  username: admin, remote host: 10.64.3.104
Dec 12 2022 02:37:55  [admin] axapi: [13:10.64.3.104:33162] RESP HTTP status 200 OK
Dec 12 2022 02:37:55  Session[13] closed
Dec 12 2022 02:37:55  [admin] axapi: [13:10.64.3.104:33162] POST: /axapi/v3/logoff
Dec 12 2022 02:37:55  [admin] axapi: [13:10.64.3.104:33160] RESP HTTP status 200 OK
Dec 12 2022 02:37:55  [admin] axapi: [13:10.64.3.104:33160] payload section 1
{"client-ssl": {"name": "7966ef69-bbba-464e-a555-84662e5de842", "cert": "srv2", "key": "srv2.key", "key-passphrase": null}}
Dec 12 2022 02:37:55  [admin] axapi: [13:10.64.3.104:33160] POST: /axapi/v3/slb/template/client-ssl/7966ef69-bbba-464e-a555-84662e5de842
Dec 12 2022 02:37:55  [admin] axapi: [13:10.64.3.104:33158] RESP HTTP status 200 OK
Dec 12 2022 02:37:55  [admin] axapi: [13:10.64.3.104:33158] GET: /axapi/v3/slb/template/client-ssl/7966ef69-bbba-464e-a555-84662e5de842
Dec 12 2022 02:37:55  [admin] axapi: [13:10.64.3.104:33156] RESP HTTP status 200 OK
Dec 12 2022 02:37:55  [admin] axapi: [13:10.64.3.104:33156] GET: /axapi/v3/slb/template/client-ssl/7966ef69-bbba-464e-a555-84662e5de842
Dec 12 2022 02:37:55  [admin] axapi: [13:10.64.3.104:33154] RESP HTTP status 200 OK
Dec 12 2022 02:37:55  [admin] axapi: [13:10.64.3.104:33154] POST: /axapi/v3/auth
Dec 12 2022 02:37:55  A aXAPI session[13] opened,  username: admin, remote host: 10.64.3.104
Dec 12 2022 02:37:55  [admin] axapi: [12:10.64.3.104:33152] RESP HTTP status 200 OK
Dec 12 2022 02:37:55  Session[12] closed
Dec 12 2022 02:37:55  [admin] axapi: [12:10.64.3.104:33152] POST: /axapi/v3/logoff
Dec 12 2022 02:37:55  [admin] axapi: [12:10.64.3.104:33150] RESP HTTP status 204 No Content : No content.
Dec 12 2022 02:37:55  [admin] axapi: [12:10.64.3.104:33150] payload section 1
{"ssl-key": {"file": "srv2.key", "file-handle": "srv2.key", "action": "import"}}
Dec 12 2022 02:37:55  [admin] axapi: [12:10.64.3.104:33150] POST: /axapi/v3/file/ssl-key/
Dec 12 2022 02:37:55  [admin] axapi: [12:10.64.3.104:33148] RESP HTTP status 200 OK
Dec 12 2022 02:37:55  [admin] axapi: [12:10.64.3.104:33148] GET: /axapi/v3/file/ssl-key/srv2.key
Dec 12 2022 02:37:55  [admin] axapi: [12:10.64.3.104:33146] RESP HTTP status 200 OK
Dec 12 2022 02:37:55  [admin] axapi: [12:10.64.3.104:33146] POST: /axapi/v3/auth
Dec 12 2022 02:37:55  A aXAPI session[12] opened,  username: admin, remote host: 10.64.3.104
Dec 12 2022 02:37:55  [admin] axapi: [11:10.64.3.104:33144] RESP HTTP status 200 OK
Dec 12 2022 02:37:55  Session[11] closed
Dec 12 2022 02:37:55  [admin] axapi: [11:10.64.3.104:33144] POST: /axapi/v3/logoff
Dec 12 2022 02:37:55  [admin] axapi: [11:10.64.3.104:33142] RESP HTTP status 204 No Content : No content.
Dec 12 2022 02:37:55  [admin] axapi: [11:10.64.3.104:33142] payload section 1
{"ssl-cert": {"file": "srv2", "file-handle": "srv2", "certificate-type": "pem", "action": "import"}}
Dec 12 2022 02:37:55  [admin] axapi: [11:10.64.3.104:33142] POST: /axapi/v3/file/ssl-cert/
Dec 12 2022 02:37:55  [admin] axapi: [11:10.64.3.104:33140] RESP HTTP status 200 OK
Dec 12 2022 02:37:55  [admin] axapi: [11:10.64.3.104:33140] GET: /axapi/v3/file/ssl-cert/srv2
Dec 12 2022 02:37:55  [admin] axapi: [11:10.64.3.104:33138] RESP HTTP status 200 OK
Dec 12 2022 02:37:55  [admin] axapi: [11:10.64.3.104:33138] POST: /axapi/v3/auth
Dec 12 2022 02:37:55  A aXAPI session[11] opened,  username: admin, remote host: 10.64.3.104
Dec 12 2022 02:37:47  [admin] cli: [192.168.120.8:64006] clear audit

```
