### PR TITLE
[STACK-3647] Batch Member Update Regression

### DIFF
--- a/a10_octavia/common/utils.py
+++ b/a10_octavia/common/utils.py
@@ -407,21 +407,24 @@ def get_ipv6_address_from_conf(address_list, subnet_id, amp_network=False):
 
 def get_network_ipv6_address_from_conf(address_list, network):
     addr_list = []
+    network_driver = get_network_driver()
+
     addr_list = get_ipv6_address_from_conf(address_list, network.id, True)
     if addr_list:
         return addr_list
 
     for subnet_id in network.subnets:
-        addr_list = get_ipv6_address_from_conf(address_list, subnet_id, True)
-        if addr_list:
-            break
+        subnet = network_driver.get_subnet(subnet_id)
+        if subnet.ip_version == 6:
+            addr_list = get_ipv6_address_from_conf(address_list, subnet_id, True)
+            if addr_list:
+                break
     return addr_list
 
 
-def get_ipv6_address(ifnum_oper, subnet, nics, address_list, loadbalancers_list):
+def get_ipv6_address(ifnum_oper, nics, address_list, loadbalancers_list):
     final_address_list = []
     network_driver = get_network_driver()
-    amp_boot_networks = CONF.a10_controller_worker.amp_boot_network_list
     acos_mac_address = ifnum_oper['ethernet']['oper']['mac'].replace(".", "")
     for nic in nics:
         network = network_driver.get_network(nic.network_id)
@@ -432,17 +435,11 @@ def get_ipv6_address(ifnum_oper, subnet, nics, address_list, loadbalancers_list)
         port_mac_address = neutron_port.mac_address.replace(":", "")
         LOG.debug("[IPv6 Addr] get_ipv6_address get addr for mac:%s", port_mac_address)
         if port_mac_address == acos_mac_address:
-            if nic.network_id in amp_boot_networks:
-                final_address_list = get_network_ipv6_address_from_conf(address_list, network)
-                if len(final_address_list) > 0:
-                    break
+            final_address_list = get_network_ipv6_address_from_conf(address_list, network)
+            if len(final_address_list) > 0:
+                break
 
-            if (nic.network_id == subnet.network_id and not loadbalancers_list and
-                    subnet.ip_version == 6):
-                final_address_list = get_ipv6_address_from_conf(address_list, subnet.id)
-                if len(final_address_list) > 0:
-                    break
-
+            # do we still need this block?
             if loadbalancers_list:
                 for lb in loadbalancers_list:
                     if (lb.vip.network_id == nic.network_id and

--- a/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_load_balancer_flows.py
@@ -318,24 +318,24 @@ class LoadBalancerFlows(object):
             delete_LB_flow.add(vthunder_tasks.GetValidIPv6Address(
                 name=a10constants.GET_MASTER_IPV6_ADDRESS,
                 requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
-                          constants.SUBNET, a10constants.LOADBALANCERS_LIST),
+                          a10constants.LOADBALANCERS_LIST),
                 provides=a10constants.IPV6_ADDRESS_LIST))
             delete_LB_flow.add(vthunder_tasks.EnableInterface(
                 name=a10constants.ENABLE_VTHUNDER_INTERFACE,
                 requires=(a10constants.VTHUNDER, constants.LOADBALANCER,
-                          constants.ADDED_PORTS, constants.SUBNET,
+                          constants.ADDED_PORTS,
                           a10constants.IPV6_ADDRESS_LIST)))
             if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
                 delete_LB_flow.add(vthunder_tasks.GetValidIPv6Address(
                     name=a10constants.GET_BACKUP_IPV6_ADDRESS,
                     rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
                     requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
-                              constants.SUBNET, a10constants.LOADBALANCERS_LIST),
+                              a10constants.LOADBALANCERS_LIST),
                     provides=a10constants.IPV6_ADDRESS_LIST))
                 delete_LB_flow.add(vthunder_tasks.EnableInterface(
                     name=a10constants.BACKUP_ENABLE_INTERFACE,
                     requires=(a10constants.VTHUNDER, constants.LOADBALANCER,
-                              constants.ADDED_PORTS, constants.SUBNET, a10constants.BACKUP_VTHUNDER,
+                              constants.ADDED_PORTS, a10constants.BACKUP_VTHUNDER,
                               a10constants.IPV6_ADDRESS_LIST)))
         delete_LB_flow.add(
             a10_database_tasks.GetChildProjectsOfParentPartition(
@@ -472,12 +472,12 @@ class LoadBalancerFlows(object):
             new_LB_net_subflow.add(vthunder_tasks.GetValidIPv6Address(
                 name=a10constants.GET_MASTER_IPV6_ADDRESS,
                 requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
-                          constants.SUBNET, a10constants.LOADBALANCERS_LIST),
+                          a10constants.LOADBALANCERS_LIST),
                 provides=a10constants.IPV6_ADDRESS_LIST))
             new_LB_net_subflow.add(vthunder_tasks.EnableInterface(
                 name=a10constants.ENABLE_VTHUNDER_INTERFACE,
                 requires=(a10constants.VTHUNDER, constants.LOADBALANCER,
-                          constants.ADDED_PORTS, constants.SUBNET,
+                          constants.ADDED_PORTS,
                           a10constants.IPV6_ADDRESS_LIST)))
             new_LB_net_subflow.add(a10_database_tasks.GetBackupVThunderByLoadBalancer(
                 name=a10constants.GET_BACKUP_VTHUNDER_FROM_DB,
@@ -488,12 +488,12 @@ class LoadBalancerFlows(object):
                     name=a10constants.GET_BACKUP_IPV6_ADDRESS,
                     rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
                     requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
-                              constants.SUBNET, a10constants.LOADBALANCERS_LIST),
+                              a10constants.LOADBALANCERS_LIST),
                     provides=a10constants.IPV6_ADDRESS_LIST))
                 new_LB_net_subflow.add(vthunder_tasks.EnableInterface(
                     name=a10constants.BACKUP_ENABLE_INTERFACE,
                     requires=(a10constants.VTHUNDER, constants.LOADBALANCER,
-                              constants.ADDED_PORTS, constants.SUBNET,
+                              constants.ADDED_PORTS,
                               a10constants.BACKUP_VTHUNDER, a10constants.IPV6_ADDRESS_LIST)))
         else:
             new_LB_net_subflow.add(vthunder_tasks.VThunderComputeConnectivityWait(
@@ -502,13 +502,13 @@ class LoadBalancerFlows(object):
         new_LB_net_subflow.add(vthunder_tasks.GetValidIPv6Address(
             name=a10constants.GET_IPV6_ADDRESS,
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
-                      constants.SUBNET, a10constants.LOADBALANCERS_LIST),
+                      a10constants.LOADBALANCERS_LIST),
             provides=a10constants.IPV6_ADDRESS_LIST))
         new_LB_net_subflow.add(vthunder_tasks.EnableInterface(
             name=a10constants.ENABLE_MASTER_VTHUNDER_INTERFACE,
             inject={constants.ADDED_PORTS: {}},
             requires=(a10constants.VTHUNDER, constants.LOADBALANCER, constants.ADDED_PORTS,
-                      constants.SUBNET, a10constants.IPV6_ADDRESS_LIST)))
+                      a10constants.IPV6_ADDRESS_LIST)))
         new_LB_net_subflow.add(a10_database_tasks.MarkVThunderStatusInDB(
             name=a10constants.MARK_VTHUNDER_MASTER_ACTIVE_IN_DB,
             requires=a10constants.VTHUNDER,
@@ -523,13 +523,13 @@ class LoadBalancerFlows(object):
                 name=a10constants.GET_IPV6_ADDRESS_FOR_BACKUP,
                 rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
                 requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
-                          constants.SUBNET, a10constants.LOADBALANCERS_LIST),
+                          a10constants.LOADBALANCERS_LIST),
                 provides=a10constants.IPV6_ADDRESS_LIST))
             new_LB_net_subflow.add(vthunder_tasks.EnableInterface(
                 name=a10constants.ENABLE_BACKUP_VTHUNDER_INTERFACE,
                 rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
                 inject={constants.ADDED_PORTS: {}},
-                requires=(constants.LOADBALANCER, constants.ADDED_PORTS, constants.SUBNET,
+                requires=(constants.LOADBALANCER, constants.ADDED_PORTS,
                           a10constants.IPV6_ADDRESS_LIST)))
             new_LB_net_subflow.add(a10_database_tasks.MarkVThunderStatusInDB(
                 name=a10constants.MARK_VTHUNDER_BACKUP_ACTIVE_IN_DB,

--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -112,7 +112,7 @@ class MemberFlows(object):
         create_member_flow.add(vthunder_tasks.GetValidIPv6Address(
             name=a10constants.GET_IPV6_ADDRESS,
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
-                      constants.SUBNET, a10constants.LOADBALANCERS_LIST),
+                      a10constants.LOADBALANCERS_LIST),
             provides=a10constants.IPV6_ADDRESS_LIST))
         create_member_flow.add(
             vthunder_tasks.EnableInterfaceForMembers(
@@ -121,14 +121,13 @@ class MemberFlows(object):
                     constants.ADDED_PORTS,
                     constants.LOADBALANCER,
                     a10constants.VTHUNDER,
-                    constants.SUBNET,
                     a10constants.IPV6_ADDRESS_LIST]))
         if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
             create_member_flow.add(vthunder_tasks.GetValidIPv6Address(
                 name=a10constants.GET_IPV6_ADDRESS_FOR_BACKUP,
                 rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
                 requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
-                          constants.SUBNET, a10constants.LOADBALANCERS_LIST),
+                          a10constants.LOADBALANCERS_LIST),
                 provides=a10constants.IPV6_ADDRESS_LIST))
             create_member_flow.add(
                 vthunder_tasks.EnableInterfaceForMembers(
@@ -137,7 +136,6 @@ class MemberFlows(object):
                         constants.ADDED_PORTS,
                         constants.LOADBALANCER,
                         a10constants.VTHUNDER,
-                        constants.SUBNET,
                         a10constants.BACKUP_VTHUNDER,
                         a10constants.IPV6_ADDRESS_LIST]))
         if CONF.a10_global.handle_vrid:
@@ -306,7 +304,7 @@ class MemberFlows(object):
         delete_member_flow.add(vthunder_tasks.GetValidIPv6Address(
             name=a10constants.GET_IPV6_ADDRESS,
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
-                      constants.SUBNET, a10constants.LOADBALANCERS_LIST),
+                      a10constants.LOADBALANCERS_LIST),
             provides=a10constants.IPV6_ADDRESS_LIST))
         delete_member_flow.add(
             vthunder_tasks.EnableInterfaceForMembers(
@@ -315,14 +313,13 @@ class MemberFlows(object):
                     constants.ADDED_PORTS,
                     constants.LOADBALANCER,
                     a10constants.VTHUNDER,
-                    constants.SUBNET,
                     a10constants.IPV6_ADDRESS_LIST]))
         if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
             delete_member_flow.add(vthunder_tasks.GetValidIPv6Address(
                 name=a10constants.GET_IPV6_ADDRESS_FOR_BACKUP,
                 rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
                 requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
-                          constants.SUBNET, a10constants.LOADBALANCERS_LIST),
+                          a10constants.LOADBALANCERS_LIST),
                 provides=a10constants.IPV6_ADDRESS_LIST))
             delete_member_flow.add(
                 vthunder_tasks.EnableInterfaceForMembers(
@@ -331,7 +328,6 @@ class MemberFlows(object):
                         constants.ADDED_PORTS,
                         constants.LOADBALANCER,
                         a10constants.VTHUNDER,
-                        constants.SUBNET,
                         a10constants.BACKUP_VTHUNDER,
                         a10constants.IPV6_ADDRESS_LIST]))
         delete_member_flow.add(server_tasks.MemberFindNatPool(
@@ -1388,7 +1384,7 @@ class MemberFlows(object):
         batch_update_members_flow.add(vthunder_tasks.GetValidIPv6Address(
             name=a10constants.GET_IPV6_ADDRESS,
             requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
-                      constants.SUBNET, a10constants.LOADBALANCERS_LIST),
+                      a10constants.LOADBALANCERS_LIST),
             provides=a10constants.IPV6_ADDRESS_LIST))
         batch_update_members_flow.add(
             vthunder_tasks.EnableInterfaceForMembers(
@@ -1397,14 +1393,13 @@ class MemberFlows(object):
                     constants.ADDED_PORTS,
                     constants.LOADBALANCER,
                     a10constants.VTHUNDER,
-                    constants.SUBNET,
                     a10constants.IPV6_ADDRESS_LIST]))
         if topology == constants.TOPOLOGY_ACTIVE_STANDBY:
             batch_update_members_flow.add(vthunder_tasks.GetValidIPv6Address(
                 name=a10constants.GET_IPV6_ADDRESS_FOR_BACKUP,
                 rebind={a10constants.VTHUNDER: a10constants.BACKUP_VTHUNDER},
                 requires=(constants.LOADBALANCER, a10constants.VTHUNDER,
-                          constants.SUBNET, a10constants.LOADBALANCERS_LIST),
+                          a10constants.LOADBALANCERS_LIST),
                 provides=a10constants.IPV6_ADDRESS_LIST))
             batch_update_members_flow.add(
                 vthunder_tasks.EnableInterfaceForMembers(
@@ -1413,7 +1408,6 @@ class MemberFlows(object):
                         constants.ADDED_PORTS,
                         constants.LOADBALANCER,
                         a10constants.VTHUNDER,
-                        constants.SUBNET,
                         a10constants.BACKUP_VTHUNDER,
                         a10constants.IPV6_ADDRESS_LIST]))
         existing_members = [m[0] for m in updated_members]

--- a/a10_octavia/controller/worker/tasks/vthunder_tasks.py
+++ b/a10_octavia/controller/worker/tasks/vthunder_tasks.py
@@ -281,7 +281,7 @@ class EnableInterface(VThunderBaseTask):
     """Task to configure vThunder ports"""
 
     @axapi_client_decorator
-    def execute(self, vthunder, loadbalancer, added_ports, subnet, ifnum_master=None,
+    def execute(self, vthunder, loadbalancer, added_ports, ifnum_master=None,
                 ifnum_backup=None, backup_vthunder=None, ifnum_address=None):
 
         if not vthunder:
@@ -364,7 +364,7 @@ class EnableInterface(VThunderBaseTask):
 class GetValidIPv6Address(VThunderBaseTask):
 
     @axapi_client_decorator
-    def execute(self, loadbalancer, vthunder, subnet, loadbalancers_list):
+    def execute(self, loadbalancer, vthunder, loadbalancers_list):
         if vthunder:
             ipv6_address_list = {}
             topology = CONF.a10_controller_worker.loadbalancer_topology
@@ -386,7 +386,7 @@ class GetValidIPv6Address(VThunderBaseTask):
             for i in range(len(interfaces['interface']['ethernet-list'])):
                 ifnum = interfaces['interface']['ethernet-list'][i]['ifnum']
                 ifnum_oper = self.axapi_client.interface.ethernet.get_oper(ifnum)
-                ifnum_address = a10_utils.get_ipv6_address(ifnum_oper, subnet, nics,
+                ifnum_address = a10_utils.get_ipv6_address(ifnum_oper, nics,
                                                            address_list, loadbalancers_list)
                 if ifnum_address:
                     ipv6_address_list[ifnum] = ifnum_address
@@ -399,7 +399,7 @@ class EnableInterfaceForMembers(VThunderBaseTask):
     """Task to enable an interface associated with a member"""
 
     @axapi_client_decorator
-    def execute(self, added_ports, loadbalancer, vthunder, subnet, backup_vthunder=None,
+    def execute(self, added_ports, loadbalancer, vthunder, backup_vthunder=None,
                 ifnum_address=None):
         """Enable specific interface of amphora"""
         topology = CONF.a10_controller_worker.loadbalancer_topology
@@ -414,7 +414,7 @@ class EnableInterfaceForMembers(VThunderBaseTask):
 
                     if "ipv6" in eth and "address-list" in eth['ipv6']:
                         old_addr = eth['ipv6']['address-list'][0].get('ipv6-addr')
-                        if ifnum_address[ifnum] and ifnum_address[ifnum] == old_addr:
+                        if ifnum_address.get(ifnum) and ifnum_address[ifnum] == old_addr:
                             continue
                         if topology == "SINGLE":
                             self.axapi_client.system.action.setInterface(ifnum, None, 6)


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue Description
For batch member update, we have multiple subnets and we are not able to pass all subnet to GetIPv6Addr().
But actually we don't need the subnet information, since we need to get all plugged interface addresses not just the updated LB/member subnet.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3647

## Technical Approach
For batch member update, we have multiple subnets and we are not able to pass all subnet to GetIPv6Addr().
But actually we don't need the subnet information, since we need to get all plugged interface addresses not just the updated LB/member subnet

## Config Changes
- **SINGLE**
- **Active-Standby**
- With or without **amp_boot_network_list** and **subnet_ipv6_addresses**

## Test Cases
 - SINGLE
     - add all ipv6 subnet to boot networks
     - Configure LBs and members
     - delete LB/member
 - ACTIVE-STANDBY
     - add all ipv6 subnet to boot networks
     - Configure LBs and members
     - delete LB/member

## Manual Testing
 - add all ipv6 subnet to boot networks
amp_boot_network_list = 9558e757-f279-4120-9e61-540a91be9c10, f7c66e14-6eb1-456b-a677-65ce525d175e, 338ab9a6-520e-4804-8225-dc17c4db442d, 358d06a9-b9cd-44b7-8cc1-89c8b7157190, 28d322f4-2ef5-4e5d-a01a-37c18ed8e748, 88793323-c296-490f-bd28-066a083a5390, 0553182b-3497-457a-bd04-722ca5e955cf
subnet_ipv6_addresses = [{"c8556731-9316-480c-b7f3-15c7521416c4": "2400:8500:2002:1270::56/64"}, {"7fb1800d-5714-4af4-ab9e-9b43eb14f62f": "2002::56/64"}]




 - Configure LBs and members
```
openstack loadbalancer create --vip-subnet-id 2005 --name vip1
openstack loadbalancer create --vip-subnet-id 2002 --name vip2
openstack loadbalancer listener create --protocol TCP --protocol-port 80 --name vport2 vip2
openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener vport2 --name sg2
openstack loadbalancer member create --address 2003::24 --subnet-id 2003 --protocol-port 80 --name srv21 sg2
openstack loadbalancer member create --address 2004::24 --subnet-id 2004 --protocol-port 80 --name srv22 sg2
openstack loadbalancer create --vip-subnet-id tp92 --name vip3
```
```
amphora-dbff9d1f-6aa7-4616-a4e0(NOLICENSE)#show interfaces brief
Port                Link  Dupl  Speed  Trunk Vlan Encap     MAC             IP Address          IPs Flags  Name
---------------------------------------------------------------------------------------------------------------
mgmt                Up    auto  auto   N/A   N/A  N/A       fa16.3ede.550e  192.168.0.138/24      1
1                   Up    Full  10000  none  1    N/A       fa16.3e8c.7612  192.168.91.138/24     1  DataPort
2                   Up    Full  10000  none  1    N/A       fa16.3e71.62b0  0.0.0.0/0             0  DataPort
3                   Up    Full  10000  none  1    N/A       fa16.3ef5.b462  0.0.0.0/0             0  DataPort
4                   Up    Full  10000  none  1    N/A       fa16.3e88.bf4a  0.0.0.0/0             0  DataPort
5                   Up    Full  10000  none  1    N/A       fa16.3e49.11e1  0.0.0.0/0             0  DataPort
6                   Up    Full  10000  none  1    N/A       fa16.3e36.ed2c  192.168.92.225/24     1  DataPort

Global Throughput:544 bits/sec (68 bytes/sec)
Throughput:544 bits/sec (68 bytes/sec)
amphora-dbff9d1f-6aa7-4616-a4e0(NOLICENSE)#show running-config | sec ethernet
interface ethernet 1
  name DataPort
  enable
  ip address dhcp
interface ethernet 2
  name DataPort
  enable
  ipv6 address 2005::24/64
  ipv6 enable
interface ethernet 3
  name DataPort
  enable
  ipv6 address 2002::56/64
  ipv6 enable
interface ethernet 4
  name DataPort
  enable
  ipv6 address 2003::267/64
  ipv6 enable
interface ethernet 5
  name DataPort
  enable
  ipv6 address 2004::9c/64
  ipv6 enable
interface ethernet 6
  name DataPort
  enable
  ip address dhcp
```

 - Delete LBs and members
```
openstack loadbalancer delete vip1 --cascade
openstack loadbalancer member delete sg2 srv21
openstack loadbalancer delete vip3 --cascade
openstack loadbalancer delete vip2 --cascade
```