### PR TITLE
[STACK-3395] Case # 00349171 FW: A10 Octavia Driver and Certificate Updates Case Reference ID: ref:_00D301Kns._5004z1khY3x:ref

### DIFF
--- a/a10_octavia/api/drivers/driver.py
+++ b/a10_octavia/api/drivers/driver.py
@@ -108,6 +108,9 @@ class A10ProviderDriver(driver_base.ProviderDriver):
             listener_dict['client_crl_container_id'] = listener_dict.pop(
                 'client_crl_container_ref')
         listener_dict.pop('client_crl_container_data', None)
+        if 'default_tls_container_ref' in listener_dict:
+            listener_dict['tls_certificate_id'] = listener_dict.pop('default_tls_container_ref')
+        listener_dict.pop('default_tls_container_data', None)
 
         payload = {constants.LISTENER_ID: listener_id,
                    constants.LISTENER_UPDATES: listener_dict}

--- a/a10_octavia/controller/worker/flows/a10_listener_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_listener_flows.py
@@ -340,12 +340,12 @@ class ListenerFlows(object):
         if listener is not None:
             create_ssl_cert_flow.add(cert_tasks.GetSSLCertData(
                 name='get_ssl_cert_data_' + suffix,
-                requires=[constants.LOADBALANCER, constants.LISTENER],
+                requires=[constants.LOADBALANCER, constants.LISTENER, a10constants.VTHUNDER],
                 inject={constants.LISTENER: listener},
                 provides=a10constants.CERT_DATA))
         else:
             create_ssl_cert_flow.add(cert_tasks.GetSSLCertData(
-                requires=[constants.LOADBALANCER, constants.LISTENER],
+                requires=[constants.LOADBALANCER, constants.LISTENER, a10constants.VTHUNDER],
                 provides=a10constants.CERT_DATA))
         create_ssl_cert_flow.add(cert_tasks.SSLCertCreate(
             name='ssl_cert_create_' + suffix,
@@ -368,17 +368,23 @@ class ListenerFlows(object):
         if listener is not None:
             delete_ssl_cert_flow.add(cert_tasks.GetSSLCertData(
                 name='get_ssl_cert_data_' + suffix,
-                requires=[constants.LOADBALANCER, constants.LISTENER],
+                requires=[constants.LOADBALANCER, constants.LISTENER,
+                          a10constants.VTHUNDER],
                 inject={constants.LISTENER: listener},
                 provides=a10constants.CERT_DATA))
+            delete_ssl_cert_flow.add(cert_tasks.ClientSSLTemplateDelete(
+                name='client_ssl_template_delete_' + suffix,
+                requires=[a10constants.VTHUNDER, constants.LISTENER],
+                inject={constants.LISTENER: listener}))
         else:
             delete_ssl_cert_flow.add(cert_tasks.GetSSLCertData(
                 name='get_ssl_cert_data_' + suffix,
-                requires=[constants.LOADBALANCER, constants.LISTENER],
+                requires=[constants.LOADBALANCER, constants.LISTENER,
+                          a10constants.VTHUNDER],
                 provides=a10constants.CERT_DATA))
-        delete_ssl_cert_flow.add(cert_tasks.ClientSSLTemplateDelete(
-            name='client_ssl_template_delete_' + suffix,
-            requires=[a10constants.VTHUNDER, constants.LISTENER]))
+            delete_ssl_cert_flow.add(cert_tasks.ClientSSLTemplateDelete(
+                name='client_ssl_template_delete_' + suffix,
+                requires=[a10constants.VTHUNDER, constants.LISTENER]))
         delete_ssl_cert_flow.add(cert_tasks.SSLCertDelete(
             name='ssl_cert_delete_' + suffix,
             requires=[a10constants.CERT_DATA, a10constants.VTHUNDER]))
@@ -397,12 +403,14 @@ class ListenerFlows(object):
         if listener is not None:
             update_ssl_cert_flow.add(cert_tasks.GetSSLCertData(
                 name='get_ssl_cert_data_' + suffix,
-                requires=[constants.LOADBALANCER, constants.LISTENER, constants.UPDATE_DICT],
+                requires=[constants.LOADBALANCER, constants.LISTENER, constants.UPDATE_DICT,
+                          a10constants.VTHUNDER],
                 inject={constants.LISTENER: listener},
                 provides=a10constants.CERT_DATA))
         else:
             update_ssl_cert_flow.add(cert_tasks.GetSSLCertData(
-                requires=[constants.LOADBALANCER, constants.LISTENER],
+                requires=[constants.LOADBALANCER, constants.LISTENER, constants.UPDATE_DICT,
+                          a10constants.VTHUNDER],
                 provides=a10constants.CERT_DATA))
         update_ssl_cert_flow.add(cert_tasks.SSLCertUpdate(
             name='ssl_cert_update_' + suffix,

--- a/a10_octavia/controller/worker/flows/a10_listener_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_listener_flows.py
@@ -378,7 +378,7 @@ class ListenerFlows(object):
                 provides=a10constants.CERT_DATA))
         delete_ssl_cert_flow.add(cert_tasks.ClientSSLTemplateDelete(
             name='client_ssl_template_delete_' + suffix,
-            requires=[a10constants.CERT_DATA, a10constants.VTHUNDER]))
+            requires=[a10constants.VTHUNDER, constants.LISTENER]))
         delete_ssl_cert_flow.add(cert_tasks.SSLCertDelete(
             name='ssl_cert_delete_' + suffix,
             requires=[a10constants.CERT_DATA, a10constants.VTHUNDER]))
@@ -397,7 +397,7 @@ class ListenerFlows(object):
         if listener is not None:
             update_ssl_cert_flow.add(cert_tasks.GetSSLCertData(
                 name='get_ssl_cert_data_' + suffix,
-                requires=[constants.LOADBALANCER, constants.LISTENER],
+                requires=[constants.LOADBALANCER, constants.LISTENER, constants.UPDATE_DICT],
                 inject={constants.LISTENER: listener},
                 provides=a10constants.CERT_DATA))
         else:

--- a/a10_octavia/controller/worker/tasks/cert_tasks.py
+++ b/a10_octavia/controller/worker/tasks/cert_tasks.py
@@ -51,7 +51,7 @@ class GetSSLCertData(task.Task):
             cert_data = utils.get_cert_data(barbican_client, listener)
             if not cert_data.template_name:
                 client_ssl=self.axapi_client.slb.template.client_ssl.get(name=listener.id)
-                if client_ssl['client-ssl'].get('cert') or client_ssl['client-ssl'].get('key'):
+                if client_ssl['client-ssl'].get('cert') and client_ssl['client-ssl'].get('key'):
                     cert_data.cert_filename=client_ssl['client-ssl'].get('cert')
                     cert_data.key_filename=client_ssl['client-ssl'].get('key')
                     cert_data.template_name=listener.id

--- a/a10_octavia/controller/worker/tasks/cert_tasks.py
+++ b/a10_octavia/controller/worker/tasks/cert_tasks.py
@@ -41,12 +41,13 @@ class CheckListenerType(task.Task):
 class GetSSLCertData(task.Task):
     """Task to get SSL certificate data from Barbican"""
 
-    def execute(self, loadbalancer, listener):
+    def execute(self, loadbalancer, listener, update_dict={}):
         cert_data = None
+        if listener and update_dict:
+            listener.__dict__.update(update_dict)
         try:
             barbican_client = BarbicanACLAuth().get_barbican_client(loadbalancer.project_id)
             cert_data = utils.get_cert_data(barbican_client, listener)
-            cert_data.template_name = listener.id
             LOG.debug("Successfully received barbican data for listener: %s", listener.id)
         except (acos_errors.ACOSException, ConnectionError) as e:
             LOG.exception("Failed to get barbican data for listener: %s", listener.id)
@@ -242,17 +243,18 @@ class SSLCertDelete(task.Task):
 
     @axapi_client_decorator
     def execute(self, cert_data, vthunder):
-        try:
-            if self.axapi_client.file.ssl_cert.exists(file=cert_data.cert_filename):
-                self.axapi_client.file.ssl_cert.delete(private_key=cert_data.key_filename,
-                                                       cert_name=cert_data.cert_filename)
-                LOG.debug("Successfully deleted SSL certificate: %s", cert_data.cert_filename)
-        except acos_errors.Exists as e:
-            LOG.warning("Failed to delete SSL cert as its being used in another place")
-            LOG.exception(str(e))
-        except (acos_errors.ACOSException, ConnectionError) as e:
-            LOG.exception("Failed to delete SSL certificate: %s", cert_data.cert_filename)
-            raise e
+        if cert_data:
+            try:
+                if self.axapi_client.file.ssl_cert.exists(file=cert_data.cert_filename):
+                    self.axapi_client.file.ssl_cert.delete(private_key=cert_data.key_filename,
+                                                           cert_name=cert_data.cert_filename)
+                    LOG.debug("Successfully deleted SSL certificate: %s", cert_data.cert_filename)
+            except acos_errors.Exists as e:
+                LOG.warning("Failed to delete SSL cert as its being used in another place")
+                LOG.exception(str(e))
+            except (acos_errors.ACOSException, ConnectionError) as e:
+                LOG.exception("Failed to delete SSL certificate: %s", cert_data.cert_filename)
+                raise e
 
 
 class SSLKeyDelete(task.Task):
@@ -260,27 +262,28 @@ class SSLKeyDelete(task.Task):
 
     @axapi_client_decorator
     def execute(self, cert_data, vthunder):
-        try:
-            if self.axapi_client.file.ssl_key.exists(file=cert_data.key_filename):
-                self.axapi_client.file.ssl_key.delete(private_key=cert_data.key_filename)
-                LOG.debug("Successfully deleted SSL key: %s", cert_data.key_filename)
-        except acos_errors.Exists as e:
-            LOG.warning("Failed to delete SSL cert as its being used in another place")
-            LOG.exception(str(e))
-        except (acos_errors.ACOSException, ConnectionError) as e:
-            LOG.exception("Failed to delete SSL key: %s", cert_data.key_filename)
-            raise e
+        if cert_data:
+            try:
+                if self.axapi_client.file.ssl_key.exists(file=cert_data.key_filename):
+                    self.axapi_client.file.ssl_key.delete(private_key=cert_data.key_filename)
+                    LOG.debug("Successfully deleted SSL key: %s", cert_data.key_filename)
+            except acos_errors.Exists as e:
+                LOG.warning("Failed to delete SSL cert as its being used in another place")
+                LOG.exception(str(e))
+            except (acos_errors.ACOSException, ConnectionError) as e:
+                LOG.exception("Failed to delete SSL key: %s", cert_data.key_filename)
+                raise e
 
 
 class ClientSSLTemplateDelete(task.Task):
     """Task to delete a client ssl template for a listener"""
 
     @axapi_client_decorator
-    def execute(self, cert_data, vthunder):
+    def execute(self, vthunder, listener):
         try:
-            if self.axapi_client.slb.template.client_ssl.exists(name=cert_data.template_name):
-                self.axapi_client.slb.template.client_ssl.delete(name=cert_data.template_name)
-                LOG.debug("Successfully deleted SSL template: %s", cert_data.template_name)
+            if self.axapi_client.slb.template.client_ssl.exists(name=listener.id):
+                self.axapi_client.slb.template.client_ssl.delete(name=listener.id)
+                LOG.debug("Successfully deleted SSL template: %s", listener.id)
         except (acos_errors.ACOSException, ConnectionError) as e:
-            LOG.exception("Failed to delete SSL template: %s", cert_data.template_name)
+            LOG.exception("Failed to delete SSL template: %s", listener.id)
             raise e

--- a/a10_octavia/controller/worker/tasks/utils.py
+++ b/a10_octavia/controller/worker/tasks/utils.py
@@ -44,9 +44,8 @@ def get_cert_data(barbican_client, listener):
                                     key_content=cert_container.private_key.payload,
                                     key_pass=cert_container.private_key_passphrase,
                                     template_name=listener.id)
-            return cert_data
     LOG.info("Secret container not found %s", cert_ref)
-    return None
+    return cert_data
 
 
 def get_sess_pers_templates(pool):

--- a/a10_octavia/controller/worker/tasks/utils.py
+++ b/a10_octavia/controller/worker/tasks/utils.py
@@ -35,14 +35,18 @@ LOG = logging.getLogger(__name__)
 def get_cert_data(barbican_client, listener):
     cert_data = Certificate()
     cert_ref = listener.tls_certificate_id
-    cert_container = barbican_client.containers.get(container_ref=cert_ref)
-    cert_data = Certificate(cert_filename=cert_container.certificate.name,
-                            key_filename=cert_container.private_key.name,
-                            cert_content=cert_container.certificate.payload,
-                            key_content=cert_container.private_key.payload,
-                            key_pass=cert_container.private_key_passphrase,
-                            template_name=listener.id)
-    return cert_data
+    cert_containers = barbican_client.containers.list()
+    for cert_container in cert_containers:
+        if cert_container.container_ref == cert_ref:
+            cert_data = Certificate(cert_filename=cert_container.certificate.name,
+                                    key_filename=cert_container.private_key.name,
+                                    cert_content=cert_container.certificate.payload,
+                                    key_content=cert_container.private_key.payload,
+                                    key_pass=cert_container.private_key_passphrase,
+                                    template_name=listener.id)
+            return cert_data
+    LOG.info("Secret container not found %s", cert_ref)
+    return None
 
 
 def get_sess_pers_templates(pool):

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_cert_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_cert_tasks.py
@@ -60,7 +60,7 @@ class TestCertHandlerTasks(BaseTaskTestCase):
     @mock.patch('a10_octavia.controller.worker.tasks.utils.get_cert_data', return_value=CERT_DATA)
     def test_GetSSLCertData_success(self, barbican_class, cert_data):
         mock_ssl_cert = cert_tasks.GetSSLCertData()
-        out = mock_ssl_cert.execute(LB, LISTENER)
+        out = mock_ssl_cert.execute(LB, LISTENER, VTHUNDER)
         self.assertEqual(out, CERT_DATA)
 
     @patch.object(BarbicanACLAuth, 'get_barbican_client')

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_cert_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_cert_tasks.py
@@ -188,9 +188,9 @@ class TestCertHandlerTasks(BaseTaskTestCase):
         mock_client_ssl_template.axapi_client = self.client_mock
         mock_client_ssl_template.execute(CERT_DATA, VTHUNDER)
         self.client_mock.slb.template.client_ssl.exists.assert_called_with(
-            name=a10_test_constants.MOCK_LISTENER_ID)
+            name=a10_test_constants.MOCK_TEMPLATE_NAME)
         self.client_mock.slb.template.client_ssl.update.assert_called_with(
-            name=a10_test_constants.MOCK_LISTENER_ID,
+            name=a10_test_constants.MOCK_TEMPLATE_NAME,
             cert=a10_test_constants.MOCK_CERT_FILENAME,
             key=a10_test_constants.MOCK_KEY_FILENAME,
             passphrase=a10_test_constants.MOCK_KEY_PASS)
@@ -202,7 +202,7 @@ class TestCertHandlerTasks(BaseTaskTestCase):
         self.client_mock.slb.template.client_ssl.exists.return_value = False
         mock_client_ssl_template.execute(CERT_DATA, VTHUNDER)
         self.client_mock.slb.template.client_ssl.create.assert_called_with(
-            name=a10_test_constants.MOCK_LISTENER_ID,
+            name=a10_test_constants.MOCK_TEMPLATE_NAME,
             cert=a10_test_constants.MOCK_CERT_FILENAME,
             key=a10_test_constants.MOCK_KEY_FILENAME,
             passphrase=a10_test_constants.MOCK_KEY_PASS)
@@ -213,16 +213,16 @@ class TestCertHandlerTasks(BaseTaskTestCase):
         mock_client_ssl_template.axapi_client = self.client_mock
         mock_client_ssl_template.revert(CERT_DATA, VTHUNDER)
         self.client_mock.slb.template.client_ssl.delete.assert_called_with(
-            name=a10_test_constants.MOCK_LISTENER_ID)
+            name=a10_test_constants.MOCK_TEMPLATE_NAME)
 
     def test_client_ssl_template_update(self):
         mock_client_ssl_template = cert_tasks.ClientSSLTemplateUpdate()
         mock_client_ssl_template.axapi_client = self.client_mock
         mock_client_ssl_template.execute(CERT_DATA, VTHUNDER)
         self.client_mock.slb.template.client_ssl.exists.assert_called_with(
-            name=a10_test_constants.MOCK_LISTENER_ID)
+            name=a10_test_constants.MOCK_TEMPLATE_NAME)
         self.client_mock.slb.template.client_ssl.update.assert_called_with(
-            name=a10_test_constants.MOCK_LISTENER_ID,
+            name=a10_test_constants.MOCK_TEMPLATE_NAME,
             cert=a10_test_constants.MOCK_CERT_FILENAME,
             key=a10_test_constants.MOCK_KEY_FILENAME,
             passphrase=a10_test_constants.MOCK_KEY_PASS)
@@ -230,6 +230,6 @@ class TestCertHandlerTasks(BaseTaskTestCase):
     def test_client_ssl_template_delete(self):
         mock_client_ssl_template = cert_tasks.ClientSSLTemplateDelete()
         mock_client_ssl_template.axapi_client = self.client_mock
-        mock_client_ssl_template.execute(CERT_DATA, VTHUNDER)
+        mock_client_ssl_template.execute(VTHUNDER, LISTENER)
         self.client_mock.slb.template.client_ssl.delete.assert_called_with(
             name=a10_test_constants.MOCK_LISTENER_ID)


### PR DESCRIPTION
## Description
Fixed TERMINATED_HTTPS listener update and delete issues
 
Severity Level: Critical


## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3395

## Technical Approach
- For resolving update issue. Passed **update_dict** and updated the listener as per to the parameters present in the update dictionary
- Updated **listener_update** In driver.py to fetch value of updated **default_tls_container_ref**
- Skipped the delete operation in **SSLCertDelete** and  **SSLKeyDelete**  if the **cert_data** is **None** (If default_tls_container_ref is not found in Openstack secret container )


## Test Cases
- Create listener, Update listener, delete listener

## Manual Testing

**Testing Rack flow with 4.x vThunder version:**

```
stack@qa45:~#openstack loadbalancer create --vip-subnet-id 172.16.0.0 --name lb10

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2023-01-04T14:14:28                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | c95ec82a-0270-4ddf-8b4a-5cee22458e03 |
| listeners           |                                      |
| name                | lb10                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 13cf92b72ee144968b19f34000754835     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 172.16.0.36                          |
| vip_network_id      | d6ccc382-e364-48ad-9f76-7182914acf87 |
| vip_port_id         | c100538a-4b99-45fb-88e0-fea6263d7531 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 9af40ad4-a58f-4a5e-ae5f-c5f357fa81ce |
+---------------------+--------------------------------------+

stack@qa45:~#

stack@qa45:~#openstack loadbalancer list

+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+
| c95ec82a-0270-4ddf-8b4a-5cee22458e03 | lb10 | 13cf92b72ee144968b19f34000754835 | 172.16.0.36 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+------------------+----------+

stack@qa45:~#

stack@qa45:~#openstack secret container list

+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+
| Container href                                                                    | Name   | Created                   | Status | Type        | Secrets                                                                                    | Consumers |
+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+
| http://10.64.25.45/key-manager/v1/containers/5823a595-08b4-4666-8c68-a40f1367622a | mytls1 | 2021-12-21T11:49:23+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/880c0d0a-5e8b-4cc6-81c9-566c8dd80000 | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/3cec7b85-68a1-4971-aac9-03f5dd0c1960 |           |
| http://10.64.25.45/key-manager/v1/containers/0305044a-5656-4df2-bcf5-69c031426a7a | srv2   | 2023-01-03T09:01:00+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/6d45d135-6513-4422-859d-ca006074777d | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/4a222b6d-c57c-4cf8-8801-3171a26ab59d |           |
| http://10.64.25.45/key-manager/v1/containers/93063cf5-a08c-4526-87a7-05ff144b9180 | demo2  | 2023-01-04T14:16:49+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/d8d0ea35-392c-43b0-a5fe-2151beaa3a41 | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/e693ac16-7791-429e-819b-4551487d7711 |           |
+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+

stack@qa45:~#

stack@qa45:~#openstack loadbalancer listener create --protocol TERMINATED_HTTPS --default-tls-container-ref $(openstack secret container list | awk '/ demo2 / {print $2}') --protocol-port 8040 --name lt54_lb1 lb10

+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | -1                                                                                                                                                                                                                                                                                 |
| created_at                  | 2023-01-04T14:17:26                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | http://10.64.25.45/key-manager/v1/containers/93063cf5-a08c-4526-87a7-05ff144b9180                                                                                                                                                                                                  |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | c117ba16-ebcd-46ca-a596-8db3b758eba4                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | c95ec82a-0270-4ddf-8b4a-5cee22458e03                                                                                                                                                                                                                                               |
| name                        | lt54_lb1                                                                                                                                                                                                                                                                           |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | 13cf92b72ee144968b19f34000754835                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 8040                                                                                                                                                                                                                                                                               |
| provisioning_status         | PENDING_CREATE                                                                                                                                                                                                                                                                     |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | None                                                                                                                                                                                                                                                                               |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

stack@qa45:~#
```

**vThunder Configurations:**

```
vThunder-vMaster[14/1](NOLICENSE)#show running-config slb
!Section configuration: 627 bytes
!
slb template http th1
!
slb template client-ssl c117ba16-ebcd-46ca-a596-8db3b758eba4
  cert demo1
  key demo1.key
!
slb template policy tp1
!
slb template policy tp3
!
slb template port tp2
!
slb template server ts1
!
slb template tcp tt1
!
slb template udp tu1
!
slb template virtual-port tvp1
!
slb server octavia_health_manager_controller 192.64.0.254
  health-check octavia_health_monitor
!
slb virtual-server c95ec82a-0270-4ddf-8b4a-5cee22458e03 172.16.0.36
  port 8040 https
    name c117ba16-ebcd-46ca-a596-8db3b758eba4
    extended-stats
    template client-ssl c117ba16-ebcd-46ca-a596-8db3b758eba4
!
vThunder-vMaster[14/1](NOLICENSE)#
vThunder-vMaster[14/1](NOLICENSE)#show pki cert
Name: demo1  Type: certificate  Expiration: Dec 21 11:47:52 2022 GMT [Unexpired, Bound]
Name: demo1.key  Type: key  [Bound]
vThunder-vMaster[14/1](NOLICENSE)#

```

**Update listener**

`stack@qa45:~#openstack loadbalancer listener set --default-tls-container-ref $(openstack secret container list | awk '/ srv2 / {print $2}') lt54_lb1    `                


**vThunder Configurations:**


```
vThunder-vMaster[14/1](NOLICENSE)#show running-config slb
!Section configuration: 625 bytes
!
slb template http th1
!
slb template client-ssl c117ba16-ebcd-46ca-a596-8db3b758eba4
  cert srv1
  key srv1.key
!
slb template policy tp1
!
slb template policy tp3
!
slb template port tp2
!
slb template server ts1
!
slb template tcp tt1
!
slb template udp tu1
!
slb template virtual-port tvp1
!
slb server octavia_health_manager_controller 192.64.0.254
  health-check octavia_health_monitor
!
slb virtual-server c95ec82a-0270-4ddf-8b4a-5cee22458e03 172.16.0.36
  port 8040 https
    name c117ba16-ebcd-46ca-a596-8db3b758eba4
    extended-stats
    template client-ssl c117ba16-ebcd-46ca-a596-8db3b758eba4
!
vThunder-vMaster[14/1](NOLICENSE)#
vThunder-vMaster[14/1](NOLICENSE)#show pki cert
Name: srv1  Type: certificate  Expiration: Dec 21 11:47:52 2022 GMT [Unexpired, Bound]
Name: srv1.key  Type: key  [Bound]
vThunder-vMaster[14/1](NOLICENSE)#

```

**Delete Operation:**


```
stack@qa45:~#openstack secret container delete $(openstack secret container list | awk '/ srv2 / {print $2}')

stack@qa45:~#

stack@qa45:~#openstack secret container list

+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+
| Container href                                                                    | Name   | Created                   | Status | Type        | Secrets                                                                                    | Consumers |
+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+
| http://10.64.25.45/key-manager/v1/containers/5823a595-08b4-4666-8c68-a40f1367622a | mytls1 | 2021-12-21T11:49:23+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/880c0d0a-5e8b-4cc6-81c9-566c8dd80000 | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/3cec7b85-68a1-4971-aac9-03f5dd0c1960 |           |
| http://10.64.25.45/key-manager/v1/containers/93063cf5-a08c-4526-87a7-05ff144b9180 | demo2  | 2023-01-04T14:16:49+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/d8d0ea35-392c-43b0-a5fe-2151beaa3a41 | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/e693ac16-7791-429e-819b-4551487d7711 |           |
+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+

stack@qa45:~#

stack@qa45:~#openstack loadbalancer listener delete lt54_lb1

stack@qa45:~#

stack@qa45:~#openstack loadbalancer listener list


stack@qa45:~#

```

**vThunder Configurations:**

```
vThunder-vMaster[14/1](NOLICENSE)#show running-config slb
!Section configuration: 384 bytes
!
slb template http th1
!
slb template policy tp1
!
slb template policy tp3
!
slb template port tp2
!
slb template server ts1
!
slb template tcp tt1
!
slb template udp tu1
!
slb template virtual-port tvp1
!
slb server octavia_health_manager_controller 192.64.0.254
  health-check octavia_health_monitor
!
slb virtual-server c95ec82a-0270-4ddf-8b4a-5cee22458e03 172.16.0.36
!
vThunder-vMaster[14/1](NOLICENSE)#
vThunder-vMaster[14/1](NOLICENSE)#show pki cert
vThunder-vMaster[14/1](NOLICENSE)#

```

**Cascade delete Operation:**

```
stack@qa45:~#openstack loadbalancer listener create --protocol TERMINATED_HTTPS --default-tls-container-ref $(openstack secret container list | awk '/ demo2 / {print $2}') --protocol-port 8040 --name lt54_lb1 lb10

+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | -1                                                                                                                                                                                                                                                                                 |
| created_at                  | 2023-01-04T14:24:19                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | http://10.64.25.45/key-manager/v1/containers/93063cf5-a08c-4526-87a7-05ff144b9180                                                                                                                                                                                                  |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | 7eacbb1b-ba8c-4be8-97ee-0c2e94ad5182                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | c95ec82a-0270-4ddf-8b4a-5cee22458e03                                                                                                                                                                                                                                               |
| name                        | lt54_lb1                                                                                                                                                                                                                                                                           |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | 13cf92b72ee144968b19f34000754835                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 8040                                                                                                                                                                                                                                                                               |
| provisioning_status         | PENDING_CREATE                                                                                                                                                                                                                                                                     |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | None                                                                                                                                                                                                                                                                               |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

stack@qa45:~#

stack@qa45:~#openstack loadbalancer listener list

+--------------------------------------+-----------------+----------+----------------------------------+------------------+---------------+----------------+
| id                                   | default_pool_id | name     | project_id                       | protocol         | protocol_port | admin_state_up |
+--------------------------------------+-----------------+----------+----------------------------------+------------------+---------------+----------------+
| 7eacbb1b-ba8c-4be8-97ee-0c2e94ad5182 | None            | lt54_lb1 | 13cf92b72ee144968b19f34000754835 | TERMINATED_HTTPS |          8040 | True           |
+--------------------------------------+-----------------+----------+----------------------------------+------------------+---------------+----------------+

stack@qa45:~#

```

**vThunder Configurations:**

```
vThunder-vMaster[14/1](NOLICENSE)#show running-config slb
!Section configuration: 627 bytes
!
slb template http th1
!
slb template client-ssl 7eacbb1b-ba8c-4be8-97ee-0c2e94ad5182
  cert demo1
  key demo1.key
!
slb template policy tp1
!
slb template policy tp3
!
slb template port tp2
!
slb template server ts1
!
slb template tcp tt1
!
slb template udp tu1
!
slb template virtual-port tvp1
!
slb server octavia_health_manager_controller 192.64.0.254
  health-check octavia_health_monitor
!
slb virtual-server c95ec82a-0270-4ddf-8b4a-5cee22458e03 172.16.0.36
  port 8040 https
    name 7eacbb1b-ba8c-4be8-97ee-0c2e94ad5182
    extended-stats
    template client-ssl 7eacbb1b-ba8c-4be8-97ee-0c2e94ad5182
!
vThunder-vMaster[14/1](NOLICENSE)#
vThunder-vMaster[14/1](NOLICENSE)#show pki cert
Name: demo1  Type: certificate  Expiration: Dec 21 11:47:52 2022 GMT [Unexpired, Bound]
Name: demo1.key  Type: key  [Bound]
vThunder-vMaster[14/1](NOLICENSE)#


```

**Delete secret container and then delete loadbalancer:**


```
stack@qa45:~#openstack secret container delete $(openstack secret container list | awk '/ demo2 / {print $2}')   
                                                       
stack@qa45:~#openstack secret container delete $(openstack secret container list | awk '/ demo2 / {print $2}')                                                          

stack@qa45:~#openstack secret container list

+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+
| Container href                                                                    | Name   | Created                   | Status | Type        | Secrets                                                                                    | Consumers |
+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+
| http://10.64.25.45/key-manager/v1/containers/5823a595-08b4-4666-8c68-a40f1367622a | mytls1 | 2021-12-21T11:49:23+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/880c0d0a-5e8b-4cc6-81c9-566c8dd80000 | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/3cec7b85-68a1-4971-aac9-03f5dd0c1960 |           |
| http://10.64.25.45/key-manager/v1/containers/cf635390-8c9c-49c7-9c9c-43f88c00644d | srv1   | 2023-01-04T14:24:00+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/6d45d135-6513-4422-859d-ca006074777d | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/4a222b6d-c57c-4cf8-8801-3171a26ab59d |           |
+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+

stack@qa45:~#

stack@qa45:~#openstack loadbalancer delete lb10 --cascade


stack@qa45:~#openstack loadbalancer list

stack@qa45:~#

```

**vThunder Configurations:**

```
vThunder-vMaster[14/1](NOLICENSE)#show running-config slb
!Section configuration: 213 bytes
!
slb template http th1
!
slb template policy tp1
!
slb template policy tp3
!
slb template port tp2
!
slb template server ts1
!
slb template tcp tt1
!
slb template udp tu1
!
slb template virtual-port tvp1
!
vThunder-vMaster[14/1](NOLICENSE)#
vThunder-vMaster[14/1](NOLICENSE)#show pki cert
vThunder-vMaster[14/1](NOLICENSE)#

```

**Rack Flow testing with 5.x vthunder version**

**Loadbalancer create**

```
stack@qa45:~#openstack loadbalancer create --vip-subnet-id 172.16.0.0 --name lb10

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2023-01-05T03:59:04                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 99f5b852-edfd-499a-8a69-cf311518ba17 |
| listeners           |                                      |
| name                | lb10                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 13cf92b72ee144968b19f34000754835     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 172.16.0.67                          |
| vip_network_id      | d6ccc382-e364-48ad-9f76-7182914acf87 |
| vip_port_id         | 96325bd1-9463-47b5-b428-7d96eee3d124 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 9af40ad4-a58f-4a5e-ae5f-c5f357fa81ce |
+---------------------+--------------------------------------+

stack@qa45:~#

stack@qa45:~#openstack secret container list

+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+
| Container href                                                                    | Name   | Created                   | Status | Type        | Secrets                                                                                    | Consumers |
+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+
| http://10.64.25.45/key-manager/v1/containers/5823a595-08b4-4666-8c68-a40f1367622a | mytls1 | 2021-12-21T11:49:23+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/880c0d0a-5e8b-4cc6-81c9-566c8dd80000 | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/3cec7b85-68a1-4971-aac9-03f5dd0c1960 |           |
| http://10.64.25.45/key-manager/v1/containers/dbb9eb79-89bb-4e67-9b18-afd5b3494cd2 | demo   | 2023-01-05T03:58:00+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/d8d0ea35-392c-43b0-a5fe-2151beaa3a41 | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/e693ac16-7791-429e-819b-4551487d7711 |           |
| http://10.64.25.45/key-manager/v1/containers/0dd96014-e17f-419c-9506-9a00da873244 | srv1   | 2023-01-05T04:04:34+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/6d45d135-6513-4422-859d-ca006074777d | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/4a222b6d-c57c-4cf8-8801-3171a26ab59d |           |
+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+

stack@qa45:~#

```

**Listener Create**

```
stack@qa45:~#openstack loadbalancer listener create --protocol TERMINATED_HTTPS --default-tls-container-ref $(openstack secret container list | awk '/ demo / {print $2}') --protocol-port 8040 --name lt54_lb1 lb10

+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | -1                                                                                                                                                                                                                                                                                 |
| created_at                  | 2023-01-05T04:00:52                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | http://10.64.25.45/key-manager/v1/containers/dbb9eb79-89bb-4e67-9b18-afd5b3494cd2                                                                                                                                                                                                  |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | 3ad9d99d-dc59-4065-b1e0-c8fd3fa48337                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | 99f5b852-edfd-499a-8a69-cf311518ba17                                                                                                                                                                                                                                               |
| name                        | lt54_lb1                                                                                                                                                                                                                                                                           |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | 13cf92b72ee144968b19f34000754835                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 8040                                                                                                                                                                                                                                                                               |
| provisioning_status         | PENDING_CREATE                                                                                                                                                                                                                                                                     |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | None                                                                                                                                                                                                                                                                               |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

stack@qa45:~#

```

**vThunder Configurations:**

```
vThunder-vMaster[15/1](NOLICENSE)#show running-config slb
!Section configuration: 575 bytes
!
slb template http th1
!
slb template client-ssl 3ad9d99d-dc59-4065-b1e0-c8fd3fa48337
  cert demo1
  key demo1.key
!
slb template policy tp1
!
slb template policy tp3
!
slb template tcp tt1
!
slb template udp tu1
!
slb template virtual-port tvp1
!
slb server octavia_health_manager_controller 192.64.0.254
  health-check octavia_health_monitor
!
slb virtual-server 99f5b852-edfd-499a-8a69-cf311518ba17 172.16.0.67
  port 8040 https
    name 3ad9d99d-dc59-4065-b1e0-c8fd3fa48337
    extended-stats
    template client-ssl 3ad9d99d-dc59-4065-b1e0-c8fd3fa48337
!
vThunder-vMaster[15/1](NOLICENSE)#

vThunder-vMaster[15/1](NOLICENSE)#show pki cert
Name       Type                       Expiration  Status
------------------------------------------------------------------
demo1      certificate  Dec 21 11:47:52 2022 GMT  [Expired, Bound]
demo1.key  key                                    [Bound]
vThunder-vMaster[15/1](NOLICENSE)#

```

**Update Listener**

`stack@qa45:~#openstack loadbalancer listener set --default-tls-container-ref $(openstack secret container list | awk '/ srv1 / {print $2}') lt54_lb1`



**vThunder Configurations:**

```
vThunder-vMaster[15/1](NOLICENSE)#show running-config slb
!Section configuration: 573 bytes
!
slb template http th1
!
slb template client-ssl 3ad9d99d-dc59-4065-b1e0-c8fd3fa48337
  cert srv1
  key srv1.key
!
slb template policy tp1
!
slb template policy tp3
!
slb template tcp tt1
!
slb template udp tu1
!
slb template virtual-port tvp1
!
slb server octavia_health_manager_controller 192.64.0.254
  health-check octavia_health_monitor
!
slb virtual-server 99f5b852-edfd-499a-8a69-cf311518ba17 172.16.0.67
  port 8040 https
    name 3ad9d99d-dc59-4065-b1e0-c8fd3fa48337
    extended-stats
    template client-ssl 3ad9d99d-dc59-4065-b1e0-c8fd3fa48337
!
vThunder-vMaster[15/1](NOLICENSE)#

```

**Delete listener after deleting secret container attached** 

```
stack@qa45:~#openstack secret container delete $(openstack secret container list | awk '/ srv1 / {print $2}')

stack@qa45:~#

stack@qa45:~#openstack secret container list

+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+
| Container href                                                                    | Name   | Created                   | Status | Type        | Secrets                                                                                    | Consumers |
+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+
| http://10.64.25.45/key-manager/v1/containers/5823a595-08b4-4666-8c68-a40f1367622a | mytls1 | 2021-12-21T11:49:23+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/880c0d0a-5e8b-4cc6-81c9-566c8dd80000 | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/3cec7b85-68a1-4971-aac9-03f5dd0c1960 |           |
| http://10.64.25.45/key-manager/v1/containers/dbb9eb79-89bb-4e67-9b18-afd5b3494cd2 | demo   | 2023-01-05T03:58:00+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/d8d0ea35-392c-43b0-a5fe-2151beaa3a41 | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/e693ac16-7791-429e-819b-4551487d7711 |           |
+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+

stack@qa45:~#

stack@qa45:~#openstack loadbalancer listener delete lt54_lb1

stack@qa45:~#

stack@qa45:~#openstack loadbalancer listener list

stack@qa45:~#

```

**vThunder Configurations:**


```
vThunder-vMaster[15/1](NOLICENSE)#show running-config slb
!Section configuration: 332 bytes
!
slb template http th1
!
slb template policy tp1
!
slb template policy tp3
!
slb template tcp tt1
!
slb template udp tu1
!
slb template virtual-port tvp1
!
slb server octavia_health_manager_controller 192.64.0.254
  health-check octavia_health_monitor
!
slb virtual-server 99f5b852-edfd-499a-8a69-cf311518ba17 172.16.0.67
!
vThunder-vMaster[15/1](NOLICENSE)#
vThunder-vMaster[15/1](NOLICENSE)#show pki cert
Name       Type                       Expiration  Status
--------------------------------------------------------------------
demo1      certificate  Dec 21 11:47:52 2022 GMT  [Expired, Unbound]
srv1       certificate  Dec 21 11:47:52 2022 GMT  [Expired, Unbound]
srv1.key   key                                    [Unbound]
demo1.key  key                                    [Unbound]
vThunder-vMaster[15/1](NOLICENSE)#

```

**Cascade Delete operation:**

```
stack@qa45:~#openstack loadbalancer listener create --protocol TERMINATED_HTTPS --default-tls-container-ref $(openstack secret container list | awk '/ demo / {print $2}') --protocol-port 8040 --name lt54_lb1 lb10

+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | -1                                                                                                                                                                                                                                                                                 |
| created_at                  | 2023-01-05T04:09:08                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | http://10.64.25.45/key-manager/v1/containers/dbb9eb79-89bb-4e67-9b18-afd5b3494cd2                                                                                                                                                                                                  |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | b1ae6b03-6eca-4a8c-a9eb-80e7203d829b                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | 99f5b852-edfd-499a-8a69-cf311518ba17                                                                                                                                                                                                                                               |
| name                        | lt54_lb1                                                                                                                                                                                                                                                                           |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | 13cf92b72ee144968b19f34000754835                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 8040                                                                                                                                                                                                                                                                               |
| provisioning_status         | PENDING_CREATE                                                                                                                                                                                                                                                                     |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | None                                                                                                                                                                                                                                                                               |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

stack@qa45:~#

```

**vThunder Configurations:**

```
vThunder-vMaster[15/1](NOLICENSE)#show running-config slb
!Section configuration: 575 bytes
!
slb template http th1
!
slb template client-ssl b1ae6b03-6eca-4a8c-a9eb-80e7203d829b
  cert demo1
  key demo1.key
!
slb template policy tp1
!
slb template policy tp3
!
slb template tcp tt1
!
slb template udp tu1
!
slb template virtual-port tvp1
!
slb server octavia_health_manager_controller 192.64.0.254
  health-check octavia_health_monitor
!
slb virtual-server 99f5b852-edfd-499a-8a69-cf311518ba17 172.16.0.67
  port 8040 https
    name b1ae6b03-6eca-4a8c-a9eb-80e7203d829b
    extended-stats
    template client-ssl b1ae6b03-6eca-4a8c-a9eb-80e7203d829b
!
vThunder-vMaster[15/1](NOLICENSE)#

vThunder-vMaster[15/1](NOLICENSE)#show pki cert
Name       Type                       Expiration  Status
--------------------------------------------------------------------
demo1      certificate  Dec 21 11:47:52 2022 GMT  [Expired, Bound]
srv1       certificate  Dec 21 11:47:52 2022 GMT  [Expired, Unbound]
srv1.key   key                                    [Unbound]
demo1.key  key                                    [Bound]
vThunder-vMaster[15/1](NOLICENSE)#

```

**Delete secret container attahed and delete lb10**

```
stack@qa45:~#openstack secret container delete $(openstack secret container list | awk '/ demo / {print $2}')                                                           

stack@qa45:~#openstack secret container list

+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+
| Container href                                                                    | Name   | Created                   | Status | Type        | Secrets                                                                                    | Consumers |
+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+
| http://10.64.25.45/key-manager/v1/containers/5823a595-08b4-4666-8c68-a40f1367622a | mytls1 | 2021-12-21T11:49:23+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/880c0d0a-5e8b-4cc6-81c9-566c8dd80000 | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/3cec7b85-68a1-4971-aac9-03f5dd0c1960 |           |
+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+

stack@qa45:~#

stack@qa45:~#openstack loadbalancer delete lb10 --cascade

stack@qa45:~#

stack@qa45:~#openstack loadbalancer list


stack@qa45:~#

```

**vThunder Configurations:**

```
vThunder-vMaster[15/1](NOLICENSE)#show running-config slb
!Section configuration: 161 bytes
!
slb template http th1
!
slb template policy tp1
!
slb template policy tp3
!
slb template tcp tt1
!
slb template udp tu1
!
slb template virtual-port tvp1
!
vThunder-vMaster[15/1](NOLICENSE)#
vThunder-vMaster[15/1](NOLICENSE)#show pki cert
Name       Type                       Expiration  Status
--------------------------------------------------------------------
demo1      certificate  Dec 21 11:47:52 2022 GMT  [Expired, Unbound]
srv1       certificate  Dec 21 11:47:52 2022 GMT  [Expired, Unbound]
srv1.key   key                                    [Unbound]
demo1.key  key                                    [Unbound]
vThunder-vMaster[15/1](NOLICENSE)#

```

**vThunder Flow on 5.x** 

```
stack@qa45:~#openstack loadbalancer create --vip-subnet-id 172.16.0.0 --name lb10

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2023-01-04T14:40:03                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | bea7bc94-50d8-4a50-9c16-efcc3f80cb25 |
| listeners           |                                      |
| name                | lb10                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 13cf92b72ee144968b19f34000754835     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 172.16.0.152                         |
| vip_network_id      | d6ccc382-e364-48ad-9f76-7182914acf87 |
| vip_port_id         | 0f67e76a-8c77-4faf-93be-47d081893fb3 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 9af40ad4-a58f-4a5e-ae5f-c5f357fa81ce |
+---------------------+--------------------------------------+

stack@qa45:~#

stack@qa45:~#openstack loadbalancer list

+--------------------------------------+------+----------------------------------+--------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address  | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+--------------+---------------------+------------------+----------+
| c54e54bc-fb08-45dc-94e0-21843bd6b3c6 | lb11 | 13cf92b72ee144968b19f34000754835 | 172.16.0.242 | ACTIVE              | OFFLINE          | a10      |
| bea7bc94-50d8-4a50-9c16-efcc3f80cb25 | lb10 | 13cf92b72ee144968b19f34000754835 | 172.16.0.152 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+--------------+---------------------+------------------+----------+

stack@qa45:~#

stack@qa45:~#openstack server list

+--------------------------------------+----------------------------------------------+--------+------------------------------------------------+----------------+-----------------+
| ID                                   | Name                                         | Status | Networks                                       | Image          | Flavor          |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------+----------------+-----------------+
| aac88da2-1fbf-4502-b57f-07df93f560cc | amphora-5773fbb7-ff71-42ac-ba97-22709690c05d | ACTIVE | lb-mgmt-net=192.168.0.116; private=172.16.0.64 | vThunder.qcow2 | vThunder_flavor |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------+----------------+-----------------+

stack@qa45:~#

stack@qa45:~#openstack secret container list

+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+
| Container href                                                                    | Name   | Created                   | Status | Type        | Secrets                                                                                    | Consumers |
+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+
| http://10.64.25.45/key-manager/v1/containers/5823a595-08b4-4666-8c68-a40f1367622a | mytls1 | 2021-12-21T11:49:23+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/880c0d0a-5e8b-4cc6-81c9-566c8dd80000 | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/3cec7b85-68a1-4971-aac9-03f5dd0c1960 |           |
| http://10.64.25.45/key-manager/v1/containers/cf635390-8c9c-49c7-9c9c-43f88c00644d | srv1   | 2023-01-04T14:24:00+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/6d45d135-6513-4422-859d-ca006074777d | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/4a222b6d-c57c-4cf8-8801-3171a26ab59d |           |
| http://10.64.25.45/key-manager/v1/containers/ee37465b-dfa3-4c5b-ba89-4d754c0f7784 | demo   | 2023-01-04T14:42:33+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/d8d0ea35-392c-43b0-a5fe-2151beaa3a41 | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/e693ac16-7791-429e-819b-4551487d7711 |           |
+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+

stack@qa45:~#

Create Listener

stack@qa45:~#openstack loadbalancer listener create --protocol TERMINATED_HTTPS --default-tls-container-ref $(openstack secret container list | awk '/ demo / {print $2}') --protocol-port 8040 --name lt54_lb1 lb10

+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | -1                                                                                                                                                                                                                                                                                 |
| created_at                  | 2023-01-04T14:43:49                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | http://10.64.25.45/key-manager/v1/containers/ee37465b-dfa3-4c5b-ba89-4d754c0f7784                                                                                                                                                                                                  |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | bf6eacb3-c2ec-408d-96a9-46487f5009eb                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | bea7bc94-50d8-4a50-9c16-efcc3f80cb25                                                                                                                                                                                                                                               |
| name                        | lt54_lb1                                                                                                                                                                                                                                                                           |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | 13cf92b72ee144968b19f34000754835                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 8040                                                                                                                                                                                                                                                                               |
| provisioning_status         | PENDING_CREATE                                                                                                                                                                                                                                                                     |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | None                                                                                                                                                                                                                                                                               |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

stack@qa45:~#

```

**vThunder Configurations:**

```
amphora-5773fbb7-ff71-42ac-ba97(NOLICENSE)#show running-config slb
!Section configuration: 487 bytes
!
slb template client-ssl bf6eacb3-c2ec-408d-96a9-46487f5009eb
  cert demo1
  key demo1.key
!
slb server octavia_health_manager_controller 192.64.0.254
  health-check octavia_health_monitor
!
slb virtual-server bea7bc94-50d8-4a50-9c16-efcc3f80cb25 172.16.0.152
  port 8040 https
    name bf6eacb3-c2ec-408d-96a9-46487f5009eb
    extended-stats
    template client-ssl bf6eacb3-c2ec-408d-96a9-46487f5009eb
!
slb virtual-server c54e54bc-fb08-45dc-94e0-21843bd6b3c6 172.16.0.242
!
amphora-5773fbb7-ff71-42ac-ba97(NOLICENSE)#

amphora-5773fbb7-ff71-42ac-ba97(NOLICENSE)#show pki cert
Name       Type                       Expiration  Status
------------------------------------------------------------------
demo1      certificate  Dec 21 11:47:52 2022 GMT  [Expired, Bound]
demo1.key  key                                    [Bound]
amphora-5773fbb7-ff71-42ac-ba97(NOLICENSE)#

```

**Update operation**

```
stack@qa45:~#openstack loadbalancer listener set --default-tls-container-ref $(openstack secret container list | awk '/ srv1 / {print $2}') lt54_lb1

stack@qa45:~#

```

**vThunder Configurations:**

```
amphora-5773fbb7-ff71-42ac-ba97(NOLICENSE)#show running-config slb
!Section configuration: 485 bytes
!
slb template client-ssl bf6eacb3-c2ec-408d-96a9-46487f5009eb
  cert srv1
  key srv1.key
!
slb server octavia_health_manager_controller 192.64.0.254
  health-check octavia_health_monitor
!
slb virtual-server bea7bc94-50d8-4a50-9c16-efcc3f80cb25 172.16.0.152
  port 8040 https
    name bf6eacb3-c2ec-408d-96a9-46487f5009eb
    extended-stats
    template client-ssl bf6eacb3-c2ec-408d-96a9-46487f5009eb
!
slb virtual-server c54e54bc-fb08-45dc-94e0-21843bd6b3c6 172.16.0.242
!
amphora-5773fbb7-ff71-42ac-ba97(NOLICENSE)#

```

**Delete Operation:**

```
stack@qa45:~#openstack secret container delete $(openstack secret container list | awk '/ srv1 / {print $2}')

stack@qa45:~#

stack@qa45:~#openstack secret container list

+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+
| Container href                                                                    | Name   | Created                   | Status | Type        | Secrets                                                                                    | Consumers |
+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+
| http://10.64.25.45/key-manager/v1/containers/5823a595-08b4-4666-8c68-a40f1367622a | mytls1 | 2021-12-21T11:49:23+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/880c0d0a-5e8b-4cc6-81c9-566c8dd80000 | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/3cec7b85-68a1-4971-aac9-03f5dd0c1960 |           |
| http://10.64.25.45/key-manager/v1/containers/ee37465b-dfa3-4c5b-ba89-4d754c0f7784 | demo   | 2023-01-04T14:42:33+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/d8d0ea35-392c-43b0-a5fe-2151beaa3a41 | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/e693ac16-7791-429e-819b-4551487d7711 |           |
+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+

stack@qa45:~#

stack@qa45:~#openstack loadbalancer listener delete lt54_lb1

stack@qa45:~#

stack@qa45:~#openstack loadbalancer listener list


stack@qa45:~#
```


**vThunder Configurations:**

```
amphora-5773fbb7-ff71-42ac-ba97(NOLICENSE)#show running-config slb
!Section configuration: 244 bytes
!
slb server octavia_health_manager_controller 192.64.0.254
  health-check octavia_health_monitor
!
slb virtual-server bea7bc94-50d8-4a50-9c16-efcc3f80cb25 172.16.0.152
!
slb virtual-server c54e54bc-fb08-45dc-94e0-21843bd6b3c6 172.16.0.242
!
amphora-5773fbb7-ff71-42ac-ba97(NOLICENSE)#

```

**Cascade delete operation:**

```
stack@qa45:~#openstack secret container list

+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+
| Container href                                                                    | Name   | Created                   | Status | Type        | Secrets                                                                                    | Consumers |
+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+
| http://10.64.25.45/key-manager/v1/containers/5823a595-08b4-4666-8c68-a40f1367622a | mytls1 | 2021-12-21T11:49:23+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/880c0d0a-5e8b-4cc6-81c9-566c8dd80000 | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/3cec7b85-68a1-4971-aac9-03f5dd0c1960 |           |
| http://10.64.25.45/key-manager/v1/containers/ee37465b-dfa3-4c5b-ba89-4d754c0f7784 | demo   | 2023-01-04T14:42:33+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/d8d0ea35-392c-43b0-a5fe-2151beaa3a41 | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/e693ac16-7791-429e-819b-4551487d7711 |           |
| http://10.64.25.45/key-manager/v1/containers/9bb549fc-75ab-4ad4-8828-16a5161e7079 | srv1   | 2023-01-04T14:55:19+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/6d45d135-6513-4422-859d-ca006074777d | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/4a222b6d-c57c-4cf8-8801-3171a26ab59d |           |
+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+

stack@qa45:~#

stack@qa45:~#openstack loadbalancer listener create --protocol TERMINATED_HTTPS --default-tls-container-ref $(openstack secret container list | awk '/ demo / {print $2}') --protocol-port 8040 --name lt54_lb1 lb10

+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | -1                                                                                                                                                                                                                                                                                 |
| created_at                  | 2023-01-04T14:56:10                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | http://10.64.25.45/key-manager/v1/containers/ee37465b-dfa3-4c5b-ba89-4d754c0f7784                                                                                                                                                                                                  |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | 25c0846e-853b-4e8f-94c7-a76eee4455b8                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | bea7bc94-50d8-4a50-9c16-efcc3f80cb25                                                                                                                                                                                                                                               |
| name                        | lt54_lb1                                                                                                                                                                                                                                                                           |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | 13cf92b72ee144968b19f34000754835                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 8040                                                                                                                                                                                                                                                                               |
| provisioning_status         | PENDING_CREATE                                                                                                                                                                                                                                                                     |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | None                                                                                                                                                                                                                                                                               |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

stack@qa45:~#

```

**vThunder Configurations:**

```
amphora-5773fbb7-ff71-42ac-ba97(NOLICENSE)#show running-config slb
!Section configuration: 487 bytes
!
slb template client-ssl 25c0846e-853b-4e8f-94c7-a76eee4455b8
  cert demo1
  key demo1.key
!
slb server octavia_health_manager_controller 192.64.0.254
  health-check octavia_health_monitor
!
slb virtual-server bea7bc94-50d8-4a50-9c16-efcc3f80cb25 172.16.0.152
  port 8040 https
    name 25c0846e-853b-4e8f-94c7-a76eee4455b8
    extended-stats
    template client-ssl 25c0846e-853b-4e8f-94c7-a76eee4455b8
!
slb virtual-server c54e54bc-fb08-45dc-94e0-21843bd6b3c6 172.16.0.242
!
amphora-5773fbb7-ff71-42ac-ba97(NOLICENSE)#

```

```
stack@qa45:~#openstack secret container delete $(openstack secret container list | awk '/ demo / {print $2}')

stack@qa45:~#

stack@qa45:~#openstack secret container list

+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+
| Container href                                                                    | Name   | Created                   | Status | Type        | Secrets                                                                                    | Consumers |
+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+
| http://10.64.25.45/key-manager/v1/containers/5823a595-08b4-4666-8c68-a40f1367622a | mytls1 | 2021-12-21T11:49:23+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/880c0d0a-5e8b-4cc6-81c9-566c8dd80000 | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/3cec7b85-68a1-4971-aac9-03f5dd0c1960 |           |
| http://10.64.25.45/key-manager/v1/containers/9bb549fc-75ab-4ad4-8828-16a5161e7079 | srv1   | 2023-01-04T14:55:19+00:00 | ACTIVE | certificate | certificate=http://10.64.25.45/key-manager/v1/secrets/6d45d135-6513-4422-859d-ca006074777d | None      |
|                                                                                   |        |                           |        |             | private_key=http://10.64.25.45/key-manager/v1/secrets/4a222b6d-c57c-4cf8-8801-3171a26ab59d |           |
+-----------------------------------------------------------------------------------+--------+---------------------------+--------+-------------+--------------------------------------------------------------------------------------------+-----------+

stack@qa45:~#


stack@qa45:~#openstack loadbalancer delete lb10 --cascade

stack@qa45:~#

stack@qa45:~#openstack loadbalancer list

+--------------------------------------+------+----------------------------------+--------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address  | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+--------------+---------------------+------------------+----------+
| c54e54bc-fb08-45dc-94e0-21843bd6b3c6 | lb11 | 13cf92b72ee144968b19f34000754835 | 172.16.0.242 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+--------------+---------------------+------------------+----------+


stack@qa45:~#

```

**vThunder Configurations:**

```
amphora-5773fbb7-ff71-42ac-ba97(NOLICENSE)#show running-config slb
!Section configuration: 172 bytes
!
slb server octavia_health_manager_controller 192.64.0.254
  health-check octavia_health_monitor
!
slb virtual-server c54e54bc-fb08-45dc-94e0-21843bd6b3c6 172.16.0.242
!
amphora-5773fbb7-ff71-42ac-ba97(NOLICENSE)#


```




[STACK-3395]: https://a10networks.atlassian.net/browse/STACK-3395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ