### PR TITLE
move GetMembersOnThunder and CountMembersOnThunderBySubnet tasks to d…

### DIFF
--- a/a10_octavia/controller/worker/flows/a10_member_flows.py
+++ b/a10_octavia/controller/worker/flows/a10_member_flows.py
@@ -408,17 +408,6 @@ class MemberFlows(object):
             name=a10constants.GET_LB_RESOURCE_SUBNET,
             rebind={a10constants.LB_RESOURCE: constants.MEMBER},
             provides=constants.SUBNET))
-        delete_member_flow.add(
-            a10_network_tasks.GetMembersOnThunder(
-                requires=[a10constants.VTHUNDER, a10constants.USE_DEVICE_FLAVOR],
-                provides=a10constants.MEMBERS))
-        delete_member_flow.add(
-            a10_database_tasks.CountMembersOnThunderBySubnet(
-                requires=[
-                    constants.SUBNET,
-                    a10constants.USE_DEVICE_FLAVOR,
-                    a10constants.MEMBERS],
-                provides=a10constants.MEMBER_COUNT_THUNDER))
         delete_member_flow.add(server_tasks.MemberFindNatPool(
             requires=[a10constants.VTHUNDER, constants.POOL,
                       constants.FLAVOR], provides=a10constants.NAT_FLAVOR))
@@ -530,6 +519,17 @@ class MemberFlows(object):
     def get_delete_member_vrid_subflow(self):
         delete_member_vrid_subflow = linear_flow.Flow(
             a10constants.DELETE_MEMBER_VRID_SUBFLOW)
+        delete_member_vrid_subflow.add(
+            a10_network_tasks.GetMembersOnThunder(
+                requires=[a10constants.VTHUNDER, a10constants.USE_DEVICE_FLAVOR],
+                provides=a10constants.MEMBERS))
+        delete_member_vrid_subflow.add(
+            a10_database_tasks.CountMembersOnThunderBySubnet(
+                requires=[
+                    constants.SUBNET,
+                    a10constants.USE_DEVICE_FLAVOR,
+                    a10constants.MEMBERS],
+                provides=a10constants.MEMBER_COUNT_THUNDER))        
         delete_member_vrid_subflow.add(a10_network_tasks.GetLBResourceSubnet(
             rebind={a10constants.LB_RESOURCE: constants.MEMBER},
             provides=constants.SUBNET))


### PR DESCRIPTION
…elete_member_vrid_subflow (which we do not use) because they're slow

I believe the main cause for slowness is that a database session is established for each member:
https://github.com/a10networks/a10-octavia/blob/be28b219411357d4a06846d0fd67519ae8634316/a10_octavia/controller/worker/tasks/a10_database_tasks.py#L1257

While this db session could likely be reused and therefore speed up the task, I believe it's also unnecessary to perform  this task as part of the get_rack_vthunder_delete_member_flow.

Tasks are added to get_rack_vthunder_delete_member_flow even though the constants they provide are not used in this flow.
https://github.com/a10networks/a10-octavia/blob/be28b219411357d4a06846d0fd67519ae8634316/a10_octavia/controller/worker/flows/a10_member_flows.py#L411-L421

Instead, the a10constants.MEMBER_COUNT_THUNDER constant is used in the get_delete_member_vrid_subflow. Moving these tasks to the relevant flow significantly speeds up member deletion for us.

https://github.com/a10networks/a10-octavia/blob/be28b219411357d4a06846d0fd67519ae8634316/a10_octavia/controller/worker/flows/a10_member_flows.py#L573