### PR TITLE
[STACK-3431]: ACOS 5 SSL aXAPI support

### DIFF
--- a/a10_octavia/controller/worker/flows/vthunder_flows.py
+++ b/a10_octavia/controller/worker/flows/vthunder_flows.py
@@ -531,6 +531,9 @@ class VThunderFlows(object):
         amp_for_lb_flow.add(a10_database_tasks.GetVThunderByLoadBalancer(
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
+        amp_for_lb_flow.add(vthunder_tasks.UpdateAcosVersionInVthunderEntry(
+            name=sf_name + '-' + a10constants.UPDATE_ACOS_VERSION_IN_VTHUNDER_ENTRY,
+            requires=(a10constants.VTHUNDER)))
         return amp_for_lb_flow
 
     def _is_vrrp_configured(self, history):

--- a/a10_octavia/controller/worker/tasks/cert_tasks.py
+++ b/a10_octavia/controller/worker/tasks/cert_tasks.py
@@ -40,7 +40,7 @@ class CheckListenerType(task.Task):
 
 class GetSSLCertData(task.Task):
     """Task to get SSL certificate data from Barbican"""
-     
+
     @axapi_client_decorator
     def execute(self, loadbalancer, listener, vthunder, update_dict={}):
         cert_data = None
@@ -50,13 +50,22 @@ class GetSSLCertData(task.Task):
             barbican_client = BarbicanACLAuth().get_barbican_client(loadbalancer.project_id)
             cert_data = utils.get_cert_data(barbican_client, listener)
             if not cert_data.template_name:
-                client_ssl=self.axapi_client.slb.template.client_ssl.get(name=listener.id)
-                if client_ssl['client-ssl'].get('cert') and client_ssl['client-ssl'].get('key'):
-                    cert_data.cert_filename=client_ssl['client-ssl'].get('cert')
-                    cert_data.key_filename=client_ssl['client-ssl'].get('key')
-                    cert_data.template_name=listener.id
+                client_ssl = self.axapi_client.slb.template.client_ssl.get(name=listener.id)
+                if utils.acos_version_cmp(vthunder.acos_version, "5.2.1") >= 0:
+                    certificate_list = client_ssl['client-ssl']['certificate-list'][0]
+                    if certificate_list.get('cert') and certificate_list.get('key'):
+                        cert_data.cert_filename = certificate_list.get('cert')
+                        cert_data.key_filename = certificate_list.get('key')
+                        cert_data.template_name = listener.id
+                    else:
+                        cert_data = None
                 else:
-                   cert_data=None
+                    if client_ssl['client-ssl'].get('cert') and client_ssl['client-ssl'].get('key'):
+                        cert_data.cert_filename = client_ssl['client-ssl'].get('cert')
+                        cert_data.key_filename = client_ssl['client-ssl'].get('key')
+                        cert_data.template_name = listener.id
+                    else:
+                        cert_data = None
 
             LOG.debug("Successfully received barbican data for listener: %s", listener.id)
         except (acos_errors.ACOSException, ConnectionError) as e:
@@ -230,14 +239,22 @@ class ClientSSLTemplateUpdate(task.Task):
                                                                  passphrase=cert_data.key_pass)
 
                 try:
-                    if 'cert' in old['client-ssl'].keys() and 'key' in old['client-ssl'].keys():
-                        if old['client-ssl']['cert'] != cert_data.cert_filename:
-                            self.axapi_client.file.ssl_cert.delete(
-                                private_key=old['client-ssl']['key'],
-                                cert_name=old['client-ssl']['cert'])
-                        if old['client-ssl']['key'] != cert_data.key_filename:
-                            self.axapi_client.file.ssl_key.delete(
-                                private_key=old['client-ssl']['key'])
+                    if utils.acos_version_cmp(vthunder.acos_version, "5.2.1") >= 0:
+                        old_certificate_list = old['client-ssl']['certificate-list'][0]
+                        if 'cert' in old_certificate_list and 'key' in old_certificate_list:
+                            if old_certificate_list['cert'] != cert_data.cert_filename:
+                                self.axapi_client.file.ssl_cert.delete(
+                                    private_key=old_certificate_list['key'],
+                                    cert_name=old_certificate_list['cert'])
+                    else:
+                        if 'cert' in old['client-ssl'].keys() and 'key' in old['client-ssl'].keys():
+                            if old['client-ssl']['cert'] != cert_data.cert_filename:
+                                self.axapi_client.file.ssl_cert.delete(
+                                    private_key=old['client-ssl']['key'],
+                                    cert_name=old['client-ssl']['cert'])
+                            if old['client-ssl']['key'] != cert_data.key_filename:
+                                self.axapi_client.file.ssl_key.delete(
+                                    private_key=old['client-ssl']['key'])
                 except Exception as e:
                     LOG.warning("Clean up old cert/key files failed. error:%s", str(e))
                     # clean up with best effort, don't raise here

--- a/a10_octavia/controller/worker/tasks/utils.py
+++ b/a10_octavia/controller/worker/tasks/utils.py
@@ -216,3 +216,53 @@ def get_member_server_name(axapi_client, member, raise_not_found=True):
                     raise e
                 return default_name
     return server_name['server']['name']
+
+
+def acos_version_str2int(ver):
+    if ver.isdigit():
+        return int(ver)
+    else:
+        vnum = ""
+        for index in range(len(ver)):
+            if ver[index].isdigit():
+                vnum = vnum + ver[index]
+            else:
+                break
+        return int(vnum)
+
+
+def acos_revision_parse(revision):
+    rev = []
+    revision_list = ['GR', 'P', 'SP']
+    for tag in revision_list:
+        tag_index = revision.find(tag)
+        if tag_index >= 0:
+            tag_len = len(tag)
+            rev.append(acos_version_str2int(revision[(tag_index + tag_len):]))
+        else:
+            rev.append(0)
+
+    return tuple(rev)
+
+
+def acos_version(acos_version):
+    major = acos_version_str2int(acos_version.split('.')[0])
+    minor = acos_version_str2int(acos_version.split('.')[1])
+    patch = acos_version_str2int(acos_version.split('.')[2])
+
+    revision = ""
+    prev = acos_version.find('-')
+    if prev > 0:
+        revision = acos_version[prev + 1:].upper()
+    gr, p, sp = acos_revision_parse(revision)
+
+    return (major, minor, patch, gr, p, sp)
+
+
+def acos_version_cmp(ver1, ver2):
+    vtup1 = acos_version(ver1)
+    vtup2 = acos_version(ver2)
+    for index in range(len(vtup1)):
+        if vtup1[index] != vtup2[index]:
+            return vtup1[index] - vtup2[index]
+    return 0


### PR DESCRIPTION
## Description
SSL template aXAPIs has been changed in ACOS version 5.2.1, due to which we are facing some issues for importing/updating/deleting pki certs and keys on ACOS 5.2.1 corresponding to client-ssl template configured while creating/updating/deleting a TERMINATED_HTTPS listener.
By this feature, correct SSL APIs for appropriate ACOS versions will get called by checking the version before calling them.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3431

## Technical Approach
- Added a task `UpdateAcosVersionInVthunderEntry` for updating acos-version in vthunders table during loadbalancer creation for rack flows.
- Added some methods for comparing current acos version with a specific provided version in utils.py
- Modified task GetSSLCertData() to check whether the current acos-version is greater than or equal to 5.2.1 and if so then use correct attributes for getting cert and key associated with the client-ssl template, otherwise use existing logic.
- Modified task ClientSSLTemplateUpdate() to check whether the current acos-version is greater than or equal to 5.2.1 and if so then call corresponding APIs for deletion of ssl_cert and ssl_key.

## Config Changes
N/A

## Related PR
https://github.com/a10networks/acos-client/pull/383

## Test Cases
On both ACOS 5.2.1 and ACOS 4.1.4:
- Create a loadbalancer and terminated_https listener with a --default-tls-container-ref.
- Update the listener with an another --default-tls-container-ref.
- Check if the ssl cert and key bound to client-ssl template got changed and the existing pki cert and key got replaced with the new one.
- Delete the listener.
- Check if the ssl cert and key got removed from acos.

## Manual Testing
1. For Rack flows on ACOS 5.2.1-p5:

Create a loadbalancer:
stack@neha-victoria:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name vip1

```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2023-02-16T11:43:30                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 1fee1134-c52f-4e2e-ac8f-49482c5d56d2 |
| listeners           |                                      |
| name                | vip1                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | a05572e76f6d40e78bbb644ee825a9c9     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.196                          |
| vip_network_id      | 373806e6-26ae-4d60-ace7-9d796370cb5a |
| vip_port_id         | 2120d9db-028c-49b8-9b28-0784c06cd1e5 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 1da6c4ac-d102-489e-b65f-018b015051a3 |
+---------------------+--------------------------------------+
```

Create a TERMINATED_HTTPS listener
```
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | -1                                                                                                                                                                                                                                                                                 |
| created_at                  | 2023-02-16T11:44:20                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | http://10.64.3.141/key-manager/v1/containers/630fff17-809c-47b4-96d7-c5fbc888d338                                                                                                                                                                                                  |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | 65633fcb-523c-4c69-ad95-5f1f876d2eef                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | 1fee1134-c52f-4e2e-ac8f-49482c5d56d2                                                                                                                                                                                                                                               |
| name                        | l1                                                                                                                                                                                                                                                                                 |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | a05572e76f6d40e78bbb644ee825a9c9                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 9001                                                                                                                                                                                                                                                                               |
| provisioning_status         | PENDING_CREATE                                                                                                                                                                                                                                                                     |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | None                                                                                                                                                                                                                                                                               |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

vThunder configurations:

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 314 bytes
!Configuration last updated at 11:43:24 GMT Thu Feb 16 2023
!Configuration last saved at 11:43:26 GMT Thu Feb 16 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p5, build 114 (Jul-14-2022,09:59)
!
multi-config enable
!
!
interface management
  ip address 10.64.26.109 255.255.255.0
  ip control-apps-use-mgmt-port
  ip default-gateway 10.64.26.1
!
interface ethernet 1
  enable
  ip address 10.10.10.13 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.11.10.13 255.255.255.0
!
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb template client-ssl 65633fcb-523c-4c69-ad95-5f1f876d2eef
  certificate mycert key mykey
!
slb virtual-server 1fee1134-c52f-4e2e-ac8f-49482c5d56d2 10.0.11.196
  port 9001 https
    name 65633fcb-523c-4c69-ad95-5f1f876d2eef
    extended-stats
    template client-ssl 65633fcb-523c-4c69-ad95-5f1f876d2eef
!
sflow setting local-collection
!
sflow collector ip 127.0.0.1 6343
!
!



vThunder(NOLICENSE)#show pki cert
Name                                  Type                       Expiration  Status
-------------------------------------------------------------------------------------------------
mycert                                certificate  Feb  9 11:56:09 2024 GMT  [Unexpired, Bound]
default-s1-nginx-certs-keys-srv-cert  certificate  Sep  7 05:59:05 2023 GMT  [Unexpired, Unbound]
default-c1-nginx-certs-keys-srv-cert  certificate  Sep  7 05:59:05 2023 GMT  [Unexpired, Unbound]
default-c1-nginx-certs-keys-srv-key   key                                    [Unbound]
mykey                                 key                                    [Bound]
default-s1-nginx-certs-keys-srv-key   key                                    [Unbound]

```

Update the listener with an another --default-tls-container-ref.

stack@neha-victoria:~$ openstack loadbalancer listener set --default-tls-container-ref http://10.64.3.141/key-manager/v1/containers/524c0636-1d37-434b-9dc9-24213562d613 l1

vThunder configurations after the update:

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 314 bytes
!Configuration last updated at 11:44:07 GMT Thu Feb 16 2023
!Configuration last saved at 11:44:27 GMT Thu Feb 16 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p5, build 114 (Jul-14-2022,09:59)
!
multi-config enable
!
!
interface management
  ip address 10.64.26.109 255.255.255.0
  ip control-apps-use-mgmt-port
  ip default-gateway 10.64.26.1
!
interface ethernet 1
  enable
  ip address 10.10.10.13 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.11.10.13 255.255.255.0
!
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb template client-ssl 65633fcb-523c-4c69-ad95-5f1f876d2eef
  certificate mycert-new key mykey-new
!
slb virtual-server 1fee1134-c52f-4e2e-ac8f-49482c5d56d2 10.0.11.196
  port 9001 https
    name 65633fcb-523c-4c69-ad95-5f1f876d2eef
    extended-stats
    template client-ssl 65633fcb-523c-4c69-ad95-5f1f876d2eef
!
sflow setting local-collection
!
sflow collector ip 127.0.0.1 6343
!


vThunder(NOLICENSE)#show pki cert
Name                                  Type                       Expiration  Status
-------------------------------------------------------------------------------------------------
mycert-new                            certificate  Feb 10 07:10:41 2024 GMT  [Unexpired, Bound]
default-s1-nginx-certs-keys-srv-cert  certificate  Sep  7 05:59:05 2023 GMT  [Unexpired, Unbound]
default-c1-nginx-certs-keys-srv-cert  certificate  Sep  7 05:59:05 2023 GMT  [Unexpired, Unbound]
default-c1-nginx-certs-keys-srv-key   key                                    [Unbound]
mykey-new                             key                                    [Bound]
default-s1-nginx-certs-keys-srv-key   key                                    [Unbound]

```

Delete the listener.
stack@neha-victoria:~$ openstack loadbalancer listener delete l1

vThunder configuration after the delete:

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 383 bytes
!Configuration last updated at 11:44:47 GMT Thu Feb 16 2023
!Configuration last saved at 11:44:49 GMT Thu Feb 16 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p5, build 114 (Jul-14-2022,09:59)
!
multi-config enable
!
!
interface management
  ip address 10.64.26.109 255.255.255.0
  ip control-apps-use-mgmt-port
  ip default-gateway 10.64.26.1
!
interface ethernet 1
  enable
  ip address 10.10.10.13 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.11.10.13 255.255.255.0
!
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb virtual-server 1fee1134-c52f-4e2e-ac8f-49482c5d56d2 10.0.11.196
!
sflow setting local-collection
!
sflow collector ip 127.0.0.1 6343
!


vThunder(NOLICENSE)#show pki cert
Name                                  Type                       Expiration  Status
-------------------------------------------------------------------------------------------------
default-s1-nginx-certs-keys-srv-cert  certificate  Sep  7 05:59:05 2023 GMT  [Unexpired, Unbound]
default-c1-nginx-certs-keys-srv-cert  certificate  Sep  7 05:59:05 2023 GMT  [Unexpired, Unbound]
default-c1-nginx-certs-keys-srv-key   key                                    [Unbound]
default-s1-nginx-certs-keys-srv-key   key                                    [Unbound]

```

2. For Rack flows on ACOS 4.1.4-GR1-p9

Create a loadbalancer and TERMINATED_HTTPS listener:

stack@neha-victoria:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name vip1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2023-02-16T11:50:06                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 7d5fc5e5-d82a-4f83-850e-3d72b768a02f |
| listeners           |                                      |
| name                | vip1                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | a05572e76f6d40e78bbb644ee825a9c9     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.122                          |
| vip_network_id      | 373806e6-26ae-4d60-ace7-9d796370cb5a |
| vip_port_id         | 3802a953-9da8-48b9-bf55-ac9cfee84761 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 1da6c4ac-d102-489e-b65f-018b015051a3 |
+---------------------+--------------------------------------+
```


stack@neha-victoria:~$ openstack loadbalancer listener create --protocol TERMINATED_HTTPS --default-tls-container-ref http://10.64.3.141/key-manager/v1/containers/630fff17-809c-47b4-96d7-c5fbc888d338 --protocol-port 9001 vip1 --name l1
```
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | -1                                                                                                                                                                                                                                                                                 |
| created_at                  | 2023-02-16T11:50:14                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | http://10.64.3.141/key-manager/v1/containers/630fff17-809c-47b4-96d7-c5fbc888d338                                                                                                                                                                                                  |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | bcb0b194-0078-420b-a258-15c0e47cdf72                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | 7d5fc5e5-d82a-4f83-850e-3d72b768a02f                                                                                                                                                                                                                                               |
| name                        | l1                                                                                                                                                                                                                                                                                 |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | a05572e76f6d40e78bbb644ee825a9c9                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 9001                                                                                                                                                                                                                                                                               |
| provisioning_status         | PENDING_CREATE                                                                                                                                                                                                                                                                     |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | None                                                                                                                                                                                                                                                                               |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

vThunder configurations:

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 304 bytes
!Configuration last updated at 11:48:53 GMT Thu Feb 16 2023
!Configuration last saved at 11:48:55 GMT Thu Feb 16 2023
!64-bit Advanced Core OS (ACOS) version 4.1.4-GR1-P9, build 69 (Nov-23-2021,00:50)
!
multi-config enable
!
!
interface management
  ip address 10.64.26.108 255.255.255.0
  ip default-gateway 10.64.26.1
!
interface ethernet 1
  enable
  ip address 10.10.10.108 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.11.10.108 255.255.255.0
!
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb template client-ssl bcb0b194-0078-420b-a258-15c0e47cdf72
  cert mycert
  key mykey
!
slb virtual-server 7d5fc5e5-d82a-4f83-850e-3d72b768a02f 10.0.11.122
  port 9001 https
    name bcb0b194-0078-420b-a258-15c0e47cdf72
    extended-stats
    template client-ssl bcb0b194-0078-420b-a258-15c0e47cdf72
!
!
end


vThunder(NOLICENSE)#show pki cert | include mycert
Name: mycert  Type: certificate  Expiration: Feb  9 11:56:09 2024 GMT [Unexpired, Bound]
vThunder(NOLICENSE)#show pki cert | include mykey
Name: mykey  Type: key  [Bound]

```

Update the listener with an another -default-tls-container-ref.

stack@neha-victoria:~$ openstack loadbalancer listener set --default-tls-container-ref http://10.64.3.141/key-manager/v1/containers/524c0636-1d37-434b-9dc9-24213562d613 l1

vThunder configurations after the update:

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 312 bytes
!Configuration last updated at 11:50:09 GMT Thu Feb 16 2023
!Configuration last saved at 11:50:26 GMT Thu Feb 16 2023
!64-bit Advanced Core OS (ACOS) version 4.1.4-GR1-P9, build 69 (Nov-23-2021,00:50)
!
multi-config enable
!
!
interface management
  ip address 10.64.26.108 255.255.255.0
  ip default-gateway 10.64.26.1
!
interface ethernet 1
  enable
  ip address 10.10.10.108 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.11.10.108 255.255.255.0
!
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb template client-ssl bcb0b194-0078-420b-a258-15c0e47cdf72
  cert mycert-new
  key mykey-new
!
slb virtual-server 7d5fc5e5-d82a-4f83-850e-3d72b768a02f 10.0.11.122
  port 9001 https
    name bcb0b194-0078-420b-a258-15c0e47cdf72
    extended-stats
    template client-ssl bcb0b194-0078-420b-a258-15c0e47cdf72
!
!
end


vThunder(NOLICENSE)#show pki cert | include mycert
Name: mycert-new  Type: certificate  Expiration: Feb 10 07:10:41 2024 GMT [Unexpired, Bound]
vThunder(NOLICENSE)#show pki cert | include mykey
Name: mykey-new  Type: key  [Bound]
```

Delete the listener.

stack@neha-victoria:~$ openstack loadbalancer listener delete l1

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 283 bytes
!Configuration last updated at 11:51:42 GMT Thu Feb 16 2023
!Configuration last saved at 11:51:44 GMT Thu Feb 16 2023
!64-bit Advanced Core OS (ACOS) version 4.1.4-GR1-P9, build 69 (Nov-23-2021,00:50)
!
multi-config enable
!
!
interface management
  ip address 10.64.26.108 255.255.255.0
  ip default-gateway 10.64.26.1
!
interface ethernet 1
  enable
  ip address 10.10.10.108 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.11.10.108 255.255.255.0
!
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb virtual-server 7d5fc5e5-d82a-4f83-850e-3d72b768a02f 10.0.11.122
!
!
end


vThunder(NOLICENSE)#show pki cert | include mycert
vThunder(NOLICENSE)#show pki cert | include mykey
```


3. For Automated flows with ACOS 5.2.1:

Create a loadbalancer and TERMINATED_HTTPS listener.

stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name vip1
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2023-02-17T05:17:51                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 987efe3d-fbdd-45a0-bb07-d163a3649736 |
| listeners           |                                      |
| name                | vip1                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | a05572e76f6d40e78bbb644ee825a9c9     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.126                          |
| vip_network_id      | 373806e6-26ae-4d60-ace7-9d796370cb5a |
| vip_port_id         | ece31cfd-0576-47a7-adef-abc5d55d7cf3 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 1da6c4ac-d102-489e-b65f-018b015051a3 |
+---------------------+--------------------------------------+
```


stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer listener create --protocol TERMINATED_HTTPS --default-tls-container-ref http://10.64.3.141/key-manager/v1/containers/630fff17-809c-47b4-96d7-c5fbc888d338 --protocol-port 9001 vip1 --name l1
```
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                       | Value                                                                                                                                                                                                                                                                              |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up              | True                                                                                                                                                                                                                                                                               |
| connection_limit            | -1                                                                                                                                                                                                                                                                                 |
| created_at                  | 2023-02-17T05:23:29                                                                                                                                                                                                                                                                |
| default_pool_id             | None                                                                                                                                                                                                                                                                               |
| default_tls_container_ref   | http://10.64.3.141/key-manager/v1/containers/630fff17-809c-47b4-96d7-c5fbc888d338                                                                                                                                                                                                  |
| description                 |                                                                                                                                                                                                                                                                                    |
| id                          | b7af4838-6737-4b05-aaad-4f249b1f053f                                                                                                                                                                                                                                               |
| insert_headers              | None                                                                                                                                                                                                                                                                               |
| l7policies                  |                                                                                                                                                                                                                                                                                    |
| loadbalancers               | 987efe3d-fbdd-45a0-bb07-d163a3649736                                                                                                                                                                                                                                               |
| name                        | l1                                                                                                                                                                                                                                                                                 |
| operating_status            | OFFLINE                                                                                                                                                                                                                                                                            |
| project_id                  | a05572e76f6d40e78bbb644ee825a9c9                                                                                                                                                                                                                                                   |
| protocol                    | TERMINATED_HTTPS                                                                                                                                                                                                                                                                   |
| protocol_port               | 9001                                                                                                                                                                                                                                                                               |
| provisioning_status         | PENDING_CREATE                                                                                                                                                                                                                                                                     |
| sni_container_refs          | []                                                                                                                                                                                                                                                                                 |
| timeout_client_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_member_connect      | 5000                                                                                                                                                                                                                                                                               |
| timeout_member_data         | 50000                                                                                                                                                                                                                                                                              |
| timeout_tcp_inspect         | 0                                                                                                                                                                                                                                                                                  |
| updated_at                  | None                                                                                                                                                                                                                                                                               |
| client_ca_tls_container_ref | None                                                                                                                                                                                                                                                                               |
| client_authentication       | NONE                                                                                                                                                                                                                                                                               |
| client_crl_container_ref    | None                                                                                                                                                                                                                                                                               |
| allowed_cidrs               | None                                                                                                                                                                                                                                                                               |
| tls_ciphers                 | TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256 |
| tls_versions                | ['TLSv1.2', 'TLSv1.3']                                                                                                                                                                                                                                                             |
| alpn_protocols              | ['http/1.1', 'http/1.0']                                                                                                                                                                                                                                                           |
+-----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

```

vThunder configurations:

```
amphora-9f602697-3ba6-4925-811f(NOLICENSE)#show running-config
!Current configuration: 238 bytes
!Configuration last updated at 05:23:29 GMT Fri Feb 17 2023
!Configuration last saved at 05:23:32 GMT Fri Feb 17 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p3, build 70 (Oct-20-2021,22:08)
!
hostname amphora-9f602697-3ba6-4925-811f
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb template client-ssl b7af4838-6737-4b05-aaad-4f249b1f053f
  certificate mycert key mykey
!
slb virtual-server 987efe3d-fbdd-45a0-bb07-d163a3649736 10.0.11.126
  port 9001 https
    name b7af4838-6737-4b05-aaad-4f249b1f053f
    extended-stats
    template client-ssl b7af4838-6737-4b05-aaad-4f249b1f053f
!
!
cloud-services meta-data
  enable
  provider openstack
!
end



amphora-9f602697-3ba6-4925-811f(NOLICENSE)#show pki cert
Name    Type                       Expiration  Status
-----------------------------------------------------------------
mycert  certificate  Feb  9 11:56:09 2024 GMT  [Unexpired, Bound]
mykey   key                                    [Bound]
```

Update the listener with an another default-tls-container-ref.

stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer listener set --default-tls-container-ref http://10.64.3.141/key-manager/v1/containers/524c0636-1d37-434b-9dc9-24213562d613 l1

```
amphora-9f602697-3ba6-4925-811f(NOLICENSE)#show running-config
!Current configuration: 238 bytes
!Configuration last updated at 05:24:17 GMT Fri Feb 17 2023
!Configuration last saved at 05:24:20 GMT Fri Feb 17 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p3, build 70 (Oct-20-2021,22:08)
!
hostname amphora-9f602697-3ba6-4925-811f
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb template client-ssl b7af4838-6737-4b05-aaad-4f249b1f053f
  certificate mycert-new key mykey-new
!
slb virtual-server 987efe3d-fbdd-45a0-bb07-d163a3649736 10.0.11.126
  port 9001 https
    name b7af4838-6737-4b05-aaad-4f249b1f053f
    extended-stats
    template client-ssl b7af4838-6737-4b05-aaad-4f249b1f053f
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode


amphora-9f602697-3ba6-4925-811f(NOLICENSE)#show pki cert
Name        Type                       Expiration  Status
---------------------------------------------------------------------
mycert-new  certificate  Feb 10 07:10:41 2024 GMT  [Unexpired, Bound]
mykey-new   key                                    [Bound]

```

Delete the listener:
stack@neha-victoria:~$ openstack loadbalancer listener delete l1

```
amphora-9f602697-3ba6-4925-811f(NOLICENSE)#show running-config
!Current configuration: 307 bytes
!Configuration last updated at 05:25:20 GMT Fri Feb 17 2023
!Configuration last saved at 05:25:24 GMT Fri Feb 17 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p3, build 70 (Oct-20-2021,22:08)
!
hostname amphora-9f602697-3ba6-4925-811f
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb virtual-server 987efe3d-fbdd-45a0-bb07-d163a3649736 10.0.11.126
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
amphora-9f602697-3ba6-4925-811f(NOLICENSE)#
amphora-9f602697-3ba6-4925-811f(NOLICENSE)#show pki cert

```