### PR TITLE
[Feature][STACK-3420] Pending Resource Cleanup

### DIFF
--- a/a10_octavia/cmd/a10_house_keeper.py
+++ b/a10_octavia/cmd/a10_house_keeper.py
@@ -130,7 +130,7 @@ def pending_resource_cleanup():
             except Exception as e:
                 LOG.exception('Pending resource cleanup caught the following exception and '
                               ' is restarting: {}'.format(e))
-            write_memory_thread_event.wait(interval)
+            pending_resource_cleanup_thread_event.wait(interval)
     else:
         LOG.warning("Pending resource cleanup flag is disabled...")
 

--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -398,7 +398,14 @@ A10_HOUSE_KEEPING_OPTS = [
     cfg.StrOpt('use_periodic_write_memory',
                choices=['enable', 'disable'],
                default='disable',
-               help=_('Enable to use periodic write memory on all thunders'))
+               help=_('Enable to use periodic write memory on all thunders')),
+    cfg.StrOpt('pending_resource_cleanup',
+               choices=['enable', 'disable'],
+               default='disable',
+               help=_('Disable pending resource cleanup')),
+    cfg.IntOpt('resource_cleanup_interval',
+               default=3600,
+               help=_('Pending resource cleanup interval in seconds'))
 ]
 
 A10_NOVA_OPTS = [

--- a/a10_octavia/controller/housekeeping/house_keeping.py
+++ b/a10_octavia/controller/housekeeping/house_keeping.py
@@ -190,10 +190,11 @@ class PendingResourceCleanup(object):
                                               provisioning_status=constants.ERROR)
                 vthunder = self.vthunder_repo.get_vthunder_from_lb(
                     db_api.get_session(), pending_lb.id)
-                self.vthunder_repo.update(
-                    db_api.get_session(),
-                    vthunder.id,
-                    status=constants.ACTIVE)
+                if vthunder is not None:
+                    self.vthunder_repo.update(
+                        db_api.get_session(),
+                        vthunder.id,
+                        status=constants.ACTIVE)
             except Exception as e:
                 LOG.exception("Failed to update load balancer %(lb) "
                               "provisioning status to ERROR due to: "

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -1505,6 +1505,10 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
     def delete_load_balancer_with_housekeeping(self, pending_lb, cascade=True):
         """Function to delete load balancer for A10 provider using Housekeeper thread"""
+        vthunder = self._vthunder_repo.get_vthunder_from_lb(
+            db_apis.get_session(), pending_lb.id)
+        if vthunder and vthunder.compute_id is not None:
+            return
         if pending_lb.project_id in CONF.hardware_thunder.devices:
             try:
                 self._lb_repo.update(db_apis.get_session(),

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -1503,51 +1503,44 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             return flavor_data
         return None
 
-    def delete_load_balancer_with_housekeeping(self, load_balancer_id, ctx_map, ctx_lock,
-                                               cascade=True):
+    def delete_load_balancer_with_housekeeping(self, pending_lb, cascade=True):
         """Function to delete load balancer for A10 provider using Housekeeper thread"""
-        self.ctx_map = ctx_map
-        self.ctx_lock = ctx_lock
-        lb = self._lb_repo.get(db_apis.get_session(),
-                               id=load_balancer_id)
-        vthunder = self._vthunder_repo.get_vthunder_from_lb(db_apis.get_session(),
-                                                            load_balancer_id)
-        deleteCompute = False
-        ctx_flags = [False]
-        busy = self._vthunder_busy_check(lb.project_id, True, ctx_flags, lb)
-        try:
-            if vthunder:
-                deleteCompute = self._vthunder_repo.get_delete_compute_flag(db_apis.get_session(),
-                                                                            vthunder.compute_id)
-
-            if self._is_rack_flow(lb.project_id, loadbalancer=lb):
+        if pending_lb.project_id in CONF.hardware_thunder.devices:
+            try:
+                self._lb_repo.update(db_apis.get_session(),
+                                     pending_lb.id,
+                                     provisioning_status=constants.ERROR)
+                vthunder = self._vthunder_repo.get_vthunder_from_lb(
+                    db_apis.get_session(), pending_lb.id)
+                if vthunder is not None:
+                    self._vthunder_repo.update(
+                        db_apis.get_session(),
+                        vthunder.id,
+                        status=constants.ACTIVE)
+            except Exception as e:
+                LOG.exception("Failed to update load balancer %(lb) "
+                              "provisioning status to ERROR due to: "
+                              "%(except)s", {'lb': pending_lb.id, 'except': e})
+                raise e
+            lb = self._lb_repo.get(db_apis.get_session(), id=pending_lb.id)
+            vthunder = self._vthunder_repo.get_vthunder_from_lb(db_apis.get_session(),
+                                                                lb.id)
+            try:
                 vthunder_conf = CONF.hardware_thunder.devices.get(lb.project_id, None)
                 device_dict = CONF.hardware_thunder.devices
                 (flow, store) = self._lb_flows.get_delete_rack_vthunder_load_balancer_flow(
                     lb, cascade,
                     vthunder_conf=vthunder_conf, device_dict=device_dict)
                 store.update({constants.LOADBALANCER: lb,
-                              a10constants.COMPUTE_BUSY: busy,
+                              a10constants.COMPUTE_BUSY: False,
                               constants.VIP: lb.vip,
                               constants.SERVER_GROUP_ID: lb.server_group_id})
-            else:
-                (flow, store) = self._lb_flows.get_delete_load_balancer_flow(
-                    lb, deleteCompute, cascade)
-                store.update({constants.LOADBALANCER: lb,
-                              a10constants.COMPUTE_BUSY: busy,
-                              constants.VIP: lb.vip,
-                              constants.SERVER_GROUP_ID: lb.server_group_id,
-                              constants.LOADBALANCER_ID: lb.id,
-                              a10constants.MASTER_AMPHORA_STATUS: True,
-                              a10constants.VTHUNDER_CONFIG: None,
-                              a10constants.USE_DEVICE_FLAVOR: False,
-                              a10constants.LB_COUNT_THUNDER: None,
-                              a10constants.MEMBER_COUNT_THUNDER: None})
 
-            delete_lb_tf = self.taskflow_load(flow, store=store)
+                delete_lb_tf = self.taskflow_load(flow, store=store)
 
-            with tf_logging.DynamicLoggingListener(delete_lb_tf,
-                                                   log=LOG):
-                delete_lb_tf.run()
-        finally:
-            self._set_vthunder_available(lb.project_id, True, ctx_flags, lb)
+                with tf_logging.DynamicLoggingListener(delete_lb_tf,
+                                                       log=LOG):
+                    delete_lb_tf.run()
+            except Exception:
+                # continue on other thunders (assume exception is logged)
+                pass

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -1505,22 +1505,21 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
 
     def delete_load_balancer_with_housekeeping(self, pending_lb, cascade=True):
         """Function to delete load balancer for A10 provider using Housekeeper thread"""
-        vthunder = self._vthunder_repo.get_vthunder_from_lb(
-            db_apis.get_session(), pending_lb.id)
-        if vthunder and vthunder.compute_id is not None:
-            return
         if pending_lb.project_id in CONF.hardware_thunder.devices:
             try:
-                self._lb_repo.update(db_apis.get_session(),
-                                     pending_lb.id,
-                                     provisioning_status=constants.ERROR)
                 vthunder = self._vthunder_repo.get_vthunder_from_lb(
                     db_apis.get_session(), pending_lb.id)
                 if vthunder is not None:
-                    self._vthunder_repo.update(
-                        db_apis.get_session(),
-                        vthunder.id,
-                        status=constants.ACTIVE)
+                    if vthunder.compute_id is not None:
+                        return
+                    else:
+                        self._vthunder_repo.update(
+                            db_apis.get_session(),
+                            vthunder.id,
+                            status=constants.ACTIVE)
+                self._lb_repo.update(db_apis.get_session(),
+                                     pending_lb.id,
+                                     provisioning_status=constants.ERROR)
             except Exception as e:
                 LOG.exception("Failed to update load balancer %(lb) "
                               "provisioning status to ERROR due to: "

--- a/a10_octavia/controller/worker/controller_worker.py
+++ b/a10_octavia/controller/worker/controller_worker.py
@@ -1503,7 +1503,8 @@ class A10ControllerWorker(base_taskflow.BaseTaskFlowEngine):
             return flavor_data
         return None
 
-    def delete_load_balancer_with_housekeeping(self, load_balancer_id, ctx_map, ctx_lock, cascade=True):
+    def delete_load_balancer_with_housekeeping(self, load_balancer_id, ctx_map, ctx_lock,
+                                               cascade=True):
         """Function to delete load balancer for A10 provider using Housekeeper thread"""
         self.ctx_map = ctx_map
         self.ctx_lock = ctx_lock

--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -1155,8 +1155,11 @@ class GetSpareComputeForProject(BaseDatabaseTask):
 
     def revert(self, compute_id=None, *args, **kwargs):
         if self.spare is not None:
-            self.vthunder_repo.set_spare_vthunder_status(
-                db_apis.get_session(), self.spare.id, "READY")
+            try:
+                self.vthunder_repo.set_spare_vthunder_status(
+                    db_apis.get_session(), self.spare.id, "READY")
+            except Exception as e:
+                LOG.exception("Failed to set spare vthunder status to READY: %s", e)
 
 
 class TryGetSpareCompute(BaseDatabaseTask):
@@ -1387,7 +1390,10 @@ class LoadBalancerListToErrorOnRevertTask(BaseDatabaseTask):
 
     def revert(self, loadbalancers_list, *args, **kwargs):
         for lb in loadbalancers_list:
-            self.task_utils.mark_loadbalancer_prov_status_error(lb.id)
+            try:
+                self.task_utils.mark_loadbalancer_prov_status_error(lb.id)
+            except Exception as e:
+                LOG.exception("Failed to change LB status to error: %s", e)
 
 
 class GetPoolListener(BaseDatabaseTask):

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -662,14 +662,17 @@ class ApplyQos(BaseNetworkTask):
     def revert(self, result, loadbalancer, amps_data=None, update_dict=None,
                *args, **kwargs):
         """Handle a failure to apply QoS to VIP"""
-        request_qos_id = loadbalancer.vip.qos_policy_id
-        orig_lb = self.task_utils.get_current_loadbalancer_from_db(
-            loadbalancer.id)
-        orig_qos_id = orig_lb.vip.qos_policy_id
-        if request_qos_id != orig_qos_id:
-            self._apply_qos_on_vrrp_ports(loadbalancer, amps_data, orig_qos_id,
-                                          is_revert=True,
-                                          request_qos_id=request_qos_id)
+        try:
+            request_qos_id = loadbalancer.vip.qos_policy_id
+            orig_lb = self.task_utils.get_current_loadbalancer_from_db(
+                loadbalancer.id)
+            orig_qos_id = orig_lb.vip.qos_policy_id
+            if request_qos_id != orig_qos_id:
+                self._apply_qos_on_vrrp_ports(loadbalancer, amps_data, orig_qos_id,
+                                              is_revert=True,
+                                              request_qos_id=request_qos_id)
+        except Exception:
+            LOG.exception("Error for Apply qos policy on the vrrp ports")
         return
 
 

--- a/a10_octavia/controller/worker/tasks/glm_tasks.py
+++ b/a10_octavia/controller/worker/tasks/glm_tasks.py
@@ -128,14 +128,16 @@ class DNSConfiguration(task.Task):
     @axapi_client_decorator_for_revert
     def revert(self, vthunder, flavor=None, *args, **kwargs):
         flavor = flavor if flavor else {}
-        primary_dns, secondary_dns = self._get_dns_nameservers(vthunder, flavor)
-        if not primary_dns and not secondary_dns:
-            return None
-
         try:
+            primary_dns, secondary_dns = self._get_dns_nameservers(vthunder, flavor)
+            if not primary_dns and not secondary_dns:
+                return None
+
             self.axapi_client.dns.delete(primary_dns, secondary_dns)
         except req_exceptions.ConnectionError:
             LOG.exception("Failed to connect A10 Thunder device: %s", vthunder.ip_address)
+        except Exception as e:
+            LOG.exception("Failed to connect A10 Thunder device due to: %s", e)
 
 
 class ActivateFlexpoolLicense(task.Task):

--- a/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
+++ b/a10_octavia/controller/worker/tasks/health_monitor_tasks.py
@@ -191,4 +191,7 @@ class HealthMonitorToErrorOnRevertTask(lifecycle_tasks.BaseLifecycleTask):
         pass
 
     def revert(self, health_mon, *args, **kwargs):
-        self.task_utils.mark_health_mon_prov_status_error(health_mon.pool_id)
+        try:
+            self.task_utils.mark_health_mon_prov_status_error(health_mon.pool_id)
+        except Exception as e:
+            LOG.exception("Failed to change status to error due to: %s", e)

--- a/a10_octavia/controller/worker/tasks/l7policy_tasks.py
+++ b/a10_octavia/controller/worker/tasks/l7policy_tasks.py
@@ -181,4 +181,7 @@ class L7PolicyToErrorOnRevertTask(lifecycle_tasks.BaseLifecycleTask):
         pass
 
     def revert(self, l7policy, *args, **kwargs):
-        self.task_utils.mark_l7policy_prov_status_error(l7policy.id)
+        try:
+            self.task_utils.mark_l7policy_prov_status_error(l7policy.id)
+        except Exception as e:
+            LOG.exception("Failed to change status due to: %s", e)

--- a/a10_octavia/controller/worker/tasks/l7policy_tasks.py
+++ b/a10_octavia/controller/worker/tasks/l7policy_tasks.py
@@ -165,8 +165,10 @@ class DeleteL7Policy(task.Task):
             raise e
 
         try:
-            self.axapi_client.slb.aflex_policy.delete(l7policy.id)
-            LOG.debug("Successfully deleted l7policy: %s", l7policy.id)
+            l7policy_exists = self.axapi_client.slb.aflex_policy.exists(l7policy.id)
+            if l7policy_exists:
+                self.axapi_client.slb.aflex_policy.delete(l7policy.id)
+                LOG.debug("Successfully deleted l7policy: %s", l7policy.id)
         except (acos_errors.ACOSException, exceptions.ConnectionError) as e:
             LOG.exception("Failed to delete l7policy: %s", l7policy.id)
             raise e

--- a/a10_octavia/controller/worker/tasks/l7rule_tasks.py
+++ b/a10_octavia/controller/worker/tasks/l7rule_tasks.py
@@ -165,4 +165,7 @@ class L7RuleToErrorOnRevertTask(lifecycle_tasks.BaseLifecycleTask):
         pass
 
     def revert(self, l7rule, *args, **kwargs):
-        self.task_utils.mark_l7rule_prov_status_error(l7rule.id)
+        try:
+            self.task_utils.mark_l7rule_prov_status_error(l7rule.id)
+        except Exception as e:
+            LOG.exception("Failed to change status due to: %s", e)

--- a/a10_octavia/controller/worker/tasks/nat_pool_tasks.py
+++ b/a10_octavia/controller/worker/tasks/nat_pool_tasks.py
@@ -83,9 +83,10 @@ class NatPoolCreate(task.Task):
     @axapi_client_decorator_for_revert
     def revert(self, loadbalancer, vthunder, flavor_data=None, *args, **kwargs):
         if flavor_data:
-            natpool_flavor_list = flavor_data.get('nat_pool_list')
-            natpool_flavor = flavor_data.get('nat_pool')
             try:
+                natpool_flavor_list = flavor_data.get('nat_pool_list')
+                natpool_flavor = flavor_data.get('nat_pool')
+
                 if len(self._added_pool_list) > 0:
                     if natpool_flavor_list:
                         for nat_pool in natpool_flavor_list:

--- a/a10_octavia/controller/worker/tasks/server_tasks.py
+++ b/a10_octavia/controller/worker/tasks/server_tasks.py
@@ -261,4 +261,7 @@ class MemberToErrorOnRevertTask(lifecycle_tasks.BaseLifecycleTask):
         pass
 
     def revert(self, member, *args, **kwargs):
-        self.task_utils.mark_member_prov_status_error(member.id)
+        try:
+            self.task_utils.mark_member_prov_status_error(member.id)
+        except Exception as e:
+            LOG.exception("Failed to change status due to: %s", e)

--- a/a10_octavia/controller/worker/tasks/service_group_tasks.py
+++ b/a10_octavia/controller/worker/tasks/service_group_tasks.py
@@ -209,4 +209,7 @@ class PoolToErrorOnRevertTask(lifecycle_tasks.BaseLifecycleTask):
         pass
 
     def revert(self, pool, *args, **kwargs):
-        self.task_utils.mark_pool_prov_status_error(pool.id)
+        try:
+            self.task_utils.mark_pool_prov_status_error(pool.id)
+        except Exception as e:
+            LOG.exception("Failed to change status due to: %s", e)

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -177,11 +177,15 @@ class AllowL2DSR(VThunderBaseTask):
             return
 
         if flavor_data:
-            deployment = flavor_data.get('deployment')
-            if deployment and 'dsr_type' in deployment:
-                if deployment['dsr_type'] == "l2dsr_transparent":
-                    for amp in amphora:
-                        self.network_driver.remove_any_source_ip_on_egress(subnet.network_id, amp)
+            try:
+                deployment = flavor_data.get('deployment')
+                if deployment and 'dsr_type' in deployment:
+                    if deployment['dsr_type'] == "l2dsr_transparent":
+                        for amp in amphora:
+                            self.network_driver.remove_any_source_ip_on_egress(
+                                subnet.network_id, amp)
+            except Exception as e:
+                LOG.exception("Failed to revert AllowL2DSR due to: %s", e)
 
 
 class DeleteL2DSR(VThunderBaseTask):

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -523,7 +523,7 @@ class LoadBalancerRepository(repo.LoadBalancerRepository):
     def get_pending_lbs_to_be_deleted(self, session, cleanup_interval):
         lb_list = []
         time_interval = datetime.datetime.utcnow() - datetime.timedelta(
-                seconds=CONF.a10_house_keeping.resource_cleanup_interval)
+                seconds=cleanup_interval)
         query = session.query(self.model_class).filter(
                 self.model_class.created_at < time_interval).filter(
                 and_(or_(self.model_class.updated_at == None,

--- a/a10_octavia/db/repositories.py
+++ b/a10_octavia/db/repositories.py
@@ -520,6 +520,23 @@ class LoadBalancerRepository(repo.LoadBalancerRepository):
             return None
         return model.to_data_model()
 
+    def get_pending_lbs_to_be_deleted(self, session, cleanup_interval):
+        lb_list = []
+        time_interval = datetime.datetime.utcnow() - datetime.timedelta(
+                seconds=CONF.a10_house_keeping.resource_cleanup_interval)
+        query = session.query(self.model_class).filter(
+                self.model_class.created_at < time_interval).filter(
+                and_(or_(self.model_class.updated_at == None,
+                         self.model_class.updated_at < time_interval),
+                or_(self.model_class.provisioning_status == "PENDING_CREATE",
+                    self.model_class.provisioning_status == "PENDING_DELETE",
+                    self.model_class.provisioning_status == "PENDING_UPDATE")))
+        query = query.options(noload('*'))
+        model_list = query.all()
+        for data in model_list:
+            lb_list.append(data.to_data_model())
+        return lb_list
+
 
 class ListenerRepository(repo.ListenerRepository):
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 acos-client>=2.9.1		#
-octavia>=7.0.0			# victoria version of octavia
-octavia-lib			#
+octavia>=7.0.0,<=10.0.0	# victoria version of octavia
+octavia-lib			    #
 keystone==18.0.0
 python-barbicanclient>=4.5.2 	# copied from octavia requirements.txt
 python-glanceclient>=2.8.0 	# Apache-2.0


### PR DESCRIPTION
## Description
Sometimes execution of A10-octavia can get failed during slb objects’ creation/updation/deletion due to some interrupting situations and then the slb objects may stay in PENDING status. 
There is no way to delete these PENDING objects from OpenStack side and thus those PENDING objects also remain as it is in database. 
This feature will let the a10-octavia to cleanup all the pending resources along with their ports and security groups(in case of LB and member) after a specific interval of time.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3420

## Technical Approach
- Added support for `pending_resource_cleanup` and `resource_cleanup_interval` config options in `[a10_house_keeping]` section.
- Implemented a method `pending_resource_cleanup()` for cleaning up the pending resources in a specified interval of time and called it by creating a thread for handling pending resource cleanup activity.
- Implemented a DB method to fetch loadbalancers in PENDING_CREATE/PENDING_UPDATE/PENDING_DELETE status which need to be deleted.
- Implemented a method `cleanup_slb_resources()` for deleting the pending LBs and their dependent objects from vThunder as well as from OpenStack side.
- Created a new flow `delete_load_balancer_with_housekeeping()` for deleting load_balancer using housekeeper process and called it in cleanup_slb_resources() for deleting the pending LBs and their children in cascade way.

## Config Changes
<pre>
[a10_house_keeping]
pending_resource_cleanup = "enable"
resource_cleanup_interval = 1800
</pre>

## Test Cases
Testset 1:
1. Create a loadbalancer and restart the controller-worker service in the middle of the creation process.
2. Wait for specified amount of resource cleanup interval and then check whether the PENDING_CREATE loadbalancer got deleted along with its port and security group.

Testset 2:
1. Create a loadbalancer, listener and pool.
2. Create a member and restart the controller-worker service in the middle of the creation process.
3. Make sure the status of member is PENDING_CREATE and so the status of pool and LB is PENDING_UPDATE.
4. Wait for specified amount of resource cleanup interval and then check whether the pending resources got deleted.

Testset 3:
1. Create a loadbalancer, listener, pool, member and health-monitor and l7policy
2. Create l7rule and restart the controller-worker service in the middle of the creation process.
3. Make sure the status of l7rule is PENDING_CREATE and so the status of the other slb objects is PENDING_UPDATE.
4. Wait for specified amount of resource cleanup interval and then check whether the pending resources got deleted.

Testset 4:
1. Create a loadbalancer, listener, pool and member.
2. Delete the member and restart the controller-worker service in the middle of the deletion process.
3. Make sure the status of member is PENDING_DELETE and so the status of pool and LB is PENDING_UPDATE.
4. Wait for specified amount of resource cleanup interval and then check whether the pending resources got deleted.


## Manual Testing

Following [a10_house_keeping] section is added for the testing:

```
[a10_house_keeping]
pending_resource_cleanup = "enable"
resource_cleanup_interval = 300
```

1. Create a loadbalancer, listener and pool:
```
stack@adeeb-victoria:~/neha/a10-octavia#openstack loadbalancer create --vip-subnet-id vip_subnet --name vip1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2023-01-25T11:58:45                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 02f55350-0cca-4c71-b9bc-2e95e8287c31 |
| listeners           |                                      |
| name                | vip1                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | bb6295b395d24ce7b8b8c47b8b418522     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 192.168.12.231                       |
| vip_network_id      | c725bcb7-b154-4d52-8cb6-07846afae59a |
| vip_port_id         | da9d0f75-3eb5-40f5-b1a4-ac1df1c3ec84 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 23f92976-5ec0-4ca9-bc0e-a387cca1f98e |
+---------------------+--------------------------------------+
```

```
stack@adeeb-victoria:~/neha/a10-octavia#openstack loadbalancer list
+--------------------------------------+------+----------------------------------+----------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address    | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+----------------+---------------------+------------------+----------+
| 02f55350-0cca-4c71-b9bc-2e95e8287c31 | vip1 | bb6295b395d24ce7b8b8c47b8b418522 | 192.168.12.231 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+----------------+---------------------+------------------+----------+
```

```
stack@adeeb-victoria:~/neha/a10-octavia#openstack loadbalancer listener create --protocol http --protocol-port 80 --name vport1 vip1
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2023-01-25T12:09:23                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 42729e53-02a5-4372-8b0c-b7338c276b45 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 02f55350-0cca-4c71-b9bc-2e95e8287c31 |
| name                        | vport1                               |
| operating_status            | OFFLINE                              |
| project_id                  | bb6295b395d24ce7b8b8c47b8b418522     |
| protocol                    | HTTP                                 |
| protocol_port               | 80                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
| allowed_cidrs               | None                                 |
| tls_ciphers                 | None                                 |
| tls_versions                | None                                 |
| alpn_protocols              | None                                 |
+-----------------------------+--------------------------------------+
```
```
stack@adeeb-victoria:~/neha/a10-octavia#openstack loadbalancer listener list
+--------------------------------------+-----------------+--------+----------------------------------+----------+---------------+----------------+
| id                                   | default_pool_id | name   | project_id                       | protocol | protocol_port | admin_state_up |
+--------------------------------------+-----------------+--------+----------------------------------+----------+---------------+----------------+
| 42729e53-02a5-4372-8b0c-b7338c276b45 | None            | vport1 | bb6295b395d24ce7b8b8c47b8b418522 | HTTP     |            80 | True           |
+--------------------------------------+-----------------+--------+----------------------------------+----------+---------------+----------------+
```

```
stack@adeeb-victoria:~/neha/a10-octavia#openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --name p1 --loadbala
ncer vip1
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2023-01-25T12:14:28                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | b3f83091-e580-4e95-9dc9-46ec553c9d5f |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            |                                      |
| loadbalancers        | 02f55350-0cca-4c71-b9bc-2e95e8287c31 |
| members              |                                      |
| name                 | p1                                   |
| operating_status     | OFFLINE                              |
| project_id           | bb6295b395d24ce7b8b8c47b8b418522     |
| protocol             | TCP                                  |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+

```

```
stack@adeeb-victoria:~/neha/a10-octavia#openstack loadbalancer pool list
+--------------------------------------+------+----------------------------------+---------------------+----------+--------------+----------------+
| id                                   | name | project_id                       | provisioning_status | protocol | lb_algorithm | admin_state_up |
+--------------------------------------+------+----------------------------------+---------------------+----------+--------------+----------------+
| b3f83091-e580-4e95-9dc9-46ec553c9d5f | p1   | bb6295b395d24ce7b8b8c47b8b418522 | ACTIVE              | TCP      | ROUND_ROBIN  | True           |
+--------------------------------------+------+----------------------------------+---------------------+----------+--------------+----------------+
```

6. Create a member and restart a10-controller-worker service in between of the creation sothat the menber will stay into PENDING_CREATE state.

```
stack@adeeb-victoria:~/neha/a10-octavia#openstack loadbalancer member create --subnet-id 81028fee-7750-4f32-b25a-301b7f568e57 --protocol-port 85 --address 192.168.11.11 p1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 192.168.11.11                        |
| admin_state_up      | True                                 |
| created_at          | 2023-01-25T12:17:05                  |
| id                  | 3716bccc-3001-4dd5-8e78-7d99f3af5e6b |
| name                |                                      |
| operating_status    | NO_MONITOR                           |
| project_id          | bb6295b395d24ce7b8b8c47b8b418522     |
| protocol_port       | 85                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 81028fee-7750-4f32-b25a-301b7f568e57 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
```

```
stack@adeeb-victoria:~/neha/a10-octavia#openstack loadbalancer member list p1
+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
| id                                   | name | project_id                       | provisioning_status | address       | protocol_port | operating_status | weight |
+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
| 3716bccc-3001-4dd5-8e78-7d99f3af5e6b |      | bb6295b395d24ce7b8b8c47b8b418522 | PENDING_CREATE      | 192.168.11.11 |            85 | NO_MONITOR       |      1 |
+--------------------------------------+------+----------------------------------+---------------------+---------------+---------------+------------------+--------+
```

7. Check status of pool, listener and loadbalancer:

```
stack@adeeb-victoria:~/neha/a10-octavia#openstack loadbalancer pool list
+--------------------------------------+------+----------------------------------+---------------------+----------+--------------+----------------+
| id                                   | name | project_id                       | provisioning_status | protocol | lb_algorithm | admin_state_up |
+--------------------------------------+------+----------------------------------+---------------------+----------+--------------+----------------+
| b3f83091-e580-4e95-9dc9-46ec553c9d5f | p1   | bb6295b395d24ce7b8b8c47b8b418522 | PENDING_UPDATE      | TCP      | ROUND_ROBIN  | True           |
+--------------------------------------+------+----------------------------------+---------------------+----------+--------------+----------------+
```

```
stack@adeeb-victoria:~/neha/a10-octavia#openstack loadbalancer list
+--------------------------------------+------+----------------------------------+----------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address    | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+----------------+---------------------+------------------+----------+
| 02f55350-0cca-4c71-b9bc-2e95e8287c31 | vip1 | bb6295b395d24ce7b8b8c47b8b418522 | 192.168.12.231 | PENDING_UPDATE      | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+----------------+---------------------+------------------+----------+

```

8. Check the resources after specified amount of resource cleanup interval i.e half hour:
```
stack@adeeb-victoria:~/neha/a10-octavia#openstack loadbalancer list

stack@adeeb-victoria:~/neha/a10-octavia#openstack loadbalancer listener list

stack@adeeb-victoria:~/neha/a10-octavia#openstack loadbalancer pool list

stack@adeeb-victoria:~/neha/a10-octavia#openstack loadbalancer member list p1
Unable to locate p1 in pools

```

All the pending resources are getting removed along with their port and security group from OpenStack as well as ACOS.

