### PR TITLE
[STACK-3635] Create ipv4 LB failed without ipv6_subnet_list option

### DIFF
--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -349,11 +349,11 @@ class GetValidIPv6Address(VThunderBaseTask):
                 backup_nics = network_driver.get_plugged_networks(loadbalancer.amphorae[1].compute_id)
                 nics = nics + backup_nics
             address_list = CONF.a10_global.subnet_ipv6_addresses
-            address_list[0] = address_list[0].strip("[")
-            address_list[len(address_list) - 1] = address_list[len(address_list) - 1].strip("]")
-            interfaces = self.axapi_client.interface.get_list()
-            for i in range(len(interfaces['interface']['ethernet-list'])):
-                if address_list:
+            if address_list:
+                address_list[0] = address_list[0].strip("[")
+                address_list[len(address_list) - 1] = address_list[len(address_list) - 1].strip("]")
+                interfaces = self.axapi_client.interface.get_list()
+                for i in range(len(interfaces['interface']['ethernet-list'])):
                     ifnum = interfaces['interface']['ethernet-list'][i]['ifnum']
                     ifnum_oper = self.axapi_client.interface.ethernet.get_oper(ifnum)
                     ifnum_address = a10_utils.get_ipv6_address(ifnum_oper, subnet, nics,


### PR DESCRIPTION
## Description
- Severity Level: Critical
- Issue Description:
Create ipv4 LB failed without ipv6_subnet_list option in configuration file.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3635

## Technical Approach
Add list empty check before use it.

## Config Changes
Same as the configuration in bug ticket.

## Test Cases
```
openstack loadbalancer create --vip-subnet-id tp91 --vip-address 192.168.91.56 --name vip1
```

## Manual Testing
Result:
```
stack@ytsai-victoria:~/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+------------------+----------+
| eefdca1c-2991-467c-a6f8-e71b1065464c | vip1 | ecc2542be2644881b049636b719ca536 | 192.168.91.56 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+------------------+----------+

```

