### PR TITLE
[STACK-3648] Add use_subnet_ipv6_addresses_only option

### DIFF
--- a/a10_octavia/common/config_options.py
+++ b/a10_octavia/common/config_options.py
@@ -56,6 +56,9 @@ A10_GLOBAL_OPTS = [
                        ' subnet (for use with kube cloud provider)')),
     cfg.BoolOpt('nlbaas_member_names', default=False,
                 help=_('Use neutron lbaas member names in a10 config.')),
+    cfg.BoolOpt('use_subnet_ipv6_addresses_only', default=False,
+                help=_('Configure only IPv6 addresses in subnet_ipv6_addresses for ACOS '
+                       'interfaces.')),
     cfg.ListOpt('subnet_ipv6_addresses',
                 default='',
                 help=_('A list of subnet and IPv6 address pair, which a10-octavia will attach '


### PR DESCRIPTION
## Description
Add use_subnet_ipv6_addresses_only option for:
- False: configure both subnet_ipv6_addresses and DHCPv6 addresses for interface.
- True: configure only subnet_ipv6_addresses addresses for interface.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3648

## Technical Approach
Add use_subnet_ipv6_addresses_only option for:
- False: configure both subnet_ipv6_addresses and DHCPv6 addresses for interface.
- True: configure only subnet_ipv6_addresses addresses for interface.

## Config Changes
N/A

## Test Cases
- SINGLE
    - add all ipv6 subnet to boot networks
    - Configure LBs and members
    - delete LB/member
- ACTIVE-STANDBY
     - add all ipv6 subnet to boot networks
     - Configure LBs and members
     - delete LB/member

## Manual Testing
Testing still ongoing
