### PR TITLE
[STACK-3589] Resolved Atoms with duplicate name issue for Fully populated loadbalaner feature.

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -883,6 +883,7 @@ class LoadBalancerFlows(object):
         handle_vrid_for_lb_subflow = linear_flow.Flow(
             a10constants.HANDLE_VRID_LOADBALANCER_SUBFLOW)
         handle_vrid_for_lb_subflow.add(a10_network_tasks.GetLBResourceSubnet(
+            name=a10constants.GET_LB_RESOURCE_SUBNET,
             rebind={a10constants.LB_RESOURCE: constants.LOADBALANCER},
             provides=constants.SUBNET))
         handle_vrid_for_lb_subflow.add(


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description: Getting Atoms with duplicate name found issue while performing fully populated loadbalancer creation.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3589

## Technical Approach
- Added a name for the issuing task in the a10_load_balancer_flow.

## Config Changes
N/A

## Test Cases
1. Create fully populated IPv6 loadbalancer with all other slb objects  with rack flows.
2. Create fully populated IPv4 loadbalancer with all other slb objects  with rack flows

## Manual Testing
For IPv6:
Perform following fully_populated_loadbalancer creation script for IPv6 LB creation:

```
#!/bin/sh

set -e

subnet_id=$(openstack subnet show ipv6_subnet_vlan_11 -c id -f value)

TOKEN=$(openstack token issue -f value -c id)
OCTAVIA_BASE_URL=$(openstack endpoint list --service load-balancer --interface public -c URL -f value)

cat <<EOF > tree.json
{
    "loadbalancer": {
        "name": "vip1",
        "vip_subnet_id": "$subnet_id",
        "provider": "a10",
        "listeners": [
            {
                "name": "vport1",
                "protocol": "HTTP",
                "protocol_port": 80,
                "l7policies": [
                    {
                        "action": "REDIRECT_TO_URL",
                        "name": "redirect_policy",
                        "redirect_url": "https://www.example.com/",
                        "rules": [
                            {
                                "type": "HEADER",
                                "compare_type": "CONTAINS",
                                "key": "X-My-Header",
                                "value": "sample_substring"
                            }
                        ]
                    }
                ],
                "default_pool": {
                    "name": "pool1",
                    "protocol": "HTTP",
                    "lb_algorithm": "SOURCE_IP_PORT",
                    "members": [
                        {
                            "address": "3001:db8:3333:4444::6",
                            "protocol_port": 8080
                        }, {
                            "address": "5001:db8:3333:4444::7",
                            "protocol_port": 80
                        }
                    ],
                    "healthmonitor": {
                        "type": "HTTP",
                        "delay": "3",
                        "max_retries": 2,
                        "timeout": 1,
                        "http_method": "GET",
                        "expected_codes": "200"
                    }
                }
            }
        ]
    }
}
EOF

echo curl -X POST -H "Content-Type: application/json" -H "X-Auth-Token: $TOKEN" -d @tree.json ${OCTAVIA_BASE_URL}/v2.0/lbaas/loadbalancers
echo "........."
echo ""

curl -X POST \
    -H "Content-Type: application/json" \
    -H "X-Auth-Token: $TOKEN" \
    -d @tree.json \
    ${OCTAVIA_BASE_URL}/v2.0/lbaas/loadbalancers

echo ""
```
 
```
stack@neha-victoria:~$ sh fully_populated_rack.sh
curl -X POST -H Content-Type: application/json -H X-Auth-Token: gAAAAABkLrhju6wJkJYTa_hyOe9VBCQO3iggZIhYuypBw_XIn3S_0WQtO6yZVIvZhM4eE7WXtQtQs4AUX3xIWbDdCNT-3ztObVrI_Xe6yWPMmaXebB3LUfKos6BaUJpDiFssCps4LLIqoiOVJ9qFAIofseThkPsJ6LvNgZvf9q9rh6YZ-XZ74rU -d @tree.json http://10.64.3.141/load-balancer/v2.0/lbaas/loadbalancers
.........

{"loadbalancer": {"listeners": [{"l7policies": [{"rules": [{"id": "3307b3bf-c37c-47c5-8ca4-c20f2eccfda9", "type": "HEADER", "compare_type": "CONTAINS", "key": "X-My-Header", "value": "sample_substring", "invert": false, "provisioning_status": "PENDING_CREATE", "operating_status": "OFFLINE", "created_at": "2023-04-06T12:17:42", "updated_at": null, "project_id": "f4079be17ddb41ee97d863a08e2e5f18", "admin_state_up": true, "tags": [], "tenant_id": "f4079be17ddb41ee97d863a08e2e5f18"}], "id": "ff94219a-ea19-4bf4-a59f-4482e482cfff", "name": "redirect_policy", "description": "", "provisioning_status": "PENDING_CREATE", "operating_status": "OFFLINE", "admin_state_up": true, "project_id": "f4079be17ddb41ee97d863a08e2e5f18", "action": "REDIRECT_TO_URL", "listener_id": "2629ecfc-f1c1-4924-865d-0586651a0b10", "redirect_pool_id": null, "redirect_url": "https://www.example.com/", "redirect_prefix": null, "position": 1, "created_at": "2023-04-06T12:17:42", "updated_at": null, "tags": [], "redirect_http_code": 302, "tenant_id": "f4079be17ddb41ee97d863a08e2e5f18"}], "id": "2629ecfc-f1c1-4924-865d-0586651a0b10", "name": "vport1", "description": "", "provisioning_status": "PENDING_CREATE", "operating_status": "OFFLINE", "admin_state_up": true, "protocol": "HTTP", "protocol_port": 80, "connection_limit": -1, "default_tls_container_ref": null, "sni_container_refs": [], "project_id": "f4079be17ddb41ee97d863a08e2e5f18", "default_pool_id": "b4154703-bd30-4c63-a969-a913d334157d", "insert_headers": {}, "created_at": "2023-04-06T12:17:42", "updated_at": "2023-04-06T12:17:42", "timeout_client_data": 50000, "timeout_member_connect": 5000, "timeout_member_data": 50000, "timeout_tcp_inspect": 0, "tags": [], "client_ca_tls_container_ref": null, "client_authentication": "NONE", "client_crl_container_ref": null, "allowed_cidrs": null, "tls_ciphers": null, "tls_versions": null, "alpn_protocols": null, "tenant_id": "f4079be17ddb41ee97d863a08e2e5f18"}], "pools": [{"members": [{"id": "456e6ed7-f52a-4a80-9b5c-3d4f842e6bc1", "name": "", "operating_status": "NO_MONITOR", "provisioning_status": "PENDING_CREATE", "admin_state_up": true, "address": "3001:db8:3333:4444::6", "protocol_port": 8080, "weight": 1, "backup": false, "subnet_id": null, "project_id": "f4079be17ddb41ee97d863a08e2e5f18", "created_at": "2023-04-06T12:17:42", "updated_at": null, "monitor_address": null, "monitor_port": null, "tags": [], "tenant_id": "f4079be17ddb41ee97d863a08e2e5f18"}, {"id": "ccff7b26-4f8a-4c94-a5ea-208355afff81", "name": "", "operating_status": "NO_MONITOR", "provisioning_status": "PENDING_CREATE", "admin_state_up": true, "address": "5001:db8:3333:4444::7", "protocol_port": 80, "weight": 1, "backup": false, "subnet_id": null, "project_id": "f4079be17ddb41ee97d863a08e2e5f18", "created_at": "2023-04-06T12:17:42", "updated_at": null, "monitor_address": null, "monitor_port": null, "tags": [], "tenant_id": "f4079be17ddb41ee97d863a08e2e5f18"}], "healthmonitor": null, "id": "b4154703-bd30-4c63-a969-a913d334157d", "name": "pool1", "description": "", "provisioning_status": "PENDING_CREATE", "operating_status": "OFFLINE", "admin_state_up": true, "protocol": "HTTP", "lb_algorithm": "SOURCE_IP_PORT", "session_persistence": null, "project_id": "f4079be17ddb41ee97d863a08e2e5f18", "listeners": [{"id": "2629ecfc-f1c1-4924-865d-0586651a0b10"}], "created_at": "2023-04-06T12:17:42", "updated_at": null, "tags": [], "tls_container_ref": null, "ca_tls_container_ref": null, "crl_container_ref": null, "tls_enabled": false, "tls_ciphers": null, "tls_versions": null, "tenant_id": "f4079be17ddb41ee97d863a08e2e5f18"}], "id": "4c7a1f46-f818-4795-b099-59bd955401c8", "name": "vip1", "description": "", "provisioning_status": "PENDING_CREATE", "operating_status": "OFFLINE", "admin_state_up": true, "project_id": "f4079be17ddb41ee97d863a08e2e5f18", "created_at": "2023-04-06T12:17:41", "updated_at": null, "vip_address": "3001:db8:3333:4444::3c8", "vip_port_id": "b1779647-5c64-44df-9072-1ec32e6d778b", "vip_subnet_id": "2e3dfb8d-5e13-4f27-ac66-fb39efb091e5", "vip_network_id": "dd8119a3-863b-4aa2-bf46-b36783b4f99c", "provider": "a10", "flavor_id": null, "vip_qos_policy_id": null, "tags": [], "availability_zone": null, "tenant_id": "f4079be17ddb41ee97d863a08e2e5f18"}}
```

vThunder configurations:

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 482 bytes
!Configuration last updated at 13:16:37 IST Thu Apr 6 2023
!Configuration last saved at 13:16:40 IST Thu Apr 6 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p5, build 114 (Jul-14-2022,09:59)
!
multi-config enable
!
partition test-ipv6 id 2
!
!
interface management
  ip address 10.64.26.109 255.255.255.0
  ip control-apps-use-mgmt-port
  ip default-gateway 10.64.26.1
!
interface ethernet 1
  enable
  ip address 10.10.10.13 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.11.10.13 255.255.255.0
!
vrrp-a vrid 0
  floating-ip 3001:db8:3333:4444::7b
!
ip route 30.30.30.0 /26 lif acosk8s-81_200
!
ip route 192.168.81.192 /26 lif acosk8s-81_200
!
ip route 192.168.220.192 /26 lif acosk8s-220_192
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
health monitor 2d81b6ee-9616-49fa-b835-8a1186c532b0
  retry 2
  interval 3 timeout 1
  method http port 8080 expect response-code 200 url GET /
!
slb server f4079_3001:db8:3333:4444::6 3001:db8:3333:4444::6
  health-check 2d81b6ee-9616-49fa-b835-8a1186c532b0
  port 8080 tcp
!
slb server f4079_5001:db8:3333:4444::7 5001:db8:3333:4444::7
  health-check 2d81b6ee-9616-49fa-b835-8a1186c532b0
  port 80 tcp
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb service-group b4154703-bd30-4c63-a969-a913d334157d tcp
  method src-ip-hash
  member f4079_3001:db8:3333:4444::6 8080
  member f4079_5001:db8:3333:4444::7 80
!
slb virtual-server 4c7a1f46-f818-4795-b099-59bd955401c8 3001:db8:3333:4444::3c8
  port 80 http
    name 2629ecfc-f1c1-4924-865d-0586651a0b10
    extended-stats
    aflex ff94219a-ea19-4bf4-a59f-4482e482cfff
    service-group b4154703-bd30-4c63-a969-a913d334157d
!
sflow setting local-collection
!
sflow collector ip 127.0.0.1 6343
!
!
end
```


For IPv4:

Perform following fully_populated_loadbalancer script for IPv4 LB creation:

```
#!/bin/sh

set -e

subnet_id=$(openstack subnet show provider-vlan-11-subnet -c id -f value)

TOKEN=$(openstack token issue -f value -c id)
OCTAVIA_BASE_URL=$(openstack endpoint list --service load-balancer --interface public -c URL -f value)

cat <<EOF > tree.json
{
    "loadbalancer": {
        "name": "vip1",
        "vip_subnet_id": "$subnet_id",
        "provider": "a10",
        "listeners": [
            {
                "name": "vport1",
                "protocol": "HTTP",
                "protocol_port": 80,
                "l7policies": [
                    {
                        "action": "REDIRECT_TO_URL",
                        "name": "redirect_policy",
                        "redirect_url": "https://www.example.com/",
                        "rules": [
                            {
                                "type": "HEADER",
                                "compare_type": "CONTAINS",
                                "key": "X-My-Header",
                                "value": "sample_substring"
                            }
                        ]
                    }
                ],
                "default_pool": {
                    "name": "pool1",
                    "protocol": "HTTP",
                    "lb_algorithm": "SOURCE_IP_PORT",
                    "members": [
                        {
                            "address": "10.0.11.10",
                            "protocol_port": 8080
                        }, {
                            "address": "10.0.12.11",
                            "protocol_port": 80
                        }
                    ],
                    "healthmonitor": {
                        "type": "HTTP",
                        "delay": "3",
                        "max_retries": 2,
                        "timeout": 1,
                        "http_method": "GET",
                        "expected_codes": "200"
                    }
                }
            }
        ]
    }
}
EOF

echo curl -X POST -H "Content-Type: application/json" -H "X-Auth-Token: $TOKEN" -d @tree.json ${OCTAVIA_BASE_URL}/v2.0/lbaas/loadbalancers
echo "........."
echo ""
curl -X POST \
    -H "Content-Type: application/json" \
    -H "X-Auth-Token: $TOKEN" \
    -d @tree.json \
    ${OCTAVIA_BASE_URL}/v2.0/lbaas/loadbalancers

echo ""
```

```
stack@neha-victoria:~$ sh fully_populated_ipv4_rack.sh
curl -X POST -H Content-Type: application/json -H X-Auth-Token: gAAAAABkLr8RDm0PNJaVbPHDZP8fQWAwH6sStxcO4yX_MBetpz9syR-FH6i1C7tz3qWjNFIjDR2SJEKyeipUNntZrVhM-ggeMUwKzZ05zRqA_KNdUr3_TtVEv3pCGYkaqkHqFgMLDWeox7PqWVZX6qucHlfc-kmn90KNeUJ1Q2uQxwq-0Lvc-YQ -d @tree.json http://10.64.3.141/load-balancer/v2.0/lbaas/loadbalancers
.........

{"loadbalancer": {"listeners": [{"l7policies": [{"rules": [{"id": "42c1b71c-c32d-47e2-9705-141822aa4df7", "type": "HEADER", "compare_type": "CONTAINS", "key": "X-My-Header", "value": "sample_substring", "invert": false, "provisioning_status": "PENDING_CREATE", "operating_status": "OFFLINE", "created_at": "2023-04-06T12:46:12", "updated_at": null, "project_id": "f4079be17ddb41ee97d863a08e2e5f18", "admin_state_up": true, "tags": [], "tenant_id": "f4079be17ddb41ee97d863a08e2e5f18"}], "id": "54b6414d-a5c4-4031-9903-ffbd6c37ef12", "name": "redirect_policy", "description": "", "provisioning_status": "PENDING_CREATE", "operating_status": "OFFLINE", "admin_state_up": true, "project_id": "f4079be17ddb41ee97d863a08e2e5f18", "action": "REDIRECT_TO_URL", "listener_id": "d1d24018-ef00-4c08-b976-f162ac273849", "redirect_pool_id": null, "redirect_url": "https://www.example.com/", "redirect_prefix": null, "position": 1, "created_at": "2023-04-06T12:46:12", "updated_at": null, "tags": [], "redirect_http_code": 302, "tenant_id": "f4079be17ddb41ee97d863a08e2e5f18"}], "id": "d1d24018-ef00-4c08-b976-f162ac273849", "name": "vport1", "description": "", "provisioning_status": "PENDING_CREATE", "operating_status": "OFFLINE", "admin_state_up": true, "protocol": "HTTP", "protocol_port": 80, "connection_limit": -1, "default_tls_container_ref": null, "sni_container_refs": [], "project_id": "f4079be17ddb41ee97d863a08e2e5f18", "default_pool_id": "d2df8793-76ce-4668-b596-2a934e3166ed", "insert_headers": {}, "created_at": "2023-04-06T12:46:12", "updated_at": "2023-04-06T12:46:12", "timeout_client_data": 50000, "timeout_member_connect": 5000, "timeout_member_data": 50000, "timeout_tcp_inspect": 0, "tags": [], "client_ca_tls_container_ref": null, "client_authentication": "NONE", "client_crl_container_ref": null, "allowed_cidrs": null, "tls_ciphers": null, "tls_versions": null, "alpn_protocols": null, "tenant_id": "f4079be17ddb41ee97d863a08e2e5f18"}], "pools": [{"members": [{"id": "28bae8d2-3937-4892-8c24-0c3357a6adf7", "name": "", "operating_status": "OFFLINE", "provisioning_status": "PENDING_CREATE", "admin_state_up": true, "address": "10.0.11.10", "protocol_port": 8080, "weight": 1, "backup": false, "subnet_id": null, "project_id": "f4079be17ddb41ee97d863a08e2e5f18", "created_at": "2023-04-06T12:46:12", "updated_at": null, "monitor_address": null, "monitor_port": null, "tags": [], "tenant_id": "f4079be17ddb41ee97d863a08e2e5f18"}, {"id": "ddd6c5e9-08c3-4d5d-8b5b-2ad4bd139c35", "name": "", "operating_status": "OFFLINE", "provisioning_status": "PENDING_CREATE", "admin_state_up": true, "address": "10.0.12.11", "protocol_port": 80, "weight": 1, "backup": false, "subnet_id": null, "project_id": "f4079be17ddb41ee97d863a08e2e5f18", "created_at": "2023-04-06T12:46:12", "updated_at": null, "monitor_address": null, "monitor_port": null, "tags": [], "tenant_id": "f4079be17ddb41ee97d863a08e2e5f18"}], "healthmonitor": null, "id": "d2df8793-76ce-4668-b596-2a934e3166ed", "name": "pool1", "description": "", "provisioning_status": "PENDING_CREATE", "operating_status": "OFFLINE", "admin_state_up": true, "protocol": "HTTP", "lb_algorithm": "SOURCE_IP_PORT", "session_persistence": null, "project_id": "f4079be17ddb41ee97d863a08e2e5f18", "listeners": [{"id": "d1d24018-ef00-4c08-b976-f162ac273849"}], "created_at": "2023-04-06T12:46:12", "updated_at": null, "tags": [], "tls_container_ref": null, "ca_tls_container_ref": null, "crl_container_ref": null, "tls_enabled": false, "tls_ciphers": null, "tls_versions": null, "tenant_id": "f4079be17ddb41ee97d863a08e2e5f18"}], "id": "d131780f-9fa0-4b10-9b58-abb573e5b346", "name": "vip1", "description": "", "provisioning_status": "PENDING_CREATE", "operating_status": "OFFLINE", "admin_state_up": true, "project_id": "f4079be17ddb41ee97d863a08e2e5f18", "created_at": "2023-04-06T12:46:11", "updated_at": null, "vip_address": "10.0.11.151", "vip_port_id": "30b093ed-6362-464b-b25d-36930c8a2027", "vip_subnet_id": "1aa76f34-f5b5-42e2-a4dd-98569764db56", "vip_network_id": "dd8119a3-863b-4aa2-bf46-b36783b4f99c", "provider": "a10", "flavor_id": null, "vip_qos_policy_id": null, "tags": [], "availability_zone": null, "tenant_id": "f4079be17ddb41ee97d863a08e2e5f18"}}
```

vThunder configurations:

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 482 bytes
!Configuration last updated at 13:45:07 IST Thu Apr 6 2023
!Configuration last saved at 13:45:10 IST Thu Apr 6 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p5, build 114 (Jul-14-2022,09:59)
!
multi-config enable
!
partition test-ipv6 id 2
!
!
interface management
  ip address 10.64.26.109 255.255.255.0
  ip control-apps-use-mgmt-port
  ip default-gateway 10.64.26.1
!
interface ethernet 1
  enable
  ip address 10.10.10.13 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.11.10.13 255.255.255.0
!
vrrp-a vrid 0
  floating-ip 10.0.11.107
!
ip route 30.30.30.0 /26 lif acosk8s-81_200
!
ip route 192.168.81.192 /26 lif acosk8s-81_200
!
ip route 192.168.220.192 /26 lif acosk8s-220_192
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
health monitor 68f47b6d-b3a2-4080-a47f-c8f99c62cd97
  retry 2
  interval 3 timeout 1
  method http port 8080 expect response-code 200 url GET /
!
slb server f4079_10_0_11_10 10.0.11.10
  health-check 68f47b6d-b3a2-4080-a47f-c8f99c62cd97
  port 8080 tcp
!
slb server f4079_10_0_12_11 10.0.12.11
  health-check 68f47b6d-b3a2-4080-a47f-c8f99c62cd97
  port 80 tcp
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb service-group d2df8793-76ce-4668-b596-2a934e3166ed tcp
  method src-ip-hash
  member f4079_10_0_11_10 8080
  member f4079_10_0_12_11 80
!
slb virtual-server d131780f-9fa0-4b10-9b58-abb573e5b346 10.0.11.151
  port 80 http
    name d1d24018-ef00-4c08-b976-f162ac273849
    extended-stats
    aflex 54b6414d-a5c4-4031-9903-ffbd6c37ef12
    service-group d2df8793-76ce-4668-b596-2a934e3166ed
!
sflow setting local-collection
!
sflow collector ip 127.0.0.1 6343
!
!
end
```

