### PR TITLE
[STACK-3596]: Fixed issue of deleting ERROR state IPv6 loadbalancer.

### DIFF
--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -283,6 +283,8 @@ class EnableInterface(VThunderBaseTask):
     @axapi_client_decorator
     def execute(self, vthunder, loadbalancer, added_ports, subnet, ifnum_master=None,
                 ifnum_backup=None, backup_vthunder=None, ifnum_address=None):
+        if not vthunder:
+            return
         topology = CONF.a10_controller_worker.loadbalancer_topology
         amphora_id = loadbalancer.amphorae[0].id
         lb_exists_flag = self.loadbalancer_repo.check_lb_exists_in_project(
@@ -348,28 +350,31 @@ class GetValidIPv6Address(VThunderBaseTask):
 
     @axapi_client_decorator
     def execute(self, loadbalancer, vthunder, subnet, loadbalancers_list):
-        ipv6_address_list = {}
-        if subnet.ip_version != 6:
+        if vthunder:
+            if subnet.ip_version != 6:
+                return None
+            ipv6_address_list = {}
+            topology = CONF.a10_controller_worker.loadbalancer_topology
+            compute_id = loadbalancer.amphorae[0].compute_id
+            network_driver = utils.get_network_driver()
+            nics = network_driver.get_plugged_networks(compute_id)
+            if topology == "ACTIVE_STANDBY":
+                backup_nics = network_driver.get_plugged_networks(loadbalancer.amphorae[1].compute_id)
+                nics = nics + backup_nics
+            address_list = CONF.a10_global.subnet_ipv6_addresses
+            address_list[0] = address_list[0].strip("[")
+            address_list[len(address_list) - 1] = address_list[len(address_list) - 1].strip("]")
+            interfaces = self.axapi_client.interface.get_list()
+            for i in range(len(interfaces['interface']['ethernet-list'])):
+                if address_list:
+                    ifnum = interfaces['interface']['ethernet-list'][i]['ifnum']
+                    ifnum_oper = self.axapi_client.interface.ethernet.get_oper(ifnum)
+                    ifnum_address = a10_utils.get_ipv6_address(ifnum_oper, subnet, nics,
+                                                               address_list, loadbalancers_list)
+                    ipv6_address_list[ifnum] = ifnum_address
+            return ipv6_address_list
+        else:
             return None
-        topology = CONF.a10_controller_worker.loadbalancer_topology
-        compute_id = loadbalancer.amphorae[0].compute_id
-        network_driver = utils.get_network_driver()
-        nics = network_driver.get_plugged_networks(compute_id)
-        if topology == "ACTIVE_STANDBY":
-            backup_nics = network_driver.get_plugged_networks(loadbalancer.amphorae[1].compute_id)
-            nics = nics + backup_nics
-        address_list = CONF.a10_global.subnet_ipv6_addresses
-        address_list[0] = address_list[0].strip("[")
-        address_list[len(address_list) - 1] = address_list[len(address_list) - 1].strip("]")
-        interfaces = self.axapi_client.interface.get_list()
-        for i in range(len(interfaces['interface']['ethernet-list'])):
-            if address_list:
-                ifnum = interfaces['interface']['ethernet-list'][i]['ifnum']
-                ifnum_oper = self.axapi_client.interface.ethernet.get_oper(ifnum)
-                ifnum_address = a10_utils.get_ipv6_address(ifnum_oper, subnet, nics,
-                                                           address_list, loadbalancers_list)
-                ipv6_address_list[ifnum] = ifnum_address
-        return ipv6_address_list
 
 
 class EnableInterfaceForMembers(VThunderBaseTask):


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description: When we try to delete an ERROR loadbalancer, getting an error like "IndexError: list index out of range".

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3596

## Technical Approach
- Added a check for vthunder before computing amphora_id wherever calculated.

## Config Changes
N/A

## Test Cases
- Create a loadbalancer such that it goes into ERROR state.
- Delete the loadbalancer.

## Manual Testing
```
stack@neha-victoria:~$ openstack loadbalancer create --vip-subnet-id ipv6_subnet_vlan_11 --name vip1                                     +---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2023-04-10T09:27:35                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 20196644-8932-4608-a5d0-6de134fdcdc9 |
| listeners           |                                      |
| name                | vip1                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | f4079be17ddb41ee97d863a08e2e5f18     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 3001:db8:3333:4444::3e4              |
| vip_network_id      | dd8119a3-863b-4aa2-bf46-b36783b4f99c |
| vip_port_id         | 25abb18d-d408-43a4-a325-4dc4edb25802 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 2e3dfb8d-5e13-4f27-ac66-fb39efb091e5 |
+---------------------+--------------------------------------+
```
 
```
stack@neha-victoria:~$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+-------------------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address             | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+-------------------------+---------------------+------------------+----------+
| 20196644-8932-4608-a5d0-6de134fdcdc9 | vip1 | f4079be17ddb41ee97d863a08e2e5f18 | 3001:db8:3333:4444::3e4 | ERROR               | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+-------------------------+---------------------+------------------+----------+
```

stack@neha-victoria:~$ openstack loadbalancer delete vip1

stack@neha-victoria:~$ openstack loadbalancer list

