### PR TITLE
[STACK-3594] [STACK-3604] [IPv6 support][Rack flow] Failed to create IPv6 loadbalancer when IPv4 loadbalancer and member already exists on the vThunder.

### DIFF
--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -401,12 +401,12 @@ def get_ipv6_address(ifnum_oper, subnet, nics, address_list, loadbalancers_list)
         if port_mac_address == acos_mac_address:
             if nic.network_id in amp_boot_networks:
                 final_address_list = get_ipv6_address_from_conf(address_list, nic.network_id)
-                if len(final_address_list) > 0:
+                if final_address_list and len(final_address_list) > 0:
                     break
 
             if nic.network_id == subnet.network_id and not loadbalancers_list:
                 final_address_list = get_ipv6_address_from_conf(address_list, subnet.id)
-                if len(final_address_list) > 0:
+                if final_address_list and len(final_address_list) > 0:
                     break
 
             if loadbalancers_list:
@@ -414,15 +414,15 @@ def get_ipv6_address(ifnum_oper, subnet, nics, address_list, loadbalancers_list)
                     if lb.vip.network_id == nic.network_id:
                         final_address_list = get_ipv6_address_from_conf(address_list,
                                                                         lb.vip.subnet_id)
-                        if len(final_address_list) > 0:
+                        if final_address_list and len(final_address_list) > 0:
                             break
-                for pool in lb.pools:
-                    for member in pool.members:
-                        member_subnet = network_driver.get_subnet(member.subnet_id)
-                        if member_subnet.network_id == nic.network_id:
-                            final_address_list = get_ipv6_address_from_conf(address_list,
-                                                                            member.subnet_id)
-                            if len(final_address_list) > 0:
+                    for pool in lb.pools:
+                        for member in pool.members:
+                            member_subnet = network_driver.get_subnet(member.subnet_id)
+                            if member_subnet.network_id == nic.network_id:
+                                final_address_list = get_ipv6_address_from_conf(address_list,
+                                                                                member.subnet_id)
+                            if final_address_list and len(final_address_list) > 0:
                                 break
     return final_address_list
 

--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -401,12 +401,12 @@ def get_ipv6_address(ifnum_oper, subnet, nics, address_list, loadbalancers_list)
         if port_mac_address == acos_mac_address:
             if nic.network_id in amp_boot_networks:
                 final_address_list = get_ipv6_address_from_conf(address_list, nic.network_id)
-                if final_address_list and len(final_address_list) > 0:
+                if len(final_address_list) > 0:
                     break
 
             if nic.network_id == subnet.network_id and not loadbalancers_list:
                 final_address_list = get_ipv6_address_from_conf(address_list, subnet.id)
-                if final_address_list and len(final_address_list) > 0:
+                if len(final_address_list) > 0:
                     break
 
             if loadbalancers_list:
@@ -414,7 +414,7 @@ def get_ipv6_address(ifnum_oper, subnet, nics, address_list, loadbalancers_list)
                     if lb.vip.network_id == nic.network_id:
                         final_address_list = get_ipv6_address_from_conf(address_list,
                                                                         lb.vip.subnet_id)
-                        if final_address_list and len(final_address_list) > 0:
+                        if len(final_address_list) > 0:
                             break
                     for pool in lb.pools:
                         for member in pool.members:
@@ -422,7 +422,7 @@ def get_ipv6_address(ifnum_oper, subnet, nics, address_list, loadbalancers_list)
                             if member_subnet.network_id == nic.network_id:
                                 final_address_list = get_ipv6_address_from_conf(address_list,
                                                                                 member.subnet_id)
-                            if final_address_list and len(final_address_list) > 0:
+                            if len(final_address_list) > 0:
                                 break
     return final_address_list
 

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -325,11 +325,11 @@ class EnableInterface(VThunderBaseTask):
                                 self.axapi_client.system.action.setInterface(ifnum,
                                                                              ifnum_address[ifnum],
                                                                              6)
-                    else:
-                        self.axapi_client.device_context.switch(1, None)
-                        self.axapi_client.system.action.setInterface(ifnum, None, 4)
-                        self.axapi_client.device_context.switch(2, None)
-                        self.axapi_client.system.action.setInterface(ifnum, None, 4)
+                        else:
+                            self.axapi_client.device_context.switch(1, None)
+                            self.axapi_client.system.action.setInterface(ifnum, None, 4)
+                            self.axapi_client.device_context.switch(2, None)
+                            self.axapi_client.system.action.setInterface(ifnum, None, 4)
         except(acos_errors.ACOSException, req_exceptions.ConnectionError) as e:
             LOG.exception("Failed to configure ethernet interface vThunder: %s", str(e))
             raise e

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
@@ -129,11 +129,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
                 return_value=a10constants.MOCK_VRID_FLOATING_IP_1)
     @mock.patch('a10_octavia.common.utils.get_patched_ip_address',
                 return_value=a10constants.MOCK_VRID_FLOATING_IP_1)
-    @mock.patch(
-        'a10_octavia.common.utils.get_acos_parameter_for_vrid',
-        return_value=[constants.IP_ADDRESS, constants.IP_ADDRESS_CFG])
     def test_HandleVRIDFloatingIP_create_floating_ip_in_shared_partition_with_static_ip(
-            self, mock_patched_ip, mock_floating_ip, mock_acos_params):
+            self, mock_patched_ip, mock_floating_ip):
         member = copy.deepcopy(MEMBER)
         member.subnet_id = SUBNET_1.id
         vthunder = copy.deepcopy(VTHUNDER)
@@ -160,11 +157,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
 
     @mock.patch('a10_octavia.common.utils.get_patched_ip_address',
                 return_value=a10constants.MOCK_VRID_FLOATING_IP_1)
-    @mock.patch(
-        'a10_octavia.common.utils.get_acos_parameter_for_vrid',
-        return_value=[constants.IP_ADDRESS, constants.IP_ADDRESS_CFG])
     def test_HandleVRIDFloatingIP_create_floating_ip_with_device_name_flavor(
-            self, mock_patched_ip, mock_acos_params):
+            self, mock_patched_ip):
         member = copy.deepcopy(MEMBER)
         member.subnet_id = SUBNET_1.id
         vthunder = copy.deepcopy(VTHUNDER)
@@ -193,11 +187,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
     @mock.patch('a10_octavia.common.utils.get_patched_ip_address',
                 return_value=a10constants.MOCK_VRID_FLOATING_IP_1)
     @mock.patch('a10_octavia.controller.worker.tasks.a10_network_tasks.a10_task_utils')
-    @mock.patch(
-        'a10_octavia.common.utils.get_acos_parameter_for_vrid',
-        return_value=[constants.IP_ADDRESS_PARTITION, constants.IP_ADDRESS_PARTITION_CFG])
     def test_HandleVRIDFloatingIP_create_floating_ip_in_specified_partition_with_static_ip(
-            self, mock_utils, mock_patched_ip, get_floating_ip, mock_acos_params):
+            self, mock_utils, mock_patched_ip, get_floating_ip):
         member = copy.deepcopy(MEMBER)
         member.subnet_id = SUBNET_1.id
         subnet = copy.deepcopy(SUBNET_1)
@@ -261,11 +252,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
     @mock.patch(
         'a10_octavia.common.utils.get_vrid_floating_ip_for_project',
         return_value='dhcp')
-    @mock.patch(
-        'a10_octavia.common.utils.get_acos_parameter_for_vrid',
-        return_value=[constants.IP_ADDRESS_PARTITION, constants.IP_ADDRESS_PARTITION_CFG])
     def test_HandleVRIDFloatingIP_create_floating_ip_in_specified_partition_with_dhcp(
-            self, get_floating_ip, check_subnet, mock_acos_params):
+            self, get_floating_ip, check_subnet):
         member = copy.deepcopy(MEMBER)
         member.subnet_id = SUBNET_1.id
         subnet = copy.deepcopy(SUBNET_1)
@@ -313,11 +301,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
                 return_value=a10constants.MOCK_VRID_FLOATING_IP_1)
     @mock.patch('a10_octavia.common.utils.get_patched_ip_address',
                 return_value=a10constants.MOCK_VRID_FLOATING_IP_1)
-    @mock.patch(
-        'a10_octavia.common.utils.get_acos_parameter_for_vrid',
-        return_value=[constants.IP_ADDRESS, constants.IP_ADDRESS_CFG])
     def test_HandleVRIDFloatingIP_noop_device_fip_and_conf_fip_both_given_same_ip(
-            self, mock_patched_ip, get_floating_ip, mock_acos_params):
+            self, mock_patched_ip, get_floating_ip):
         vrid = copy.deepcopy(VRID_1)
         vrid.vrid_floating_ip = a10constants.MOCK_VRID_FLOATING_IP_1
         vrid.vrid = VRID_VALUE
@@ -343,11 +328,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
     @mock.patch('a10_octavia.common.utils.get_patched_ip_address',
                 return_value=a10constants.MOCK_VRID_FLOATING_IP_2)
     @mock.patch('a10_octavia.controller.worker.tasks.a10_network_tasks.a10_task_utils')
-    @mock.patch(
-        'a10_octavia.common.utils.get_acos_parameter_for_vrid',
-        return_value=[constants.IP_ADDRESS, constants.IP_ADDRESS_CFG])
     def test_HandleVRIDFloatingIP_replace_floating_ip_in_shared_partition_with_static_ip(
-            self, mock_utils, mock_patched_ip, get_floating_ip, mock_acos_params):
+            self, mock_utils, mock_patched_ip, get_floating_ip):
         vrid = copy.deepcopy(VRID_1)
         vthunder = copy.deepcopy(VTHUNDER)
         vthunder.ip_address = '10.0.0.1'
@@ -383,11 +365,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
     @mock.patch('a10_octavia.common.utils.get_patched_ip_address',
                 return_value=a10constants.MOCK_VRID_FLOATING_IP_2)
     @mock.patch('a10_octavia.controller.worker.tasks.a10_network_tasks.a10_task_utils')
-    @mock.patch(
-        'a10_octavia.common.utils.get_acos_parameter_for_vrid',
-        return_value=[constants.IP_ADDRESS_PARTITION, constants.IP_ADDRESS_PARTITION_CFG])
     def test_HandleVRIDFloatingIP_replace_floating_ip_in_specified_partition_with_static_ip(
-            self, mock_utils, mock_patched_ip, get_floating_ip, mock_acos_params):
+            self, mock_utils, mock_patched_ip, get_floating_ip):
         vrid = copy.deepcopy(VRID_1)
         vrid.vrid_floating_ip = a10constants.MOCK_VRID_FLOATING_IP_1
         vrid.vrid = VRID_VALUE
@@ -490,11 +469,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
     @mock.patch('a10_octavia.common.utils.get_vrid_floating_ip_for_project',
                 return_value='dhcp')
     @mock.patch('a10_octavia.controller.worker.tasks.a10_network_tasks.a10_task_utils')
-    @mock.patch(
-        'a10_octavia.common.utils.get_acos_parameter_for_vrid',
-        return_value=[constants.IP_ADDRESS_PARTITION, constants.IP_ADDRESS_PARTITION_CFG])
     def test_HandleVRIDFloatingIP_replace_floating_ip_diff_subnet_in_set_part_conf_fip_set_dhcp(
-            self, mock_utils, get_floating_ip, check_subnet, mock_acos_params):
+            self, mock_utils, get_floating_ip, check_subnet):
         vrid = copy.deepcopy(VRID_1)
         vrid.vrid_floating_ip = a10constants.MOCK_VRID_FLOATING_IP_1
         vrid.vrid = VRID_VALUE
@@ -655,11 +631,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
                 return_value=a10constants.MOCK_VRID_FLOATING_IP_1)
     @mock.patch('a10_octavia.common.utils.get_patched_ip_address',
                 return_value=a10constants.MOCK_VRID_FLOATING_IP_1)
-    @mock.patch(
-        'a10_octavia.common.utils.get_acos_parameter_for_vrid',
-        return_value=[constants.IP_ADDRESS, constants.IP_ADDRESS_CFG])
     def test_HandleVRIDFloatingIP_create_floating_ip_for_subnet_list(
-            self, mock_patched_ip, mock_floating_ip, mock_acos_params):
+            self, mock_patched_ip, mock_floating_ip):
         vthunder = copy.deepcopy(VTHUNDER)
         vthunder.ip_address = '10.0.0.1'
         subnet = copy.deepcopy(SUBNET_1)


### PR DESCRIPTION
## Description

If Bug Fix:
- Severity Level: High
- [IPv6 support][Rack flow] Failed to create IPv6 loadbalancer when IPv4 loadbalancer and member already exists on the vThunder.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3594
https://a10networks.atlassian.net/browse/STACK-3604

## Technical Approach
- Fixed VRID issues
- Fixed interface attachment and detachment issues.

## Manual Testing

**Rack flow testing:**

stack@neha-victoria:~$ openstack loadbalancer create --vip-subnet-id ipv6_subnet_12 --name vip1_ipv6

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2023-04-24T05:43:21                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 1a63c845-4d96-4acc-a766-483cac2d66a2 |
| listeners           |                                      |
| name                | vip1_ipv6                            |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 593ec626d3f646c7a597eeb1e203d8e9     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 4001:d00::1b3                        |
| vip_network_id      | 0342395e-8ca5-44b6-9076-7c0913e32b9b |
| vip_port_id         | 240de113-f51f-484d-a688-d323bc759e86 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 8049bf7b-025d-47f7-880d-539988d820ed |
+---------------------+--------------------------------------+

stack@neha-victoria:~$

vThunder Configurations:


vThunder(NOLICENSE)#show running-config
!Current configuration: 284 bytes
!Configuration last updated at 05:51:44 IST Mon Apr 24 2023
!Configuration last saved at 05:51:46 IST Mon Apr 24 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p4, build 112 (Feb-20-2022,03:17)
!
partition L3V id 1
!
partition testing id 2
!
!
interface management
  ip address 10.64.3.107 255.255.255.0
  enable
!
interface ethernet 1
  enable
  ip address 10.10.11.107 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.20.11.107 255.255.255.0
!
vrrp-a vrid 0
  floating-ip 4001:d00::2e1
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb server s1 10.0.13.123
  port 90 tcp
!
slb virtual-server 1a63c845-4d96-4acc-a766-483cac2d66a2 4001:d00::1b3
!
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#

2. Create IPV4 LB

stack@neha-victoria:~$ openstack loadbalancer create --vip-subnet-id provider-vlan-11-subnet --name vip2_ipv4

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2023-04-24T05:44:44                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | b090333d-0323-4a18-a396-046d53e31c0b |
| listeners           |                                      |
| name                | vip2_ipv4                            |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | 593ec626d3f646c7a597eeb1e203d8e9     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 10.0.11.183                          |
| vip_network_id      | 5bdff1e1-688d-4488-82ce-989f9c2e5cf3 |
| vip_port_id         | c781171b-098a-4ea2-8cc8-7c39d9867344 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 4818c02c-b144-4464-974e-a703f8f63e3d |
+---------------------+--------------------------------------+

stack@neha-victoria:~$

vThunder Configurations:


vThunder(NOLICENSE)#show running-config
!Current configuration: 353 bytes
!Configuration last updated at 05:53:07 IST Mon Apr 24 2023
!Configuration last saved at 05:53:09 IST Mon Apr 24 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p4, build 112 (Feb-20-2022,03:17)
!
partition L3V id 1
!
partition testing id 2
!
!
interface management
  ip address 10.64.3.107 255.255.255.0
  enable
!
interface ethernet 1
  enable
  ip address 10.10.11.107 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.20.11.107 255.255.255.0
!
vrrp-a vrid 0
  floating-ip 10.0.11.152
  floating-ip 4001:d00::2e1
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb server s1 10.0.13.123
  port 90 tcp
!
slb virtual-server 1a63c845-4d96-4acc-a766-483cac2d66a2 4001:d00::1b3
!
slb virtual-server b090333d-0323-4a18-a396-046d53e31c0b 10.0.11.183
!
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#

2. Create listener pool member in different subnet for ipv6 LB

stack@neha-victoria:~$ openstack loadbalancer listener create --protocol HTTP --protocol-port 443 --name vport1 vip1_ipv6

+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2023-04-24T05:46:47                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 7220bf3a-493f-46c2-a363-8ecf8dd32b9a |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 1a63c845-4d96-4acc-a766-483cac2d66a2 |
| name                        | vport1                               |
| operating_status            | OFFLINE                              |
| project_id                  | 593ec626d3f646c7a597eeb1e203d8e9     |
| protocol                    | HTTP                                 |
| protocol_port               | 443                                  |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
| allowed_cidrs               | None                                 |
| tls_ciphers                 | None                                 |
| tls_versions                | None                                 |
| alpn_protocols              | None                                 |
+-----------------------------+--------------------------------------+

stack@neha-victoria:~$

stack@neha-victoria:~$ openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener vport1 --name pool1      

+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2023-04-24T05:47:19                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | dde2e31d-5f82-41f5-b544-f9d62c037133 |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | 7220bf3a-493f-46c2-a363-8ecf8dd32b9a |
| loadbalancers        | 1a63c845-4d96-4acc-a766-483cac2d66a2 |
| members              |                                      |
| name                 | pool1                                |
| operating_status     | OFFLINE                              |
| project_id           | 593ec626d3f646c7a597eeb1e203d8e9     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+

stack@neha-victoria:~$

stack@neha-victoria:~$ openstack loadbalancer member create --subnet-id ipv6-public-subnet --protocol-port 82 --address 2001:db8::7 --name member1 pool1

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 2001:db8::7                          |
| admin_state_up      | True                                 |
| created_at          | 2023-04-24T05:47:42                  |
| id                  | 0dbba0b9-3030-4e07-8447-fef79ebeefdd |
| name                | member1                              |
| operating_status    | NO_MONITOR                           |
| project_id          | 593ec626d3f646c7a597eeb1e203d8e9     |
| protocol_port       | 82                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | cdc15fee-0ec8-4e65-a015-9b010cdf0827 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+

stack@neha-victoria:~$

vThunder configurations:


vThunder(NOLICENSE)#show running-config
!Current configuration: 282 bytes
!Configuration last updated at 05:56:02 IST Mon Apr 24 2023
!Configuration last saved at 05:56:03 IST Mon Apr 24 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p4, build 112 (Feb-20-2022,03:17)
!
partition L3V id 1
!
partition testing id 2
!
!
interface management
  ip address 10.64.3.107 255.255.255.0
  enable
!
interface ethernet 1
  enable
  ip address 10.10.11.107 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.20.11.107 255.255.255.0
!
vrrp-a vrid 0
  floating-ip 10.0.11.152
  floating-ip 4001:d00::2e1
  floating-ip 2001:db8::305
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  interval 5 timeout 3
  method udp port 5550
!
slb server 593ec_2001:db8::7 2001:db8::7
  port 82 tcp
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb server s1 10.0.13.123
  port 90 tcp
!
slb service-group dde2e31d-5f82-41f5-b544-f9d62c037133 tcp
  member 593ec_2001:db8::7 82
!
slb virtual-server 1a63c845-4d96-4acc-a766-483cac2d66a2 4001:d00::1b3
  port 443 http
    name 7220bf3a-493f-46c2-a363-8ecf8dd32b9a
    extended-stats
    service-group dde2e31d-5f82-41f5-b544-f9d62c037133
!
slb virtual-server b090333d-0323-4a18-a396-046d53e31c0b 10.0.11.183
!
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#

3. Create listener pool member in different subnet for ipv4 LB

stack@neha-victoria:~$ openstack loadbalancer listener create --protocol HTTP --protocol-port 443 --name vport2 vip2_ipv4

+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2023-04-24T05:54:25                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 84263dd5-77b1-4be3-8298-66a747117b89 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | b090333d-0323-4a18-a396-046d53e31c0b |
| name                        | vport2                               |
| operating_status            | OFFLINE                              |
| project_id                  | 593ec626d3f646c7a597eeb1e203d8e9     |
| protocol                    | HTTP                                 |
| protocol_port               | 443                                  |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
| allowed_cidrs               | None                                 |
| tls_ciphers                 | None                                 |
| tls_versions                | None                                 |
| alpn_protocols              | None                                 |
+-----------------------------+--------------------------------------+

stack@neha-victoria:~$


stack@neha-victoria:~$ openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener vport2 --name pool2      
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2023-04-24T05:54:50                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | d8b89dfc-e0e6-4f12-89d9-e5547743fc1b |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | 84263dd5-77b1-4be3-8298-66a747117b89 |
| loadbalancers        | b090333d-0323-4a18-a396-046d53e31c0b |
| members              |                                      |
| name                 | pool2                                |
| operating_status     | OFFLINE                              |
| project_id           | 593ec626d3f646c7a597eeb1e203d8e9     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+

stack@neha-victoria:~$

stack@neha-victoria:~$ openstack loadbalancer member create --subnet-id provider-vlan-13-subnet --protocol-port 82 --address 10.0.13.14 --name member1 pool2

+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 10.0.13.14                           |
| admin_state_up      | True                                 |
| created_at          | 2023-04-24T05:55:20                  |
| id                  | aa435137-6798-4ddb-aea1-57eb695db86e |
| name                | member1                              |
| operating_status    | NO_MONITOR                           |
| project_id          | 593ec626d3f646c7a597eeb1e203d8e9     |
| protocol_port       | 82                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 8b725bc2-a3c6-4c95-b36d-e7a8c659b0ff |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+

stack@neha-victoria:~$

vThunder Configurations:


vThunder(NOLICENSE)#show running-config
!Current configuration: 213 bytes
!Configuration last updated at 06:03:40 IST Mon Apr 24 2023
!Configuration last saved at 06:03:42 IST Mon Apr 24 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p4, build 112 (Feb-20-2022,03:17)
!
partition L3V id 1
!
partition testing id 2
!
!
interface management
  ip address 10.64.3.107 255.255.255.0
  enable
!
interface ethernet 1
  enable
  ip address 10.10.11.107 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.20.11.107 255.255.255.0
!
vrrp-a vrid 0
  floating-ip 10.0.11.152
  floating-ip 10.0.13.195
  floating-ip 4001:d00::2e1
  floating-ip 2001:db8::305
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  interval 5 timeout 3
  method udp port 5550
!
slb server 593ec_10_0_13_14 10.0.13.14
  port 82 tcp
!
slb server 593ec_2001:db8::7 2001:db8::7
  port 82 tcp
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb server s1 10.0.13.123
  port 90 tcp
!
slb service-group d8b89dfc-e0e6-4f12-89d9-e5547743fc1b tcp
  member 593ec_10_0_13_14 82
!
slb service-group dde2e31d-5f82-41f5-b544-f9d62c037133 tcp
  member 593ec_2001:db8::7 82
!
slb virtual-server 1a63c845-4d96-4acc-a766-483cac2d66a2 4001:d00::1b3
  port 443 http
    name 7220bf3a-493f-46c2-a363-8ecf8dd32b9a
    extended-stats
    service-group dde2e31d-5f82-41f5-b544-f9d62c037133
!
slb virtual-server b090333d-0323-4a18-a396-046d53e31c0b 10.0.11.183
  port 443 http
    name 84263dd5-77b1-4be3-8298-66a747117b89
    extended-stats
    service-group d8b89dfc-e0e6-4f12-89d9-e5547743fc1b
!
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#

4. Delete member in pool1

stack@neha-victoria:~$ openstack loadbalancer member list pool1

+--------------------------------------+---------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| id                                   | name    | project_id                       | provisioning_status | address     | protocol_port | operating_status | weight |
+--------------------------------------+---------+----------------------------------+---------------------+-------------+---------------+------------------+--------+
| 0dbba0b9-3030-4e07-8447-fef79ebeefdd | member1 | 593ec626d3f646c7a597eeb1e203d8e9 | ACTIVE              | 2001:db8::7 |            82 | NO_MONITOR       |      1 |
+--------------------------------------+---------+----------------------------------+---------------------+-------------+---------------+------------------+--------+

stack@neha-victoria:~$

stack@neha-victoria:~$ openstack loadbalancer member delete pool1 member1

stack@neha-victoria:~$

stack@neha-victoria:~$ openstack loadbalancer member list pool1


stack@neha-victoria:~$

vThunder Configuration:


vThunder(NOLICENSE)#show running-config
!Current configuration: 273 bytes
!Configuration last updated at 06:06:08 IST Mon Apr 24 2023
!Configuration last saved at 06:06:10 IST Mon Apr 24 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p4, build 112 (Feb-20-2022,03:17)
!
partition L3V id 1
!
partition testing id 2
!
!
interface management
  ip address 10.64.3.107 255.255.255.0
  enable
!
interface ethernet 1
  enable
  ip address 10.10.11.107 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.20.11.107 255.255.255.0
!
vrrp-a vrid 0
  floating-ip 10.0.11.152
  floating-ip 10.0.13.195
  floating-ip 4001:d00::2e1
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  interval 5 timeout 3
  method udp port 5550
!
slb server 593ec_10_0_13_14 10.0.13.14
  port 82 tcp
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb server s1 10.0.13.123
  port 90 tcp
!
slb service-group d8b89dfc-e0e6-4f12-89d9-e5547743fc1b tcp
  member 593ec_10_0_13_14 82
!
slb service-group dde2e31d-5f82-41f5-b544-f9d62c037133 tcp
!
slb virtual-server 1a63c845-4d96-4acc-a766-483cac2d66a2 4001:d00::1b3
  port 443 http
    name 7220bf3a-493f-46c2-a363-8ecf8dd32b9a
    extended-stats
    service-group dde2e31d-5f82-41f5-b544-f9d62c037133
!
slb virtual-server b090333d-0323-4a18-a396-046d53e31c0b 10.0.11.183
  port 443 http
    name 84263dd5-77b1-4be3-8298-66a747117b89
    extended-stats
    service-group d8b89dfc-e0e6-4f12-89d9-e5547743fc1b
!
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#


5. Delete member in pool2

stack@neha-victoria:~$ openstack loadbalancer member list pool2

+--------------------------------------+---------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| id                                   | name    | project_id                       | provisioning_status | address    | protocol_port | operating_status | weight |
+--------------------------------------+---------+----------------------------------+---------------------+------------+---------------+------------------+--------+
| aa435137-6798-4ddb-aea1-57eb695db86e | member1 | 593ec626d3f646c7a597eeb1e203d8e9 | ACTIVE              | 10.0.13.14 |            82 | NO_MONITOR       |      1 |
+--------------------------------------+---------+----------------------------------+---------------------+------------+---------------+------------------+--------+
stack@neha-victoria:~$

stack@neha-victoria:~$ openstack loadbalancer member delete pool2 member1

stack@neha-victoria:~$


stack@neha-victoria:~$ openstack loadbalancer member list pool2


stack@neha-victoria:~$

vThunder Configurations:


vThunder(NOLICENSE)#show running-config
!Current configuration: 333 bytes
!Configuration last updated at 06:09:12 IST Mon Apr 24 2023
!Configuration last saved at 06:09:14 IST Mon Apr 24 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p4, build 112 (Feb-20-2022,03:17)
!
partition L3V id 1
!
partition testing id 2
!
!
interface management
  ip address 10.64.3.107 255.255.255.0
  enable
!
interface ethernet 1
  enable
  ip address 10.10.11.107 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.20.11.107 255.255.255.0
!
vrrp-a vrid 0
  floating-ip 10.0.11.152
  floating-ip 4001:d00::2e1
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb server s1 10.0.13.123
  port 90 tcp
!
slb service-group d8b89dfc-e0e6-4f12-89d9-e5547743fc1b tcp
!
slb service-group dde2e31d-5f82-41f5-b544-f9d62c037133 tcp
!
slb virtual-server 1a63c845-4d96-4acc-a766-483cac2d66a2 4001:d00::1b3
  port 443 http
    name 7220bf3a-493f-46c2-a363-8ecf8dd32b9a
    extended-stats
    service-group dde2e31d-5f82-41f5-b544-f9d62c037133
!
slb virtual-server b090333d-0323-4a18-a396-046d53e31c0b 10.0.11.183
  port 443 http
    name 84263dd5-77b1-4be3-8298-66a747117b89
    extended-stats
    service-group d8b89dfc-e0e6-4f12-89d9-e5547743fc1b
!
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#

6. Delete LB2


stack@neha-victoria:~$ openstack loadbalancer list

+--------------------------------------+-----------+----------------------------------+---------------+---------------------+------------------+----------+
| id                                   | name      | project_id                       | vip_address   | provisioning_status | operating_status | provider |
+--------------------------------------+-----------+----------------------------------+---------------+---------------------+------------------+----------+
| 1a63c845-4d96-4acc-a766-483cac2d66a2 | vip1_ipv6 | 593ec626d3f646c7a597eeb1e203d8e9 | 4001:d00::1b3 | ACTIVE              | OFFLINE          | a10      |
| b090333d-0323-4a18-a396-046d53e31c0b | vip2_ipv4 | 593ec626d3f646c7a597eeb1e203d8e9 | 10.0.11.183   | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+-----------+----------------------------------+---------------+---------------------+------------------+----------+

stack@neha-victoria:~$


stack@neha-victoria:~$ openstack loadbalancer delete vip1_ipv6 --cascade

stack@neha-victoria:~$

vThunder Configurations:


vThunder(NOLICENSE)#show running-config
!Current configuration: 273 bytes
!Configuration last updated at 06:11:24 IST Mon Apr 24 2023
!Configuration last saved at 06:11:25 IST Mon Apr 24 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p4, build 112 (Feb-20-2022,03:17)
!
partition L3V id 1
!
partition testing id 2
!
!
interface management
  ip address 10.64.3.107 255.255.255.0
  enable
!
interface ethernet 1
  enable
  ip address 10.10.11.107 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.20.11.107 255.255.255.0
!
vrrp-a vrid 0
  floating-ip 10.0.11.152
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.142
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.142
  health-check octavia_health_monitor
!
slb server s1 10.0.13.123
  port 90 tcp
!
slb service-group d8b89dfc-e0e6-4f12-89d9-e5547743fc1b tcp
!
slb virtual-server b090333d-0323-4a18-a396-046d53e31c0b 10.0.11.183
  port 443 http
    name 84263dd5-77b1-4be3-8298-66a747117b89
    extended-stats
    service-group d8b89dfc-e0e6-4f12-89d9-e5547743fc1b
!
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#

7. Delete LB1

stack@neha-victoria:~$ openstack loadbalancer list

+--------------------------------------+-----------+----------------------------------+-------------+---------------------+------------------+----------+
| id                                   | name      | project_id                       | vip_address | provisioning_status | operating_status | provider |
+--------------------------------------+-----------+----------------------------------+-------------+---------------------+------------------+----------+
| b090333d-0323-4a18-a396-046d53e31c0b | vip2_ipv4 | 593ec626d3f646c7a597eeb1e203d8e9 | 10.0.11.183 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+-----------+----------------------------------+-------------+---------------------+------------------+----------+

stack@neha-victoria:~$

stack@neha-victoria:~$ openstack loadbalancer delete vip2_ipv4 --cascade

stack@neha-victoria:~$


stack@neha-victoria:~$ openstack loadbalancer list


stack@neha-victoria:~$


vThundder Configurations:

vThunder(NOLICENSE)#show running-config
!Current configuration: 116 bytes
!Configuration last updated at 06:12:41 IST Mon Apr 24 2023
!Configuration last saved at 06:12:43 IST Mon Apr 24 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p4, build 112 (Feb-20-2022,03:17)
!
partition L3V id 1
!
partition testing id 2
!
!
interface management
  ip address 10.64.3.107 255.255.255.0
  enable
!
interface ethernet 1
  enable
  ip address 10.10.11.107 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.20.11.107 255.255.255.0
!
!
slb server s1 10.0.13.123
  port 90 tcp
!
!
end
!Current config commit point for partition 0 is 0 & config mode is classical-mode
vThunder(NOLICENSE)#

Please fine below document for vTHunder flow testing result :

https://a10networks.sharepoint.com/:w:/s/Openstack/ERHtttibU1BBnl_88K_YXt4B_5qccTz9T6hdBZtOxqSaYg?e=YSg2ed
