### PR TITLE
[STACK-3442]: Fixed issue of Static VRID floating IP configurations.

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -861,8 +861,11 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
                     vrid = self._replace_vrid_port(vrid, vrid_subnet, lb_resource)
                     update_vrid_flag = True
             else:
-                new_ip = a10_utils.get_patched_ip_address(
-                    conf_floating_ip, vrid_subnet.cidr, vrid_subnet.ip_version)
+                if vrid.vrid_floating_ip == None:
+                    new_ip = a10_utils.get_patched_ip_address(
+                        conf_floating_ip, vrid_subnet.cidr, vrid_subnet.ip_version)
+                else:
+                    new_ip = vrid.vrid_floating_ip
                 if new_ip != vrid.vrid_floating_ip:
                     vrid = self._replace_vrid_port(vrid, vrid_subnet, lb_resource, new_ip)
                     update_vrid_flag = True

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
@@ -333,7 +333,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         vrid = copy.deepcopy(VRID_1)
         vthunder = copy.deepcopy(VTHUNDER)
         vthunder.ip_address = '10.0.0.1'
-        vrid.vrid_floating_ip = a10constants.MOCK_VRID_FLOATING_IP_1
+        vrid.vrid_floating_ip = None
         vrid.vrid = VRID_VALUE
         vrid.vrid_port_id = a10constants.MOCK_VRRP_PORT_ID
         member = copy.deepcopy(MEMBER)
@@ -368,7 +368,7 @@ class TestNetworkTasks(base.BaseTaskTestCase):
     def test_HandleVRIDFloatingIP_replace_floating_ip_in_specified_partition_with_static_ip(
             self, mock_utils, mock_patched_ip, get_floating_ip):
         vrid = copy.deepcopy(VRID_1)
-        vrid.vrid_floating_ip = a10constants.MOCK_VRID_FLOATING_IP_1
+        vrid.vrid_floating_ip = None
         vrid.vrid = VRID_VALUE
         vrid.vrid_port_id = a10constants.MOCK_VRRP_PORT_ID
         member = copy.deepcopy(MEMBER)
@@ -526,12 +526,8 @@ class TestNetworkTasks(base.BaseTaskTestCase):
         self.conf.config(group=a10constants.A10_GLOBAL_OPTS,
                          vrid=VRID_VALUE)
         mock_network_task.execute(vthunder, member, [VRID_1], subnet, vthunder_config)
-        self.network_driver_mock.allocate_vrid_fip.assert_called_with(
-            mock.ANY, subnet.network_id, mock.ANY,
-            fixed_ip=a10constants.MOCK_VRID_FULL_FLOATING_IP)
-        self.client_mock.vrrpa.update.assert_called_with(
-            VRID_VALUE, floating_ips=[a10constants.MOCK_VRID_FULL_FLOATING_IP],
-            is_partition=False)
+        self.network_driver_mock.allocate_vrid_fip.assert_not_called()
+        self.client_mock.vrrpa.update.assert_not_called()
 
     @mock.patch('a10_octavia.controller.worker.tasks.a10_network_tasks.a10_task_utils')
     @mock.patch(


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description: While using static vrid_floating_ip, getting an error while creating a loadbalancer or member with different subnet than that of an existing loadbalancer.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3442

## Technical Approach
-  In case of static or patched vrid_floating_ip, calling `a10_utils.get_patched_ip_address()` only when vrid.vrid_floating_ip is None i.e calling it for a loadbalancer or member that is getting created but not for existing LBs or members to avoid the `VRIDIPNotInSubentRangeError` 

## Config Changes
N/A

## Test Cases
Case 1: vThunder flows
- Create a LB with ipv6 subnet1 and static vrid_floating_ip.
- Create an another LB with ipv6 subnet2 and static vrid_floating_ip.
- Create a member with ipv6 subnet3 and static vrid_floating_ip.
- Check vThunder configurations.

Case 2: rack flows
- Create a LB with ipv6 subnet1 and static vrid_floating_ip.
- Create an another LB with ipv6 subnet2 and static vrid_floating_ip.
- Create a member with ipv6 subnet3 and static vrid_floating_ip.
- Check vThunder configurations.

## Manual Testing
Case 1: vThunder flows
1. Create a LB with ipv6 subnet1 and static vrid_floating_ip.

```
[a10_global]
network_type = 'flat'
vrid_floating_ip = "3001:db8:3333:4444:4:3:2:1"
subnet_ipv6_addresses = [{"4bfd7aec-bb6e-4831-9875-65c1856aeaed": "fd95:1e85:23af::2/64"}, {"f75f0595-c298-4df7-bb2b-5a81492c07a6": "3001:db8:3333:4444:3:3:3:3/64"}, {"729ed9ac-dd81-42e7-a3bd-41895c02ab76": "5001:db8:3333:4444:3:3:3:3/64"}, {"26557618-e028-4990-b9a7-46f3c8336ce8": "6001:db8:3333:4444:3:3:3:3/64"}, {"3896172c-fc2a-4227-8d77-1f3d9b33dac1": "8001:db8:3333:4444::6/64"}, {"2613f0fe-e0ba-422c-871f-b382704cb9f4": "2001:db8::2"}, {"fba05f13-a1e6-4888-9660-cb4a38df5c6a": "6001:db8:3333:4444:3:3:4:4/64"}]

[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"

[a10_controller_worker]
amp_image_owner_id = e67519c2d45c41d5bd68cf45db599d46
amp_secgroup_list = 0c1e3d23-58ae-46c5-a2b5-e9fd72a08c28
amp_flavor_id = b4b5c574-a167-46a4-92bd-1e15a6375855
amp_boot_network_list = ab91259e-701c-467f-9a80-b567887b10e3
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 100
amp_active_wait_sec = 2
amp_image_id = 3582fffd-f98e-4996-9eae-0ee56277afdb
amp_image_tag = vThunder521p3
loadbalancer_topology = SINGLE
```

```
stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer create --vip-subnet-id ipv6_subnet_vlan_11 --name vip1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2023-04-24T10:40:07                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 204958e3-90ee-4fa2-85b5-af0c16f9b776 |
| listeners           |                                      |
| name                | vip1                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e67519c2d45c41d5bd68cf45db599d46     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 3001:db8:3333:4444::230              |
| vip_network_id      | d59af818-6eaf-4564-a0a2-6bfec3d9b917 |
| vip_port_id         | c835c573-e3c2-489a-8245-4617be47ba97 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | f75f0595-c298-4df7-bb2b-5a81492c07a6 |
+---------------------+--------------------------------------+
```

vThunder config:

```
amphora-665861d3-8466-4f2d-b1d2(NOLICENSE)#show running-config
!Current configuration: 319 bytes
!Configuration last updated at 11:44:06 IST Mon Apr 24 2023
!Configuration last saved at 11:44:33 IST Mon Apr 24 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p3, build 70 (Oct-20-2021,22:08)
!
hostname amphora-665861d3-8466-4f2d-b1d2
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  ipv6 address 3001:db8:3333:4444:3:3:3:3/64
  ipv6 enable
!
vrrp-a vrid 0
  floating-ip 3001:db8:3333:4444:4:3:2:1
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb virtual-server 204958e3-90ee-4fa2-85b5-af0c16f9b776 3001:db8:3333:4444::230
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

2. Create an another LB with ipv6 subnet2 and static vrid_floating_ip.

```
[a10_global]
network_type = 'flat'
vrid_floating_ip = "5001:db8:3333:4444:4:3:2:1"
subnet_ipv6_addresses = [{"4bfd7aec-bb6e-4831-9875-65c1856aeaed": "fd95:1e85:23af::2/64"}, {"f75f0595-c298-4df7-bb2b-5a81492c07a6": "3001:db8:3333:4444:3:3:3:3/64"}, {"729ed9ac-dd81-42e7-a3bd-41895c02ab76": "5001:db8:3333:4444:3:3:3:3/64"}, {"26557618-e028-4990-b9a7-46f3c8336ce8": "6001:db8:3333:4444:3:3:3:3/64"}, {"3896172c-fc2a-4227-8d77-1f3d9b33dac1": "8001:db8:3333:4444::6/64"}, {"2613f0fe-e0ba-422c-871f-b382704cb9f4": "2001:db8::2"}, {"fba05f13-a1e6-4888-9660-cb4a38df5c6a": "6001:db8:3333:4444:3:3:4:4/64"}]

[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"

[a10_controller_worker]
amp_image_owner_id = e67519c2d45c41d5bd68cf45db599d46
amp_secgroup_list = 0c1e3d23-58ae-46c5-a2b5-e9fd72a08c28
amp_flavor_id = b4b5c574-a167-46a4-92bd-1e15a6375855
amp_boot_network_list = ab91259e-701c-467f-9a80-b567887b10e3
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 100
amp_active_wait_sec = 2
amp_image_id = 3582fffd-f98e-4996-9eae-0ee56277afdb
amp_image_tag = vThunder521p3
loadbalancer_topology = SINGLE
```

```
stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer create --vip-subnet-id ipv6_subnet_vlan_12 --name vip2
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2023-04-24T10:49:20                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | f09e594a-6b2b-41fa-84a1-f387f847d108 |
| listeners           |                                      |
| name                | vip2                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e67519c2d45c41d5bd68cf45db599d46     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 5001:db8:3333:4444::2d9              |
| vip_network_id      | 3ca06648-48d2-4c77-b54f-1c8d8994693c |
| vip_port_id         | 077b9648-8f57-4983-9058-f8565f17a3ea |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 729ed9ac-dd81-42e7-a3bd-41895c02ab76 |
+---------------------+--------------------------------------+
```

vThunder config:

```
amphora-665861d3-8466-4f2d-b1d2(NOLICENSE)#show running-config
!Current configuration: 400 bytes
!Configuration last updated at 11:51:31 IST Mon Apr 24 2023
!Configuration last saved at 11:51:36 IST Mon Apr 24 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p3, build 70 (Oct-20-2021,22:08)
!
hostname amphora-665861d3-8466-4f2d-b1d2
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  ipv6 address 3001:db8:3333:4444:3:3:3:3/64
  ipv6 enable
!
interface ethernet 2
  name DataPort
  ipv6 address 5001:db8:3333:4444:3:3:3:3/64
  ipv6 enable
!
vrrp-a vrid 0
  floating-ip 3001:db8:3333:4444:4:3:2:1
  floating-ip 5001:db8:3333:4444:4:3:2:1
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb virtual-server 204958e3-90ee-4fa2-85b5-af0c16f9b776 3001:db8:3333:4444::230
!
slb virtual-server f09e594a-6b2b-41fa-84a1-f387f847d108 5001:db8:3333:4444::2d9
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

3. Create a member with ipv6 subnet3 and static vrid_floating_ip.

```
[a10_global]
network_type = 'flat'
vrid_floating_ip = "6001:db8:3333:4444:4:3:2:1"
subnet_ipv6_addresses = [{"4bfd7aec-bb6e-4831-9875-65c1856aeaed": "fd95:1e85:23af::2/64"}, {"f75f0595-c298-4df7-bb2b-5a81492c07a6": "3001:db8:3333:4444:3:3:3:3/64"}, {"729ed9ac-dd81-42e7-a3bd-41895c02ab76": "5001:db8:3333:4444:3:3:3:3/64"}, {"26557618-e028-4990-b9a7-46f3c8336ce8": "6001:db8:3333:4444:3:3:3:3/64"}, {"3896172c-fc2a-4227-8d77-1f3d9b33dac1": "8001:db8:3333:4444::6/64"}, {"2613f0fe-e0ba-422c-871f-b382704cb9f4": "2001:db8::2"}, {"fba05f13-a1e6-4888-9660-cb4a38df5c6a": "6001:db8:3333:4444:3:3:4:4/64"}]

[vthunder]
default_vthunder_username = "admin"
default_vthunder_password = "a10"
default_axapi_version = "30"

[a10_controller_worker]
amp_image_owner_id = e67519c2d45c41d5bd68cf45db599d46
amp_secgroup_list = 0c1e3d23-58ae-46c5-a2b5-e9fd72a08c28
amp_flavor_id = b4b5c574-a167-46a4-92bd-1e15a6375855
amp_boot_network_list = ab91259e-701c-467f-9a80-b567887b10e3
amp_ssh_key_name = octavia_ssh_key
network_driver = a10_octavia_neutron_driver
workers = 2
amp_active_retries = 100
amp_active_wait_sec = 2
amp_image_id = 3582fffd-f98e-4996-9eae-0ee56277afdb
amp_image_tag = vThunder521p3
loadbalancer_topology = SINGLE
```

```
stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer listener create --protocol http --protocol-port 90 --name vport1 vip1     
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2023-04-24T10:52:38                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | f4326f49-2f51-40c8-866b-eb3d7c6532d6 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 204958e3-90ee-4fa2-85b5-af0c16f9b776 |
| name                        | vport1                               |
| operating_status            | OFFLINE                              |
| project_id                  | e67519c2d45c41d5bd68cf45db599d46     |
| protocol                    | HTTP                                 |
| protocol_port               | 90                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
| allowed_cidrs               | None                                 |
| tls_ciphers                 | None                                 |
| tls_versions                | None                                 |
| alpn_protocols              | None                                 |
+-----------------------------+--------------------------------------+
stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer pool create --protocol http --lb-algorithm ROUND_ROBIN --listener vport1 --name pool1
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2023-04-24T10:52:44                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | 51b6dc97-60c9-4345-8133-e9c2822edd62 |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | f4326f49-2f51-40c8-866b-eb3d7c6532d6 |
| loadbalancers        | 204958e3-90ee-4fa2-85b5-af0c16f9b776 |
| members              |                                      |
| name                 | pool1                                |
| operating_status     | OFFLINE                              |
| project_id           | e67519c2d45c41d5bd68cf45db599d46     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+
stack@neha-victoria:~/neha/a10-octavia$ openstack loadbalancer member create --address 6001:db8:3333:4444::28 --subnet-id ipv6_subnet_vlan_13 --protocol-port 94 --name member1 pool1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 6001:db8:3333:4444::28               |
| admin_state_up      | True                                 |
| created_at          | 2023-04-24T10:56:38                  |
| id                  | 9c1cd2ef-5e68-4445-91cd-b384b1a16720 |
| name                | member1                              |
| operating_status    | NO_MONITOR                           |
| project_id          | e67519c2d45c41d5bd68cf45db599d46     |
| protocol_port       | 94                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 26557618-e028-4990-b9a7-46f3c8336ce8 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+
```

vThunder config:

```
amphora-665861d3-8466-4f2d-b1d2(NOLICENSE)#show running-config
!Current configuration: 319 bytes
!Configuration last updated at 11:59:35 IST Mon Apr 24 2023
!Configuration last saved at 11:59:38 IST Mon Apr 24 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p3, build 70 (Oct-20-2021,22:08)
!
hostname amphora-665861d3-8466-4f2d-b1d2
!
!
interface management
  ip address dhcp
!
interface ethernet 1
  name DataPort
  ipv6 address 3001:db8:3333:4444:3:3:3:3/64
  ipv6 enable
!
interface ethernet 2
  name DataPort
  ipv6 address 5001:db8:3333:4444:3:3:3:3/64
  ipv6 enable
!
interface ethernet 3
  name DataPort
  ipv6 address 6001:db8:3333:4444:3:3:3:3/64
  ipv6 enable
!
vrrp-a vrid 0
  floating-ip 3001:db8:3333:4444:4:3:2:1
  floating-ip 5001:db8:3333:4444:4:3:2:1
  floating-ip 6001:db8:3333:4444:4:3:2:1
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
slb server e6751_6001:db8:3333:4444::28 6001:db8:3333:4444::28
  port 94 tcp
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb service-group 51b6dc97-60c9-4345-8133-e9c2822edd62 tcp
  member e6751_6001:db8:3333:4444::28 94
!
slb virtual-server 204958e3-90ee-4fa2-85b5-af0c16f9b776 3001:db8:3333:4444::230
  port 90 http
    name f4326f49-2f51-40c8-866b-eb3d7c6532d6
    extended-stats
    service-group 51b6dc97-60c9-4345-8133-e9c2822edd62
!
slb virtual-server f09e594a-6b2b-41fa-84a1-f387f847d108 5001:db8:3333:4444::2d9
!
!
cloud-services meta-data
  enable
  provider openstack
!
end
```

Case 2: Rack flows

1. Create a LB with ipv6 subnet1 and static vrid_floating_ip.

```
[a10_global]
network_type = 'flat'
vrid_floating_ip = "3001:db8:3333:4444:4:3:2:1"
subnet_ipv6_addresses = [{"4bfd7aec-bb6e-4831-9875-65c1856aeaed": "fd95:1e85:23af::2/64"}, {"f75f0595-c298-4df7-bb2b-5a81492c07a6": "3001:db8:3333:4444:3:3:3:3/64"}, {"729ed9ac-dd81-42e7-a3bd-41895c02ab76": "5001:db8:3333:4444:3:3:3:3/64"}, {"26557618-e028-4990-b9a7-46f3c8336ce8": "6001:db8:3333:4444:3:3:3:3/64"}, {"3896172c-fc2a-4227-8d77-1f3d9b33dac1": "8001:db8:3333:4444::6/64"}, {"2613f0fe-e0ba-422c-871f-b382704cb9f4": "2001:db8::2"}, {"fba05f13-a1e6-4888-9660-cb4a38df5c6a": "6001:db8:3333:4444:3:3:4:4/64"}]

[a10_controller_worker]
network_driver = a10_octavia_neutron_driver
workers = 2
loadbalancer_topology = SINGLE

[hardware_thunder]
devices = [
                    {
                     "project_id":"e67519c2d45c41d5bd68cf45db599d46",
                     "ip_address": "10.64.26.109",
                     "username":"admin",
                     "password":"a10",
                     "device_name":"device1",
                    }
          ]
```

```
stack@neha-victoria:~$ openstack loadbalancer create --vip-subnet-id ipv6_subnet_vlan_11 --name vip1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2023-04-25T05:58:54                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | 0e686758-ad39-4a7f-83b6-8124fe51a74c |
| listeners           |                                      |
| name                | vip1                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e67519c2d45c41d5bd68cf45db599d46     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 3001:db8:3333:4444::3b               |
| vip_network_id      | d59af818-6eaf-4564-a0a2-6bfec3d9b917 |
| vip_port_id         | 8365776c-9899-49e5-9f35-322d80b24e33 |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | f75f0595-c298-4df7-bb2b-5a81492c07a6 |
+---------------------+--------------------------------------+
```


```
vThunder(NOLICENSE)#show running-config
!Current configuration: 562 bytes
!Configuration last updated at 06:57:45 IST Tue Apr 25 2023
!Configuration last saved at 06:57:47 IST Tue Apr 25 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p5, build 114 (Jul-14-2022,09:59)
!
multi-config enable
!
partition test-ipv6 id 2
!
!
interface management
  ip address 10.64.26.109 255.255.255.0
  ip control-apps-use-mgmt-port
  ip default-gateway 10.64.26.1
!
interface ethernet 1
  enable
  ip address 10.10.10.13 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.11.10.13 255.255.255.0
!
vrrp-a vrid 0
  floating-ip 3001:db8:3333:4444:4:3:2:1
!
ip route 30.30.30.0 /26 lif acosk8s-81_200
!
ip route 192.168.81.192 /26 lif acosk8s-81_200
!
ip route 192.168.220.192 /26 lif acosk8s-220_192
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb virtual-server 0e686758-ad39-4a7f-83b6-8124fe51a74c 3001:db8:3333:4444::3b
!
sflow setting local-collection
!
sflow collector ip 127.0.0.1 6343
!
!
end
```

2. Create an another LB with ipv6 subnet2 and static vrid_floating_ip.

```
[a10_global]
network_type = 'flat'
vrid_floating_ip = "5001:db8:3333:4444:4:3:2:1"
subnet_ipv6_addresses = [{"4bfd7aec-bb6e-4831-9875-65c1856aeaed": "fd95:1e85:23af::2/64"}, {"f75f0595-c298-4df7-bb2b-5a81492c07a6": "3001:db8:3333:4444:3:3:3:3/64"}, {"729ed9ac-dd81-42e7-a3bd-41895c02ab76": "5001:db8:3333:4444:3:3:3:3/64"}, {"26557618-e028-4990-b9a7-46f3c8336ce8": "6001:db8:3333:4444:3:3:3:3/64"}, {"3896172c-fc2a-4227-8d77-1f3d9b33dac1": "8001:db8:3333:4444::6/64"}, {"2613f0fe-e0ba-422c-871f-b382704cb9f4": "2001:db8::2"}, {"fba05f13-a1e6-4888-9660-cb4a38df5c6a": "6001:db8:3333:4444:3:3:4:4/64"}]

[a10_controller_worker]
network_driver = a10_octavia_neutron_driver
workers = 2
loadbalancer_topology = SINGLE

[hardware_thunder]
devices = [
                    {
                     "project_id":"e67519c2d45c41d5bd68cf45db599d46",
                     "ip_address": "10.64.26.109",
                     "username":"admin",
                     "password":"a10",
                     "device_name":"device1",
                    }
          ]
```

```
stack@neha-victoria:~$ openstack loadbalancer create --vip-subnet-id ipv6_subnet_vlan_12 --name vip2
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| availability_zone   | None                                 |
| created_at          | 2023-04-25T06:03:02                  |
| description         |                                      |
| flavor_id           | None                                 |
| id                  | d4c0b086-5e68-42c1-a812-de112a86729c |
| listeners           |                                      |
| name                | vip2                                 |
| operating_status    | OFFLINE                              |
| pools               |                                      |
| project_id          | e67519c2d45c41d5bd68cf45db599d46     |
| provider            | a10                                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| vip_address         | 5001:db8:3333:4444::2a3              |
| vip_network_id      | 3ca06648-48d2-4c77-b54f-1c8d8994693c |
| vip_port_id         | 360f10f2-94d0-41cf-9c08-c6b521eae79f |
| vip_qos_policy_id   | None                                 |
| vip_subnet_id       | 729ed9ac-dd81-42e7-a3bd-41895c02ab76 |
+---------------------+--------------------------------------+
```

vThunder config:

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 643 bytes
!Configuration last updated at 07:01:53 IST Tue Apr 25 2023
!Configuration last saved at 07:01:55 IST Tue Apr 25 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p5, build 114 (Jul-14-2022,09:59)
!
multi-config enable
!
partition test-ipv6 id 2
!
!
interface management
  ip address 10.64.26.109 255.255.255.0
  ip control-apps-use-mgmt-port
  ip default-gateway 10.64.26.1
!
interface ethernet 1
  enable
  ip address 10.10.10.13 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.11.10.13 255.255.255.0
!
vrrp-a vrid 0
  floating-ip 3001:db8:3333:4444:4:3:2:1
  floating-ip 5001:db8:3333:4444:4:3:2:1
!
ip route 30.30.30.0 /26 lif acosk8s-81_200
!
ip route 192.168.81.192 /26 lif acosk8s-81_200
!
ip route 192.168.220.192 /26 lif acosk8s-220_192
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb virtual-server 0e686758-ad39-4a7f-83b6-8124fe51a74c 3001:db8:3333:4444::3b
!
slb virtual-server d4c0b086-5e68-42c1-a812-de112a86729c 5001:db8:3333:4444::2a3
!
sflow setting local-collection
!
sflow collector ip 127.0.0.1 6343
!
!
end
```

3. Create a member with ipv6 subnet3 and static vrid_floating_ip.

```
[a10_global]
network_type = 'flat'
vrid_floating_ip = "5001:db8:3333:4444:4:3:2:1"
subnet_ipv6_addresses = [{"4bfd7aec-bb6e-4831-9875-65c1856aeaed": "fd95:1e85:23af::2/64"}, {"f75f0595-c298-4df7-bb2b-5a81492c07a6": "3001:db8:3333:4444:3:3:3:3/64"}, {"729ed9ac-dd81-42e7-a3bd-41895c02ab76": "5001:db8:3333:4444:3:3:3:3/64"}, {"26557618-e028-4990-b9a7-46f3c8336ce8": "6001:db8:3333:4444:3:3:3:3/64"}, {"3896172c-fc2a-4227-8d77-1f3d9b33dac1": "8001:db8:3333:4444::6/64"}, {"2613f0fe-e0ba-422c-871f-b382704cb9f4": "2001:db8::2"}, {"fba05f13-a1e6-4888-9660-cb4a38df5c6a": "6001:db8:3333:4444:3:3:4:4/64"}]

[a10_controller_worker]
network_driver = a10_octavia_neutron_driver
workers = 2
loadbalancer_topology = SINGLE

[hardware_thunder]
devices = [
                    {
                     "project_id":"e67519c2d45c41d5bd68cf45db599d46",
                     "ip_address": "10.64.26.109",
                     "username":"admin",
                     "password":"a10",
                     "device_name":"device1",
                    }
          ]
```

```
stack@neha-victoria:~$ openstack loadbalancer listener create --protocol http --protocol-port 90 --name vport1 vip1                      
+-----------------------------+--------------------------------------+
| Field                       | Value                                |
+-----------------------------+--------------------------------------+
| admin_state_up              | True                                 |
| connection_limit            | -1                                   |
| created_at                  | 2023-04-25T06:04:51                  |
| default_pool_id             | None                                 |
| default_tls_container_ref   | None                                 |
| description                 |                                      |
| id                          | 48851d0a-a732-484b-99e8-8b131e8a8608 |
| insert_headers              | None                                 |
| l7policies                  |                                      |
| loadbalancers               | 0e686758-ad39-4a7f-83b6-8124fe51a74c |
| name                        | vport1                               |
| operating_status            | OFFLINE                              |
| project_id                  | e67519c2d45c41d5bd68cf45db599d46     |
| protocol                    | HTTP                                 |
| protocol_port               | 90                                   |
| provisioning_status         | PENDING_CREATE                       |
| sni_container_refs          | []                                   |
| timeout_client_data         | 50000                                |
| timeout_member_connect      | 5000                                 |
| timeout_member_data         | 50000                                |
| timeout_tcp_inspect         | 0                                    |
| updated_at                  | None                                 |
| client_ca_tls_container_ref | None                                 |
| client_authentication       | NONE                                 |
| client_crl_container_ref    | None                                 |
| allowed_cidrs               | None                                 |
| tls_ciphers                 | None                                 |
| tls_versions                | None                                 |
| alpn_protocols              | None                                 |
+-----------------------------+--------------------------------------+
```

```
stack@neha-victoria:~$ openstack loadbalancer pool create --protocol http --lb-algorithm ROUND_ROBIN --listener vport1 --name pool1      
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| admin_state_up       | True                                 |
| created_at           | 2023-04-25T06:04:57                  |
| description          |                                      |
| healthmonitor_id     |                                      |
| id                   | b44b803e-2948-4ed4-8a58-d25b8beb9f3e |
| lb_algorithm         | ROUND_ROBIN                          |
| listeners            | 48851d0a-a732-484b-99e8-8b131e8a8608 |
| loadbalancers        | 0e686758-ad39-4a7f-83b6-8124fe51a74c |
| members              |                                      |
| name                 | pool1                                |
| operating_status     | OFFLINE                              |
| project_id           | e67519c2d45c41d5bd68cf45db599d46     |
| protocol             | HTTP                                 |
| provisioning_status  | PENDING_CREATE                       |
| session_persistence  | None                                 |
| updated_at           | None                                 |
| tls_container_ref    | None                                 |
| ca_tls_container_ref | None                                 |
| crl_container_ref    | None                                 |
| tls_enabled          | False                                |
| tls_ciphers          | None                                 |
| tls_versions         | None                                 |
+----------------------+--------------------------------------+
```


```
stack@neha-victoria:~$ openstack loadbalancer member create --address 6001:db8:3333:4444::28 --subnet-id ipv6_subnet_vlan_13 --protocol-port 94 --name member1 pool1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 6001:db8:3333:4444::28               |
| admin_state_up      | True                                 |
| created_at          | 2023-04-25T06:06:23                  |
| id                  | 90848a7b-bfc5-4b18-bfc6-fdbbff141ce4 |
| name                | member1                              |
| operating_status    | NO_MONITOR                           |
| project_id          | e67519c2d45c41d5bd68cf45db599d46     |
| protocol_port       | 94                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 26557618-e028-4990-b9a7-46f3c8336ce8 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+

```

```
vThunder(NOLICENSE)#show running-config
!Current configuration: 563 bytes
!Configuration last updated at 07:05:11 IST Tue Apr 25 2023
!Configuration last saved at 07:05:14 IST Tue Apr 25 2023
!64-bit Advanced Core OS (ACOS) version 5.2.1-p5, build 114 (Jul-14-2022,09:59)
!
multi-config enable
!
partition test-ipv6 id 2
!
!
interface management
  ip address 10.64.26.109 255.255.255.0
  ip control-apps-use-mgmt-port
  ip default-gateway 10.64.26.1
!
interface ethernet 1
  enable
  ip address 10.10.10.13 255.255.255.0
!
interface ethernet 2
  enable
  ip address 10.11.10.13 255.255.255.0
!
vrrp-a vrid 0
  floating-ip 3001:db8:3333:4444:4:3:2:1
  floating-ip 5001:db8:3333:4444:4:3:2:1
  floating-ip 6001:db8:3333:4444:4:3:2:1
!
ip route 30.30.30.0 /26 lif acosk8s-81_200
!
ip route 192.168.81.192 /26 lif acosk8s-81_200
!
ip route 192.168.220.192 /26 lif acosk8s-220_192
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 10.64.3.141
  interval 5 timeout 3
  method udp port 5550
!
slb server e6751_6001:db8:3333:4444::28 6001:db8:3333:4444::28
  port 94 tcp
!
slb server octavia_health_manager_controller 10.64.3.141
  health-check octavia_health_monitor
!
slb service-group b44b803e-2948-4ed4-8a58-d25b8beb9f3e tcp
  member e6751_6001:db8:3333:4444::28 94
!
slb virtual-server 0e686758-ad39-4a7f-83b6-8124fe51a74c 3001:db8:3333:4444::3b
  port 90 http
    name 48851d0a-a732-484b-99e8-8b131e8a8608
    extended-stats
    service-group b44b803e-2948-4ed4-8a58-d25b8beb9f3e
!
slb virtual-server d4c0b086-5e68-42c1-a812-de112a86729c 5001:db8:3333:4444::2a3
!
sflow setting local-collection
!
sflow collector ip 127.0.0.1 6343
!
!
end
```