### PR TITLE
[STACK-3646] NATv6 pool address reservation

### DIFF
--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -361,11 +361,20 @@ def validate_interface_vlan_map(hardware_device):
 
 def get_natpool_addr_list(nat_flavor):
     addr_list = []
-    start = (struct.unpack(">L", socket.inet_aton(nat_flavor['start_address'])))[0]
-    end = (struct.unpack(">L", socket.inet_aton(nat_flavor['end_address'])))[0]
-    while start <= end:
-        addr_list.append(socket.inet_ntoa(struct.pack(">L", start)))
-        start += 1
+    if type(ip_address(nat_flavor['start_address'])) is IPv6Address:
+        sh, sl = struct.unpack(">QQ",
+                               socket.inet_pton(socket.AF_INET6, nat_flavor['start_address']))
+        eh, el = struct.unpack(">QQ",
+                               socket.inet_pton(socket.AF_INET6, nat_flavor['end_address']))
+        while sl <= el:
+            addr_list.append(socket.inet_ntop(socket.AF_INET6, struct.pack(">QQ", sh, sl)))
+            sl += 1
+    else:
+        start = (struct.unpack(">L", socket.inet_aton(nat_flavor['start_address'])))[0]
+        end = (struct.unpack(">L", socket.inet_aton(nat_flavor['end_address'])))[0]
+        while start <= end:
+            addr_list.append(socket.inet_ntoa(struct.pack(">L", start)))
+            start += 1
     return addr_list
 
 


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description:
The implementation for IPv6 NAT pool address reservation is missing.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3646

## Technical Approach
In get_natpool_addr_list(), add IPv6 support for the logic.

## Config Changes
Same as bug ticket

## Test Cases
 - NAT in member subnet range: (where 2003::100~2003::106) is in member subnet range.
```
openstack loadbalancer flavorprofile create --name fp_snat6 --provider a10 --flavor-data '{"nat-pool":{"pool-name":"pool1", "start-address":"2003::100", "end-address":"2003::106", "netmask":"64"}}'
openstack loadbalancer flavor create --name f_snat6 --flavorprofile fp_snat6 --description "flaovr all test1" --enable
openstack loadbalancer create --flavor f_snat6 --vip-subnet-id 2002 --name vip2
openstack loadbalancer listener create --protocol TCP --protocol-port 80 --name vport2 vip2
openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener vport2 --name sg2
openstack loadbalancer member create --address 2003::24 --subnet-id 2003 --protocol-port 80 --name srv21 sg2
openstack loadbalancer member delete sg2 srv21
```
 - NAT not in range
```
openstack loadbalancer flavorprofile create --name fp_snat6_list --provider a10 --flavor-data '{"nat-pool":{"pool-name":"pool1", "start-address":"7001:db8:3333:4444::5", "end-address":"7001:db8:3333:4444::6", "netmask":"64", "gateway":"7001:db8:3333:4444::1"}, "nat-pool-list":[{"pool-name":"pool2", "start-address":"3001:db8:3333:4444::6", "end-address":"3001:db8:3333:4444::7", "netmask":"64", "gateway":"3001:db8:3333:4444::1"}, {"pool-name":"pool3", "start-address":"3001:db8:3333:4444::4", "end-address":"3001:db8:3333:4444::5", "netmask":"64", "gateway":"3001:db8:3333:4444::1"}], "virtual-port": {"name-expressions": [{"regex": "vport2", "json": {"pool": "pool2"}}]}}'
openstack loadbalancer flavor create --name f_snat6_list --flavorprofile fp_snat6_list --description "flaovr all test1" --enable

openstack loadbalancer create --flavor f_snat6_list --vip-subnet-id 2002 --name vip2
openstack loadbalancer listener create --protocol TCP --protocol-port 80 --name vport2 vip2
openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener vport2 --name sg2
openstack loadbalancer member create --address 2003::24 --subnet-id 2003 --protocol-port 80 --name srv21 sg2

```
## Manual Testing
 - NAT in member subnet range: (where 2003::100~2003::106) is in member subnet range.
```
ipv6 nat pool pool1 2003::100 2003::106 netmask 64
!
slb server ecc25_2003::24 2003::24
  port 80 tcp
!
slb service-group 5012d8c8-327c-484e-aec2-35b292505515 tcp
  member ecc25_2003::24 80
!
slb virtual-server 7a329fb2-a245-48ba-ad92-4b6d000cd377 2002::4
  port 80 tcp
    name f775d1a2-ebc1-4c98-829e-0bd0f15417cc
    extended-stats
    source-nat pool pool1
    source-nat auto
    service-group 5012d8c8-327c-484e-aec2-35b292505515
!


stack@ytsai-victoria:~/source/a10-octavia/latest/a10-octavia$ openstack port list | grep 2003::
| 5417f197-f0cb-4fab-a161-3555067d9555 | octavia-port-28d322f4-2ef5-4e5d-a01a-37c18ed8e748 | fa:16:3e:db:3f:81 | ip_address='2003::100', subnet_id='5d1316cf-6d74-468d-aa02-9d1efb50d1d1'                           | DOWN   |
|                                      |                                                   |                   | ip_address='2003::101', subnet_id='5d1316cf-6d74-468d-aa02-9d1efb50d1d1'                           |        |
|                                      |                                                   |                   | ip_address='2003::102', subnet_id='5d1316cf-6d74-468d-aa02-9d1efb50d1d1'                           |        |
|                                      |                                                   |                   | ip_address='2003::103', subnet_id='5d1316cf-6d74-468d-aa02-9d1efb50d1d1'                           |        |
|                                      |                                                   |                   | ip_address='2003::104', subnet_id='5d1316cf-6d74-468d-aa02-9d1efb50d1d1'                           |        |
|                                      |                                                   |                   | ip_address='2003::105', subnet_id='5d1316cf-6d74-468d-aa02-9d1efb50d1d1'                           |        |
|                                      |                                                   |                   | ip_address='2003::106', subnet_id='5d1316cf-6d74-468d-aa02-9d1efb50d1d1'                           |        |
stack@ytsai-victoria:~/source/a10-octavia/latest/a10-octavia$ openstack loadbalancer member delete sg2 srv21
stack@ytsai-victoria:~/source/a10-octavia/latest/a10-octavia$ openstack port list | grep 2003::
stack@ytsai-victoria:~/source/a10-octavia/latest/a10-octavia$
```

 - NAT not in range

```
ipv6 nat pool pool2 3001:db8:3333:4444::6 3001:db8:3333:4444::7 netmask 64 gateway 3001:db8:3333:4444::1
!
ipv6 nat pool pool3 3001:db8:3333:4444::4 3001:db8:3333:4444::5 netmask 64 gateway 3001:db8:3333:4444::1
!
ipv6 nat pool pool1 7001:db8:3333:4444::5 7001:db8:3333:4444::6 netmask 64 gateway 7001:db8:3333:4444::1
!
slb server ecc25_2003::24 2003::24
  port 80 tcp
!
slb service-group 2732e5a5-ef2e-44ac-a844-cc8255233e35 tcp
  member ecc25_2003::24 80
!
slb virtual-server 417415d8-3faf-4139-9f28-ac6b3bfc5bc0 2002::1c5
  port 80 tcp
    name ee020b6b-c595-4cce-b923-19accc07c227
    extended-stats
    source-nat pool pool2
    source-nat auto
    service-group 2732e5a5-ef2e-44ac-a844-cc8255233e35
!

```