### PR TITLE
[STACK-3636] Failed with IPv6 network in amp_boot_network_list

### DIFF
--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -23,7 +23,8 @@ import netaddr
 import socket
 import struct
 
-from ipaddress import ip_address, IPv6Address
+from ipaddress import ip_address
+from ipaddress import IPv6Address
 from oslo_config import cfg
 from oslo_log import log as logging
 
@@ -433,14 +434,16 @@ def get_ipv6_address(ifnum_oper, subnet, nics, address_list, loadbalancers_list)
                 if len(final_address_list) > 0:
                     break
 
-            if nic.network_id == subnet.network_id and not loadbalancers_list and subnet.ip_version == 6:
+            if (nic.network_id == subnet.network_id and not loadbalancers_list and
+                    subnet.ip_version == 6):
                 final_address_list = get_ipv6_address_from_conf(address_list, subnet.id)
                 if len(final_address_list) > 0:
                     break
 
             if loadbalancers_list:
                 for lb in loadbalancers_list:
-                    if lb.vip.network_id == nic.network_id and type(ip_address(lb.vip.ip_address)) is IPv6Address:
+                    if (lb.vip.network_id == nic.network_id and
+                            type(ip_address(lb.vip.ip_address)) is IPv6Address):
                         final_address_list = get_ipv6_address_from_conf(address_list,
                                                                         lb.vip.subnet_id)
                         if len(final_address_list) > 0:
@@ -448,7 +451,8 @@ def get_ipv6_address(ifnum_oper, subnet, nics, address_list, loadbalancers_list)
                     for pool in lb.pools:
                         for member in pool.members:
                             member_subnet = network_driver.get_subnet(member.subnet_id)
-                            if member_subnet.network_id == nic.network_id and member_subnet.ip_version == 6:
+                            if (member_subnet.network_id == nic.network_id and
+                                    member_subnet.ip_version == 6):
                                 final_address_list = get_ipv6_address_from_conf(address_list,
                                                                                 member.subnet_id)
                             if len(final_address_list) > 0:

--- a/a10_octavia/controller/worker/tasks/a10_network_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_network_tasks.py
@@ -875,7 +875,7 @@ class HandleVRIDFloatingIP(BaseNetworkTask):
                     vrid = self._replace_vrid_port(vrid, vrid_subnet, lb_resource)
                     update_vrid_flag = True
             else:
-                if vrid.vrid_floating_ip == None:
+                if vrid.vrid_floating_ip is None:
                     new_ip = a10_utils.get_patched_ip_address(
                         conf_floating_ip, vrid_subnet.cidr, vrid_subnet.ip_version)
                 else:

--- a/a10_octavia/controller/worker/tasks/nat_pool_tasks.py
+++ b/a10_octavia/controller/worker/tasks/nat_pool_tasks.py
@@ -51,7 +51,7 @@ class NatPoolCreate(task.Task):
                             else:
                                 self.axapi_client.nat.pool.create(**nat_pool)
                             self._added_pool_list.append(nat_pool['pool_name'])
-                        except(acos_errors.Exists) as e:
+                        except (acos_errors.Exists) as e:
                             LOG.exception("Nat-pool with name %s already exists on partition %s of "
                                           "thunder device %s",
                                           nat_pool['pool_name'], vthunder.partition_name,
@@ -80,7 +80,7 @@ class NatPoolCreate(task.Task):
                     else:
                         self.axapi_client.nat.pool.create(**natpool_flavor)
                     self._added_pool_list.append(natpool_flavor['pool_name'])
-                except(acos_errors.Exists) as e:
+                except (acos_errors.Exists) as e:
                     LOG.exception("Nat-pool with name %s already exists on partition %s of "
                                   "thunder device %s",
                                   natpool_flavor['pool_name'], vthunder.partition_name,
@@ -144,7 +144,7 @@ class NatPoolDelete(task.Task):
                                     self.axapi_client.nat.ipv6pool.delete(pool_name)
                                 else:
                                     self.axapi_client.nat.pool.delete(pool_name)
-                            except(acos_errors.ACOSException) as e:
+                            except (acos_errors.ACOSException) as e:
                                 LOG.exception("Failed to delete Nat-pool with name %s due to %s",
                                               pool_name, str(e))
                     if natpool_flavor:
@@ -154,7 +154,7 @@ class NatPoolDelete(task.Task):
                                 self.axapi_client.nat.ipv6pool.delete(pool_name)
                             else:
                                 self.axapi_client.nat.pool.delete(pool_name)
-                        except(acos_errors.ACOSException) as e:
+                        except (acos_errors.ACOSException) as e:
                             LOG.exception("Failed to delete Nat-pool with name %s due to %s",
                                           pool_name, str(e))
             else:

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -330,7 +330,7 @@ class EnableInterface(VThunderBaseTask):
                             self.axapi_client.system.action.setInterface(ifnum, None, 4)
                             self.axapi_client.device_context.switch(2, None)
                             self.axapi_client.system.action.setInterface(ifnum, None, 4)
-        except(acos_errors.ACOSException, req_exceptions.ConnectionError) as e:
+        except (acos_errors.ACOSException, req_exceptions.ConnectionError) as e:
             LOG.exception("Failed to configure ethernet interface vThunder: %s", str(e))
             raise e
 
@@ -346,7 +346,8 @@ class GetValidIPv6Address(VThunderBaseTask):
             network_driver = utils.get_network_driver()
             nics = network_driver.get_plugged_networks(compute_id)
             if topology == "ACTIVE_STANDBY":
-                backup_nics = network_driver.get_plugged_networks(loadbalancer.amphorae[1].compute_id)
+                backup_nics = network_driver.get_plugged_networks(
+                    loadbalancer.amphorae[1].compute_id)
                 nics = nics + backup_nics
             address_list = CONF.a10_global.subnet_ipv6_addresses
             if address_list:

--- a/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
+++ b/a10_octavia/tests/unit/controller/worker/tasks/test_a10_network_tasks.py
@@ -25,10 +25,10 @@ from oslo_config import fixture as oslo_fixture
 from octavia.common import data_models as o_data_models
 from octavia.network import data_models as o_net_data_models
 
+from a10_octavia.common import a10constants as constants
 from a10_octavia.common import config_options
 from a10_octavia.common import data_models
 from a10_octavia.controller.worker.tasks import a10_network_tasks
-from a10_octavia.common import a10constants as constants
 from a10_octavia.tests.common import a10constants
 from a10_octavia.tests.unit import base
 


### PR DESCRIPTION
## Description
- Severity Level: Critical
- Issue Description:
Use IPv6 network in amp_boot_network_list, a10-octavia failed to create LB in vthunder flow.

root cause: In get_ipv6_address(), the nic.network_id is network id not subnet id. get_ipv6_address_from_conf() can only works for subnet_id.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3636

## Technical Approach
- Implement get_network_ipv6_address_from_conf() to get ipv6 address for network_id.
- In get_ipv6_address(), skip ipv4 nics.


## Config Changes

<pre>
[a10_controller_worker]
amp_boot_network_list = 9558e757-f279-4120-9e61-540a91be9c10, f7c66e14-6eb1-456b-a677-65ce525d175e, 338ab9a6-520e-4804-8225-dc17c4db442d


[a10_global]
subnet_ipv6_addresses = [{"c8556731-9316-480c-b7f3-15c7521416c4": "2400:8500:2002:1270::56/64"}]
</pre>


## Test Cases
Same as bug ticket

## Manual Testing
with 
openstack loadbalancer create --vip-subnet-id tp91 --vip-address 192.168.91.56 --name vip1:
```
stack@ytsai-victoria:~/a10-octavia$ openstack loadbalancer list
+--------------------------------------+------+----------------------------------+---------------+---------------------+------------------+----------+
| id                                   | name | project_id                       | vip_address   | provisioning_status | operating_status | provider |
+--------------------------------------+------+----------------------------------+---------------+---------------------+------------------+----------+
| fa2967bd-30dc-4d35-a600-f892c8bd0c21 | vip1 | ecc2542be2644881b049636b719ca536 | 192.168.91.56 | ACTIVE              | OFFLINE          | a10      |
+--------------------------------------+------+----------------------------------+---------------+---------------------+------------------+----------+

```
