### PR TITLE
[STACK-3640] ACOS interface use port IPv6 address

### DIFF
--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -430,6 +430,7 @@ def get_ipv6_address(ifnum_oper, subnet, nics, address_list, loadbalancers_list)
 
         neutron_port = network_driver.get_port(nic.port_id)
         port_mac_address = neutron_port.mac_address.replace(":", "")
+        LOG.debug("[IPv6 Addr] get_ipv6_address get addr for mac:%s", port_mac_address)
         if port_mac_address == acos_mac_address:
             if nic.network_id in amp_boot_networks:
                 final_address_list = get_network_ipv6_address_from_conf(address_list, network)
@@ -460,13 +461,15 @@ def get_ipv6_address(ifnum_oper, subnet, nics, address_list, loadbalancers_list)
                             if len(final_address_list) > 0:
                                 break
 
-            for fixed_ip in neutron_port.fixed_ips:
-                if type(ip_address(fixed_ip.ip_address)) is IPv6Address:
-                    addr_subnet = network_driver.get_subnet(fixed_ip.subnet_id)
-                    subnet_prefix, subnet_mask = addr_subnet.cidr.split('/')
-                    final_addr = fixed_ip.ip_address + '/' + subnet_mask
-                    final_address_list.append({'ipv6-addr': final_addr})
-                    break
+            if not final_address_list:
+                for fixed_ip in neutron_port.fixed_ips:
+                    if type(ip_address(fixed_ip.ip_address)) is IPv6Address:
+                        addr_subnet = network_driver.get_subnet(fixed_ip.subnet_id)
+                        subnet_prefix, subnet_mask = addr_subnet.cidr.split('/')
+                        final_addr = fixed_ip.ip_address + '/' + subnet_mask
+                        final_address_list.append({'ipv6-addr': final_addr})
+                        LOG.debug("[IPv6 Addr] got: %s for mac: %s", final_addr, port_mac_address)
+                        break
     return final_address_list
 
 

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -379,14 +379,17 @@ class GetValidIPv6Address(VThunderBaseTask):
             if address_list:
                 address_list[0] = address_list[0].strip("[")
                 address_list[len(address_list) - 1] = address_list[len(address_list) - 1].strip("]")
-                interfaces = self.axapi_client.interface.get_list()
-                for i in range(len(interfaces['interface']['ethernet-list'])):
-                    ifnum = interfaces['interface']['ethernet-list'][i]['ifnum']
-                    ifnum_oper = self.axapi_client.interface.ethernet.get_oper(ifnum)
-                    ifnum_address = a10_utils.get_ipv6_address(ifnum_oper, subnet, nics,
-                                                               address_list, loadbalancers_list)
-                    if ifnum_address:
-                        ipv6_address_list[ifnum] = ifnum_address
+            else:
+                address_list = []
+
+            interfaces = self.axapi_client.interface.get_list()
+            for i in range(len(interfaces['interface']['ethernet-list'])):
+                ifnum = interfaces['interface']['ethernet-list'][i]['ifnum']
+                ifnum_oper = self.axapi_client.interface.ethernet.get_oper(ifnum)
+                ifnum_address = a10_utils.get_ipv6_address(ifnum_oper, subnet, nics,
+                                                           address_list, loadbalancers_list)
+                if ifnum_address:
+                    ipv6_address_list[ifnum] = ifnum_address
             return ipv6_address_list
         else:
             return None


### PR DESCRIPTION
## Description
- Required: Related user story
Use port IPv6 address


## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3640

## Technical Approach
Get IPv6 address from port and configure to ACOS interface

## Config Changes

Use no subnet_ipv6_addresses in a10-octavia.conf

## Test Cases
- STANDALONE
```
openstack loadbalancer create --vip-subnet-id 2002 --name vip2
openstack loadbalancer listener create --protocol TCP --protocol-port 80 --name vport2 vip2
openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener vport2 --name sg2
openstack loadbalancer member create --address 2003::24 --subnet-id 2003 --protocol-port 80 --name srv21 sg2
openstack loadbalancer member create --address 2004::24 --subnet-id 2004 --protocol-port 80 --name srv22 sg2

```
- Active-standby

```
openstack loadbalancer create --vip-subnet-id 2002 --name vip2
openstack loadbalancer listener create --protocol TCP --protocol-port 80 --name vport2 vip2
openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener vport2 --name sg2
openstack loadbalancer member create --address 2003::24 --subnet-id 2003 --protocol-port 80 --name srv21 sg2
openstack loadbalancer member create --address 2004::24 --subnet-id 2004 --protocol-port 80 --name srv22 sg2

```

## Manual Testing
- STANDALONE
```
stack@ytsai-victoria:~/source/a10-octavia/latest/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------------------------------+-------------------+---------------+
| ID                                   | Name                                         | Status | Networks                                                                                             | Image             | Flavor        |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------------------------------+-------------------+---------------+
| 962bcb4b-9ce7-437f-8067-b0f5f81d8e7a | amphora-08ec0474-4ba8-46d7-a84c-79c661c2b802 | ACTIVE | lb-mgmt-net=192.168.0.143; tp-ipv6=2002::10f; tp2003=2003::1d3; tp2004=2004::23e; tp91=192.168.91.74 | vthunder_5_2_1-p2 | vthunder_4cpu |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------------------------------+-------------------+---------------+

interface ethernet 1
  name DataPort
  enable
  ip address dhcp
!
interface ethernet 2
  name DataPort
  enable
  ipv6 address 2002::10f/56
  ipv6 enable
!
interface ethernet 3
  name DataPort
  enable
  ipv6 address 2003::1d3/64
  ipv6 enable
!
interface ethernet 4
  name DataPort
  enable
  ipv6 address 2004::23e/64
  ipv6 enable
!

```
- Active-standby

```
stack@ytsai-victoria:~/source/a10-octavia/latest/a10-octavia$ openstack server list
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------------------------------+-------------------+---------------+
| ID                                   | Name                                         | Status | Networks                                                                                             | Image             | Flavor        |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------------------------------+-------------------+---------------+
| 0c49b7be-bf04-49fa-90b8-1781868a09d7 | amphora-9f8467e0-f1ac-4c4e-b28a-fd2002c03871 | ACTIVE | lb-mgmt-net=192.168.0.199; tp-ipv6=2002::186; tp2003=2003::3b; tp2004=2004::5b; tp91=192.168.91.180  | vthunder_5_2_1-p2 | vthunder_4cpu |
| 9ae1a2a1-a76d-48dd-9420-682c5ffeb2d4 | amphora-4c0541e2-3607-41a6-b8d9-585cc292c80d | ACTIVE | lb-mgmt-net=192.168.0.121; tp-ipv6=2002::1fa; tp2003=2003::2c2; tp2004=2004::34; tp91=192.168.91.120 | vthunder_5_2_1-p2 | vthunder_4cpu |
+--------------------------------------+----------------------------------------------+--------+------------------------------------------------------------------------------------------------------+-------------------+---------------+
stack@ytsai-victoria:~/source/a10-octavia/latest/a10-octavia$ ssh admin@192.168.0.121
Password:
Last login: Wed May  3 03:47:36 2023 from 192.168.0.164

System is ready now.

amphora-4c0541e2-3607-41a6-b8d9-Active-vMaster[1/1](NOLICENSE)#show running-config | sec ethernet
interface ethernet 1/1
  name DataPort
  enable
  ipv6 address 2002::1fa/56
  ipv6 enable
interface ethernet 1/2
  name DataPort
  enable
  ip address dhcp
interface ethernet 1/3
  name DataPort
  enable
  ipv6 address 2003::2c2/64
  ipv6 enable
interface ethernet 1/4
  name DataPort
  enable
  ipv6 address 2004::34/64
  ipv6 enable
interface ethernet 2/1
  name DataPort
  enable
  ipv6 address 2002::186/56
  ipv6 enable
interface ethernet 2/2
  name DataPort
  enable
  ip address dhcp
interface ethernet 2/3
  name DataPort
  enable
  ipv6 address 2003::3b/64
  ipv6 enable
interface ethernet 2/4
  name DataPort
  enable
  ipv6 address 2004::5b/64
  ipv6 enable

```