### PR TITLE
[STACK-3637][STACK-3639] vthunder IPv6 interface and address issues

### DIFF
--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -308,7 +308,7 @@ class EnableInterface(VThunderBaseTask):
                         ifnum = eth['ifnum']
                         if "ipv6" in eth and "address-list" in eth['ipv6']:
                             old_addr = eth['ipv6']['address-list'][0].get('ipv6-addr')
-                            if ifnum_address[ifnum] and ifnum_address[ifnum] == old_addr:
+                            if ifnum_address.get(ifnum) and ifnum_address[ifnum] == old_addr:
                                 continue
                             self.axapi_client.system.action.setInterface(ifnum, None, 6)
 
@@ -329,7 +329,7 @@ class EnableInterface(VThunderBaseTask):
                         ifnum = eth['ifnum']
                         if "ipv6" in eth and "address-list" in eth['ipv6']:
                             old_addr = eth['ipv6']['address-list'][0].get('ipv6-addr')
-                            if ifnum_address[ifnum] and ifnum_address[ifnum] == old_addr:
+                            if ifnum_address.get(ifnum) and ifnum_address[ifnum] == old_addr:
                                 continue
                             if backup_vthunder:
                                 self.axapi_client.device_context.switch(2, None)


### PR DESCRIPTION
## Description
- Severity Level: Critical
- Issue Description:
    - IPv6 interfaces not enabled
    - Failed to configure IPv6 interface for member/LB delete case.

acos-client changes: https://github.com/a10networks/acos-client/pull/387

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3637
https://a10networks.atlassian.net/browse/STACK-3639

## Technical Approach
1. enable ipv6 interfaces
2. Clear all unmatched ipv6 addresses for all interfaces before configure ipv6 address.

## Config Changes
Please check bug tickets

## Test Cases
```
openstack loadbalancer create --vip-subnet-id tp91 --name vip1
openstack loadbalancer listener create --protocol TCP --protocol-port 80 --name vport1 vip1
openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener vport1 --name sg1
openstack loadbalancer member create --address 192.168.92.24 --subnet-id tp92 --protocol-port 80 --name srv1 sg1
openstack loadbalancer member create --address 192.168.90.24 --subnet-id tp90 --protocol-port 80 --name srv2 sg1

openstack loadbalancer create --vip-subnet-id 2002 --name vip2
openstack loadbalancer listener create --protocol TCP --protocol-port 80 --name vport2 vip2
openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener vport2 --name sg2
openstack loadbalancer member create --address 2003::24 --subnet-id 2003 --protocol-port 80 --name srv21 sg2
openstack loadbalancer member create --address 2004::24 --subnet-id 2004 --protocol-port 80 --name srv22 sg2
openstack loadbalancer member create --address 2005::24 --subnet-id 2005 --protocol-port 80 --name srv23 sg2
openstack loadbalancer member delete sg1 srv1
openstack loadbalancer member delete sg1 srv2
openstack loadbalancer member delete sg2 srv22
openstack loadbalancer delete vip1 --cascade
openstack loadbalancer delete vip2 --cascade
```


## Manual Testing
```
amphora-c0883402-442b-44f0-a7d6-Active-vMaster[1/1](NOLICENSE)#show running-config | sec ethernet
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
interface ethernet 1/3
  name DataPort
  enable
  ipv6 address 2002::56/64
  ipv6 enable
interface ethernet 1/4
  name DataPort
  enable
  ipv6 address 2003::56/64
  ipv6 enable
interface ethernet 1/5
  name DataPort
  enable
  ipv6 address 2004::56/64
  ipv6 enable
interface ethernet 1/6
  name DataPort
  enable
  ipv6 address 2005::56/64
  ipv6 enable
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
interface ethernet 2/3
  name DataPort
  enable
  ipv6 address 2002::56/64
  ipv6 enable
interface ethernet 2/4
  name DataPort
  enable
  ipv6 address 2003::56/64
  ipv6 enable
interface ethernet 2/5
  name DataPort
  enable
  ipv6 address 2004::56/64
  ipv6 enable
interface ethernet 2/6
  name DataPort
  enable
  ipv6 address 2005::56/64
  ipv6 enable

amphora-c0883402-442b-44f0-a7d6-Active-vMaster[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ea8.e9c2  192.168.0.43/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3ee9.ae59  192.168.91.71/24      1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e85.881a  192.168.92.124/24     1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e71.86c1  0.0.0.0/0             0  DataPort
4                   Up    Full  10000  none  1    N/A       fa16.3e81.47cb  0.0.0.0/0             0  DataPort
5                   Up    Full  10000  none  1    N/A       fa16.3ebd.c387  0.0.0.0/0             0  DataPort
6                   Up    Full  10000  none  1    N/A       fa16.3e41.687e  0.0.0.0/0             0  DataPort



openstack loadbalancer create --vip-subnet-id tp91 --name vip1
openstack loadbalancer listener create --protocol TCP --protocol-port 80 --name vport1 vip1
openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener vport1 --name sg1
stack@ytsai-victoria:~/source/a10-octavia/latest/a10-octavia$ openstack loadbalancer member create --address 192.168.92.24 --subnet-id tp92 --protocol-port 80 --name srv1 sg1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 192.168.92.24                        |
| admin_state_up      | True                                 |
| created_at          | 2023-05-02T15:37:52                  |
| id                  | 8a7f8899-e57e-443a-9f52-4c3ac543709a |
| name                | srv1                                 |
| operating_status    | NO_MONITOR                           |
| project_id          | ecc2542be2644881b049636b719ca536     |
| protocol_port       | 80                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 7d940d92-c8e2-48cc-89d5-74c4a4d3374c |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+

vrrp-a vrid 0
  floating-ip 192.168.91.199
  floating-ip 192.168.92.199
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 192.168.0.164
  interval 20 timeout 3
  method udp port 5550
!
slb server ecc25_192_168_92_24 192.168.92.24
  port 80 tcp
!
slb server octavia_health_manager_controller 192.168.0.164
  health-check octavia_health_monitor
!
slb service-group 6ce12c2d-afe1-4ad4-93e9-1b6bc015fe18 tcp
  member ecc25_192_168_92_24 80
!
slb virtual-server f08e675b-8c2a-41d5-bac5-a64cad7af2e7 192.168.91.52
  port 80 tcp
    name 387d9296-6507-46e7-bb25-84a06c48600d
    extended-stats
    source-nat auto
    service-group 6ce12c2d-afe1-4ad4-93e9-1b6bc015fe18
!


stack@ytsai-victoria:~/source/a10-octavia/latest/a10-octavia$ openstack loadbalancer member create --address 192.168.90.24 --subnet-id tp90 --protocol-port 80 --name srv2 sg1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| address             | 192.168.90.24                        |
| admin_state_up      | True                                 |
| created_at          | 2023-05-02T15:44:43                  |
| id                  | 6aa389c3-c51b-4e95-86dc-f224dfd53424 |
| name                | srv2                                 |
| operating_status    | NO_MONITOR                           |
| project_id          | ecc2542be2644881b049636b719ca536     |
| protocol_port       | 80                                   |
| provisioning_status | PENDING_CREATE                       |
| subnet_id           | 47519092-a7a6-411b-80dd-e0cdd00fb598 |
| updated_at          | None                                 |
| weight              | 1                                    |
| monitor_port        | None                                 |
| monitor_address     | None                                 |
| backup              | False                                |
+---------------------+--------------------------------------+

vrrp-a vrid 0
  floating-ip 192.168.91.199
  floating-ip 192.168.92.199
  floating-ip 192.168.90.199
!
health monitor octavia_health_monitor
  retry 5
  override-ipv4 192.168.0.164
  interval 20 timeout 3
  method udp port 5550
!
slb server ecc25_192_168_90_24 192.168.90.24
  port 80 tcp
!
slb server ecc25_192_168_92_24 192.168.92.24
  port 80 tcp
!
slb server octavia_health_manager_controller 192.168.0.164
  health-check octavia_health_monitor
!
slb service-group 6ce12c2d-afe1-4ad4-93e9-1b6bc015fe18 tcp
  member ecc25_192_168_90_24 80
  member ecc25_192_168_92_24 80
!
slb virtual-server f08e675b-8c2a-41d5-bac5-a64cad7af2e7 192.168.91.52
  port 80 tcp
    name 387d9296-6507-46e7-bb25-84a06c48600d
    extended-stats
    source-nat auto
    service-group 6ce12c2d-afe1-4ad4-93e9-1b6bc015fe18
!

openstack loadbalancer create --vip-subnet-id 2002 --name vip2
openstack loadbalancer listener create --protocol TCP --protocol-port 80 --name vport2 vip2
openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener vport2 --name sg2
openstack loadbalancer member create --address 2003::24 --subnet-id 2003 --protocol-port 80 --name srv21 sg2
openstack loadbalancer member create --address 2004::24 --subnet-id 2004 --protocol-port 80 --name srv22 sg2
openstack loadbalancer member create --address 2005::24 --subnet-id 2005 --protocol-port 80 --name srv23 sg2
openstack loadbalancer member delete sg1 srv2
amphora-c0883402-442b-44f0-a7d6-Active-vMaster[1/1](NOLICENSE)#show running-config | sec ethernet
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
interface ethernet 1/3
  name DataPort
  enable
  ipv6 address 2002::56/64
  ipv6 enable
interface ethernet 1/4
  name DataPort
  enable
  ipv6 address 2003::56/64
  ipv6 enable
interface ethernet 1/5
  name DataPort
  enable
  ipv6 address 2004::56/64
  ipv6 enable
interface ethernet 1/6
  name DataPort
  enable
  ipv6 address 2005::56/64
  ipv6 enable
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
interface ethernet 2/3
  name DataPort
  enable
  ipv6 address 2002::56/64
  ipv6 enable
interface ethernet 2/4
  name DataPort
  enable
  ipv6 address 2003::56/64
  ipv6 enable
interface ethernet 2/5
  name DataPort
  enable
  ipv6 address 2004::56/64
  ipv6 enable
interface ethernet 2/6
  name DataPort
  enable
  ipv6 address 2005::56/64
  ipv6 enable

amphora-c0883402-442b-44f0-a7d6-Active-vMaster[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ea8.e9c2  192.168.0.43/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3ee9.ae59  192.168.91.71/24      1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e85.881a  192.168.92.124/24     1  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e71.86c1  0.0.0.0/0             0  DataPort
4                   Up    Full  10000  none  1    N/A       fa16.3e81.47cb  0.0.0.0/0             0  DataPort
5                   Up    Full  10000  none  1    N/A       fa16.3ebd.c387  0.0.0.0/0             0  DataPort
6                   Up    Full  10000  none  1    N/A       fa16.3e41.687e  0.0.0.0/0             0  DataPort


stack@ytsai-victoria:~/source/a10-octavia/latest/a10-octavia$ openstack loadbalancer member delete sg1 srv1

amphora-c0883402-442b-44f0-a7d6-Active-vMaster[1/1](NOLICENSE)#show running-config | sec ethernet
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
interface ethernet 1/2
  name DataPort
  enable
  ipv6 address 2002::56/64
  ipv6 enable
interface ethernet 1/3
  name DataPort
  enable
  ipv6 address 2003::56/64
  ipv6 enable
interface ethernet 1/4
  name DataPort
  enable
  ipv6 address 2004::56/64
  ipv6 enable
interface ethernet 1/5
  name DataPort
  enable
  ipv6 address 2005::56/64
  ipv6 enable
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
interface ethernet 2/2
  name DataPort
  enable
  ipv6 address 2002::56/64
  ipv6 enable
interface ethernet 2/3
  name DataPort
  enable
  ipv6 address 2003::56/64
  ipv6 enable
interface ethernet 2/4
  name DataPort
  enable
  ipv6 address 2004::56/64
  ipv6 enable
interface ethernet 2/5
  name DataPort
  enable
  ipv6 address 2005::56/64
  ipv6 enable
!
amphora-c0883402-442b-44f0-a7d6-Active-vMaster[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ea8.e9c2  192.168.0.43/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3ee9.ae59  192.168.91.71/24      1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e71.86c1  0.0.0.0/0             0  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e81.47cb  0.0.0.0/0             0  DataPort
4                   Up    Full  10000  none  1    N/A       fa16.3ebd.c387  0.0.0.0/0             0  DataPort
5                   Up    Full  10000  none  1    N/A       fa16.3e41.687e  0.0.0.0/0             0  DataPort

stack@ytsai-victoria:~/source/a10-octavia/latest/a10-octavia$ openstack loadbalancer member delete sg2 srv22
amphora-c0883402-442b-44f0-a7d6-Active-vMaster[1/1](NOLICENSE)#show running-config | sec ethernet
interface ethernet 1/1
  name DataPort
  enable
  ip address dhcp
interface ethernet 1/2
  name DataPort
  enable
  ipv6 address 2002::56/64
  ipv6 enable
interface ethernet 1/3
  name DataPort
  enable
  ipv6 address 2003::56/64
  ipv6 enable
interface ethernet 1/4
  name DataPort
  enable
  ipv6 address 2005::56/64
  ipv6 enable
interface ethernet 2/1
  name DataPort
  enable
  ip address dhcp
interface ethernet 2/2
  name DataPort
  enable
  ipv6 address 2002::56/64
  ipv6 enable
interface ethernet 2/3
  name DataPort
  enable
  ipv6 address 2003::56/64
  ipv6 enable
interface ethernet 2/4
  name DataPort
  enable
  ipv6 address 2005::56/64
  ipv6 enable
amphora-c0883402-442b-44f0-a7d6-Active-vMaster[1/1](NOLICENSE)#show in
amphora-c0883402-442b-44f0-a7d6-Active-vMaster[1/1](NOLICENSE)#show interfaces br
amphora-c0883402-442b-44f0-a7d6-Active-vMaster[1/1](NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ea8.e9c2  192.168.0.43/24       1
1                   Up    Full  10000  none  1    N/A       fa16.3ee9.ae59  192.168.91.71/24      1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e71.86c1  0.0.0.0/0             0  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3e81.47cb  0.0.0.0/0             0  DataPort
4                   Up    Full  10000  none  1    N/A       fa16.3e41.687e  0.0.0.0/0             0  DataPort


```
