### PR TITLE
[STACK-3603]: Raised exception if ipv6 address not found in config file

### DIFF
--- a/a10_octavia/common/exceptions.py
+++ b/a10_octavia/common/exceptions.py
@@ -313,3 +313,11 @@ class IpVersionNotSupport(base.NetworkException):
     def __init__(self, version):
         msg = ('Unsupported IP Version {0}').format(version)
         super(IpVersionNotSupport, self).__init__(msg)
+
+
+class IPv6AddressNotFoundInConfig(acos_errors.ACOSException):
+
+    def __init__(self, subnet_id):
+        msg = ('IPv6 address for subnet {0} is not found in the configuration'
+               ' file.').format(subnet_id)
+        super(IPv6AddressNotFoundInConfig, self).__init__(msg=msg)

--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -388,7 +388,10 @@ def get_ipv6_address_from_conf(address_list, subnet_id):
         for key in address:
             if key == subnet_id:
                 final_address_list.append({'ipv6-addr': address[key]})
-                return final_address_list
+    if not final_address_list:
+        raise exceptions.IPv6AddressNotFoundInConfig(subnet_id)
+    else:
+        return final_address_list
 
 
 def get_ipv6_address(ifnum_oper, subnet, nics, address_list, loadbalancers_list):


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description: It is expected to get an exception or warning if we don’t specify ipv6 address for a network specified in amp_boot_network_list or for a subnet used for creating a loadbalancer. But got an error in this case.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3603

## Technical Approach
- Created a custom exception `IPv6AddressNotFoundInConfig`  in exceptions.py
- Raising the exception if `final_address_list` is empty calculated in `get_ipv6_address_from_conf()`.

## Config Changes
N/A

## Test Cases
- Create a loadbalancer with ipv6 subnet with not specifying ipv6 address for that subnet in `subnet_ipv6_addresses` in config file.
- Check the logs for exception.
- Create a loadbalancer with 2 networks in `amp_boot_network_list` in config file - 1 management and another ipv6 n/w, and don't add the ipv6 n/w in `subnet_ipv6_addresses` in the config file.
- Check the logs for exception.

## Manual Testing
 1. Create a loadbalancer with ipv6 subnet with not specifying ipv6 address for that subnet in `subnet_ipv6_addresses` in config file
 
Used following `a10_global` config:
```
[a10_global]
network_type = 'flat'
vrid_floating_ip = ".3"
subnet_ipv6_addresses = [{"4bfd7aec-bb6e-4831-9875-65c1856aeaed": "fd95:1e85:23af::2/64"}, {"729ed9ac-dd81-42e7-a3bd-41895c02ab76": "5001:db8:3333:4444:3:3:3:3/64"}, {"26557618-e028-4990-b9a7-46f3c8336ce8": "6001:db8:3333:4444:3:3:3:3/64"}, {"3896172c-fc2a-4227-8d77-1f3d9b33dac1": "8001:db8:3333:4444::6/64"}, {"2613f0fe-e0ba-422c-871f-b382704cb9f4": "2001:db8::2"}, {"fba05f13-a1e6-4888-9660-cb4a38df5c6a": "6001:db8:3333:4444:3:3:4:4/64"}]
```

```
stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer create --vip-subnet-id ipv6_subnet_vlan_11 --name vip1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2023-04-19T12:17:46                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 1e852ac8-af3d-4d4b-85fd-2966874f8664 |
| listeners           |                                      |
| name                | vip1                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e67519c2d45c41d5bd68cf45db599d46     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 3001:db8:3333:4444::34a              |
| vip_network_id      | d59af818-6eaf-4564-a0a2-6bfec3d9b917 |
| vip_port_id         | f8f0cf5e-a04a-456a-b81b-ca04f7875f3c |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | f75f0595-c298-4df7-bb2b-5a81492c07a6 |
+---------------------+--------------------------------------+
```

Check the logs for exception.

```
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server [-] Exception during message handling: a10_octavia.common.exceptions.IPv6AddressNotFoundInConfig: 1 IPv6 address for subnet f75f0595-c298-4df7-bb2b-5a81492c07a6 is not found in the configuration file.
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server Traceback (most recent call last):
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/oslo_messaging/rpc/server.py", line 165, in _process_incoming
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server     res = self.dispatcher.dispatch(message)
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/oslo_messaging/rpc/dispatcher.py", line 309, in dispatch
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server     return self._do_dispatch(endpoint, method, ctxt, args)
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/oslo_messaging/rpc/dispatcher.py", line 229, in _do_dispatch
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server     result = func(ctxt, **new_args)
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server   File "/opt/stack/neha/a10-octavia/a10_octavia/controller/queue/endpoint.py", line 46, in create_load_balancer
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server     self.worker.create_load_balancer(load_balancer_id, flavor)
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/tenacity/__init__.py", line 329, in wrapped_f
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server     return self.call(f, *args, **kw)
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/tenacity/__init__.py", line 409, in call
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server     do = self.iter(retry_state=retry_state)
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/tenacity/__init__.py", line 356, in iter
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server     return fut.result()
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server   File "/usr/lib/python3.8/concurrent/futures/_base.py", line 437, in result
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server     return self.__get_result()
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server   File "/usr/lib/python3.8/concurrent/futures/_base.py", line 389, in __get_result
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server     raise self._exception
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/tenacity/__init__.py", line 412, in call
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server     result = fn(*args, **kwargs)
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server   File "/opt/stack/neha/a10-octavia/a10_octavia/controller/worker/controller_worker.py", line 445, in create_load_balancer
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server     create_lb_tf.run()
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/taskflow/engines/action_engine/engine.py", line 247, in run
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server     for _state in self.run_iter(timeout=timeout):
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/taskflow/engines/action_engine/engine.py", line 340, in run_iter
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server     failure.Failure.reraise_if_any(er_failures)
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/taskflow/types/failure.py", line 339, in reraise_if_any
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server     failures[0].reraise()
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/taskflow/types/failure.py", line 346, in reraise
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server     six.reraise(*self._exc_info)
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/six.py", line 703, in reraise
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server     raise value
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server     result = task.execute(**arguments)
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server   File "/opt/stack/neha/a10-octavia/a10_octavia/controller/worker/tasks/decorators.py", line 51, in wrapper
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server     result = func(self, *args, **kwargs)
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server   File "/opt/stack/neha/a10-octavia/a10_octavia/controller/worker/tasks/vthunder_tasks.py", line 372, in execute
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server     ifnum_address = a10_utils.get_ipv6_address(ifnum_oper, subnet, nics,
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server   File "/opt/stack/neha/a10-octavia/a10_octavia/common/utils.py", line 418, in get_ipv6_address
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server     final_address_list = get_ipv6_address_from_conf(address_list,
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server   File "/opt/stack/neha/a10-octavia/a10_octavia/common/utils.py", line 392, in get_ipv6_address_from_conf
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server     raise exceptions.IPv6AddressNotFoundInConfig(subnet_id)
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server a10_octavia.common.exceptions.IPv6AddressNotFoundInConfig: 1 IPv6 address for subnet f75f0595-c298-4df7-bb2b-5a81492c07a6 is not found in the configuration file.
Apr 19 12:21:47 neha-victoria a10-octavia-worker[2995419]: ERROR oslo_messaging.rpc.server
```

2. Create a loadbalancer with 2 networks in `amp_boot_network_list` in config file - 1 management and another ipv6 n/w, and don't add the ipv6 n/w in `subnet_ipv6_addresses` in the config file.

```
[a10_global]
network_type = 'flat'
vrid_floating_ip = ".3"
subnet_ipv6_addresses = [{"4bfd7aec-bb6e-4831-9875-65c1856aeaed": "fd95:1e85:23af::2/64"}, {"729ed9ac-dd81-42e7-a3bd-41895c02ab76": "5001:db8:3333:4444:3:3:3:3/64"}, {"26557618-e028-4990-b9a7-46f3c8336ce8": "6001:db8:3333:4444:3:3:3:3/64"}, {"3896172c-fc2a-4227-8d77-1f3d9b33dac1": "8001:db8:3333:4444::6/64"}, {"2613f0fe-e0ba-422c-871f-b382704cb9f4": "2001:db8::2"}, {"fba05f13-a1e6-4888-9660-cb4a38df5c6a": "6001:db8:3333:4444:3:3:4:4/64"}]

[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"

[a10_controller_worker]
amp_image_owner_id = e67519c2d45c41d5bd68cf45db599d46
amp_secgroup_list = 0c1e3d23-58ae-46c5-a2b5-e9fd72a08c28
amp_flavor_id = b4b5c574-a167-46a4-92bd-1e15a6375855
amp_boot_network_list = ab91259e-701c-467f-9a80-b567887b10e3, f75f0595-c298-4df7-bb2b-5a81492c07a6
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 100
amp_active_wait_sec = 2
amp_image_id = 3582fffd-f98e-4996-9eae-0ee56277afdb
amp_image_tag = vThunder521p3
loadbalancer_topology = SINGLE
```

```
stack@neha-victoria:~$ openstack loadbalancer create --vip-subnet-id ipv6_subnet_vlan_13 --name vip1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2023-04-20T07:05:35                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | a4165c36-d64d-4e70-b2db-7ff68319fb45 |
| listeners           |                                      |
| name                | vip1                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e67519c2d45c41d5bd68cf45db599d46     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 6001:db8:3333:4444::eb               |
| vip_network_id      | fba05f13-a1e6-4888-9660-cb4a38df5c6a |
| vip_port_id         | 7690457e-081b-409f-a599-3dcfce9f8641 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 26557618-e028-4990-b9a7-46f3c8336ce8 |
+---------------------+--------------------------------------+
```

```
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server [-] Exception during message handling: a10_octavia.common.exceptions.IPv6AddressNotFoundInConfig: 1 IPv6 address for subnet d59af818-6eaf-4564-a0a2-6bfec3d9b917 is not found in the configuration file.
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server Traceback (most recent call last):
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/oslo_messaging/rpc/server.py", line 165, in _process_incoming
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server     res = self.dispatcher.dispatch(message)
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/oslo_messaging/rpc/dispatcher.py", line 309, in dispatch
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server     return self._do_dispatch(endpoint, method, ctxt, args)
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/oslo_messaging/rpc/dispatcher.py", line 229, in _do_dispatch
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server     result = func(ctxt, **new_args)
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server   File "/opt/stack/neha/a10-octavia/a10_octavia/controller/queue/endpoint.py", line 46, in create_load_balancer
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server     self.worker.create_load_balancer(load_balancer_id, flavor)
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/tenacity/__init__.py", line 329, in wrapped_f
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server     return self.call(f, *args, **kw)
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/tenacity/__init__.py", line 409, in call
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server     do = self.iter(retry_state=retry_state)
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/tenacity/__init__.py", line 356, in iter
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server     return fut.result()
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server   File "/usr/lib/python3.8/concurrent/futures/_base.py", line 437, in result
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server     return self.__get_result()
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server   File "/usr/lib/python3.8/concurrent/futures/_base.py", line 389, in __get_result
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server     raise self._exception
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/tenacity/__init__.py", line 412, in call
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server     result = fn(*args, **kwargs)
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server   File "/opt/stack/neha/a10-octavia/a10_octavia/controller/worker/controller_worker.py", line 445, in create_load_balancer
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server     create_lb_tf.run()
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/taskflow/engines/action_engine/engine.py", line 247, in run
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server     for _state in self.run_iter(timeout=timeout):
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/taskflow/engines/action_engine/engine.py", line 340, in run_iter
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server     failure.Failure.reraise_if_any(er_failures)
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/taskflow/types/failure.py", line 339, in reraise_if_any
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server     failures[0].reraise()
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/taskflow/types/failure.py", line 346, in reraise
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server     six.reraise(*self._exc_info)
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/six.py", line 703, in reraise
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server     raise value
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python3.8/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server     result = task.execute(**arguments)
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server   File "/opt/stack/neha/a10-octavia/a10_octavia/controller/worker/tasks/decorators.py", line 51, in wrapper
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server     result = func(self, *args, **kwargs)
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server   File "/opt/stack/neha/a10-octavia/a10_octavia/controller/worker/tasks/vthunder_tasks.py", line 372, in execute
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server     ifnum_address = a10_utils.get_ipv6_address(ifnum_oper, subnet, nics,
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server   File "/opt/stack/neha/a10-octavia/a10_octavia/common/utils.py", line 406, in get_ipv6_address
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server     final_address_list = get_ipv6_address_from_conf(address_list, nic.network_id)
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server   File "/opt/stack/neha/a10-octavia/a10_octavia/common/utils.py", line 392, in get_ipv6_address_from_conf
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server     raise exceptions.IPv6AddressNotFoundInConfig(subnet_id)
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server a10_octavia.common.exceptions.IPv6AddressNotFoundInConfig: 1 IPv6 address for subnet d59af818-6eaf-4564-a0a2-6bfec3d9b917 is not found in the configuration file.
Apr 20 07:09:41 neha-victoria a10-octavia-worker[3139630]: ERROR oslo_messaging.rpc.server
```
