### PR TITLE
[STACK-3592]: Resolved issue of aflex deletion on vThunder happening on pool deletion.

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_pool_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_pool_flows.py
@@ -73,7 +73,8 @@ class PoolFlows(object):
             provides=constants.POOL)
         create_pool_flow.add(*self._get_sess_pers_subflow(create_pool))
         create_pool_flow.add(virtual_port_tasks.ListenerUpdateForPool(
-            requires=[constants.LOADBALANCER, constants.LISTENER, a10constants.VTHUNDER]))
+            requires=[constants.LOADBALANCER, constants.LISTENER,
+                      constants.POOL, a10constants.VTHUNDER]))
         create_pool_flow.add(database_tasks.MarkPoolActiveInDB(
             requires=constants.POOL))
         create_pool_flow.add(database_tasks.MarkLBAndListenersActiveInDB(
@@ -170,7 +171,8 @@ class PoolFlows(object):
                 requires=a10constants.VTHUNDER,
                 provides=a10constants.VTHUNDER))
         delete_pool_flow.add(virtual_port_tasks.ListenerUpdateForPool(
-            requires=[constants.LOADBALANCER, constants.LISTENER, a10constants.VTHUNDER]))
+            requires=[constants.LOADBALANCER, constants.LISTENER,
+                      constants.POOL, a10constants.VTHUNDER]))
         delete_pool_flow.add(persist_tasks.DeleteSessionPersistence(
             requires=[a10constants.VTHUNDER, constants.POOL]))
         delete_pool_flow.add(a10_database_tasks.GetProxyProtocolPoolCount(
@@ -277,7 +279,8 @@ class PoolFlows(object):
             provides=constants.POOL)
         update_pool_flow.add(*self._get_sess_pers_subflow(update_pool))
         update_pool_flow.add(virtual_port_tasks.ListenerUpdateForPool(
-            requires=[constants.LOADBALANCER, constants.LISTENER, a10constants.VTHUNDER]))
+            requires=[constants.LOADBALANCER, constants.LISTENER,
+                      constants.POOL, a10constants.VTHUNDER]))
         update_pool_flow.add(database_tasks.UpdatePoolInDB(
             requires=[constants.POOL, constants.UPDATE_DICT]))
         update_pool_flow.add(database_tasks.MarkPoolActiveInDB(
@@ -327,10 +330,11 @@ class PoolFlows(object):
             rebind={constants.POOL: pool_name}))
         delete_pool_flow.add(virtual_port_tasks.ListenerUpdateForPool(
             name='listener_update_for_pool_' + pool_name,
-            requires=[constants.LOADBALANCER, constants.LISTENER, a10constants.VTHUNDER,
-                      a10constants.FLOW_TYPE],
+            requires=[constants.LOADBALANCER, constants.LISTENER, constants.POOL,
+                      a10constants.VTHUNDER, a10constants.FLOW_TYPE],
             inject={a10constants.FLOW_TYPE: a10constants.FLOW_TYPE_DELETE},
-            rebind={constants.LISTENER: pool_listener_name}))
+            rebind={constants.LISTENER: pool_listener_name,
+                    constants.POOL: pool_name}))
         delete_pool_flow.add(persist_tasks.DeleteSessionPersistence(
             name='delete_session_persistence_' + pool_name,
             requires=[a10constants.VTHUNDER, constants.POOL],
@@ -387,7 +391,8 @@ class PoolFlows(object):
             requires=constants.LOADBALANCER,
             provides=a10constants.VTHUNDER))
         delete_pool_flow.add(virtual_port_tasks.ListenerUpdateForPool(
-            requires=[constants.LOADBALANCER, constants.LISTENER, a10constants.VTHUNDER]))
+            requires=[constants.LOADBALANCER, constants.LISTENER,
+                      constants.POOL, a10constants.VTHUNDER]))
         delete_pool_flow.add(persist_tasks.DeleteSessionPersistence(
             requires=[a10constants.VTHUNDER, constants.POOL]))
         delete_pool_flow.add(vthunder_tasks.SetupDeviceNetworkMap(

--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -244,7 +244,7 @@ class ListenerUpdateForPool(ListenersParent, task.Task):
                 c_pers, s_pers = utils.get_sess_pers_templates(pool)
                 listener.protocol = openstack_mappings.virtual_port_protocol(
                     self.axapi_client, listener.protocol).lower()
-                clear_aflex = True
+                clear_aflex = False
 
                 if aflex is not None:
                     curr_vport = self.axapi_client.slb.virtual_server.vport.get(
@@ -253,7 +253,7 @@ class ListenerUpdateForPool(ListenersParent, task.Task):
                     exclude = a10constants.PROXY_PROTOCPL_AFLEX_NAME
                     aflex_scripts = utils.get_proxy_aflex_list(curr_vport, aflex, exclude)
                     kargs["aflex_scripts"] = aflex_scripts
-                    clear_aflex = False
+                    clear_aflex = True
 
                 self.axapi_client.slb.virtual_server.vport.update(
                     loadbalancer.id,

--- a/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
+++ b/a10_octavia/controller/worker/tasks/virtual_port_tasks.py
@@ -244,6 +244,7 @@ class ListenerUpdateForPool(ListenersParent, task.Task):
                 c_pers, s_pers = utils.get_sess_pers_templates(pool)
                 listener.protocol = openstack_mappings.virtual_port_protocol(
                     self.axapi_client, listener.protocol).lower()
+                clear_aflex = True
 
                 if aflex is not None:
                     curr_vport = self.axapi_client.slb.virtual_server.vport.get(
@@ -252,6 +253,7 @@ class ListenerUpdateForPool(ListenersParent, task.Task):
                     exclude = a10constants.PROXY_PROTOCPL_AFLEX_NAME
                     aflex_scripts = utils.get_proxy_aflex_list(curr_vport, aflex, exclude)
                     kargs["aflex_scripts"] = aflex_scripts
+                    clear_aflex = False
 
                 self.axapi_client.slb.virtual_server.vport.update(
                     loadbalancer.id,
@@ -261,7 +263,7 @@ class ListenerUpdateForPool(ListenersParent, task.Task):
                     pool_id,
                     s_pers_name=s_pers, c_pers_name=c_pers,
                     tcp_proxy_name=tcp_proxy,
-                    aflex_scripts_clear=True,
+                    aflex_scripts_clear=clear_aflex,
                     **kargs)
                 LOG.debug("Successfully updated listener: %s", listener.id)
         except (acos_errors.ACOSException, ConnectionError) as e:


### PR DESCRIPTION
## Description
- Severity Level: Medium
- Issue Description: aflex policy was getting deleted from listener when pool is deleted.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3592

## Technical Approach
- Added a flag `clear_aflex` for deciding whether to remove aflex from listener on deleting pool.

## Config Changes
N/A

## Test Cases
- Create a loadbalancer, listener, pool, member, healthmonitor, l7policy and l7rule.
- Delete the pool.
- Check vThunder configurations. 
- Delete l7rule and l7policy.
- Check vThunder configurations.

## Manual Testing
1.  Create a loadbalancer, listener, pool, member, healthmonitor, l7policy and l7rule.

```
stack@neha-victoria:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name vip1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2023-04-12T11:42:18                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 451dbcec-a1cd-4725-83a3-5555a826a731 |
| listeners           |                                      |
| name                | vip1                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | f4079be17ddb41ee97d863a08e2e5f18     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.113                          |
| vip_network_id      | dd8119a3-863b-4aa2-bf46-b36783b4f99c |
| vip_port_id         | d38c9d3a-e8aa-4046-9268-37f3ab67c5f3 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 1aa76f34-f5b5-42e2-a4dd-98569764db56 |
+---------------------+--------------------------------------+
stack@neha-victoria:~$ openstack loadbalancer listener create --protocol HTTP --protocol-port 88 --name l1 vip1                          +-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2023-04-12T11:43:31                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | afb682ed-67a8-46ae-a86b-3b7866c2924b |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 451dbcec-a1cd-4725-83a3-5555a826a731 |
| name                        | l1                                   |
| operating_status            | OFFLINE                              |
| project_id                  | f4079be17ddb41ee97d863a08e2e5f18     |
| protocol                    | HTTP                                 |
| protocol_port               | 88                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
| allowed_cidrs               | None                                 |
| tls_ciphers                 | None                                 |
| tls_versions                | None                                 |
| alpn_protocols              | None                                 |
+-----------------------------+--------------------------------------+
stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener l1 --nam
e sg1
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2023-04-12T11:57:03                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | ebac106a-3535-402b-8d51-d1baeed47066 |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | afb682ed-67a8-46ae-a86b-3b7866c2924b |
| loadbalancers        | 451dbcec-a1cd-4725-83a3-5555a826a731 |
| members              |                                      |
| name                 | sg1                                  |
| operating_status     | OFFLINE                              |
| project_id           | f4079be17ddb41ee97d863a08e2e5f18     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+
stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer member create --address 10.0.12.12 --subnet-id provider-vlan-12-subnet --protocol-port 82 --name member1 sg1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.12.12                           |
| admin_state_up      | True                                 |
| created_at          | 2023-04-12T11:57:13                  |
| id                  | b46ccb21-510a-4dfa-90fe-552a2ca1f00e |
| name                | member1                              |
| operating_status    | NO_MONITOR                           |
| project_id          | f4079be17ddb41ee97d863a08e2e5f18     |
| protocol_port       | 82                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 7a3f047b-4fcd-4e56-87b4-0df8c0e460de |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer member create --address 10.0.12.13 --subnet-id provider-vlan-12-subnet --protocol-port 80 --name member2 sg1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.12.13                           |
| admin_state_up      | True                                 |
| created_at          | 2023-04-12T11:57:20                  |
| id                  | 8f3ca70c-ee71-4cb0-9e70-5db733529efc |
| name                | member2                              |
| operating_status    | NO_MONITOR                           |
| project_id          | f4079be17ddb41ee97d863a08e2e5f18     |
| protocol_port       | 80                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 7a3f047b-4fcd-4e56-87b4-0df8c0e460de |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer healthmonitor create --delay 30 --timeout 3 --max-retries 3 --type HTTP sg
1 --name hm1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| project_id          | f4079be17ddb41ee97d863a08e2e5f18     |
| name                | hm1                                  |
| admin_state_up      | True                                 |
| pools               | ebac106a-3535-402b-8d51-d1baeed47066 |
| created_at          | 2023-04-12T11:57:27                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| delay               | 30                                   |
| expected_codes      | 200                                  |
| max_retries         | 3                                    |
| http_method         | GET                                  |
| timeout             | 3                                    |
| max_retries_down    | 3                                    |
| url_path            | /                                    |
| type                | HTTP                                 |
| id                  | d3c98e7a-2a09-4551-9a23-7ee5d5f4db7c |
| operating_status    | OFFLINE                              |
| http_version        | None                                 |
| domain_name         | None                                 |
+---------------------+--------------------------------------+
stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer l7policy create --action REJECT --name policy1 l1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| listener_id         | afb682ed-67a8-46ae-a86b-3b7866c2924b |
| description         |                                      |
| admin_state_up      | True                                 |
| rules               |                                      |
| project_id          | f4079be17ddb41ee97d863a08e2e5f18     |
| created_at          | 2023-04-12T11:57:35                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| redirect_pool_id    | None                                 |
| redirect_url        | None                                 |
| redirect_prefix     | None                                 |
| action              | REJECT                               |
| position            | 1                                    |
| id                  | 2004585e-9d1e-402c-8d51-85aceef53c2e |
| operating_status    | OFFLINE                              |
| name                | policy1                              |
| redirect_http_code  | None                                 |
+---------------------+--------------------------------------+
stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer l7rule create --compare-type REGEX --type HEADER --key "reject" --value "request" policy1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| created_at          | 2023-04-12T11:57:44                  |
| compare_type        | REGEX                                |
| provisioning_status | PENDING_CREATE                       |
| invert              | False                                |
| admin_state_up      | True                                 |
| updated_at          | None                                 |
| value               | request                              |
| key                 | reject                               |
| project_id          | f4079be17ddb41ee97d863a08e2e5f18     |
| type                | HEADER                               |
| id                  | 2365d1e5-fd1b-4c53-9166-e5a318012be3 |
| operating_status    | OFFLINE                              |
+---------------------+--------------------------------------+

```

vThunder configurations:

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 482 bytes
!Configuration last updated at 12:56:34 IST Wed Apr 12 2023
!Configuration last saved at 12:56:36 IST Wed Apr 12 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p5, build 114 (Jul-14-2022,09:59)
!
multi-config enable
!
partition test-ipv6 id 2
!
!
interface management
  ip address 10.64.26.109 255.255.255.0
  ip control-apps-use-mgmt-port
  ip default-gateway 10.64.26.1
!
interface ethernet 1
  enable
  ip address 10.10.10.13 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.11.10.13 255.255.255.0
!
vrrp-a vrid 0
  floating-ip 10.0.11.107
  floating-ip 10.0.12.129
!
ip route 30.30.30.0 /26 lif acosk8s-81_200
!
ip route 192.168.81.192 /26 lif acosk8s-81_200
!
ip route 192.168.220.192 /26 lif acosk8s-220_192
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
health monitor d3c98e7a-2a09-4551-9a23-7ee5d5f4db7c
  interval 30 timeout 3
  method http port 88 expect response-code 200 url GET /
!
slb server f4079_10_0_12_12 10.0.12.12
  health-check d3c98e7a-2a09-4551-9a23-7ee5d5f4db7c
  port 82 tcp
!
slb server f4079_10_0_12_13 10.0.12.13
  health-check d3c98e7a-2a09-4551-9a23-7ee5d5f4db7c
  port 80 tcp
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb service-group ebac106a-3535-402b-8d51-d1baeed47066 tcp
  member f4079_10_0_12_12 82
  member f4079_10_0_12_13 80
!
slb virtual-server 451dbcec-a1cd-4725-83a3-5555a826a731 10.0.11.113
  port 88 http
    name afb682ed-67a8-46ae-a86b-3b7866c2924b
    extended-stats
    aflex 2004585e-9d1e-402c-8d51-85aceef53c2e
    service-group ebac106a-3535-402b-8d51-d1baeed47066
!
sflow setting local-collection
!
sflow collector ip 127.0.0.1 6343
!
!
end
```


2. Delete pool.

stack@neha-victoria:~$ openstack loadbalancer pool delete sg1

vThunder configurations after deleting pool:

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 482 bytes
!Configuration last updated at 12:56:48 IST Wed Apr 12 2023
!Configuration last saved at 12:56:50 IST Wed Apr 12 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p5, build 114 (Jul-14-2022,09:59)
!
multi-config enable
!
partition test-ipv6 id 2
!
!
interface management
  ip address 10.64.26.109 255.255.255.0
  ip control-apps-use-mgmt-port
  ip default-gateway 10.64.26.1
!
interface ethernet 1
  enable
  ip address 10.10.10.13 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.11.10.13 255.255.255.0
!
vrrp-a vrid 0
  floating-ip 10.0.11.107
!
ip route 30.30.30.0 /26 lif acosk8s-81_200
!
ip route 192.168.81.192 /26 lif acosk8s-81_200
!
ip route 192.168.220.192 /26 lif acosk8s-220_192
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb virtual-server 451dbcec-a1cd-4725-83a3-5555a826a731 10.0.11.113
  port 88 http
    name afb682ed-67a8-46ae-a86b-3b7866c2924b
    extended-stats
    aflex 2004585e-9d1e-402c-8d51-85aceef53c2e
!
sflow setting local-collection
!
sflow collector ip 127.0.0.1 6343
!
!
end
```

3. Check l7policy and l7rule on OpenStack side.

```
stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer l7policy list
+--------------------------------------+---------+----------------------------------+---------------------+--------+----------+----------------+
| id                                   | name    | project_id                       | provisioning_status | action | position | admin_state_up |
+--------------------------------------+---------+----------------------------------+---------------------+--------+----------+----------------+
| 2004585e-9d1e-402c-8d51-85aceef53c2e | policy1 | f4079be17ddb41ee97d863a08e2e5f18 | ACTIVE              | REJECT |        1 | True           |
+--------------------------------------+---------+----------------------------------+---------------------+--------+----------+----------------+
stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer l7rule list policy1                                                       +--------------------------------------+----------------------------------+---------------------+--------------+--------+--------+---------+--------+----------------+
| id                                   | project_id                       | provisioning_status | compare_type | type   | key    | value   | invert | admin_state_up |
+--------------------------------------+----------------------------------+---------------------+--------------+--------+--------+---------+--------+----------------+
| 2365d1e5-fd1b-4c53-9166-e5a318012be3 | f4079be17ddb41ee97d863a08e2e5f18 | ACTIVE              | REGEX        | HEADER | reject | request | False  | True           |
+--------------------------------------+----------------------------------+---------------------+--------------+--------+--------+---------+--------+----------------+
```

4. Delete the l7rule and l7policy.
stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer l7rule delete policy1 2365d1e5-fd1b-4c53-9166-e5a318012be3
stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer l7policy delete policy1

vThunder configurations after deleting l7policy and l7rule:

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 482 bytes
!Configuration last updated at 13:03:17 IST Wed Apr 12 2023
!Configuration last saved at 13:03:19 IST Wed Apr 12 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p5, build 114 (Jul-14-2022,09:59)
!
multi-config enable
!
partition test-ipv6 id 2
!
!
interface management
  ip address 10.64.26.109 255.255.255.0
  ip control-apps-use-mgmt-port
  ip default-gateway 10.64.26.1
!
interface ethernet 1
  enable
  ip address 10.10.10.13 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.11.10.13 255.255.255.0
!
vrrp-a vrid 0
  floating-ip 10.0.11.107
!
ip route 30.30.30.0 /26 lif acosk8s-81_200
!
ip route 192.168.81.192 /26 lif acosk8s-81_200
!
ip route 192.168.220.192 /26 lif acosk8s-220_192
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb virtual-server 451dbcec-a1cd-4725-83a3-5555a826a731 10.0.11.113
  port 88 http
    name afb682ed-67a8-46ae-a86b-3b7866c2924b
    extended-stats
!
sflow setting local-collection
!
sflow collector ip 127.0.0.1 6343
!
!
end

```

Proxy protocol pool deletion:

```
stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name vip1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2023-04-13T07:13:27                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 5ab9327d-c76b-4d7b-b1c3-7d2efacc9682 |
| listeners           |                                      |
| name                | vip1                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | f4079be17ddb41ee97d863a08e2e5f18     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.111                          |
| vip_network_id      | dd8119a3-863b-4aa2-bf46-b36783b4f99c |
| vip_port_id         | 6c63ca20-a3c9-4a9d-bde5-803eb5b94c3a |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 1aa76f34-f5b5-42e2-a4dd-98569764db56 |
+---------------------+--------------------------------------+
stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name vport1 vip1
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2023-04-13T07:13:46                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | cba59710-001b-4e6b-a8dd-fe95c92154be |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 5ab9327d-c76b-4d7b-b1c3-7d2efacc9682 |
| name                        | vport1                               |
| operating_status            | OFFLINE                              |
| project_id                  | f4079be17ddb41ee97d863a08e2e5f18     |
| protocol                    | HTTP                                 |
| protocol_port               | 80                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
| allowed_cidrs               | None                                 |
| tls_ciphers                 | None                                 |
| tls_versions                | None                                 |
| alpn_protocols              | None                                 |
+-----------------------------+--------------------------------------+
stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer pool create --protocol PROXY --lb-algorithm ROUND_ROBIN --listener vport1 --name pool1
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2023-04-13T07:13:55                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | 0f2805be-c874-451f-8172-f448dd44c7bd |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | cba59710-001b-4e6b-a8dd-fe95c92154be |
| loadbalancers        | 5ab9327d-c76b-4d7b-b1c3-7d2efacc9682 |
| members              |                                      |
| name                 | pool1                                |
| operating_status     | OFFLINE                              |
| project_id           | f4079be17ddb41ee97d863a08e2e5f18     |
| protocol             | PROXY                                |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+
stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer listener create --protocol TCP --protocol-port 5000 --name vport3 vip1
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2023-04-13T07:14:10                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 8a6fe75b-1a30-4d62-b5e5-b1057d6ff1a6 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 5ab9327d-c76b-4d7b-b1c3-7d2efacc9682 |
| name                        | vport3                               |
| operating_status            | OFFLINE                              |
| project_id                  | f4079be17ddb41ee97d863a08e2e5f18     |
| protocol                    | TCP                                  |
| protocol_port               | 5000                                 |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
| allowed_cidrs               | None                                 |
| tls_ciphers                 | None                                 |
| tls_versions                | None                                 |
| alpn_protocols              | None                                 |
+-----------------------------+--------------------------------------+
stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer pool create --protocol PROXY --lb-algorithm ROUND_ROBIN --listener vport3 --name pool3
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2023-04-13T07:14:19                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | d48450e5-d2ad-4a7d-944b-92116d3238f1 |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | 8a6fe75b-1a30-4d62-b5e5-b1057d6ff1a6 |
| loadbalancers        | 5ab9327d-c76b-4d7b-b1c3-7d2efacc9682 |
| members              |                                      |
| name                 | pool3                                |
| operating_status     | OFFLINE                              |
| project_id           | f4079be17ddb41ee97d863a08e2e5f18     |
| protocol             | PROXY                                |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+


vThunder(NOLICENSE)#show running-config
!Current configuration: 678 bytes
!Configuration last updated at 08:13:09 IST Thu Apr 13 2023
!Configuration last saved at 08:13:11 IST Thu Apr 13 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p5, build 114 (Jul-14-2022,09:59)
!
multi-config enable
!
partition test-ipv6 id 2
!
!
interface management
  ip address 10.64.26.109 255.255.255.0
  ip control-apps-use-mgmt-port
  ip default-gateway 10.64.26.1
!
interface ethernet 1
  enable
  ip address 10.10.10.13 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.11.10.13 255.255.255.0
!
vrrp-a vrid 0
  floating-ip 10.0.11.186
!
ip route 30.30.30.0 /26 lif acosk8s-81_200
!
ip route 192.168.81.192 /26 lif acosk8s-81_200
!
ip route 192.168.220.192 /26 lif acosk8s-220_192
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb service-group 0f2805be-c874-451f-8172-f448dd44c7bd tcp
!
slb service-group d48450e5-d2ad-4a7d-944b-92116d3238f1 tcp
!
slb template tcp-proxy octavia_proxy_protocol_v1
  proxy-header insert v1
!
slb virtual-server 5ab9327d-c76b-4d7b-b1c3-7d2efacc9682 10.0.11.111
  port 80 http
    name cba59710-001b-4e6b-a8dd-fe95c92154be
    extended-stats
    service-group 0f2805be-c874-451f-8172-f448dd44c7bd
    template tcp-proxy octavia_proxy_protocol_v1
  port 5000 tcp
    name 8a6fe75b-1a30-4d62-b5e5-b1057d6ff1a6
    extended-stats
    aflex octavia_aflex_proxy_protocol_v1
    service-group d48450e5-d2ad-4a7d-944b-92116d3238f1
!
sflow setting local-collection
!
sflow collector ip 127.0.0.1 6343
!
!
end


stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer pool delete pool3


vThunder(NOLICENSE)#show running-config
!Current configuration: 618 bytes
!Configuration last updated at 08:13:59 IST Thu Apr 13 2023
!Configuration last saved at 08:14:00 IST Thu Apr 13 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p5, build 114 (Jul-14-2022,09:59)
!
multi-config enable
!
partition test-ipv6 id 2
!
!
interface management
  ip address 10.64.26.109 255.255.255.0
  ip control-apps-use-mgmt-port
  ip default-gateway 10.64.26.1
!
interface ethernet 1
  enable
  ip address 10.10.10.13 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.11.10.13 255.255.255.0
!
vrrp-a vrid 0
  floating-ip 10.0.11.186
!
ip route 30.30.30.0 /26 lif acosk8s-81_200
!
ip route 192.168.81.192 /26 lif acosk8s-81_200
!
ip route 192.168.220.192 /26 lif acosk8s-220_192
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb service-group 0f2805be-c874-451f-8172-f448dd44c7bd tcp
!
slb template tcp-proxy octavia_proxy_protocol_v1
  proxy-header insert v1
!
slb virtual-server 5ab9327d-c76b-4d7b-b1c3-7d2efacc9682 10.0.11.111
  port 80 http
    name cba59710-001b-4e6b-a8dd-fe95c92154be
    extended-stats
    service-group 0f2805be-c874-451f-8172-f448dd44c7bd
    template tcp-proxy octavia_proxy_protocol_v1
  port 5000 tcp
    name 8a6fe75b-1a30-4d62-b5e5-b1057d6ff1a6
    extended-stats
!
sflow setting local-collection
!
sflow collector ip 127.0.0.1 6343
!
!
end


vThunder(NOLICENSE)#show aflex octavia_aflex_proxy_protocol_v1
No such aFlex


stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer pool delete pool1

vThunder(NOLICENSE)#show running-config
!Current configuration: 482 bytes
!Configuration last updated at 08:14:48 IST Thu Apr 13 2023
!Configuration last saved at 08:14:51 IST Thu Apr 13 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p5, build 114 (Jul-14-2022,09:59)
!
multi-config enable
!
partition test-ipv6 id 2
!
!
interface management
  ip address 10.64.26.109 255.255.255.0
  ip control-apps-use-mgmt-port
  ip default-gateway 10.64.26.1
!
interface ethernet 1
  enable
  ip address 10.10.10.13 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.11.10.13 255.255.255.0
!
vrrp-a vrid 0
  floating-ip 10.0.11.186
!
ip route 30.30.30.0 /26 lif acosk8s-81_200
!
ip route 192.168.81.192 /26 lif acosk8s-81_200
!
ip route 192.168.220.192 /26 lif acosk8s-220_192
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb virtual-server 5ab9327d-c76b-4d7b-b1c3-7d2efacc9682 10.0.11.111
  port 80 http
    name cba59710-001b-4e6b-a8dd-fe95c92154be
    extended-stats
  port 5000 tcp
    name 8a6fe75b-1a30-4d62-b5e5-b1057d6ff1a6
    extended-stats
!
sflow setting local-collection
!
sflow collector ip 127.0.0.1 6343
!
!
end
```



